### PR TITLE
Fix chain swap limits validation

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1320,25 +1320,25 @@ impl LiquidSdk {
         let fees_sat;
         match req.payment_method {
             PaymentMethod::Lightning => {
-                let Some(amount_sat) = req.payer_amount_sat else {
-                    return Err(PaymentError::AmountMissing { err: "`amount_sat` must be specified when `PaymentMethod::Lightning` is used.".to_string() });
+                let Some(payer_amount_sat) = req.payer_amount_sat else {
+                    return Err(PaymentError::AmountMissing { err: "`payer_amount_sat` must be specified when `PaymentMethod::Lightning` is used.".to_string() });
                 };
                 let reverse_pair = self
                     .swapper
                     .get_reverse_swap_pairs()?
                     .ok_or(PaymentError::PairsNotFound)?;
 
-                fees_sat = reverse_pair.fees.total(amount_sat);
+                fees_sat = reverse_pair.fees.total(payer_amount_sat);
 
-                ensure_sdk!(amount_sat > fees_sat, PaymentError::AmountOutOfRange);
+                ensure_sdk!(payer_amount_sat > fees_sat, PaymentError::AmountOutOfRange);
 
                 reverse_pair
                     .limits
-                    .within(amount_sat)
+                    .within(payer_amount_sat)
                     .map_err(|_| PaymentError::AmountOutOfRange)?;
 
                 debug!(
-                    "Preparing Lightning Receive Swap with: amount_sat {amount_sat} sat, fees_sat {fees_sat} sat"
+                    "Preparing Lightning Receive Swap with: payer_amount_sat {payer_amount_sat} sat, fees_sat {fees_sat} sat"
                 );
             }
             PaymentMethod::BitcoinAddress => {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -601,6 +601,8 @@ impl LiquidSdk {
         Ok(invoice)
     }
 
+    /// For submarine swaps (Liquid -> LN), the output amount (invoice amount) is checked if it fits
+    /// the pair limits. This is unlike all the other swap types, where the input amount is checked.
     fn validate_submarine_pairs(
         &self,
         receiver_amount_sat: u64,


### PR DESCRIPTION
This PR addresses an ambiguity in `validate_chain_pairs` :

```
// before
fn validate_chain_pairs(&self, direction: Direction, amount_sat: u64) -> Result<ChainPair, PaymentError>

// after
fn validate_chain_pairs(&self, direction: Direction, payer_amount_sat: u64) -> Result<ChainPair, PaymentError>
                                                     ^^^^^^^^^^^^^^^^
```

This originally caused the method to be used both with `receiver_amount_sat` and with `payer_amount_sat` as args, whereas for both chain swap types, the `payer_amount_sat` is correct.

In addition, this PR adds a few comments and renames a few variables in related amount validation methods.