### PR TITLE
Update UDL to fix python default argment ordering

### DIFF
--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -389,17 +389,17 @@ dictionary RestoreRequest {
 };
 
 dictionary Payment {
-    string? tx_id = null;
-    string? swap_id = null;
     u32 timestamp;
     u64 amount_sat;
     u64 fees_sat;
+    PaymentType payment_type;
+    PaymentState status;
+    string? tx_id = null;
+    string? swap_id = null;
     string? preimage = null;
     string? bolt11 = null;
     string? refund_tx_id = null;
     u64? refund_tx_amount_sat = null;
-    PaymentType payment_type;
-    PaymentState status;
 };
 
 enum PaymentType {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1101,45 +1101,45 @@ fun asPayment(payment: ReadableMap): Payment? {
     ) {
         return null
     }
-    val txId = if (hasNonNullKey(payment, "txId")) payment.getString("txId") else null
-    val swapId = if (hasNonNullKey(payment, "swapId")) payment.getString("swapId") else null
     val timestamp = payment.getInt("timestamp").toUInt()
     val amountSat = payment.getDouble("amountSat").toULong()
     val feesSat = payment.getDouble("feesSat").toULong()
+    val paymentType = payment.getString("paymentType")?.let { asPaymentType(it) }!!
+    val status = payment.getString("status")?.let { asPaymentState(it) }!!
+    val txId = if (hasNonNullKey(payment, "txId")) payment.getString("txId") else null
+    val swapId = if (hasNonNullKey(payment, "swapId")) payment.getString("swapId") else null
     val preimage = if (hasNonNullKey(payment, "preimage")) payment.getString("preimage") else null
     val bolt11 = if (hasNonNullKey(payment, "bolt11")) payment.getString("bolt11") else null
     val refundTxId = if (hasNonNullKey(payment, "refundTxId")) payment.getString("refundTxId") else null
     val refundTxAmountSat = if (hasNonNullKey(payment, "refundTxAmountSat")) payment.getDouble("refundTxAmountSat").toULong() else null
-    val paymentType = payment.getString("paymentType")?.let { asPaymentType(it) }!!
-    val status = payment.getString("status")?.let { asPaymentState(it) }!!
     return Payment(
-        txId,
-        swapId,
         timestamp,
         amountSat,
         feesSat,
+        paymentType,
+        status,
+        txId,
+        swapId,
         preimage,
         bolt11,
         refundTxId,
         refundTxAmountSat,
-        paymentType,
-        status,
     )
 }
 
 fun readableMapOf(payment: Payment): ReadableMap =
     readableMapOf(
-        "txId" to payment.txId,
-        "swapId" to payment.swapId,
         "timestamp" to payment.timestamp,
         "amountSat" to payment.amountSat,
         "feesSat" to payment.feesSat,
+        "paymentType" to payment.paymentType.name.lowercase(),
+        "status" to payment.status.name.lowercase(),
+        "txId" to payment.txId,
+        "swapId" to payment.swapId,
         "preimage" to payment.preimage,
         "bolt11" to payment.bolt11,
         "refundTxId" to payment.refundTxId,
         "refundTxAmountSat" to payment.refundTxAmountSat,
-        "paymentType" to payment.paymentType.name.lowercase(),
-        "status" to payment.status.name.lowercase(),
     )
 
 fun asPaymentList(arr: ReadableArray): List<Payment> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1275,6 +1275,25 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asPayment(payment: [String: Any?]) throws -> Payment {
+        guard let timestamp = payment["timestamp"] as? UInt32 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "Payment"))
+        }
+        guard let amountSat = payment["amountSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "Payment"))
+        }
+        guard let feesSat = payment["feesSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "Payment"))
+        }
+        guard let paymentTypeTmp = payment["paymentType"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
+        }
+        let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
+
+        guard let statusTmp = payment["status"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
+        }
+        let status = try asPaymentState(paymentState: statusTmp)
+
         var txId: String?
         if hasNonNilKey(data: payment, key: "txId") {
             guard let txIdTmp = payment["txId"] as? String else {
@@ -1288,15 +1307,6 @@ enum BreezSDKLiquidMapper {
                 throw SdkError.Generic(message: errUnexpectedValue(fieldName: "swapId"))
             }
             swapId = swapIdTmp
-        }
-        guard let timestamp = payment["timestamp"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "Payment"))
-        }
-        guard let amountSat = payment["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "Payment"))
-        }
-        guard let feesSat = payment["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "Payment"))
         }
         var preimage: String?
         if hasNonNilKey(data: payment, key: "preimage") {
@@ -1326,44 +1336,35 @@ enum BreezSDKLiquidMapper {
             }
             refundTxAmountSat = refundTxAmountSatTmp
         }
