### PR TITLE
Downgrade Flutter to 3.22.3

### DIFF
--- a/.github/workflows/build-bindings-flutter.yml
+++ b/.github/workflows/build-bindings-flutter.yml
@@ -51,6 +51,7 @@ jobs:
       uses: subosito/flutter-action@v2
       with:
         channel: stable
+        flutter-version: 3.22.3 # Pinned until resource linking issues on Android is resolved with 3.24
     - run: flutter --version
 
     - name: Set up just

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.22.3 # Pinned until resource linking issues on Android is resolved with 3.24
       - run: flutter --version
 
       - name: Set up just

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -46,9 +46,11 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           path: build
 
-      - uses: subosito/flutter-action@v2
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: 3.22.3 # Pinned until resource linking issues on Android is resolved with 3.24
 
       - name: Copy package files
         working-directory: dist

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -572,5 +572,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 0.2.1
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.24.0"
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/breez/breez-sdk-liquid-flutter
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.24.0"
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Flutter version is pinned to 3.22.3 until resource linking issue is resolved on Android release builds with version 3.24.0.