### PR TITLE
[Draft] Migrate receive-payment to V2 API, use WS to get status

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=410d3a95e528fce36c02e8d414d5b647a31cc28f#410d3a95e528fce36c02e8d414d5b647a31cc28f"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=50b93fb7eba043e12a71fd7ddb1e9604a946c21b#50b93fb7eba043e12a71fd7ddb1e9604a946c21b"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=410d3a95e528fce36c02e8d414d5b647a31cc28f#410d3a95e528fce36c02e8d414d5b647a31cc28f"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=50b93fb7eba043e12a71fd7ddb1e9604a946c21b#50b93fb7eba043e12a71fd7ddb1e9604a946c21b"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 anyhow = { workspace = true }
 bip39 = { version = "2.0.0", features = ["serde"] }
-boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "410d3a95e528fce36c02e8d414d5b647a31cc28f" }
+#boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "6f45fff8b87c7530c847eb05f018906c48785a6c" }
+boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "50b93fb7eba043e12a71fd7ddb1e9604a946c21b" }
 flutter_rust_bridge = { version = "=2.0.0-dev.33", features = ["chrono"], optional = true }
 log = "0.4.20"
 lwk_common = "0.3.0"
@@ -19,12 +20,12 @@ lwk_wollet = "0.3.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
 serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.116"
 thiserror = { workspace = true }
+tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 openssl = { version = "0.10", features = ["vendored"] }
 # TODO Remove once fully migrated to v2 API
 elements = "0.24.1"
-serde_json = "1.0.116"
-tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/lib/core/src/persist/swap_in.rs
+++ b/lib/core/src/persist/swap_in.rs
@@ -1,0 +1,84 @@
+use crate::model::*;
+use crate::persist::Persister;
+
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension, Row};
+
+impl Persister {
+    pub(crate) fn insert_or_update_ongoing_swap_in(&self, swap_in: OngoingSwapIn) -> Result<()> {
+        let con = self.get_connection()?;
+
+        let mut stmt = con.prepare(
+            "
+            INSERT OR REPLACE INTO ongoing_send_swaps (
+                id,
+                invoice,
+                payer_amount_sat,
+                txid
+            )
+            VALUES (?, ?, ?, ?)",
+        )?;
+        _ = stmt.execute((
+            swap_in.id,
+            swap_in.invoice,
+            swap_in.payer_amount_sat,
+            swap_in.txid,
+        ))?;
+
+        Ok(())
+    }
+
+    fn list_ongoing_swap_in_query(where_clauses: Vec<&str>) -> String {
+        let mut where_clause_str = String::new();
+        if !where_clauses.is_empty() {
+            where_clause_str = String::from("WHERE ");
+            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
+        }
+
+        format!(
+            "
+            SELECT
+                id,
+                invoice,
+                payer_amount_sat,
+                txid,
+                created_at
+            FROM ongoing_send_swaps
+            {where_clause_str}
+            ORDER BY created_at
+        "
+        )
+    }
+
+    pub(crate) fn fetch_ongoing_swap_in(
+        con: &Connection,
+        id: &str,
+    ) -> rusqlite::Result<Option<OngoingSwapIn>> {
+        let query = Self::list_ongoing_swap_in_query(vec!["id = ?1"]);
+        con.query_row(&query, [id], Self::sql_row_to_ongoing_swap_in)
+            .optional()
+    }
+
+    fn sql_row_to_ongoing_swap_in(row: &Row) -> rusqlite::Result<OngoingSwapIn> {
+        Ok(OngoingSwapIn {
+            id: row.get(0)?,
+            invoice: row.get(1)?,
+            payer_amount_sat: row.get(2)?,
+            txid: row.get(3)?,
+        })
+    }
+
+    pub(crate) fn list_ongoing_send(
+        &self,
+        con: &Connection,
+        where_clauses: Vec<&str>,
+    ) -> rusqlite::Result<Vec<OngoingSwapIn>> {
+        let query = Self::list_ongoing_swap_in_query(where_clauses);
+        let ongoing_send = con
+            .prepare(&query)?
+            .query_map(params![], Self::sql_row_to_ongoing_swap_in)?
+            .map(|i| i.unwrap())
+            .collect();
+        Ok(ongoing_send)
+    }
+}

