### PR TITLE
Pattern match the linux x86_64 clang directory

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "anyhow",
  "breez-liquid-sdk",
  "camino",
+ "glob",
  "thiserror",
  "uniffi 0.27.1",
  "uniffi-kotlin-multiplatform",

--- a/lib/bindings/Cargo.toml
+++ b/lib/bindings/Cargo.toml
@@ -24,3 +24,4 @@ thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = [ "build" ] }
+glob = "0.3.1"

--- a/lib/bindings/build.rs
+++ b/lib/bindings/build.rs
@@ -1,7 +1,5 @@
+use glob::glob;
 use std::env;
-use std::path::Path;
-
-const DEFAULT_CLANG_VERSION: &str = "14.0.7";
 
 /// Adds a temporary workaround for an issue with the Rust compiler and Android
 /// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
@@ -19,17 +17,15 @@ fn setup_x86_64_android_workaround() {
                 "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
             ),
         };
-        let clang_version =
-            env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
-        let linux_x86_64_lib_dir = format!(
-            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+        let linux_x86_64_lib_pattern = format!(
+            "{android_ndk_home}/toolchains/llvm/prebuilt/{build_os}-x86_64/lib*/clang/**/lib/linux/"
         );
-        let linkpath = format!("{android_ndk_home}/{linux_x86_64_lib_dir}");
-        if Path::new(&linkpath).exists() {
-            println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
-            println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
-        } else {
-            panic!("Path {linkpath} not exists");
+        match glob(&linux_x86_64_lib_pattern).unwrap().last() {
+            Some(Ok(path)) => {
+                println!("cargo:rustc-link-search={}", path.to_string_lossy());
+                println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");    
+            },
+            _ => panic!("Path not found: {linux_x86_64_lib_pattern}. Try setting a different ANDROID_NDK_HOME."),
         }
     }
 }


### PR DESCRIPTION
This PR uses glob in the build to pattern match the linux x86_64 clang directory