### PR TITLE
Add `get_info` method to wallet

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -17,7 +17,7 @@ pub(crate) enum Command {
     /// Receive lbtc and send btc through a swap
     ReceivePayment { amount_sat: u64 },
     /// Get the balance of the currently loaded wallet
-    GetBalance,
+    GetInfo,
 }
 
 #[derive(Helper, Completer, Hinter, Validator)]
@@ -56,9 +56,13 @@ pub(crate) async fn handle_command(
                 response.txid
             ))
         }
-        Command::GetBalance {} => Ok(format!(
-            "Current balance: {} sat",
-            wallet.total_balance_sat(true)?
-        )),
+        Command::GetInfo {} => {
+            let info = wallet.get_info(true)?;
+
+            Ok(format!(
+                "Current Balance: {} sat\nPublic Key: {}\nLiquid Address: {}",
+                info.balance_sat, info.pubkey, info.active_address
+            ))
+        }
     }
 }

--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use boltz_client::util::{error::S5Error, secrets::LBtcReverseRecovery};
 use lwk_signer::SwSigner;
 use lwk_wollet::{ElectrumUrl, ElementsNetwork};
@@ -102,17 +100,5 @@ impl From<S5Error> for SwapError {
 pub struct WalletInfo {
     pub balance_sat: u64,
     pub pubkey: String,
-}
-
-impl fmt::Display for WalletInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            r#"
-        Current Balance: {} sat
-        Public Key: {}
-        "#,
-            self.balance_sat, self.pubkey
-        )
-    }
+    pub active_address: String,
 }


### PR DESCRIPTION
Closes #6.
Currently only displays balance and pubkey, but I believe it would be nice to wait and give the user the ability to add extra info (e.g. generated/set alias, tags etc.) once #4 is merged. 