### PR TITLE
Consolidate constants and default init values

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,20 +24,15 @@ fn show_results(res: Result<String>) {
     }
 }
 
-fn init_persistence(args: &Args) -> Result<CliPersistence> {
-    let data_dir = args.data_dir.clone().unwrap_or(".data".to_string());
-    let data_dir = PathBuf::from(&data_dir);
-
-    fs::create_dir_all(&data_dir)?;
-
-    Ok(CliPersistence { data_dir })
-}
-
 fn main() -> Result<()> {
     env_logger::init();
 
     let args = Args::parse();
-    let persistence = init_persistence(&args)?;
+    let data_dir_str = args.data_dir.clone().unwrap_or(".data".to_string());
+    let data_dir = PathBuf::from(&data_dir_str);
+    fs::create_dir_all(&data_dir)?;
+
+    let persistence = CliPersistence { data_dir };
     let history_file = &persistence.history_file();
 
     let rl = &mut Editor::new()?;
@@ -50,7 +45,7 @@ fn main() -> Result<()> {
     }
 
     let mnemonic = persistence.get_or_create_mnemonic()?;
-    let wallet = Wallet::init(&mnemonic.to_string())?;
+    let wallet = Wallet::init(&mnemonic.to_string(), Some(data_dir_str))?;
 
     loop {
         let readline = rl.readline("breez-liquid> ");

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -5,6 +5,11 @@ mod wallet;
 pub use model::*;
 pub use wallet::*;
 
+// To avoid sendrawtransaction error "min relay fee not met"
+const CLAIM_ABSOLUTE_FEES: u64 = 134;
+const DEFAULT_DATA_DIR: &str = ".data";
+const DEFAULT_ELECTRUM_URL: &str = "blockstream.info:465";
+
 #[cfg(test)]
 mod tests {
     use std::{env, fs, io, path::PathBuf, str::FromStr};
@@ -12,9 +17,8 @@ mod tests {
     use anyhow::Result;
     use bip39::{Language, Mnemonic};
 
-    use crate::{ReceivePaymentRequest, Wallet};
+    use crate::{ReceivePaymentRequest, Wallet, DEFAULT_DATA_DIR};
 
-    const DEFAULT_DATA_DIR: &str = ".data";
     const PHRASE_FILE_NAME: &str = "phrase";
 
     fn get_mnemonic() -> Result<Mnemonic> {

--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -23,8 +23,10 @@ pub struct WalletOptions {
     ///
     /// See <https://github.com/bitcoin/bips/pull/1143>
     pub descriptor: String,
-    pub db_root_path: Option<String>,
-    pub chain_cache_path: Option<String>,
+    /// Absolute or relative path to the data dir, including the dir name.
+    ///
+    /// If not set, it defaults to [crate::DEFAULT_DATA_DIR].
+    pub data_dir_path: Option<String>,
     pub electrum_url: Option<ElectrumUrl>,
 }
 


### PR DESCRIPTION
This PR:
- removes the unused `chain_cache_path`
- renames `db_root_path` to `data_dir_path`
- moves the constants into the root of `lib.rs`
- adds `data_dir` as an optional `init` arg