### PR TITLE
Remove `active_address` from `WalletInfo`

### DIFF
--- a/lib/ls-sdk-bindings/src/ls_sdk.udl
+++ b/lib/ls-sdk-bindings/src/ls_sdk.udl
@@ -25,7 +25,6 @@ enum Network {
 dictionary WalletInfo {
     u64 balance_sat;
     string pubkey;
-    string active_address;
 };
 
 dictionary PrepareSendResponse {

--- a/lib/ls-sdk-core/src/model.rs
+++ b/lib/ls-sdk-core/src/model.rs
@@ -169,7 +169,6 @@ impl From<lwk_signer::SignerError> for PaymentError {
 pub struct WalletInfo {
     pub balance_sat: u64,
     pub pubkey: String,
-    pub active_address: String,
 }
 
 #[derive(Debug)]

--- a/lib/ls-sdk-core/src/wallet.rs
+++ b/lib/ls-sdk-core/src/wallet.rs
@@ -250,10 +250,11 @@ impl Wallet {
     }
 
     pub fn get_info(&self, with_scan: bool) -> Result<WalletInfo> {
+        debug!("active_address: {}", self.address()?);
+
         Ok(WalletInfo {
             balance_sat: self.total_balance_sat(with_scan)?,
             pubkey: self.signer.xpub().public_key.to_string(),
-            active_address: self.address()?.to_string(),
         })
     }
 


### PR DESCRIPTION
This PR removes this unused field from the interface.