### PR TITLE
Mark `default_config` && `parse_invoice` to be generated as sync functions on Dart bindings

### DIFF
--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -278,10 +278,9 @@ void frbgen_breez_liquid_wire__crate__bindings__breez_log_stream(int64_t port_,
 void frbgen_breez_liquid_wire__crate__bindings__connect(int64_t port_,
                                                         struct wire_cst_connect_request *req);
 
-void frbgen_breez_liquid_wire__crate__bindings__default_config(int64_t port_, int32_t network);
+WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__default_config(int32_t network);
 
-void frbgen_breez_liquid_wire__crate__bindings__parse_invoice(int64_t port_,
-                                                              struct wire_cst_list_prim_u_8_strict *input);
+WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_invoice(struct wire_cst_list_prim_u_8_strict *input);
 
 void frbgen_breez_liquid_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(const void *ptr);
 

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -59,10 +59,12 @@ pub fn breez_log_stream(s: StreamSink<LogEntry>) -> Result<()> {
     Ok(())
 }
 
+#[frb(sync)]
 pub fn default_config(network: Network) -> Config {
     LiquidSdk::default_config(network)
 }
 
+#[frb(sync)]
 pub fn parse_invoice(input: String) -> Result<LNInvoice, PaymentError> {
     LiquidSdk::parse_invoice(&input)
 }

--- a/lib/core/src/frb/bridge.io.rs
+++ b/lib/core/src/frb/bridge.io.rs
@@ -872,18 +872,16 @@ pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__connect(
 
 #[no_mangle]
 pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__default_config(
-    port_: i64,
     network: i32,
-) {
-    wire__crate__bindings__default_config_impl(port_, network)
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__bindings__default_config_impl(network)
 }
 
 #[no_mangle]
 pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__parse_invoice(
-    port_: i64,
     input: *mut wire_cst_list_prim_u_8_strict,
-) {
-    wire__crate__bindings__parse_invoice_impl(port_, input)
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    wire__crate__bindings__parse_invoice_impl(input)
 }
 
 #[no_mangle]

--- a/lib/core/src/frb/bridge.rs
+++ b/lib/core/src/frb/bridge.rs
@@ -391,40 +391,34 @@ fn wire__crate__bindings__connect_impl(
     )
 }
 fn wire__crate__bindings__default_config_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
     network: impl CstDecode<crate::model::Network>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "default_config",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
             let api_network = network.cst_decode();
-            move |context| {
-                transform_result_dco((move || {
-                    Result::<_, ()>::Ok(crate::bindings::default_config(api_network))
-                })())
-            }
+            transform_result_dco((move || {
+                Result::<_, ()>::Ok(crate::bindings::default_config(api_network))
+            })())
         },
     )
 }
 fn wire__crate__bindings__parse_invoice_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
     input: impl CstDecode<String>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "parse_invoice",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
             let api_input = input.cst_decode();
-            move |context| {
-                transform_result_dco((move || crate::bindings::parse_invoice(api_input))())
-            }
+            transform_result_dco((move || crate::bindings::parse_invoice(api_input))())
         },
     )
 }

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -18,10 +18,10 @@ Future<BindingLiquidSdk> connect({required ConnectRequest req, dynamic hint}) =>
 Stream<LogEntry> breezLogStream({dynamic hint}) =>
     RustLib.instance.api.crateBindingsBreezLogStream(hint: hint);
 
-Future<Config> defaultConfig({required Network network, dynamic hint}) =>
+Config defaultConfig({required Network network, dynamic hint}) =>
     RustLib.instance.api.crateBindingsDefaultConfig(network: network, hint: hint);
 
-Future<LNInvoice> parseInvoice({required String input, dynamic hint}) =>
+LNInvoice parseInvoice({required String input, dynamic hint}) =>
     RustLib.instance.api.crateBindingsParseInvoice(input: input, hint: hint);
 
 // Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -100,9 +100,9 @@ abstract class RustLibApi extends BaseApi {
 
   Future<BindingLiquidSdk> crateBindingsConnect({required ConnectRequest req, dynamic hint});
 
-  Future<Config> crateBindingsDefaultConfig({required Network network, dynamic hint});
+  Config crateBindingsDefaultConfig({required Network network, dynamic hint});
 
-  Future<LNInvoice> crateBindingsParseInvoice({required String input, dynamic hint});
+  LNInvoice crateBindingsParseInvoice({required String input, dynamic hint});
 
   RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_BindingLiquidSdk;
 
