### PR TITLE
Derive Debug for relevant structs

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -84,9 +84,9 @@ pub(crate) async fn handle_command(
                 .iter()
                 .map(|tx| {
                     format!(
-                        "Id: {} | Type: {} | Amount: {} sat | Timestamp: {}",
+                        "Id: {} | Type: {:?} | Amount: {} sat | Timestamp: {}",
                         tx.id.clone().unwrap_or("None".to_string()),
-                        tx.payment_type.to_string(),
+                        tx.payment_type,
                         tx.amount_sat,
                         match tx.timestamp {
                             Some(t) => t.to_string(),

--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -40,17 +40,6 @@ pub enum SwapStatus {
     Completed,
 }
 
-impl ToString for SwapStatus {
-    fn to_string(&self) -> String {
-        match self {
-            SwapStatus::Mempool => "transaction.mempool",
-            SwapStatus::Completed => "transaction.mempool",
-            SwapStatus::Created => "swap.created",
-        }
-        .to_string()
-    }
-}
-
 pub struct ReceivePaymentRequest {
     pub invoice_amount_sat: Option<u64>,
     pub onchain_amount_sat: Option<u64>,
@@ -103,6 +92,7 @@ impl From<S5Error> for SwapError {
     }
 }
 
+#[derive(Debug)]
 pub struct WalletInfo {
     pub balance_sat: u64,
     pub pubkey: String,
@@ -128,23 +118,14 @@ pub struct OngoingSendSwap {
     // pub onchain_amount_sat: Option<u64>,
 }
 
+#[derive(Debug)]
 pub enum PaymentType {
     Sent,
     Received,
     PendingReceive,
 }
 
-impl ToString for PaymentType {
-    fn to_string(&self) -> String {
-        match self {
-            PaymentType::Sent => "Sent",
-            PaymentType::Received => "Received",
-            PaymentType::PendingReceive => "Pending Receive",
-        }
-        .to_string()
-    }
-}
-
+#[derive(Debug)]
 pub struct Payment {
     pub id: Option<String>,
     pub timestamp: Option<u32>,


### PR DESCRIPTION
This is especially relevant for structs that will be printed or returned in the wallet API.

This PR also removes unused implementations of `ToString` for some structs.