### PR TITLE
Consolidate reverse swap amounts calculation

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,6 +10,15 @@ const CLAIM_ABSOLUTE_FEES: u64 = 134;
 const DEFAULT_DATA_DIR: &str = ".data";
 const DEFAULT_ELECTRUM_URL: &str = "blockstream.info:465";
 
+#[macro_export]
+macro_rules! ensure_sdk {
+    ($cond:expr, $err:expr) => {
+        if !$cond {
+            return Err($err);
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use std::{env, fs, io, path::PathBuf, str::FromStr};


### PR DESCRIPTION
This rewrites the amount and fee calculation logic for the reverse swap (`receive-payment`) such that it's clearer how the amounts are calculated from the user input.

Some PRs were opened in the Boltz client repo, which are needed for correct reverse fee calculation, i.e. if the user specifies the desired onchain amount. When they are merged, we can integrate them and update the places marked with TODOs in this PR.

Until then, the PR uses an approximation in the fee calculation for that case.