### PR TITLE
Allow working with local library on iOS

### DIFF
--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -58,6 +58,7 @@ jobs:
           rm -rf lib
           cp -r ../build/packages/flutter/android .
           cp -r ../build/packages/flutter/ios .
+          mv ios/flutter_breez_liquid.podspec.production ios/flutter_breez_liquid.podspec
           cp -r ../build/packages/flutter/lib .
           cp -r ../build/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h ios/Classes
           cp ../build/packages/flutter/analysis_options.yaml .

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -31,7 +31,7 @@ gen: codegen && ffigen
 
 # Generate Dart/Flutter bindings && softlink C headers
 codegen:
-	mkdir -p ../../../../packages/flutter/lib/src
+	mkdir -p ../../../../packages/dart/lib/src
 	{{frb_bin}}
 	cd ../../../../packages/dart/lib/src && dart format -l 110 .
 	-ln -sf $(pwd)/breez_sdk_liquid/include/breez_sdk_liquid.h ../../../../packages/flutter/ios/Classes/breez_sdk_liquid.h

--- a/packages/flutter/example/lib/routes/home/home_page.dart
+++ b/packages/flutter/example/lib/routes/home/home_page.dart
@@ -90,7 +90,7 @@ class _HomePageState extends State<HomePage> {
     } on Exception catch (e) {
       final errMsg = "Failed to sync wallet. $e";
       debugPrint(errMsg);
-      if (context.mounted) {
+      if (mounted) {
         final snackBar = SnackBar(behavior: SnackBarBehavior.floating, content: Text(errMsg));
         ScaffoldMessenger.of(context).showSnackBar(snackBar);
       }

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -314,18 +314,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mobile_scanner:
     dependency: "direct main"
     description:
@@ -503,10 +503,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   web:
     dependency: transitive
     description:
@@ -572,5 +572,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 0.2.1
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: ">=3.10.0"
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -34,7 +34,6 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.11'
 
   spec.dependency 'Flutter'
-  spec.platform = :ios, '11.0'
   spec.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/flutter/ios/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.2.1' # generated; do not edit
+version = '0.1.0' # generated; do not edit
 tag_name = "v#{version}"
 release_tag_name = "breez_liquid-#{tag_name}"
 
@@ -6,10 +6,9 @@ release_tag_name = "breez_liquid-#{tag_name}"
 # so we have to fetch the correct version here.
 framework_name = 'breez_sdk_liquid.xcframework'
 remote_zip_name = "#{framework_name}.zip"
+url = "https://github.com/breez/breez-sdk-liquid-flutter/releases/download/#{tag_name}/#{remote_zip_name}"
 local_zip_name = "#{release_tag_name}.zip"
 
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint flutter_breez_liquid.podspec` to validate before publishing.
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
   spec.version       = "#{version}"
@@ -26,18 +25,16 @@ Pod::Spec.new do |spec|
   spec.prepare_command = <<-CMD
     cd Frameworks
     rm -rf #{framework_name}
+
+    if [ ! -f #{local_zip_name} ]
+    then
+      wget #{url} -O #{local_zip_name} || curl -L #{url} -o #{local_zip_name}
+    fi
+
     unzip #{local_zip_name}
     cd -
   CMD
   
   spec.ios.deployment_target = '12.0'
   spec.osx.deployment_target = '10.11'
-
-  spec.dependency 'Flutter'
-  spec.platform = :ios, '11.0'
-  spec.static_framework = true
-
-  # Flutter.framework does not contain a i386 slice.
-  spec.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  spec.swift_version = '5.0'
 end

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/breez/breez-sdk-liquid-flutter
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: ">=3.10.0"
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR allows working with local library on iOS by using a different `podspec` for local & production environments.

###  iOS changes:
- Create a `podspec` for local development 
 - Use production `podspec` when publishing
---
### Other changelist:
These changes addresses CI warnings & a bug when running `just codegen` for the first time.
- ####  Flutter 3.24 changes
  - Update SDK ranges
    - Dart >= `3.5.0`
    - Flutter >= `3.24.0`
  - Update dependencies to latest using `melos pub-upgrade`

- ####  Bugfix:
  - Correct the output folder creation on `codegen` just recipe
    - This would have caused an error on devices that would run `just codegen` for the first time, as the output folder wouldn't have existed

