### PR TITLE
Remove `sync` call when handling Boltz update

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -261,7 +261,6 @@ impl LiquidSdk {
                     }
                     update = updates_stream.recv() => match update {
                         Ok(update) => {
-                            let _ = cloned.sync().await;
                             let id = &update.id;
                             match cloned.persister.fetch_swap_by_id(id) {
                                 Ok(Swap::Send(_)) => match cloned.send_swap_state_handler.on_new_status(&update).await {


### PR DESCRIPTION
A `sync` call can take 2-3s.

IMO we don't need a `sync` when handling Boltz updates. For relevant new txs, we already add pseudo-txs.