### PR TITLE
Receive payment: remove MRH BIP21 amount validation

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1227,22 +1227,13 @@ impl LiquidSdk {
         let create_response = self.swapper.create_receive_swap(v2_req)?;
 
         // Check if correct MRH was added to the invoice by Boltz
-        let (bip21_lbtc_address, bip21_amount_btc) = self
+        let (bip21_lbtc_address, _bip21_amount_btc) = self
             .swapper
             .check_for_mrh(&create_response.invoice)?
             .ok_or(PaymentError::receive_error("Invoice has no MRH"))?;
-        let received_bip21_amount_sat: u64 = (bip21_amount_btc * 100_000_000.0) as u64;
         ensure_sdk!(
             bip21_lbtc_address == mrh_addr_str,
             PaymentError::receive_error("Invoice has incorrect address in MRH")
-        );
-        // The swap fee savings are passed on to the Sender: MRH amount = invoice amount - fees
-        let expected_bip21_amount_sat = payer_amount_sat - fees_sat;
-        ensure_sdk!(
-            received_bip21_amount_sat == expected_bip21_amount_sat,
-            PaymentError::receive_error(&format!(
-                "Invoice has incorrect amount in MRH: expected {expected_bip21_amount_sat} sat, MRH has {received_bip21_amount_sat} sat",
-            ))
         );
 
         let swap_id = create_response.id.clone();

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -92,10 +92,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR removes the amount validation of the BIP21 in the magic routing hint.