@@ -488,11 +488,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<Config> crateBindingsDefaultConfig({required Network network, dynamic hint}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
+  Config crateBindingsDefaultConfig({required Network network, dynamic hint}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
         var arg0 = cst_encode_network(network);
-        return wire.wire__crate__bindings__default_config(port_, arg0);
+        return wire.wire__crate__bindings__default_config(arg0);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_config,
@@ -511,11 +511,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<LNInvoice> crateBindingsParseInvoice({required String input, dynamic hint}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
+  LNInvoice crateBindingsParseInvoice({required String input, dynamic hint}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
         var arg0 = cst_encode_String(input);
-        return wire.wire__crate__bindings__parse_invoice(port_, arg0);
+        return wire.wire__crate__bindings__parse_invoice(arg0);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_ln_invoice,

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -1325,37 +1325,33 @@ class RustLibWire implements BaseWire {
   late final _wire__crate__bindings__connect = _wire__crate__bindings__connectPtr
       .asFunction<void Function(int, ffi.Pointer<wire_cst_connect_request>)>();
 
-  void wire__crate__bindings__default_config(
-    int port_,
+  WireSyncRust2DartDco wire__crate__bindings__default_config(
     int network,
   ) {
     return _wire__crate__bindings__default_config(
-      port_,
       network,
     );
   }
 
   late final _wire__crate__bindings__default_configPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Int32)>>(
           'frbgen_breez_liquid_wire__crate__bindings__default_config');
   late final _wire__crate__bindings__default_config =
-      _wire__crate__bindings__default_configPtr.asFunction<void Function(int, int)>();
+      _wire__crate__bindings__default_configPtr.asFunction<WireSyncRust2DartDco Function(int)>();
 
-  void wire__crate__bindings__parse_invoice(
-    int port_,
+  WireSyncRust2DartDco wire__crate__bindings__parse_invoice(
     ffi.Pointer<wire_cst_list_prim_u_8_strict> input,
   ) {
     return _wire__crate__bindings__parse_invoice(
-      port_,
       input,
     );
   }
 
   late final _wire__crate__bindings__parse_invoicePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
           'frbgen_breez_liquid_wire__crate__bindings__parse_invoice');
   late final _wire__crate__bindings__parse_invoice = _wire__crate__bindings__parse_invoicePtr
-      .asFunction<void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+      .asFunction<WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
 
   void
       rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -33,9 +33,13 @@ class Config {
   final String boltzUrl;
   final String electrumUrl;
 
-  /// Directory in which all SDK files (DB, log) are stored.
+  /// Directory in which all SDK files (DB, log, cache) are stored.
+  ///
+  /// Prefix can be a relative or absolute path to this directory.
   final String workingDir;
   final Network network;
+
+  /// Send payment timeout. See [crate::sdk::LiquidSdk::send_payment]
   final BigInt paymentTimeoutSec;
 
   const Config({

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -294,38 +294,35 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_wire__crate__bindings__connectPtr
           .asFunction<void Function(int, ffi.Pointer<wire_cst_connect_request>)>();
 
-  void frbgen_breez_liquid_wire__crate__bindings__default_config(
-    int port_,
+  WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__default_config(
     int network,
   ) {
     return _frbgen_breez_liquid_wire__crate__bindings__default_config(
-      port_,
       network,
     );
   }
 
   late final _frbgen_breez_liquid_wire__crate__bindings__default_configPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Int32)>>(
           'frbgen_breez_liquid_wire__crate__bindings__default_config');
   late final _frbgen_breez_liquid_wire__crate__bindings__default_config =
-      _frbgen_breez_liquid_wire__crate__bindings__default_configPtr.asFunction<void Function(int, int)>();
+      _frbgen_breez_liquid_wire__crate__bindings__default_configPtr
+          .asFunction<WireSyncRust2DartDco Function(int)>();
 
-  void frbgen_breez_liquid_wire__crate__bindings__parse_invoice(
-    int port_,
+  WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_invoice(
     ffi.Pointer<wire_cst_list_prim_u_8_strict> input,
   ) {
     return _frbgen_breez_liquid_wire__crate__bindings__parse_invoice(
-      port_,
       input,
     );
   }
 
   late final _frbgen_breez_liquid_wire__crate__bindings__parse_invoicePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
+      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
           'frbgen_breez_liquid_wire__crate__bindings__parse_invoice');
   late final _frbgen_breez_liquid_wire__crate__bindings__parse_invoice =
       _frbgen_breez_liquid_wire__crate__bindings__parse_invoicePtr
-          .asFunction<void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
+          .asFunction<WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
 
   void
       frbgen_breez_liquid_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(


### PR DESCRIPTION
Mark `default_config` && `parse_invoice` to be generated as sync functions on Dart bindings.
- Generate Dart bindings