### PR TITLE
Fix React Native CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,6 @@ jobs:
         working-directory: packages/react-native
         run: |
           yarn global add tslint typescript
-          brew update
           brew install kotlin ktlint swiftformat
           make react-native
 


### PR DESCRIPTION
Going forward we need a more reliable way to maintain these brew dependencies, but for now this fixes the CI errors.

The error was caused by brew re-linking `rustup`, causing it and `cargo` to become unavailable
```
==> Migrating formula rustup-init to rustup
==> Unlinking rustup-init
==> Moving rustup-init versions to /opt/homebrew/Cellar/rustup
==> Relinking rustup
...
cargo run
make[2]: cargo: No such file or directory
```