### PR TITLE
Fix C# symbol export

### DIFF
--- a/lib/bindings/uniffi.toml
+++ b/lib/bindings/uniffi.toml
@@ -16,6 +16,7 @@ cdylib_name = "breez_sdk_liquid_bindings"
 package_name = "breez_sdk_liquid"
 cdylib_name = "breez_sdk_liquid_bindings"
 namespace = "Breez.Sdk.Liquid"
+access_modifier = "public"
 
 # https://github.com/NordSecurity/uniffi-bindgen-go/blob/main/docs/CONFIGURATION.md
 [bindings.go]


### PR DESCRIPTION
This PR fixes the visibility of exported symbols by overriding the access modifier in the [uniffi config](https://github.com/NordSecurity/uniffi-bindgen-cs/blob/eae12c25a315d52a4ea9b2d7c49f723b9900750c/docs/CONFIGURATION.md?plain=1#L57).