### PR TITLE
Confirm chain swap claims

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -199,7 +199,7 @@ impl ChainSwapStateHandler {
         );
         for swap in chain_swaps {
             if let Err(e) = self.rescan_outgoing_chain_swap(&swap).await {
-                error!("Error rescanning incoming Chain Swap {}: {e:?}", swap.id);
+                error!("Error rescanning outgoing Chain Swap {}: {e:?}", swap.id);
             }
         }
         Ok(())
@@ -219,7 +219,7 @@ impl ChainSwapStateHandler {
             .find(|h| h.txid.to_hex().eq(&claim_tx_id) && h.height > 0);
         if claim_tx_history.is_some() {
             info!(
-                "Incoming Chain Swap {} claim tx is confirmed. Setting the swap to Complete",
+                "Outgoing Chain Swap {} claim tx is confirmed. Setting the swap to Complete",
                 swap.id
             );
             self.update_swap_info(&swap.id, Complete, None, None, None, None)

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -221,6 +221,7 @@ impl Persister {
         Ok(res)
     }
 
+    /// This only returns the swaps that have a claim tx, skipping the pending ones that are being refunded.
     pub(crate) fn list_pending_chain_swaps_by_claim_tx_id(
         &self,
     ) -> Result<HashMap<String, ChainSwap>> {

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -221,6 +221,23 @@ impl Persister {
         Ok(res)
     }
 
+    pub(crate) fn list_pending_chain_swaps_by_claim_tx_id(
+        &self,
+    ) -> Result<HashMap<String, ChainSwap>> {
+        let con: Connection = self.get_connection()?;
+        let res: HashMap<String, ChainSwap> = self
+            .list_chain_swaps_by_state(&con, vec![PaymentState::Pending])?
+            .iter()
+            .filter_map(|pending_chain_swap| {
+                pending_chain_swap
+                    .claim_tx_id
+                    .as_ref()
+                    .map(|claim_tx_id| (claim_tx_id.clone(), pending_chain_swap.clone()))
+            })
+            .collect();
+        Ok(res)
+    }
+
     pub(crate) fn update_chain_swap_accept_zero_conf(
         &self,
         swap_id: &str,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1555,6 +1555,8 @@ impl LiquidSdk {
             self.persister.list_pending_receive_swaps_by_claim_tx_id()?;
         let pending_send_swaps_by_refund_tx_id =
             self.persister.list_pending_send_swaps_by_refund_tx_id()?;
+        let pending_chain_swaps_by_claim_tx_id =
+            self.persister.list_pending_chain_swaps_by_claim_tx_id()?;
         let pending_chain_swaps_by_refund_tx_id =
             self.persister.list_pending_chain_swaps_by_refund_tx_id()?;
 
@@ -1585,6 +1587,12 @@ impl LiquidSdk {
                 if is_tx_confirmed {
                     self.send_swap_state_handler
                         .update_swap_info(&swap.id, Failed, None, None, None)
+                        .await?;
+                }
+            } else if let Some(swap) = pending_chain_swaps_by_claim_tx_id.get(&tx_id) {
+                if is_tx_confirmed {
+                    self.chain_swap_state_handler
+                        .update_swap_info(&swap.id, Complete, None, None, None, None)
                         .await?;
                 }
             } else if let Some(swap) = pending_chain_swaps_by_refund_tx_id.get(&tx_id) {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2326,7 +2326,7 @@ mod tests {
                             assert!(persisted_swap.server_lockup_tx_id.is_some());
                         }
                         true => {
-                            assert_eq!(persisted_swap.state, PaymentState::Complete);
+                            assert_eq!(persisted_swap.state, PaymentState::Pending);
                             assert!(persisted_swap.claim_tx_id.is_some());
                         }
                     };
@@ -2346,7 +2346,7 @@ mod tests {
                     }),
                     None
                 );
-                assert_eq!(persisted_swap.state, PaymentState::Complete);
+                assert_eq!(persisted_swap.state, PaymentState::Pending);
                 assert!(persisted_swap.claim_tx_id.is_some());
             }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2303,7 +2303,7 @@ mod tests {
                 // Verify that `TransactionServerMempool` correctly:
                 // 1. Sets the payment as `Pending` and creates `server_lockup_tx_id` when
                 //    `accepts_zero_conf` is false
-                // 2. Sets the payment as `Complete` and creates `claim_tx_id` when `accepts_zero_conf`
+                // 2. Sets the payment as `Pending` and creates `claim_tx_id` when `accepts_zero_conf`
                 //    is true
                 for accepts_zero_conf in [false, true] {
                     let persisted_swap = trigger_swap_update!(
@@ -2333,7 +2333,7 @@ mod tests {
                 }
 
                 // Verify that `TransactionServerConfirmed` correctly
-                // sets the payment as `Complete` and creates `claim_tx_id`
+                // sets the payment as `Pending` and creates `claim_tx_id`
                 let persisted_swap = trigger_swap_update!(
                     "chain",
                     NewSwapArgs::default().set_direction(direction),


### PR DESCRIPTION
This PR changes the chain swap so that once the claim tx is broadcast it keeps the state pending (waiting confirmation event is emitted) and waits for confirmation before setting it to complete. For the incoming chain swap the `sync()` monitors the claim tx, for outgoing chain swap the claim address is checked periodically to see if the tx is confirmed.

See: https://github.com/breez/breez-sdk-liquid/pull/399#discussion_r1716713556