### PR TITLE
prepare-pay-onchain: add option for drain

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -50,9 +50,12 @@ pub(crate) enum Command {
         /// Amount that will be received, in satoshi
         receiver_amount_sat: u64,
 
-        // The optional fee rate to use, in satoshi/vbyte
+        /// The optional fee rate to use, in satoshi/vbyte
         #[clap(short = 'f', long = "fee_rate")]
         sat_per_vbyte: Option<u32>,
+
+        #[arg(short, long)]
+        drain: Option<bool>,
     },
     /// Receive lbtc and send btc through a swap
     ReceivePayment {
@@ -342,11 +345,14 @@ pub(crate) async fn handle_command(
             address,
             receiver_amount_sat,
             sat_per_vbyte,
+            drain,
         } => {
+            let drain = drain.unwrap_or_default();
             let prepare_response = sdk
                 .prepare_pay_onchain(&PreparePayOnchainRequest {
                     receiver_amount_sat,
                     sat_per_vbyte,
+                    drain,
                 })
                 .await?;
 

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -136,6 +136,7 @@ typedef struct wire_cst_prepare_buy_bitcoin_request {
 typedef struct wire_cst_prepare_pay_onchain_request {
   uint64_t receiver_amount_sat;
   uint32_t *sat_per_vbyte;
+  bool drain;
 } wire_cst_prepare_pay_onchain_request;
 
 typedef struct wire_cst_prepare_receive_request {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -413,6 +413,7 @@ dictionary OnchainPaymentLimitsResponse {
 dictionary PreparePayOnchainRequest {
     u64 receiver_amount_sat;
     u32? sat_per_vbyte = null;
+    boolean drain;
 };
 
 dictionary PreparePayOnchainResponse {

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -582,14 +582,24 @@ impl ChainSwapStateHandler {
             lockup_details.amount, lockup_details.lockup_address
         );
 
-        let lockup_tx = self
-            .onchain_wallet
-            .build_tx(
-                None,
-                &lockup_details.lockup_address,
-                lockup_details.amount as u64,
-            )
-            .await?;
+        // TODO How to check if this is a drain? We'd need to know balance_sat, but that doesn't belong in ChainSwapStateHandler
+        let is_drain = true;
+        let lockup_tx = match is_drain {
+            true => {
+                self.onchain_wallet
+                    .build_drain_tx(None, &lockup_details.lockup_address)
+                    .await?
+            }
+            false => {
+                self.onchain_wallet
+                    .build_tx(
+                        None,
+                        &lockup_details.lockup_address,
+                        lockup_details.amount as u64,
+                    )
+                    .await?
+            }
+        };
 
         let lockup_tx_id = self
             .liquid_chain_service

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3320,9 +3320,11 @@ impl SseDecode for crate::model::PreparePayOnchainRequest {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_receiverAmountSat = <u64>::sse_decode(deserializer);
         let mut var_satPerVbyte = <Option<u32>>::sse_decode(deserializer);
+        let mut var_drain = <bool>::sse_decode(deserializer);
         return crate::model::PreparePayOnchainRequest {
             receiver_amount_sat: var_receiverAmountSat,
             sat_per_vbyte: var_satPerVbyte,
+            drain: var_drain,
         };
     }
 }
@@ -5103,6 +5105,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PreparePayOnchainRequest {
         [
             self.receiver_amount_sat.into_into_dart().into_dart(),
             self.sat_per_vbyte.into_into_dart().into_dart(),
+            self.drain.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6783,6 +6786,7 @@ impl SseEncode for crate::model::PreparePayOnchainRequest {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.receiver_amount_sat, serializer);
         <Option<u32>>::sse_encode(self.sat_per_vbyte, serializer);
+        <bool>::sse_encode(self.drain, serializer);
     }
 }
 
@@ -8419,6 +8423,7 @@ mod io {
             crate::model::PreparePayOnchainRequest {
                 receiver_amount_sat: self.receiver_amount_sat.cst_decode(),
                 sat_per_vbyte: self.sat_per_vbyte.cst_decode(),
+                drain: self.drain.cst_decode(),
             }
         }
     }
@@ -9395,6 +9400,7 @@ mod io {
             Self {
                 receiver_amount_sat: Default::default(),
                 sat_per_vbyte: core::ptr::null_mut(),
+                drain: Default::default(),
             }
         }
     }
@@ -11303,6 +11309,7 @@ mod io {
     pub struct wire_cst_prepare_pay_onchain_request {
         receiver_amount_sat: u64,
         sat_per_vbyte: *mut u32,
+        drain: bool,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -310,8 +310,13 @@ pub struct SendPaymentResponse {
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].
 #[derive(Debug, Serialize, Clone)]
 pub struct PreparePayOnchainRequest {
+    /// The amount in satoshi that will be received
     pub receiver_amount_sat: u64,
+    /// The optional fee rate of the Bitcoin claim transaction. Defaults to the swapper estimated claim fee.
     pub sat_per_vbyte: Option<u32>,
+    /// If set to true, the chosen `receiver_amount_sat` will be ignored. Instead, amounts and fees
+    /// will be returned such that all the wallet's funds are used.
+    pub drain: bool,
 }
 
 /// Returned when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2376,10 +2376,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PreparePayOnchainRequest dco_decode_prepare_pay_onchain_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return PreparePayOnchainRequest(
       receiverAmountSat: dco_decode_u_64(arr[0]),
       satPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[1]),
+      drain: dco_decode_bool(arr[2]),
     );
   }
 
@@ -4083,7 +4084,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_receiverAmountSat = sse_decode_u_64(deserializer);
     var var_satPerVbyte = sse_decode_opt_box_autoadd_u_32(deserializer);
-    return PreparePayOnchainRequest(receiverAmountSat: var_receiverAmountSat, satPerVbyte: var_satPerVbyte);
+    var var_drain = sse_decode_bool(deserializer);
+    return PreparePayOnchainRequest(
+        receiverAmountSat: var_receiverAmountSat, satPerVbyte: var_satPerVbyte, drain: var_drain);
   }
 
   @protected
@@ -5681,6 +5684,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.receiverAmountSat, serializer);
     sse_encode_opt_box_autoadd_u_32(self.satPerVbyte, serializer);
