### PR TITLE
[Flutter] Update dependencies to latest compatible

### DIFF
--- a/lib/bindings/bindings-flutter/justfile
+++ b/lib/bindings/bindings-flutter/justfile
@@ -79,6 +79,7 @@ link:
 init *args:
 	dart pub global activate melos
 	melos bootstrap {{args}}
+	melos pub-upgrade
 
 # (melos) Generate docs for packages in workspace
 docs:

--- a/lib/bindings/bindings-flutter/melos.yaml
+++ b/lib/bindings/bindings-flutter/melos.yaml
@@ -66,6 +66,10 @@ scripts:
     exec: dart format -l 110 .
     description: Format a specific package in this project.
 
+  pub-upgrade:
+    exec: dart pub upgrade
+    description: Update all the dependencies to the latest compatible versions in this project.
+
   # TODO: deprecate when first version to pub.dev is published
   docs:
     exec: dart doc -o website/\$MELOS_PACKAGE_NAME

--- a/lib/bindings/bindings-flutter/scripts/pubspec.lock
+++ b/lib/bindings/bindings-flutter/scripts/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -394,10 +394,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
+      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -423,5 +423,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
`melos pub-upgrade` is introduced with this PR that updates all dependencies to latest compatible version for packages in workspace.

This command is now run on `just init` step, which ensures `pubspec.lock` changes are caught on CI step.