### PR TITLE
Add support for logging

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "bip39",
  "breez-sdk-liquid",
  "clap",
+ "env_logger",
  "log",
  "lwk_common",
  "lwk_signer",
@@ -479,6 +480,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +619,12 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
+env_logger = "0.11"
 log = "0.4.20"
 breez-sdk-liquid = { path = "../lib" }
 tokio = { version = "1.36.0", features = ["full"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,6 +58,8 @@ fn init_wallet(persistence: &CliPersistence) -> Result<Arc<Wallet>> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    env_logger::init();
+
     let args = Args::parse();
     let persistence = init_persistence(&args)?;
     let history_file = &persistence.history_file();


### PR DESCRIPTION
To see more detailed logs, it's now possible to run the CLI with

```
RUST_LOG=info cargo run
```

or
```
RUST_LOG=debug cargo run
```