+    sse_encode_bool(self.drain, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2474,6 +2474,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PreparePayOnchainRequest apiObj, wire_cst_prepare_pay_onchain_request wireObj) {
     wireObj.receiver_amount_sat = cst_encode_u_64(apiObj.receiverAmountSat);
     wireObj.sat_per_vbyte = cst_encode_opt_box_autoadd_u_32(apiObj.satPerVbyte);
+    wireObj.drain = cst_encode_bool(apiObj.drain);
   }
 
   @protected
@@ -4787,6 +4788,9 @@ final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
   external int receiver_amount_sat;
 
   external ffi.Pointer<ffi.Uint32> sat_per_vbyte;
+
+  @ffi.Bool()
+  external bool drain;
 }
 
 final class wire_cst_prepare_receive_request extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -695,16 +695,24 @@ class PrepareBuyBitcoinResponse {
 
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].
 class PreparePayOnchainRequest {
+  /// The amount in satoshi that will be received
   final BigInt receiverAmountSat;
+
+  /// The optional fee rate of the Bitcoin claim transaction. Defaults to the swapper estimated claim fee.
   final int? satPerVbyte;
+
+  /// If set to true, the chosen `receiver_amount_sat` will be ignored. Instead, amounts and fees
+  /// will be returned such that all the wallet's funds are used.
+  final bool drain;
 
   const PreparePayOnchainRequest({
     required this.receiverAmountSat,
     this.satPerVbyte,
+    required this.drain,
   });
 
   @override
-  int get hashCode => receiverAmountSat.hashCode ^ satPerVbyte.hashCode;
+  int get hashCode => receiverAmountSat.hashCode ^ satPerVbyte.hashCode ^ drain.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -712,7 +720,8 @@ class PreparePayOnchainRequest {
       other is PreparePayOnchainRequest &&
           runtimeType == other.runtimeType &&
           receiverAmountSat == other.receiverAmountSat &&
-          satPerVbyte == other.satPerVbyte;
+          satPerVbyte == other.satPerVbyte &&
+          drain == other.drain;
 }
 
 /// Returned when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1330,6 +1330,7 @@ fun asPreparePayOnchainRequest(preparePayOnchainRequest: ReadableMap): PreparePa
             preparePayOnchainRequest,
             arrayOf(
                 "receiverAmountSat",
+                "drain",
             ),
         )
     ) {
@@ -1346,13 +1347,15 @@ fun asPreparePayOnchainRequest(preparePayOnchainRequest: ReadableMap): PreparePa
         } else {
             null
         }
-    return PreparePayOnchainRequest(receiverAmountSat, satPerVbyte)
+    val drain = preparePayOnchainRequest.getBoolean("drain")
+    return PreparePayOnchainRequest(receiverAmountSat, satPerVbyte, drain)
 }
 
 fun readableMapOf(preparePayOnchainRequest: PreparePayOnchainRequest): ReadableMap =
     readableMapOf(
         "receiverAmountSat" to preparePayOnchainRequest.receiverAmountSat,
         "satPerVbyte" to preparePayOnchainRequest.satPerVbyte,
+        "drain" to preparePayOnchainRequest.drain,
     )
 
 fun asPreparePayOnchainRequestList(arr: ReadableArray): List<PreparePayOnchainRequest> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1580,14 +1580,18 @@ enum BreezSDKLiquidMapper {
             }
             satPerVbyte = satPerVbyteTmp
         }
+        guard let drain = preparePayOnchainRequest["drain"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "drain", typeName: "PreparePayOnchainRequest"))
+        }
 
-        return PreparePayOnchainRequest(receiverAmountSat: receiverAmountSat, satPerVbyte: satPerVbyte)
+        return PreparePayOnchainRequest(receiverAmountSat: receiverAmountSat, satPerVbyte: satPerVbyte, drain: drain)
     }
 
     static func dictionaryOf(preparePayOnchainRequest: PreparePayOnchainRequest) -> [String: Any?] {
         return [
             "receiverAmountSat": preparePayOnchainRequest.receiverAmountSat,
             "satPerVbyte": preparePayOnchainRequest.satPerVbyte == nil ? nil : preparePayOnchainRequest.satPerVbyte,
+            "drain": preparePayOnchainRequest.drain,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -246,6 +246,7 @@ export interface PrepareBuyBitcoinResponse {
 export interface PreparePayOnchainRequest {
     receiverAmountSat: number
     satPerVbyte?: number
+    drain: boolean
 }
 
 export interface PreparePayOnchainResponse {


### PR DESCRIPTION
Fixes #211

Open questions
- [ ] When locking up funds in `ChainSwapStateHandler`: how to tell if we're dealing with drain or normal lockup?
- [ ] Should chain swap non-drain lockup tx use the standard feerate too, just like the drain tx?

Open tasks
- [ ] Calling `prepare_pay_onchain` with the right `receiver_amount_sat` is essentially a drain, even if it's called with `drain=false`. The `prepare_pay_onchain` and `pay_onchain` should recognize and handle that correctly.