### PR TITLE
LWK cache removal: remove dependency on hash tag

### DIFF
--- a/lib/ls-sdk-core/src/wallet.rs
+++ b/lib/ls-sdk-core/src/wallet.rs
@@ -24,10 +24,8 @@ use lwk_common::{singlesig_desc, Signer, Singlesig};
 use lwk_signer::{AnySigner, SwSigner};
 use lwk_wollet::{
     elements::{Address, Transaction},
-    full_scan_with_electrum_client,
-    hashes::{sha256t_hash_newtype, Hash},
-    BlockchainBackend, ElectrumClient, ElectrumUrl, ElementsNetwork, FsPersister,
-    Wollet as LwkWollet, WolletDescriptor,
+    full_scan_with_electrum_client, BlockchainBackend, ElectrumClient, ElectrumUrl,
+    ElementsNetwork, FsPersister, Wollet as LwkWollet, WolletDescriptor,
 };
 
 use crate::{
@@ -36,13 +34,6 @@ use crate::{
     ReceivePaymentResponse, SendPaymentResponse, WalletInfo, WalletOptions, CLAIM_ABSOLUTE_FEES,
     DEFAULT_DATA_DIR,
 };
-
-sha256t_hash_newtype! {
-    struct DirectoryIdTag = hash_str("LWK-FS-Directory-Id/1.0");
-
-    #[hash_newtype(forward)]
-    struct DirectoryIdHash(_);
-}
 
 pub struct Wallet {
     signer: SwSigner,
@@ -579,13 +570,11 @@ impl Wallet {
         Ok(txid)
     }
 
+    /// Empties all Liquid Wallet caches for this network type.
     pub fn empty_wallet_cache(&self) -> Result<()> {
         let mut path = PathBuf::from(self.data_dir_path.clone());
         path.push(Into::<ElementsNetwork>::into(self.network).as_str());
         path.push("enc_cache");
-
-        let descriptor = Wallet::get_descriptor(&self.get_signer(), self.network)?;
-        path.push(DirectoryIdHash::hash(descriptor.to_string().as_bytes()).to_string());
 
         fs::remove_dir_all(&path)?;
         fs::create_dir_all(path)?;


### PR DESCRIPTION
This PR removes the dependency on the hardcoded hash tag

```rust
struct DirectoryIdTag = hash_str("LWK-FS-Directory-Id/1.0");
```

that is used to calculate the hash of the cache directory. Instead, `empty_wallet_cache` now clears all LWK caches.

The hash tag is pre-pended to a value X when X is hashed. This means the tag directly affects the resulting hash. In our case, X is the cache directory name.

There are two reasons for this PR:
- first, if this tag changes in a future LWK version, the previous `empty_wallet_cache` version would not be able to find and remove the existing cache. The tagged hash function of the same directory name will result in a different hash.
- second, we depend on the implementation of LWK calculates the cache directory hash. If that changes in a future LWK version, we would have to copy-paste the new implementation in our `sha256t_hash_newtype!`.