### PR TITLE
Fix receive-payment by increasing claim absolute_fee

### DIFF
--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -64,8 +64,8 @@ pub struct SendPaymentResponse {
 
 #[derive(thiserror::Error, Debug)]
 pub enum SwapError {
-    #[error("Could not contact Boltz servers")]
-    ServersUnreachable,
+    #[error("Could not contact Boltz servers: {err}")]
+    ServersUnreachable { err: String },
 
     #[error("Invoice amount is out of range")]
     AmountOutOfRange,
@@ -90,7 +90,9 @@ impl From<S5Error> for SwapError {
     fn from(err: S5Error) -> Self {
         match err.kind {
             boltz_client::util::error::ErrorKind::Network
-            | boltz_client::util::error::ErrorKind::BoltzApi => SwapError::ServersUnreachable,
+            | boltz_client::util::error::ErrorKind::BoltzApi => SwapError::ServersUnreachable {
+                err: err.message
+            },
             boltz_client::util::error::ErrorKind::Input => SwapError::BadResponse,
             _ => SwapError::BoltzGeneric { err: err.message },
         }


### PR DESCRIPTION
This PR:
- preserves the original error message when converting an error into `SwapError::ServersUnreachable`. This helped diagnose the issue with broadcasting the claim tx.
- increases the claim tx absolute fee to the minimum acceptable `relayfee`. Through trial and error, this was found to be 134. A more reliable way to determine the minimum possible claim tx will be tracked in a separate issue (#25).

By increasing the claim tx absolute fee to an accepted value, the claim tx is now successfully broadcsat, which leads to a successful receive.