### PR TITLE
Fix processing of the init network flag

### DIFF
--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -76,8 +76,8 @@ pub enum SwapError {
     #[error("The specified invoice is not valid")]
     InvalidInvoice,
 
-    #[error("Could not sign/send the transaction")]
-    SendError,
+    #[error("Could not sign/send the transaction: {err}")]
+    SendError { err: String },
 
     #[error("Could not fetch the required wallet information")]
     WalletError,

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -40,12 +40,13 @@ pub struct Wallet {
 
 impl Wallet {
     pub fn init(mnemonic: &str, data_dir: Option<String>, network: Network) -> Result<Arc<Wallet>> {
-        let signer = SwSigner::new(mnemonic, network == Network::Liquid)?;
+        let is_mainnet = network == Network::Liquid;
+        let signer = SwSigner::new(mnemonic, is_mainnet)?;
         let descriptor = singlesig_desc(
             &signer,
             Singlesig::Wpkh,
             lwk_common::DescriptorBlindingKey::Slip77,
-            false,
+            is_mainnet,
         )
         .map_err(|e| anyhow!("Invalid descriptor: {e}"))?;
 
@@ -225,7 +226,7 @@ impl Wallet {
 
         let txid = self
             .sign_and_send(&[signer], None, &funding_addr, funding_amount)
-            .map_err(|_| SwapError::SendError)?;
+            .map_err(|e| SwapError::SendError { err: e.to_string() })?;
 
         Ok(SendPaymentResponse { txid })
     }


### PR DESCRIPTION
This PR:
- correctly propagates the testnet / mainnet choice in `init`
- extends `SendError` with an inner error message, so that such errors are easier to diagnose