### PR TITLE
Bugfix: Update production podpsec's version with version script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,12 @@ jobs:
         working-directory: lib/bindings/langs/flutter/
         run: melos check-format
 
+      # This step is added to ensure version recipe was run to update podspec files & CMake script.
+      # It does not catch the case where 'packages/flutter/pubspec.yaml' wasn't updated properly.
+      - name: Update version number on podspec files & CMake scripts
+        working-directory: lib/bindings/langs/flutter/
+        run: just version
+
       - name: Check git status
         env:
           GIT_PAGER: cat

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -92,6 +92,10 @@ jobs:
           rm android/build.gradle.bak
           rm android/CMakeLists.txt.bak
           rm ios/flutter_breez_liquid.podspec.bak
+      
+      - name: Update version number on podspec files & CMake scripts
+        working-directory: build/lib/bindings/langs/flutter/
+        run: bash scripts/version.sh
 
       - name: Archive flutter release
         uses: actions/upload-artifact@v4

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -86,6 +86,23 @@ link-other:
 	-ln -sf $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/linux/{{curr_version}}.tar.gz
 	-ln -sf $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/windows/{{curr_version}}.tar.gz
 
+# Copies library archives from platform-build to their expected locations
+copy:
+	just copy-apple
+	just copy-android
+	just copy-other
+
+copy-apple:
+	cp $(pwd)/platform-build/breez_sdk_liquid.xcframework.zip ../../../../packages/flutter/macos/Frameworks/{{curr_version}}.zip
+	cp $(pwd)/platform-build/breez_sdk_liquid.xcframework.zip ../../../../packages/flutter/ios/Frameworks/{{curr_version}}.zip
+
+copy-android:
+	cp $(pwd)/platform-build/android.tar.gz ../../../../packages/flutter/android/{{curr_version}}.tar.gz
+
+copy-other:
+	cp $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/linux/{{curr_version}}.tar.gz
+	cp $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/windows/{{curr_version}}.tar.gz
+
 # (melos) use instead of flutter pub get
 init *args:
 	dart pub global activate melos

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -87,6 +87,10 @@ init *args:
 init-sdk:
 	brew install protobuf
 
+# Update version number on podspec files & CMake scripts
+version:
+	bash scripts/version.sh
+
 # (melos) Generate docs for packages in workspace
 docs:
 	melos docs

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -71,11 +71,20 @@ test-dart build='true':
 
 # Softlinks library archives from platform-build to their expected locations
 link:
+	just link-apple
+	just link-android
+	just link-other
+
+link-apple:
 	-ln -sf $(pwd)/platform-build/breez_sdk_liquid.xcframework.zip ../../../../packages/flutter/macos/Frameworks/{{curr_version}}.zip
 	-ln -sf $(pwd)/platform-build/breez_sdk_liquid.xcframework.zip ../../../../packages/flutter/ios/Frameworks/{{curr_version}}.zip
+
+link-android:
+	-ln -sf $(pwd)/platform-build/android.tar.gz ../../../../packages/flutter/android/{{curr_version}}.tar.gz
+
+link-other:
 	-ln -sf $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/linux/{{curr_version}}.tar.gz
 	-ln -sf $(pwd)/platform-build/other.tar.gz ../../../../packages/flutter/windows/{{curr_version}}.tar.gz
-	-ln -sf $(pwd)/platform-build/android.tar.gz ../../../../packages/flutter/android/{{curr_version}}.tar.gz
 
 # (melos) use instead of flutter pub get
 init *args:

--- a/lib/bindings/langs/flutter/pubspec.lock
+++ b/lib/bindings/langs/flutter/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   glob:
     dependency: transitive
     description:
@@ -113,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -133,10 +149,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -149,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "96e64bbade5712c3f010137e195bca9f1b351fac34ab1f322af492ae34032067"
+      sha256: a3f06ed871e0348cb99909ad5ddf5f8b53cc61d894c302b5417d2db1ee7ec381
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "6.1.0"
   meta:
     dependency: transitive
     description:
@@ -197,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.2"
   prompts:
     dependency: transitive
     description:
@@ -221,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: b06600619c8c219065a548f8f7c192b3e080beff95488ed692780f48f69c0625
+      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.4.0"
   pubspec:
     dependency: transitive
     description:

--- a/lib/bindings/langs/flutter/pubspec.yaml
+++ b/lib/bindings/langs/flutter/pubspec.yaml
@@ -3,5 +3,5 @@ name: breez_sdk_liquid_workspace
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dev_dependencies:
-  melos: ^3.0.1
-  lints: ^3.0.0
+  melos: ^6.1.0
+  lints: ^4.0.0

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -6,6 +6,7 @@ TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 # iOS & macOS
 APPLE_HEADER="version = '$TAG_NAME' # generated; do not edit"
 sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/ios/flutter_breez_liquid.podspec
+sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/ios/flutter_breez_liquid.podspec.production
 sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/macos/flutter_breez_liquid.podspec
 rm $ROOT/packages/flutter/macos/*.bak $ROOT/packages/flutter/ios/*.bak
 

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-ROOT="../../../../.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../../../../.."
 TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 
 # iOS & macOS

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -13,7 +13,7 @@ local_zip_name = "#{release_tag_name}.zip"
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
   spec.version       = "#{version}"
-  spec.license       = { :file => '../LICENSE' }
+  spec.license       = { :file => '../LICENSE', :type => 'MIT License' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }
   spec.summary       = 'iOS/macOS Flutter bindings for Breez Liquid'

--- a/packages/flutter/ios/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.1.0' # generated; do not edit
+version = '0.2.1' # generated; do not edit
 tag_name = "v#{version}"
 release_tag_name = "breez_liquid-#{tag_name}"
 

--- a/packages/flutter/ios/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec.production
@@ -12,7 +12,7 @@ local_zip_name = "#{release_tag_name}.zip"
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
   spec.version       = "#{version}"
-  spec.license       = { :file => '../LICENSE' }
+  spec.license       = { :file => '../LICENSE', :type => 'MIT License' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }
   spec.summary       = 'iOS/macOS Flutter bindings for Breez Liquid'


### PR DESCRIPTION
Closes #417

This PR addresses a regression caused with changes on 
- #434


and makes several improvements to version script. Making it easier to use with the addition of `just version` recipe & correctly sets `ROOT` relative to the script's location.

### Changelist:
- fix: Update production podpsec's version with version script
- Resolve relative path of root from script directory
- Ran 'just version'
- Ran `melos pub-upgrade`
- Updated melos dependency
- Update versions on podspec & cmake scripts when publishing Flutter plugin
- Check if versions on podspec & cmake scripts were updated using version script on CI