-        guard let paymentTypeTmp = payment["paymentType"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
-        }
-        let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
-
-        guard let statusTmp = payment["status"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
-        }
-        let status = try asPaymentState(paymentState: statusTmp)
 
         return Payment(
-            txId: txId,
-            swapId: swapId,
             timestamp: timestamp,
             amountSat: amountSat,
             feesSat: feesSat,
+            paymentType: paymentType,
+            status: status,
+            txId: txId,
+            swapId: swapId,
             preimage: preimage,
             bolt11: bolt11,
             refundTxId: refundTxId,
-            refundTxAmountSat: refundTxAmountSat,
-            paymentType: paymentType,
-            status: status
+            refundTxAmountSat: refundTxAmountSat
         )
     }
 
     static func dictionaryOf(payment: Payment) -> [String: Any?] {
         return [
-            "txId": payment.txId == nil ? nil : payment.txId,
-            "swapId": payment.swapId == nil ? nil : payment.swapId,
             "timestamp": payment.timestamp,
             "amountSat": payment.amountSat,
             "feesSat": payment.feesSat,
+            "paymentType": valueOf(paymentType: payment.paymentType),
+            "status": valueOf(paymentState: payment.status),
+            "txId": payment.txId == nil ? nil : payment.txId,
+            "swapId": payment.swapId == nil ? nil : payment.swapId,
             "preimage": payment.preimage == nil ? nil : payment.preimage,
             "bolt11": payment.bolt11 == nil ? nil : payment.bolt11,
             "refundTxId": payment.refundTxId == nil ? nil : payment.refundTxId,
             "refundTxAmountSat": payment.refundTxAmountSat == nil ? nil : payment.refundTxAmountSat,
-            "paymentType": valueOf(paymentType: payment.paymentType),
-            "status": valueOf(paymentState: payment.status),
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -188,17 +188,17 @@ export interface PayOnchainRequest {
 }
 
 export interface Payment {
-    txId?: string
-    swapId?: string
     timestamp: number
     amountSat: number
     feesSat: number
+    paymentType: PaymentType
+    status: PaymentState
+    txId?: string
+    swapId?: string
     preimage?: string
     bolt11?: string
     refundTxId?: string
     refundTxAmountSat?: number
-    paymentType: PaymentType
-    status: PaymentState
 }
 
 export interface PreparePayOnchainRequest {


### PR DESCRIPTION
This PR changes the ordering of Payment fields to fix the python limitation of requiring non-default arguments before default arguments.
```
Traceback (most recent call last):
  File "/home/runner/work/breez-sdk-liquid/breez-sdk-liquid/lib/bindings/tests/bindings/test_breez_sdk_liquid.py", line 1, in <module>
    import breez_sdk_liquid
  File "/home/runner/work/breez-sdk-liquid/breez-sdk-liquid/lib/target/tmp/breez-sdk-liquid-bindings-8c2ab1544e4e54dd/breez_sdk_liquid.py", line 2666
    def __init__(self, tx_id: "typing.Optional[str]" = _DEFAULT, swap_id: "typing.Optional[str]" = _DEFAULT, timestamp: "int", amount_sat: "int", fees_sat: "int", preimage: "typing.Optional[str]" = _DEFAULT, bolt11: "typing.Optional[str]" = _DEFAULT, refund_tx_id: "typing.Optional[str]" = _DEFAULT, refund_tx_amount_sat: "typing.Optional[int]" = _DEFAULT, payment_type: "PaymentType", status: "PaymentState"):

SyntaxError: non-default argument follows default argument
```