### PR TITLE
Fix payment position fluctuation in `list_payments` for Send

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -192,7 +192,8 @@ impl Persister {
             AND                                  -- Filter out refund txs from Chain Swaps
                 ptx.tx_id NOT IN (SELECT refund_tx_id FROM chain_swaps WHERE refund_tx_id NOT NULL)
             AND {}
-            ORDER BY ptx.timestamp DESC
+            ORDER BY                             -- Order by tx timestamp or swap creation time
+                COALESCE(ptx.timestamp, rs.created_at, ss.created_at, cs.created_at) DESC
             LIMIT {}
             OFFSET {}
             ",


### PR DESCRIPTION
During Send Payment, the first state transitions caused the following:
- when the pending pseudo-tx was added, it had `timestamp = NOW`
  - this causes `list_payments`, which sorts descending by `timestamp`, to show the new payment as the 1st
- the next `sync` will likely find the tx as unconfirmed
  - this caused `insert_or_update_payment` to replace the pseudo-tx timestamp with `NULL`, as unconfirmed txs have no timestamp when coming from LWK
  - this caused the Pending Send Payment to jump to the end of the `list_payments` response, as `NULL` values are considered lower than any set value and that query sorts descending
- one of the next `sync` calls would find the tx as confirmed
  - this time, the tx comes with a timestamp from LWK
  - `insert_or_update_payment` would change its timestamp in the DB from `NULL` to the new timestamp
  - this would cause the payment to jump from last in `list_payments` back to 1st position again


The fix addresses this by updating `list_payment` to sort by the first non-NULL timestamp from between tx timestamp, swap timestamp.