### PR TITLE
Map `InsufficientFunds` LWK error to correct `PaymentError`

### DIFF
--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -143,8 +143,11 @@ impl From<boltz_client::bitcoin::hex::HexToArrayError> for PaymentError {
 
 impl From<lwk_wollet::Error> for PaymentError {
     fn from(err: lwk_wollet::Error) -> Self {
-        PaymentError::LwkError {
-            err: format!("{err:?}"),
+        match err {
+            lwk_wollet::Error::InsufficientFunds => PaymentError::InsufficientFunds,
+            _ => PaymentError::LwkError {
+                err: format!("{err:?}"),
+            },
         }
     }
 }


### PR DESCRIPTION
An `InsufficientFunds` error was so far wrapped in a `PaymentError.generic(err: Lwk error: InsufficientFunds)`.

This PR maps it directly to the identically-named `PaymentError` value.