### PR TITLE
Simplify readme intros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-# Breez-SDK Liquid POC
+# Breez-SDK Liquid
 
-## Setup
-In order for the test to work, an instance of a running lightning testnet node has to be used. For the sake of semplicity, I suggest using [Alby's testnet nodes](https://github.com/getAlby/lightning-browser-extension/wiki/Test-setup) through ThunderHub (in particular LND-2, as LND-1 does not seem to be well-connected).
-
-## Commands
-You can run an instance of the cli with `cargo run`, optionally followed by `--data-dir` to specify which directory to use for caching (command history and mnemonic). 
-
-Currently the cli supports the `receive` (reverse submarine swap), `send` (normal submarine swap), `get-balance` (get the liquid wallet's balance) and `get-address` (get the first fungible address, useful for funding via faucets). 
-
-## Configuration
-In order to run tests, you can execute `cargo test -- --nocapture --test-threads 1`. This is due to the fact that currently tests require some degree of interaction (e.g. adding the funding invoice) in order to work, and thus should be run with a single thread (sequentially).
+- `lib`: [lib/README.md](lib/README.md)
+- `cli`: [cli/README.md](cli/README.md)

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,25 @@
+# breez-sdk-liquid-cli
+
+## Setup
+
+You'll need a Testnet LN node to test the sending and receiving operations. A simple solution is using [Alby's testnet nodes](https://thunderhub.regtest.getalby.com). Read more about Alby's test setup [here](https://github.com/getAlby/lightning-browser-extension/wiki/Test-setup).
+
+## Commands
+
+Start the CLI with
+
+```bash
+cargo run
+```
+
+To specify a custom data directory, use
+
+```bash
+cargo run -- --data_dir temp-dir
+```
+
+To set a custom log level, use
+
+```bash
+RUST_LOG=info cargo run
+```

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,4 @@
+# breez-sdk-liquid
+
+## Tests
+In order to run tests, you can execute `cargo test -- --nocapture --test-threads 1`. This is due to the fact that currently tests require some degree of interaction (e.g. adding the funding invoice) in order to work, and thus should be run with a single thread (sequentially).


### PR DESCRIPTION
Split the main `README.md` into two, one for `lib` and one for `cli`.