### PR TITLE
Fix conversion of enum's in Kotlin

### DIFF
--- a/lib/bindings/bindings-react-native/src/gen_kotlin/templates/EnumTemplate.kt
+++ b/lib/bindings/bindings-react-native/src/gen_kotlin/templates/EnumTemplate.kt
@@ -2,7 +2,7 @@
 {%- if e.is_flat() %}
 
 fun as{{ type_name }}(type: String): {{ type_name }} {
-    return {{ type_name }}.valueOf(type.uppercase())
+    return {{ type_name }}.valueOf(camelToUpperSnakeCase(type))
 }
 
 {%- else %}

--- a/lib/bindings/bindings-react-native/src/gen_kotlin/templates/Helpers.kt
+++ b/lib/bindings/bindings-react-native/src/gen_kotlin/templates/Helpers.kt
@@ -94,3 +94,8 @@ fun errUnexpectedType(typeName: String): String {
 fun errUnexpectedValue(fieldName: String): String {
     return "Unexpected value for optional field ${fieldName}"
 }
+
+fun camelToUpperSnakeCase(str: String): String {
+    val pattern = "(?<=.)[A-Z]".toRegex()
+    return str.replace(pattern, "_$0").uppercase()
+}

--- a/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
@@ -375,7 +375,7 @@ fun asSendPaymentResponseList(arr: ReadableArray): List<SendPaymentResponse> {
 }
 
 fun asNetwork(type: String): Network {
-    return Network.valueOf(type.uppercase())
+    return Network.valueOf(camelToUpperSnakeCase(type))
 }
 
 fun asNetworkList(arr: ReadableArray): List<Network> {
@@ -497,4 +497,9 @@ fun errUnexpectedType(typeName: String): String {
 
 fun errUnexpectedValue(fieldName: String): String {
     return "Unexpected value for optional field $fieldName"
+}
+
+fun camelToUpperSnakeCase(str: String): String {
+    val pattern = "(?<=.)[A-Z]".toRegex()
+    return str.replace(pattern, "_$0").uppercase()
 }


### PR DESCRIPTION
This PR fixes conversion of the string representation of an enum in Kotlin. In React Native the string representation of an enum is for example `"liquidTestnet"`, but in Kotlin it needs changing to upper snake case `"LIQUID_TESTNET"` before converting to the enum.