### PR TITLE
Differentiate between mainnet and testnet Electrum URLs

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,7 +8,6 @@ pub use wallet::*;
 // To avoid sendrawtransaction error "min relay fee not met"
 const CLAIM_ABSOLUTE_FEES: u64 = 134;
 const DEFAULT_DATA_DIR: &str = ".data";
-const DEFAULT_ELECTRUM_URL: &str = "blockstream.info:465";
 
 #[macro_export]
 macro_rules! ensure_sdk {

--- a/lib/src/model.rs
+++ b/lib/src/model.rs
@@ -39,7 +39,21 @@ pub struct WalletOptions {
     ///
     /// If not set, it defaults to [crate::DEFAULT_DATA_DIR].
     pub data_dir_path: Option<String>,
+    /// Custom Electrum URL. If set, it must match the specified network.
+    ///
+    /// If not set, it defaults to a Blockstream instance.
     pub electrum_url: Option<ElectrumUrl>,
+}
+impl WalletOptions {
+    pub(crate) fn get_electrum_url(&self) -> ElectrumUrl {
+        self.electrum_url.clone().unwrap_or({
+            let (url, validate_domain, tls) = match &self.network {
+                Network::Liquid => ("blockstream.info:995", true, true),
+                Network::LiquidTestnet => ("blockstream.info:465", true, true),
+            };
+            ElectrumUrl::new(url, tls, validate_domain)
+        })
+    }
 }
 
 #[derive(Debug)]

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -26,7 +26,7 @@ use lwk_wollet::{
 use crate::{
     ensure_sdk, persist::Persister, Network, OngoingSwap, Payment, PaymentError, PaymentType,
     PreparePaymentResponse, ReceivePaymentRequest, ReceivePaymentResponse, SendPaymentResponse,
-    WalletInfo, WalletOptions, CLAIM_ABSOLUTE_FEES, DEFAULT_DATA_DIR, DEFAULT_ELECTRUM_URL,
+    WalletInfo, WalletOptions, CLAIM_ABSOLUTE_FEES, DEFAULT_DATA_DIR,
 };
 
 pub struct Wallet {
@@ -63,6 +63,7 @@ impl Wallet {
     fn new(opts: WalletOptions) -> Result<Arc<Self>> {
         let network = opts.network;
         let elements_network: ElementsNetwork = opts.network.into();
+        let electrum_url = opts.get_electrum_url();
 
         let lwk_persister = NoPersist::new();
         let wallet = Arc::new(Mutex::new(LwkWollet::new(
@@ -71,9 +72,6 @@ impl Wallet {
             opts.descriptor,
         )?));
 
-        let electrum_url =
-            opts.electrum_url
-                .unwrap_or(ElectrumUrl::new(DEFAULT_ELECTRUM_URL, true, false));
         let persister_path = opts.data_dir_path.unwrap_or(DEFAULT_DATA_DIR.to_string());
         fs::create_dir_all(&persister_path)?;
 


### PR DESCRIPTION
Use different Electrum endpoints, depending on which network we're on.