### PR TITLE
Remove build-other from publish CI

### DIFF
--- a/.github/workflows/build-bindings-flutter.yml
+++ b/.github/workflows/build-bindings-flutter.yml
@@ -77,14 +77,15 @@ jobs:
 
     - name: Build language packages
       working-directory: lib/bindings/langs/flutter/
-      run: melos build
+      run: |
+        melos build-apple
+        melos build-android
 
     - name: Copy build output
       run: |
         mkdir -p dist
         cp lib/bindings/langs/flutter/platform-build/android.tar.gz dist
         cp lib/bindings/langs/flutter/platform-build/breez_sdk_liquid.xcframework.zip dist
-        cp lib/bindings/langs/flutter/platform-build/other.tar.gz dist
 
     - name: Archive Flutter bindings
       uses: actions/upload-artifact@v4
@@ -101,7 +102,6 @@ jobs:
         run: |
           touch android.tar.gz
           touch breez_sdk_liquid.xcframework.zip
-          touch other.tar.gz
 
       - name: Archive Flutter dummy bindings
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -118,7 +118,6 @@ jobs:
           files: |
             bindings/android.tar.gz
             bindings/breez_sdk_liquid.xcframework.zip
-            bindings/other.tar.gz
           tag_name: v${{ inputs.package-version || '0.0.1' }}
           generate_release_notes: false
           token: ${{ secrets.SWIFT_RELEASE_TOKEN }}


### PR DESCRIPTION
Building of the "other" binaries has started to fail when publishing (and also locally after cleaning). I have removed the build-other phase as it was not used anyway.

This error in: https://github.com/breez/breez-sdk-liquid/actions/runs/9859878821/job/27224684219
```
error[E0308]: mismatched types
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-xwin-0.17.2/src/common.rs:642:40
    |
642 |         Ok(builder.tls_config(Arc::new(client_config)).build())
    |                               -------- ^^^^^^^^^^^^^ expected `ClientConfig`, found a different `ClientConfig`
    |                               |
    |                               arguments to this function are incorrect
    |
    = note: `ClientConfig` and `ClientConfig` have similar names, but are actually distinct types
note: `ClientConfig` is defined in crate `rustls`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.22.4/src/client/client_conn.rs:150:1
    |
150 | pub struct ClientConfig {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `ClientConfig` is defined in crate `rustls`
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.11/src/client/client_conn.rs:157:1
    |
157 | pub struct ClientConfig {
    | ^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `rustls` are being used?
note: associated function defined here
   --> /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/sync.rs:392:12



For more information about this error, try `rustc --explain E0308`.


error: could not compile `cargo-xwin` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...


error: failed to compile `cargo-xwin v0.17.2`, intermediate artifacts can be found at `/var/folders/h9/l1shxhdd69nct08ylzq0n6q00000gn/T/cargo-installt3ZGgr`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
     Summary Successfully installed cargo-zigbuild! Failed to install cargo-xwin (see error(s) above).
error: some crates failed to install
```