### PR TITLE
Bugfix: Correct the relative path on bindings scripts

### DIFF
--- a/lib/bindings/README.md
+++ b/lib/bindings/README.md
@@ -1,9 +1,5 @@
 To build the bindings:
 
 ```bash
-make kotlin
-
-make python
-
-make swift
+make all
 ```

--- a/lib/bindings/langs/android/.gitignore
+++ b/lib/bindings/langs/android/.gitignore
@@ -45,4 +45,4 @@ gen-external-apklibs
 # End of https://www.toptal.com/developers/gitignore/api/android
 
 lib/src/main/jniLibs/
-lib/src/main/kotlin/breez_sdk_liquid.kt
+lib/src/main/kotlin/breez_sdk_liquid/breez_sdk_liquid.kt

--- a/lib/bindings/makefile
+++ b/lib/bindings/makefile
@@ -58,7 +58,7 @@ x86_64-linux-android: $(SOURCES) ndk-home
 bindings-android: android
 	cp -r ffi/kotlin/jniLibs langs/android/lib/src/main
 	cp -r ffi/kotlin/breez_sdk_liquid langs/android/lib/src/main/kotlin/
-	cd android && ./gradlew assemble
+	cd langs/android && ./gradlew assemble
 	mkdir -p ffi/android
 	cp langs/android/lib/build/outputs/aar/lib-release.aar ffi/android
 

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: "../../dart"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.4"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -139,7 +139,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.4"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -354,18 +354,18 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
+      sha256: "490539678396d4c3c0b06efdaab75ae60675c3e0c66f72bc04c2e2c1e0e2abeb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.9"
   path_provider_foundation:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR is a pre-requisite for depending on `sdk-common` with `liquid` feature and addresses issues found within uniffi bindings.

- Correct the path of `breez_sdk_liquid.kt` on `.gitignore` 63ff806ab16e13f60e4661b1ab56fd5cffb6bcef
- Fix relative path on `bindings-android` script 0c9e08f3ead422036b8de66d848d60f7d95c0b49
- Update bindings `README.md` cca5efe70aaf204e93682ef177b0b60d58a9e7d2
  - 'python' & 'swift' scripts are not available on this crate
- chore: ran melos pub-upgrade to address CI issues 0eac4f8161d850138fa6f02eeff27f00621d2da