--- a/lib/core/src/persist/swap_out.rs
+++ b/lib/core/src/persist/swap_out.rs
@@ -1,0 +1,96 @@
+use crate::model::*;
+use crate::persist::Persister;
+
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension, Row};
+
+impl Persister {
+    pub(crate) fn insert_or_update_ongoing_swap_out(&self, swap_out: OngoingSwapOut) -> Result<()> {
+        let con = self.get_connection()?;
+
+        let mut stmt = con.prepare(
+            "
+            INSERT OR REPLACE INTO ongoing_receive_swaps (
+                id,
+                preimage,
+                redeem_script,
+                blinding_key,
+                invoice,
+                receiver_amount_sat,
+                claim_fees_sat
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )?;
+        _ = stmt.execute((
+            swap_out.id,
+            swap_out.preimage,
+            swap_out.redeem_script,
+            swap_out.blinding_key,
+            swap_out.invoice,
+            swap_out.receiver_amount_sat,
+            swap_out.claim_fees_sat,
+        ))?;
+
+        Ok(())
+    }
+
+    fn list_ongoing_swap_out_query(where_clauses: Vec<&str>) -> String {
+        let mut where_clause_str = String::new();
+        if !where_clauses.is_empty() {
+            where_clause_str = String::from("WHERE ");
+            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
+        }
+
+        format!(
+            "
+            SELECT
+                id,
+                preimage,
+                redeem_script,
+                blinding_key,
+                invoice,
+                receiver_amount_sat,
+                claim_fees_sat,
+                created_at
+            FROM ongoing_receive_swaps
+            {where_clause_str}
+            ORDER BY created_at
+        "
+        )
+    }
+
+    pub(crate) fn fetch_ongoing_swap_out(
+        con: &Connection,
+        id: &str,
+    ) -> rusqlite::Result<Option<OngoingSwapOut>> {
+        let query = Self::list_ongoing_swap_out_query(vec!["id = ?1"]);
+        con.query_row(&query, [id], Self::sql_row_to_ongoing_swap_out)
+            .optional()
+    }
+
+    fn sql_row_to_ongoing_swap_out(row: &Row) -> rusqlite::Result<OngoingSwapOut> {
+        Ok(OngoingSwapOut {
+            id: row.get(0)?,
+            preimage: row.get(1)?,
+            redeem_script: row.get(2)?,
+            blinding_key: row.get(3)?,
+            invoice: row.get(4)?,
+            receiver_amount_sat: row.get(5)?,
+            claim_fees_sat: row.get(6)?,
+        })
+    }
+
+    pub(crate) fn list_ongoing_receive(
+        &self,
+        con: &Connection,
+        where_clauses: Vec<&str>,
+    ) -> rusqlite::Result<Vec<OngoingSwapOut>> {
+        let query = Self::list_ongoing_swap_out_query(where_clauses);
+        let ongoing_receive = con
+            .prepare(&query)?
+            .query_map(params![], Self::sql_row_to_ongoing_swap_out)?
+            .map(|i| i.unwrap())
+            .collect();
+        Ok(ongoing_receive)
+    }
+}

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -1,7 +1,11 @@
 use std::net::TcpStream;
+use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
-use boltz_client::swaps::boltzv2::SwapUpdate;
+use boltz_client::swaps::{
+    boltz::RevSwapStates,
+    boltzv2::{BoltzApiClientV2, Subscription, SwapUpdate},
+};
 use log::{error, info};
 use tungstenite::{stream::MaybeTlsStream, WebSocket};
 
@@ -43,6 +47,81 @@ pub(crate) fn get_swap_status_v2(
                         info!("Got new reverse swap status: {}", update.status);
 
                         Ok(update.status.clone())
+                    }
+                    Some(update) => Err(anyhow!("WS reply has wrong swap ID {update:?}")),
+                    None => Err(anyhow!("WS reply contains no update")),
+                };
+            }
+
+            SwapUpdate::Error {
+                event,
+                channel,
+                args,
+            } => {
+                ensure!(event == "update", "Wrong WS reply event {event}");
+                ensure!(channel == "swap.update", "Wrong WS reply channel {channel}");
+
+                for e in &args {
+                    error!("Got error: {} for swap: {}", e.error, e.id);
+                }
+                return Err(anyhow!("Got SwapUpdate errors: {args:?}"));
+            }
+        }
+    }
+}
+
+/// Fetch the reverse swap status using the websocket endpoint
+pub(crate) fn get_rev_swap_status_v2(
+    client_v2: BoltzApiClientV2,
+    swap_id: &str,
+) -> Result<RevSwapStates> {
+    let mut socket = client_v2
+        .connect_ws()
+        .map_err(|e| anyhow!("Failed to connect to websocket: {e:?}"))?;
+
+    let sub_id = swap_id.to_string();
+    let subscription = Subscription::new(&sub_id);
+    let subscribe_json = serde_json::to_string(&subscription)
+        .map_err(|e| anyhow!("Failed to serialize subscription msg: {e:?}"))?;
+    socket
+        .send(tungstenite::Message::Text(subscribe_json))
+        .map_err(|e| anyhow!("Failed to subscribe to websocket updates: {e:?}"))?;
+
+    loop {
+        let response: SwapUpdate = serde_json::from_str(&socket.read()?.to_string())
+            .map_err(|e| anyhow!("WS response is invalid SwapUpdate: {e:?}"))?;
+
+        match response {
+            SwapUpdate::Subscription {
+                event,
+                channel,
+                args,
+            } => {
+                ensure!(event == "subscribe", "Wrong WS reply event {event}");
+                ensure!(channel == "swap.update", "Wrong WS reply channel {channel}");
+
+                let first_arg = args.first();
+                let is_ok = matches!(first_arg.as_ref(), Some(&x) if x == &sub_id);
+                ensure!(is_ok, "Wrong WS reply subscription ID {first_arg:?}");
+
+                info!("Subscription successful for swap : {sub_id}");
+            }
+
+            SwapUpdate::Update {
+                event,
+                channel,
+                args,
+            } => {
+                ensure!(event == "update", "Wrong WS reply event {event}");
+                ensure!(channel == "swap.update", "Wrong WS reply channel {channel}");
+
+                return match args.first() {
+                    Some(update) if update.id == sub_id => {
+                        info!("Got new reverse swap status: {}", update.status);
+
+                        RevSwapStates::from_str(&update.status).map_err(|_| {
+                            anyhow!("Invalid state for rev swap {swap_id}: {}", update.status)
+                        })
                     }
                     Some(update) => Err(anyhow!("WS reply has wrong swap ID {update:?}")),
                     None => Err(anyhow!("WS reply contains no update")),


### PR DESCRIPTION
This PR
- migrates our `receive_payment` to the V2 API
- updates the background thread to monitor the reverse swap statuses using V2 websocket calls

Open points:
- [ ] Do not store `CreateReverseResponse` in DB field for `redeem_script`. Instead expand DB model as necessary.
- [x] Sign and broadcast claim tx as soon as the lockup tx is in the mempool
- [x] Handle errors (remove unwraps)
- [x] `prepare_receive_payment`: Use v2 fees instead of v1
- [x] Validate WS replies with `ensure!` instead of `assert!` 