### PR TITLE
Fix Swift macOS platform definition

### DIFF
--- a/lib/bindings/langs/swift/Package.swift
+++ b/lib/bindings/langs/swift/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         // Required by uniffi 0.25
         // Can be reverted to v12/v11 for uniffi 0.27
-        .macOS(.v15),
+        .macOS("15.0"),
         .iOS(.v13),
     ],
     products: [


### PR DESCRIPTION
This PR fixes the Swift macOS platform definition for pre version 6 of Swift tools where `.v15` is not defined. By changing to a string literal version the package can still be used with Swift 5+.

https://forums.swift.org/t/setting-swift-package-platform-to-ios-15-macos-12-watchos-8-not-available/49425