### PR TITLE
Expose `sync` through Dart bindings

### DIFF
--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -166,6 +166,9 @@ void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_send_payment(in
                                                                               uintptr_t that,
                                                                               struct wire_cst_prepare_send_response *req);
 
+void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync(int64_t port_,
+                                                                      uintptr_t that);
+
 void frbgen_breez_liquid_wire__crate__bindings__connect(int64_t port_,
                                                         struct wire_cst_connect_request *req);
 
@@ -214,6 +217,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_receive_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_restore);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_send_payment);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__connect);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     return dummy_var;

--- a/lib/bindings/langs/flutter/scripts/build_other.dart
+++ b/lib/bindings/langs/flutter/scripts/build_other.dart
@@ -87,6 +87,7 @@ enum Targets {
     return values.firstWhere((target) => target.triple == host);
   }
 
-  String get compiler => isWindows ? 'cargo xwin build --package breez-liquid-sdk' : 'cargo zigbuild --package breez-liquid-sdk';
+  String get compiler =>
+      isWindows ? 'cargo xwin build --package breez-liquid-sdk' : 'cargo zigbuild --package breez-liquid-sdk';
   String get libName => isWindows ? windowsLibName : linuxLibName;
 }

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -48,6 +48,10 @@ impl BindingLiquidSdk {
         self.sdk.list_payments()
     }
 
+    pub fn sync(&self) -> Result<(), LiquidSdkError> {
+        self.sdk.sync().map_err(Into::into)
+    }
+
     pub fn backup(&self) -> Result<(), LiquidSdkError> {
         self.sdk.backup().map_err(Into::into)
     }

--- a/lib/core/src/frb/bridge.io.rs
+++ b/lib/core/src/frb/bridge.io.rs
@@ -529,6 +529,14 @@ pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_se
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync(
+    port_: i64,
+    that: usize,
+) {
+    wire__crate__bindings__BindingLiquidSdk_sync_impl(port_, that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__connect(
     port_: i64,
     req: *mut wire_cst_connect_request,

--- a/lib/core/src/frb/bridge.rs
+++ b/lib/core/src/frb/bridge.rs
@@ -33,7 +33,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0-dev.35";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -913565329;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2052012510;
 
 // Section: executor
 
@@ -336,6 +336,42 @@ fn wire__crate__bindings__BindingLiquidSdk_send_payment_impl(
                     }
                     let api_that = api_that_decoded.unwrap();
                     crate::bindings::BindingLiquidSdk::send_payment(&api_that, api_req)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__bindings__BindingLiquidSdk_sync_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>,
+    >,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "BindingLiquidSdk_sync",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            move |context| {
+                transform_result_dco((move || {
+                    let mut api_that_decoded = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::rust_auto_opaque_decode_compute_order(
+                            vec![api_that.rust_auto_opaque_lock_order_info(0, false)],
+                        );
+                    for i in decode_indices_ {
+                        match i {
+                            0 => {
+                                api_that_decoded = Some(api_that.rust_auto_opaque_decode_sync_ref())
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that = api_that_decoded.unwrap();
+                    crate::bindings::BindingLiquidSdk::sync(&api_that)
                 })())
             }
         },

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -49,4 +49,7 @@ class BindingLiquidSdk extends RustOpaque {
 
   Future<SendPaymentResponse> sendPayment({required PrepareSendResponse req, dynamic hint}) =>
       RustLib.instance.api.crateBindingsBindingLiquidSdkSendPayment(that: this, req: req, hint: hint);
+
+  Future<void> sync({dynamic hint}) =>
+      RustLib.instance.api.crateBindingsBindingLiquidSdkSync(that: this, hint: hint);
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -53,7 +53,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.0.0-dev.35';
 
   @override
-  int get rustContentHash => -913565329;
+  int get rustContentHash => 2052012510;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'breez_liquid_sdk',
@@ -85,6 +85,8 @@ abstract class RustLibApi extends BaseApi {
 
   Future<SendPaymentResponse> crateBindingsBindingLiquidSdkSendPayment(
       {required BindingLiquidSdk that, required PrepareSendResponse req, dynamic hint});
+
+  Future<void> crateBindingsBindingLiquidSdkSync({required BindingLiquidSdk that, dynamic hint});
 
   Future<BindingLiquidSdk> crateBindingsConnect({required ConnectRequest req, dynamic hint});
 
@@ -314,6 +316,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateBindingsBindingLiquidSdkSendPaymentConstMeta => const TaskConstMeta(
         debugName: "BindingLiquidSdk_send_payment",
         argNames: ["that", "req"],
+      );
+
+  @override
+  Future<void> crateBindingsBindingLiquidSdkSync({required BindingLiquidSdk that, dynamic hint}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        var arg0 =
+            cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(
+                that);
+        return wire.wire__crate__bindings__BindingLiquidSdk_sync(port_, arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_unit,
+        decodeErrorData: dco_decode_liquid_sdk_error,
+      ),
+      constMeta: kCrateBindingsBindingLiquidSdkSyncConstMeta,
+      argValues: [that],
+      apiImpl: this,
+      hint: hint,
+    ));
+  }
+
+  TaskConstMeta get kCrateBindingsBindingLiquidSdkSyncConstMeta => const TaskConstMeta(
+        debugName: "BindingLiquidSdk_sync",
+        argNames: ["that"],
       );
 
   @override

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -918,6 +918,22 @@ class RustLibWire implements BaseWire {
       _wire__crate__bindings__BindingLiquidSdk_send_paymentPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_send_response>)>();
 
+  void wire__crate__bindings__BindingLiquidSdk_sync(
+    int port_,
+    int that,
+  ) {
+    return _wire__crate__bindings__BindingLiquidSdk_sync(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire__crate__bindings__BindingLiquidSdk_syncPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+          'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync');
+  late final _wire__crate__bindings__BindingLiquidSdk_sync =
+      _wire__crate__bindings__BindingLiquidSdk_syncPtr.asFunction<void Function(int, int)>();
+
   void wire__crate__bindings__connect(
     int port_,
     ffi.Pointer<wire_cst_connect_request> req,

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -192,6 +192,23 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_send_paymentPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_send_response>)>();
 
+  void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync(
+    int port_,
+    int that,
+  ) {
+    return _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync(
+      port_,
+      that,
+    );
+  }
+
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_syncPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+          'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync');
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync =
+      _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_syncPtr
+          .asFunction<void Function(int, int)>();
+
   void frbgen_breez_liquid_wire__crate__bindings__connect(
     int port_,
     ffi.Pointer<wire_cst_connect_request> req,


### PR DESCRIPTION
This PR exposes `sync` API through Dart bindings.

Other changes:
- Reformat `build_other.dart`