### PR TITLE
Receive payment: remove retry backoff, reduce wait time to 1 sec

### DIFF
--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -88,11 +88,9 @@ impl HybridLiquidChainService {
             match script_history.is_empty() {
                 true => {
                     retry += 1;
-                    info!(
-                        "Script history for {} got zero transactions, retrying in {} seconds...",
-                        script_hash, retry
-                    );
-                    thread::sleep(Duration::from_secs(retry));
+                    info!("Script history for {script_hash} is empty, retrying in 1 second... ({retry} of {retries})");
+                    // Waiting 1s between retries, so we detect the new tx as soon as possible
+                    thread::sleep(Duration::from_secs(1));
                 }
                 false => break,
             }
@@ -165,7 +163,7 @@ impl LiquidChainService for HybridLiquidChainService {
         )
         .map_err(|e| anyhow!("Failed to get script from address {e:?}"))?;
 
-        let script_history = self.get_script_history_with_retry(&script, 5).await?;
+        let script_history = self.get_script_history_with_retry(&script, 30).await?;
         let lockup_tx_history = script_history.iter().find(|h| h.txid.to_hex().eq(tx_id));
 
         match lockup_tx_history {

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -156,16 +156,11 @@ impl ReceiveSwapStateHandler {
                 Ok(())
             }
             Ok(RevSwapStates::TransactionConfirmed) => {
-                // TODO: We need to ensure that the lockup tx is actually confirmed
-                // if lockup_tx_history.height <= 0 {
-                //     return Err(anyhow!("Tx state mismatch: Lockup transaction was marked as confirmed by the swapper, but isn't."));
-                // }
-
                 let Some(transaction) = update.transaction.clone() else {
                     return Err(anyhow!("Unexpected payload from Boltz status stream"));
                 };
 
-                // looking for lockup script history to verify lockup was broadcasted
+                // looking for lockup script history to verify lockup was broadcasted and confirmed
                 if let Err(e) = self
                     .verify_lockup_tx(&receive_swap, &transaction, true)
                     .await


### PR DESCRIPTION
On Receive, we verify the lockup tx before marking the payment as `Pending`. This verification process involves fetching the script history for the lockup script, which may take a few seconds to detect the new lockup tx.

This PR reduces the backoff wait periods between retries (1s, 2s, 3s, etc) to a constant 1 second. The goal is that we detect the new tx and therefore emit the Payment Pending event as soon as possible.

Sample log output with the change:

```
[2024-08-01 16:12:53.113 INFO breez_sdk_liquid::receive_swap:67] Handling Receive Swap transition to "transaction.mempool" for swap DMLaBwrbz983
[2024-08-01 16:12:53.117 INFO boltz_client::swaps::liquid:367] Taproot creation and verification success!
[2024-08-01 16:12:53.119 INFO breez_sdk_liquid::chain::liquid:82] Fetching script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72
[2024-08-01 16:12:53.276 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (1 of 30)
[2024-08-01 16:12:54.424 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (2 of 30)
[2024-08-01 16:12:55.558 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (3 of 30)
[2024-08-01 16:12:56.698 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (4 of 30)
[2024-08-01 16:12:57.864 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (5 of 30)
[2024-08-01 16:12:59.001 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (6 of 30)
[2024-08-01 16:13:00.164 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (7 of 30)
[2024-08-01 16:13:01.302 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (8 of 30)
[2024-08-01 16:13:02.428 INFO breez_sdk_liquid::chain::liquid:91] Script history for 6c8153817959f3dcfe1c629997b4b45c171f166e3a79cef87d4c60ba10964b72 is empty, retrying in 1 second... (9 of 30)
[2024-08-01 16:13:03.579 INFO breez_sdk_liquid::chain::liquid:171] Liquid transaction found, verifying transaction content...
[2024-08-01 16:13:03.582 INFO breez_sdk_liquid::receive_swap:104] swapper lockup was verified
[2024-08-01 16:13:03.582 INFO breez_sdk_liquid::receive_swap:216] Transitioning Receive swap DMLaBwrbz983 to Pending (claim_tx_id = None, lockup_tx_id = Some("c16bcd2e87c52f485782e9fe0228473b9fe7e64664267b93dd542ac2522c6092"))
```