### PR TITLE
Change to blinding variant `slip77`

### DIFF
--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -48,7 +48,7 @@ impl Wallet {
         let descriptor = singlesig_desc(
             &signer,
             Singlesig::Wpkh,
-            lwk_common::DescriptorBlindingKey::Elip151,
+            lwk_common::DescriptorBlindingKey::Slip77,
             false,
         )
         .map_err(|e| anyhow!("Invalid descriptor: {e}"))?;


### PR DESCRIPTION
Descriptions for the different variants were added here: https://github.com/Blockstream/lwk/commit/cfe93412fcebc73361231f9048232c79918e4e51

`DescriptorBlindingKey::Elip151` is intended[^2] for multisig scenarios, or cases when multiple BIP44 accounts are used. Neither of this fits our use-case.

In addition, it has the drawback[^1] that
> anyone knowing the ordinary descriptor will be able to unblind all the corresponding outputs

The ordinary descriptor is hardcoded in `lwk`, so this is not a good choice for us.

This PR is therefore switching to blinding key variant to `DescriptorBlindingKey::Slip77`, where the descriptor blinding key is derived from the BIP32 seed.

Fixes #29

[^1]: https://github.com/ElementsProject/ELIPs/blob/main/elip-0151.mediawiki#drawbacks
[^2]: https://github.com/ElementsProject/ELIPs/blob/main/elip-0151.mediawiki#motivation