### PR TITLE
Send: fix tracking swap type

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -736,7 +736,7 @@ impl LiquidSdk {
                     )?;
                     debug!("Boltz successfully claimed the funds");
 
-                    BoltzStatusStream::unmark_swap_as_tracked(swap_id, SwapType::ReverseSubmarine);
+                    BoltzStatusStream::unmark_swap_as_tracked(swap_id, SwapType::Submarine);
 
                     result = Ok(SendPaymentResponse { txid: lockup_tx_id });
 


### PR DESCRIPTION
The correct type was used in `mark_swap_as_tracked` a few lines above, but `unmark_swap_as_tracked` used the incorrect type.