### PR TITLE
Update Dart project depedencies to latest

### DIFF
--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -543,10 +543,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      sha256: "015002c060f1ae9f41a818f2d5640389cc05283e368be19dc8d77cecb43c40c9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.5.3"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
Ran `melos pub-upgrade` to address CI errors.

We should automate this;
- Run `melos pub-upgrade` and create a PR if there's an error on `Check git status` step of  `Check Dart/Flutter bindings` job because of changes in `pubspec.lock` files.