### PR TITLE
Setting claim absolute fees to constant amount

### DIFF
--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -33,7 +33,8 @@ use crate::{
     WalletOptions,
 };
 
-// const DEFAULT_DB_DIR: &str = ".wollet";
+const CLAIM_ABSOLUTE_FEES: u64 = 0;
+const DEFAULT_DB_DIR: &str = ".wollet";
 const BLOCKSTREAM_ELECTRUM_URL: &str = "blockstream.info:465";
 
 pub struct Wallet {
@@ -320,7 +321,7 @@ impl Wallet {
             lockup_address,
             blinding_str,
             preimage: preimage.to_string().unwrap(),
-            absolute_fees: 0,
+            absolute_fees: CLAIM_ABSOLUTE_FEES
         };
 
         self.pending_claims


### PR DESCRIPTION
Just a small fix since the `absolute_fees` amount does not seem relevant to the claim details itself, but rather should be chosen on a user-by-user basis (currently set to 0 as it is accepted on Liquid testnet)