### PR TITLE
[Draft] Separate public from internal structs

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,8 @@
 mod model;
 mod persist;
+pub mod prelude;
+mod swap_in;
+mod swap_out;
 mod wallet;
 
 pub use model::*;

--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -1,4 +1,3 @@
-use boltz_client::util::error::S5Error;
 use lwk_signer::SwSigner;
 use lwk_wollet::{ElectrumUrl, ElementsNetwork};
 
@@ -34,79 +33,14 @@ pub struct SwapLbtcResponse {
     pub invoice: String,
 }
 
-pub enum SwapStatus {
-    Created,
-    Mempool,
-    Completed,
-}
-
-impl ToString for SwapStatus {
-    fn to_string(&self) -> String {
-        match self {
-            SwapStatus::Mempool => "transaction.mempool",
-            SwapStatus::Completed => "transaction.mempool",
-            SwapStatus::Created => "swap.created",
-        }
-        .to_string()
-    }
-}
-
 pub struct SendPaymentResponse {
     pub txid: String,
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum SwapError {
-    #[error("Could not contact Boltz servers: {err}")]
-    ServersUnreachable { err: String },
-
-    #[error("Invoice amount is out of range")]
-    AmountOutOfRange,
-
-    #[error("Wrong response received from Boltz servers")]
-    BadResponse,
-
-    #[error("The specified invoice is not valid")]
-    InvalidInvoice,
-
-    #[error("Could not sign/send the transaction")]
-    SendError,
-
-    #[error("Could not fetch the required wallet information")]
-    WalletError,
-
-    #[error("Could not store the swap details locally")]
-    PersistError,
-
-    #[error("Generic boltz error: {err}")]
-    BoltzGeneric { err: String },
-}
-
-impl From<S5Error> for SwapError {
-    fn from(err: S5Error) -> Self {
-        match err.kind {
-            boltz_client::util::error::ErrorKind::Network
-            | boltz_client::util::error::ErrorKind::BoltzApi => {
-                SwapError::ServersUnreachable { err: err.message }
-            }
-            boltz_client::util::error::ErrorKind::Input => SwapError::BadResponse,
-            _ => SwapError::BoltzGeneric { err: err.message },
-        }
-    }
 }
 
 pub struct WalletInfo {
     pub balance_sat: u64,
     pub pubkey: String,
     pub active_address: String,
-}
-
-pub struct OngoingSwap {
-    pub id: String,
-    pub preimage: String,
-    pub redeem_script: String,
-    pub blinding_key: String,
-    pub requested_amount_sat: u64,
 }
 
 pub enum PaymentType {

--- a/lib/src/persist/mod.rs
+++ b/lib/src/persist/mod.rs
@@ -1,12 +1,11 @@
 mod migrations;
 
 use anyhow::Result;
+use migrations::current_migrations;
 use rusqlite::{params, Connection, Row};
 use rusqlite_migration::{Migrations, M};
 
-use crate::OngoingSwap;
-
-use migrations::current_migrations;
+use crate::swap_out::model::OngoingSwap;
 
 pub(crate) struct Persister {
     main_db_file: String,

--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -1,0 +1,4 @@
+//! Prelude, which exports all public structs and methods.
+
+pub use crate::model::*;
+pub use crate::wallet::*;

--- a/lib/src/swap_in/mod.rs
+++ b/lib/src/swap_in/mod.rs
@@ -1,0 +1,1 @@
+//! Swap into LN from this wallet (L-BTC -> LN) using a submarine swap

--- a/lib/src/swap_out/error.rs
+++ b/lib/src/swap_out/error.rs
@@ -1,0 +1,41 @@
+use boltz_client::util::error::S5Error;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SwapError {
+    #[error("Could not contact Boltz servers: {err}")]
+    ServersUnreachable { err: String },
+
+    #[error("Invoice amount is out of range")]
+    AmountOutOfRange,
+
+    #[error("Wrong response received from Boltz servers")]
+    BadResponse,
+
+    #[error("The specified invoice is not valid")]
+    InvalidInvoice,
+
+    #[error("Could not sign/send the transaction")]
+    SendError,
+
+    #[error("Could not fetch the required wallet information")]
+    WalletError,
+
+    #[error("Could not store the swap details locally")]
+    PersistError,
+
+    #[error("Generic boltz error: {err}")]
+    BoltzGeneric { err: String },
+}
+
+impl From<S5Error> for SwapError {
+    fn from(err: S5Error) -> Self {
+        match err.kind {
+            boltz_client::util::error::ErrorKind::Network
+            | boltz_client::util::error::ErrorKind::BoltzApi => {
+                SwapError::ServersUnreachable { err: err.message }
+            }
+            boltz_client::util::error::ErrorKind::Input => SwapError::BadResponse,
+            _ => SwapError::BoltzGeneric { err: err.message },
+        }
+    }
+}

--- a/lib/src/swap_out/mod.rs
+++ b/lib/src/swap_out/mod.rs
@@ -1,0 +1,4 @@
+//! Swap out of LN and into this wallet (LN -> L-BTC) using a reverse swap
+
+pub(crate) mod error;
+pub(crate) mod model;

--- a/lib/src/swap_out/model.rs
+++ b/lib/src/swap_out/model.rs
@@ -1,0 +1,7 @@
+pub(crate) struct OngoingSwap {
+    pub id: String,
+    pub preimage: String,
+    pub redeem_script: String,
+    pub blinding_key: String,
+    pub requested_amount_sat: u64,
+}

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -23,7 +23,7 @@ use lwk_wollet::{
 };
 
 use crate::{
-    persist::Persister, Network, OngoingSwap, Payment, PaymentType, SendPaymentResponse, SwapError,
+    persist::Persister, Network, swap_out::model::OngoingSwap, swap_out::error::SwapError, Payment, PaymentType, SendPaymentResponse,
     SwapLbtcResponse, WalletInfo, WalletOptions,
 };
 


### PR DESCRIPTION
Split the models into
- public, relevant for the user (exported via `prelude.rs`)
- internal, relevant for our internal methods and conversions (managed in `model.rs` of each submodule)