### PR TITLE
Set `PreparePayOnchainRequest` `sat_per_vbyte` default value

### DIFF
--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -357,7 +357,7 @@ dictionary OnchainPaymentLimitsResponse {
 
 dictionary PreparePayOnchainRequest {
     u64 receiver_amount_sat;
-    u32? sat_per_vbyte;
+    u32? sat_per_vbyte = null;
 };
 
 dictionary PreparePayOnchainResponse {


### PR DESCRIPTION
Sets the default value so you don't need to define it in the language bindings