### PR TITLE
Add more details to `swap_status` error

### DIFF
--- a/lib/ls-sdk-core/src/wallet.rs
+++ b/lib/ls-sdk-core/src/wallet.rs
@@ -122,7 +122,7 @@ impl Wallet {
             } => {
                 let status_response = client
                     .swap_status(SwapStatusRequest { id: id.clone() })
-                    .map_err(|e| anyhow!("Could not contact Boltz servers for claim status: {e:?}"))?;
+                    .map_err(|e| anyhow!("Failed to fetch swap status: {e:?}"))?;
 
                 let swap_state = status_response
                     .status
@@ -178,7 +178,7 @@ impl Wallet {
 
                 let status_response = client
                     .swap_status(SwapStatusRequest { id: id.clone() })
-                    .map_err(|e| anyhow!("Could not contact Boltz servers for claim status: {e:?}"))?;
+                    .map_err(|e| anyhow!("Failed to fetch swap status: {e:?}"))?;
 
                 if [
                     SubSwapStates::TransactionClaimed.to_string(),


### PR DESCRIPTION
Include original error when logging `swap_status` errors.