### PR TITLE
Set optional prepare params as null

### DIFF
--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -345,7 +345,7 @@ dictionary CheckMessageResponse {
 
 dictionary PrepareSendRequest {
     string destination;
-    u64? amount_sat;
+    u64? amount_sat = null;
 };
 
 [Enum]
@@ -374,8 +374,8 @@ enum PaymentMethod {
 };
 
 dictionary PrepareReceiveRequest {
-    u64? payer_amount_sat;
     PaymentMethod payment_method;
+    u64? payer_amount_sat = null;
 };
 
 dictionary PrepareReceiveResponse {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1412,6 +1412,7 @@ fun asPrepareReceiveRequest(prepareReceiveRequest: ReadableMap): PrepareReceiveR
     ) {
         return null
     }
+    val paymentMethod = prepareReceiveRequest.getString("paymentMethod")?.let { asPaymentMethod(it) }!!
     val payerAmountSat =
         if (hasNonNullKey(
                 prepareReceiveRequest,
@@ -1422,14 +1423,13 @@ fun asPrepareReceiveRequest(prepareReceiveRequest: ReadableMap): PrepareReceiveR
         } else {
             null
         }
-    val paymentMethod = prepareReceiveRequest.getString("paymentMethod")?.let { asPaymentMethod(it) }!!
-    return PrepareReceiveRequest(payerAmountSat, paymentMethod)
+    return PrepareReceiveRequest(paymentMethod, payerAmountSat)
 }
 
 fun readableMapOf(prepareReceiveRequest: PrepareReceiveRequest): ReadableMap =
     readableMapOf(
-        "payerAmountSat" to prepareReceiveRequest.payerAmountSat,
         "paymentMethod" to prepareReceiveRequest.paymentMethod.name.lowercase(),
+        "payerAmountSat" to prepareReceiveRequest.payerAmountSat,
     )
 
 fun asPrepareReceiveRequestList(arr: ReadableArray): List<PrepareReceiveRequest> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1648,6 +1648,11 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asPrepareReceiveRequest(prepareReceiveRequest: [String: Any?]) throws -> PrepareReceiveRequest {
+        guard let paymentMethodTmp = prepareReceiveRequest["paymentMethod"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveRequest"))
+        }
+        let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
+
         var payerAmountSat: UInt64?
         if hasNonNilKey(data: prepareReceiveRequest, key: "payerAmountSat") {
             guard let payerAmountSatTmp = prepareReceiveRequest["payerAmountSat"] as? UInt64 else {
@@ -1655,18 +1660,14 @@ enum BreezSDKLiquidMapper {
             }
             payerAmountSat = payerAmountSatTmp
         }
-        guard let paymentMethodTmp = prepareReceiveRequest["paymentMethod"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveRequest"))
-        }
-        let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
 
-        return PrepareReceiveRequest(payerAmountSat: payerAmountSat, paymentMethod: paymentMethod)
+        return PrepareReceiveRequest(paymentMethod: paymentMethod, payerAmountSat: payerAmountSat)
     }
 
     static func dictionaryOf(prepareReceiveRequest: PrepareReceiveRequest) -> [String: Any?] {
         return [
-            "payerAmountSat": prepareReceiveRequest.payerAmountSat == nil ? nil : prepareReceiveRequest.payerAmountSat,
             "paymentMethod": valueOf(paymentMethod: prepareReceiveRequest.paymentMethod),
+            "payerAmountSat": prepareReceiveRequest.payerAmountSat == nil ? nil : prepareReceiveRequest.payerAmountSat,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -255,8 +255,8 @@ export interface PreparePayOnchainResponse {
 }
 
 export interface PrepareReceiveRequest {
-    payerAmountSat?: number
     paymentMethod: PaymentMethod
+    payerAmountSat?: number
 }
 
 export interface PrepareReceiveResponse {


### PR DESCRIPTION
This PR sets the optional params in the UDL as default `null` so that they are not required to be past into the binding classes (e.g. python, kotlin, swift)