### PR TITLE
Address `cargo clippy` warnings

### DIFF
--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -697,8 +697,9 @@ pub mod duplicates {
     ///
     /// * `Ok` indicates the interaction with the endpoint was valid, and the endpoint
     ///  - started to pay the invoice asynchronously in the case of LNURL-withdraw,
-    ///  - verified the client signature in the case of LNURL-auth,////// * `Error` indicates a generic issue the LNURL endpoint encountered, including a freetext
-    /// description of the reason.
+    ///  - verified the client signature in the case of LNURL-auth,
+    /// * `Error` indicates a generic issue the LNURL endpoint encountered, including a freetext
+    ///   description of the reason.
     ///
     /// Both cases are described in LUD-03 <https://github.com/lnurl/luds/blob/luds/03.md> & LUD-04: <https://github.com/lnurl/luds/blob/luds/04.md>
     #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1176,14 +1176,14 @@ impl From<SwapTree> for InternalSwapTree {
 /// Contains the result of the entire LNURL-pay interaction, as reported by the LNURL endpoint.
 ///
 /// * `EndpointSuccess` indicates the payment is complete. The endpoint may return a `SuccessActionProcessed`,
-/// in which case, the wallet has to present it to the user as described in
-/// <https://github.com/lnurl/luds/blob/luds/09.md>
+///   in which case, the wallet has to present it to the user as described in
+///   <https://github.com/lnurl/luds/blob/luds/09.md>
 ///
 /// * `EndpointError` indicates a generic issue the LNURL endpoint encountered, including a freetext
-/// field with the reason.
+///   field with the reason.
 ///
 /// * `PayError` indicates that an error occurred while trying to pay the invoice from the LNURL endpoint.
-/// This includes the payment hash of the failed invoice and the failure reason.
+///   This includes the payment hash of the failed invoice and the failure reason.
 #[derive(Serialize)]
 pub enum LnUrlPayResult {
     EndpointSuccess { data: LnUrlPaySuccessData },

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -719,7 +719,7 @@ impl LiquidSdk {
     ///
     /// Depending on [Config]'s `payment_timeout_sec`, this function will return:
     /// * [PaymentState::Pending] payment - if the payment could be initiated but didn't yet
-    /// complete in this time
+    ///   complete in this time
     /// * [PaymentState::Complete] payment - if the payment was successfully completed in this time
     ///
     /// # Arguments
@@ -976,7 +976,7 @@ impl LiquidSdk {
     ///
     /// Depending on [Config]'s `payment_timeout_sec`, this function will return:
     /// * [PaymentState::Pending] payment - if the payment could be initiated but didn't yet
-    /// complete in this time
+    ///   complete in this time
     /// * [PaymentState::Complete] payment - if the payment was successfully completed in this time
     ///
     /// # Arguments


### PR DESCRIPTION
Fix indentations on documentations.