### PR TITLE
Add transaction persistence to lwk instance

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -27,7 +27,7 @@ pub(crate) enum Command {
     /// Get the balance of the currently loaded wallet
     GetInfo,
     /// Empties the encrypted wallet transaction cache
-    EmptyCache
+    EmptyCache,
 }
 
 #[derive(Helper, Completer, Hinter, Validator)]
@@ -101,12 +101,10 @@ pub(crate) fn handle_command(
                 .join("\n");
 
             Ok(payments_str)
-        },
-        Command::EmptyCache => {
-            Ok(match wallet.empty_wallet_cache() {
-                Ok(_) => "Cache emptied successfully".to_string(),
-                Err(e) => format!("Could not empty cache. Err: {e}")
-            })
         }
+        Command::EmptyCache => Ok(match wallet.empty_wallet_cache() {
+            Ok(_) => "Cache emptied successfully".to_string(),
+            Err(e) => format!("Could not empty cache. Err: {e}"),
+        }),
     }
 }

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1,8 +1,9 @@
 use std::{
     fs,
+    path::PathBuf,
     sync::{Arc, Mutex},
     thread,
-    time::Duration, path::PathBuf,
+    time::Duration,
 };
 
 use anyhow::{anyhow, Result};
@@ -19,8 +20,11 @@ use log::{debug, warn};
 use lwk_common::{singlesig_desc, Signer, Singlesig};
 use lwk_signer::{AnySigner, SwSigner};
 use lwk_wollet::{
-    elements::Address, full_scan_with_electrum_client, BlockchainBackend, ElectrumClient,
-    ElectrumUrl, ElementsNetwork, FsPersister, Wollet as LwkWollet, WolletDescriptor, hashes::{sha256t_hash_newtype, Hash}
+    elements::Address,
+    full_scan_with_electrum_client,
+    hashes::{sha256t_hash_newtype, Hash},
+    BlockchainBackend, ElectrumClient, ElectrumUrl, ElementsNetwork, FsPersister,
+    Wollet as LwkWollet, WolletDescriptor,
 };
 
 use crate::{
@@ -67,11 +71,7 @@ impl Wallet {
         let electrum_url = opts.get_electrum_url();
         let data_dir_path = opts.data_dir_path.unwrap_or(DEFAULT_DATA_DIR.to_string());
 
-        let lwk_persister = FsPersister::new(
-            &data_dir_path,
-            network.into(),
-            &opts.descriptor,
-        )?;
+        let lwk_persister = FsPersister::new(&data_dir_path, network.into(), &opts.descriptor)?;
         let wallet = Arc::new(Mutex::new(LwkWollet::new(
             elements_network,
             lwk_persister,
@@ -90,7 +90,7 @@ impl Wallet {
             signer: opts.signer,
             active_address: None,
             swap_persister,
-            data_dir_path
+            data_dir_path,
         });
 
         Wallet::track_claims(&wallet)?;
@@ -106,7 +106,7 @@ impl Wallet {
             lwk_common::DescriptorBlindingKey::Slip77,
             is_mainnet,
         )
-            .map_err(|e| anyhow!("Invalid descriptor: {e}"))?;
+        .map_err(|e| anyhow!("Invalid descriptor: {e}"))?;
         Ok(descriptor_str.parse()?)
     }
 


### PR DESCRIPTION
Closes #15.
Bumping to the new release in #61 seems to have fixed the exponential creation of cache files, so it is now a viable alternative for use. Additionally, we expose a `empty_wallet_cache` method so that user can clear this cache after prolonged usage (creates one file per scan).