### PR TITLE
RN: Prevent conversion of ReadableMap to HashMap

### DIFF
--- a/lib/bindings/langs/react-native/src/gen_kotlin/templates/EnumTemplate.kt
+++ b/lib/bindings/langs/react-native/src/gen_kotlin/templates/EnumTemplate.kt
@@ -45,7 +45,7 @@ fun readableMapOf({{ type_name|var_name|unquote }}: {{ type_name }}): ReadableMa
 
 fun as{{ type_name }}List(arr: ReadableArray): List<{{ type_name }}> {
     val list = ArrayList<{{ type_name }}>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
 {%- if e.is_flat() %}
             is String -> list.add(as{{ type_name }}(value)!!)            

--- a/lib/bindings/langs/react-native/src/gen_kotlin/templates/EnumTemplate.kt
+++ b/lib/bindings/langs/react-native/src/gen_kotlin/templates/EnumTemplate.kt
@@ -45,14 +45,14 @@ fun readableMapOf({{ type_name|var_name|unquote }}: {{ type_name }}): ReadableMa
 
 fun as{{ type_name }}List(arr: ReadableArray): List<{{ type_name }}> {
     val list = ArrayList<{{ type_name }}>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
 {%- if e.is_flat() %}
             is String -> list.add(as{{ type_name }}(value)!!)            
 {%- else %}
             is ReadableMap -> list.add(as{{ type_name }}(value)!!)            
 {%- endif %}
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list

--- a/lib/bindings/langs/react-native/src/gen_kotlin/templates/Helpers.kt
+++ b/lib/bindings/langs/react-native/src/gen_kotlin/templates/Helpers.kt
@@ -63,6 +63,21 @@ fun readableArrayOf(values: Iterable<*>?): ReadableArray {
     return array
 }
 
+fun asArrayList(arr: ReadableArray): ArrayList<Any> {
+    val arrayList = ArrayList<Any>();
+    for (i in 0..arr.size()-1) {
+        when (arr.getType(i)) {
+            ReadableType.Boolean -> arrayList.add(arr.getBoolean(i))
+            ReadableType.Number -> arrayList.add(arr.getDouble(i))
+            ReadableType.String -> arrayList.add(arr.getString(i))
+            ReadableType.Map -> arrayList.add(arr.getMap(i))
+            ReadableType.Array -> arrayList.add(arr.getArray(i))
+            else -> throw SdkException.Generic("Could not convert object at index: ${i}")
+        }
+    }
+    return arrayList;
+}
+
 fun asUByteList(arr: ReadableArray): List<UByte> {
     val list = ArrayList<UByte>()
     for (value in arr.toArrayList()) {

--- a/lib/bindings/langs/react-native/src/gen_kotlin/templates/RecordTemplate.kt
+++ b/lib/bindings/langs/react-native/src/gen_kotlin/templates/RecordTemplate.kt
@@ -40,7 +40,7 @@ fun readableMapOf({{ type_name|var_name|unquote }}: {{ type_name }}): ReadableMa
 
 fun as{{ type_name }}List(arr: ReadableArray): List<{{ type_name }}> {
     val list = ArrayList<{{ type_name }}>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(as{{ type_name }}(value)!!)            
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))

--- a/lib/bindings/langs/react-native/src/gen_kotlin/templates/RecordTemplate.kt
+++ b/lib/bindings/langs/react-native/src/gen_kotlin/templates/RecordTemplate.kt
@@ -40,10 +40,10 @@ fun readableMapOf({{ type_name|var_name|unquote }}: {{ type_name }}): ReadableMa
 
 fun as{{ type_name }}List(arr: ReadableArray): List<{{ type_name }}> {
     val list = ArrayList<{{ type_name }}>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(as{{ type_name }}(value)!!)            
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -27,10 +27,10 @@ fun readableMapOf(aesSuccessActionDataDecrypted: AesSuccessActionDataDecrypted):
 
 fun asAesSuccessActionDataDecryptedList(arr: ReadableArray): List<AesSuccessActionDataDecrypted> {
     val list = ArrayList<AesSuccessActionDataDecrypted>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataDecrypted(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -55,10 +55,10 @@ fun readableMapOf(backupRequest: BackupRequest): ReadableMap =
 
 fun asBackupRequestList(arr: ReadableArray): List<BackupRequest> {
     val list = ArrayList<BackupRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asBackupRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -94,10 +94,10 @@ fun readableMapOf(bitcoinAddressData: BitcoinAddressData): ReadableMap =
 
 fun asBitcoinAddressDataList(arr: ReadableArray): List<BitcoinAddressData> {
     val list = ArrayList<BitcoinAddressData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asBitcoinAddressData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -126,10 +126,10 @@ fun readableMapOf(buyBitcoinRequest: BuyBitcoinRequest): ReadableMap =
 
 fun asBuyBitcoinRequestList(arr: ReadableArray): List<BuyBitcoinRequest> {
     val list = ArrayList<BuyBitcoinRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -162,10 +162,10 @@ fun readableMapOf(checkMessageRequest: CheckMessageRequest): ReadableMap =
 
 fun asCheckMessageRequestList(arr: ReadableArray): List<CheckMessageRequest> {
     val list = ArrayList<CheckMessageRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -192,10 +192,10 @@ fun readableMapOf(checkMessageResponse: CheckMessageResponse): ReadableMap =
 
 fun asCheckMessageResponseList(arr: ReadableArray): List<CheckMessageResponse> {
     val list = ArrayList<CheckMessageResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -260,10 +260,10 @@ fun readableMapOf(config: Config): ReadableMap =
 
 fun asConfigList(arr: ReadableArray): List<Config> {
     val list = ArrayList<Config>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asConfig(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -293,10 +293,10 @@ fun readableMapOf(connectRequest: ConnectRequest): ReadableMap =
 
 fun asConnectRequestList(arr: ReadableArray): List<ConnectRequest> {
     val list = ArrayList<ConnectRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asConnectRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -338,10 +338,10 @@ fun readableMapOf(currencyInfo: CurrencyInfo): ReadableMap =
 
 fun asCurrencyInfoList(arr: ReadableArray): List<CurrencyInfo> {
     val list = ArrayList<CurrencyInfo>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asCurrencyInfo(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -371,10 +371,10 @@ fun readableMapOf(fiatCurrency: FiatCurrency): ReadableMap =
 
 fun asFiatCurrencyList(arr: ReadableArray): List<FiatCurrency> {
     val list = ArrayList<FiatCurrency>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asFiatCurrency(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -410,10 +410,10 @@ fun readableMapOf(getInfoResponse: GetInfoResponse): ReadableMap =
 
 fun asGetInfoResponseList(arr: ReadableArray): List<GetInfoResponse> {
     val list = ArrayList<GetInfoResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asGetInfoResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -483,10 +483,10 @@ fun readableMapOf(lnInvoice: LnInvoice): ReadableMap =
 
 fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
     val list = ArrayList<LnInvoice>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnInvoice(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -516,10 +516,10 @@ fun readableMapOf(lightningPaymentLimitsResponse: LightningPaymentLimitsResponse
 
 fun asLightningPaymentLimitsResponseList(arr: ReadableArray): List<LightningPaymentLimitsResponse> {
     val list = ArrayList<LightningPaymentLimitsResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLightningPaymentLimitsResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -552,10 +552,10 @@ fun readableMapOf(limits: Limits): ReadableMap =
 
 fun asLimitsList(arr: ReadableArray): List<Limits> {
     val list = ArrayList<Limits>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLimits(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -593,10 +593,10 @@ fun readableMapOf(liquidAddressData: LiquidAddressData): ReadableMap =
 
 fun asLiquidAddressDataList(arr: ReadableArray): List<LiquidAddressData> {
     val list = ArrayList<LiquidAddressData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLiquidAddressData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -645,10 +645,10 @@ fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap =
 
 fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
     val list = ArrayList<ListPaymentsRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asListPaymentsRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -683,10 +683,10 @@ fun readableMapOf(lnUrlAuthRequestData: LnUrlAuthRequestData): ReadableMap =
 
 fun asLnUrlAuthRequestDataList(arr: ReadableArray): List<LnUrlAuthRequestData> {
     val list = ArrayList<LnUrlAuthRequestData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlAuthRequestData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -713,10 +713,10 @@ fun readableMapOf(lnUrlErrorData: LnUrlErrorData): ReadableMap =
 
 fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     val list = ArrayList<LnUrlErrorData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlErrorData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -746,10 +746,10 @@ fun readableMapOf(lnUrlPayErrorData: LnUrlPayErrorData): ReadableMap =
 
 fun asLnUrlPayErrorDataList(arr: ReadableArray): List<LnUrlPayErrorData> {
     val list = ArrayList<LnUrlPayErrorData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayErrorData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -794,10 +794,10 @@ fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap =
 
 fun asLnUrlPayRequestList(arr: ReadableArray): List<LnUrlPayRequest> {
     val list = ArrayList<LnUrlPayRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -856,10 +856,10 @@ fun readableMapOf(lnUrlPayRequestData: LnUrlPayRequestData): ReadableMap =
 
 fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     val list = ArrayList<LnUrlPayRequestData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequestData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -895,10 +895,10 @@ fun readableMapOf(lnUrlPaySuccessData: LnUrlPaySuccessData): ReadableMap =
 
 fun asLnUrlPaySuccessDataList(arr: ReadableArray): List<LnUrlPaySuccessData> {
     val list = ArrayList<LnUrlPaySuccessData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPaySuccessData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -930,10 +930,10 @@ fun readableMapOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest): ReadableMap =
 
 fun asLnUrlWithdrawRequestList(arr: ReadableArray): List<LnUrlWithdrawRequest> {
     val list = ArrayList<LnUrlWithdrawRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -972,10 +972,10 @@ fun readableMapOf(lnUrlWithdrawRequestData: LnUrlWithdrawRequestData): ReadableM
 
 fun asLnUrlWithdrawRequestDataList(arr: ReadableArray): List<LnUrlWithdrawRequestData> {
     val list = ArrayList<LnUrlWithdrawRequestData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequestData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1002,10 +1002,10 @@ fun readableMapOf(lnUrlWithdrawSuccessData: LnUrlWithdrawSuccessData): ReadableM
 
 fun asLnUrlWithdrawSuccessDataList(arr: ReadableArray): List<LnUrlWithdrawSuccessData> {
     val list = ArrayList<LnUrlWithdrawSuccessData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawSuccessData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1037,10 +1037,10 @@ fun readableMapOf(localeOverrides: LocaleOverrides): ReadableMap =
 
 fun asLocaleOverridesList(arr: ReadableArray): List<LocaleOverrides> {
     val list = ArrayList<LocaleOverrides>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLocaleOverrides(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1070,10 +1070,10 @@ fun readableMapOf(localizedName: LocalizedName): ReadableMap =
 
 fun asLocalizedNameList(arr: ReadableArray): List<LocalizedName> {
     val list = ArrayList<LocalizedName>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLocalizedName(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1103,10 +1103,10 @@ fun readableMapOf(logEntry: LogEntry): ReadableMap =
 
 fun asLogEntryList(arr: ReadableArray): List<LogEntry> {
     val list = ArrayList<LogEntry>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLogEntry(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1133,10 +1133,10 @@ fun readableMapOf(messageSuccessActionData: MessageSuccessActionData): ReadableM
 
 fun asMessageSuccessActionDataList(arr: ReadableArray): List<MessageSuccessActionData> {
     val list = ArrayList<MessageSuccessActionData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asMessageSuccessActionData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1166,10 +1166,10 @@ fun readableMapOf(onchainPaymentLimitsResponse: OnchainPaymentLimitsResponse): R
 
 fun asOnchainPaymentLimitsResponseList(arr: ReadableArray): List<OnchainPaymentLimitsResponse> {
     val list = ArrayList<OnchainPaymentLimitsResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asOnchainPaymentLimitsResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1199,10 +1199,10 @@ fun readableMapOf(payOnchainRequest: PayOnchainRequest): ReadableMap =
 
 fun asPayOnchainRequestList(arr: ReadableArray): List<PayOnchainRequest> {
     val list = ArrayList<PayOnchainRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPayOnchainRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1248,10 +1248,10 @@ fun readableMapOf(payment: Payment): ReadableMap =
 
 fun asPaymentList(arr: ReadableArray): List<Payment> {
     val list = ArrayList<Payment>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPayment(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1281,10 +1281,10 @@ fun readableMapOf(prepareBuyBitcoinRequest: PrepareBuyBitcoinRequest): ReadableM
 
 fun asPrepareBuyBitcoinRequestList(arr: ReadableArray): List<PrepareBuyBitcoinRequest> {
     val list = ArrayList<PrepareBuyBitcoinRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareBuyBitcoinRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1317,10 +1317,10 @@ fun readableMapOf(prepareBuyBitcoinResponse: PrepareBuyBitcoinResponse): Readabl
 
 fun asPrepareBuyBitcoinResponseList(arr: ReadableArray): List<PrepareBuyBitcoinResponse> {
     val list = ArrayList<PrepareBuyBitcoinResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareBuyBitcoinResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1358,10 +1358,10 @@ fun readableMapOf(preparePayOnchainRequest: PreparePayOnchainRequest): ReadableM
 
 fun asPreparePayOnchainRequestList(arr: ReadableArray): List<PreparePayOnchainRequest> {
     val list = ArrayList<PreparePayOnchainRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPreparePayOnchainRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1394,10 +1394,10 @@ fun readableMapOf(preparePayOnchainResponse: PreparePayOnchainResponse): Readabl
 
 fun asPreparePayOnchainResponseList(arr: ReadableArray): List<PreparePayOnchainResponse> {
     val list = ArrayList<PreparePayOnchainResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPreparePayOnchainResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1435,10 +1435,10 @@ fun readableMapOf(prepareReceiveRequest: PrepareReceiveRequest): ReadableMap =
 
 fun asPrepareReceiveRequestList(arr: ReadableArray): List<PrepareReceiveRequest> {
     val list = ArrayList<PrepareReceiveRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareReceiveRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1479,10 +1479,10 @@ fun readableMapOf(prepareReceiveResponse: PrepareReceiveResponse): ReadableMap =
 
 fun asPrepareReceiveResponseList(arr: ReadableArray): List<PrepareReceiveResponse> {
     val list = ArrayList<PrepareReceiveResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareReceiveResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1515,10 +1515,10 @@ fun readableMapOf(prepareRefundRequest: PrepareRefundRequest): ReadableMap =
 
 fun asPrepareRefundRequestList(arr: ReadableArray): List<PrepareRefundRequest> {
     val list = ArrayList<PrepareRefundRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1550,10 +1550,10 @@ fun readableMapOf(prepareRefundResponse: PrepareRefundResponse): ReadableMap =
 
 fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse> {
     val list = ArrayList<PrepareRefundResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1582,10 +1582,10 @@ fun readableMapOf(prepareSendRequest: PrepareSendRequest): ReadableMap =
 
 fun asPrepareSendRequestList(arr: ReadableArray): List<PrepareSendRequest> {
     val list = ArrayList<PrepareSendRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSendRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1615,10 +1615,10 @@ fun readableMapOf(prepareSendResponse: PrepareSendResponse): ReadableMap =
 
 fun asPrepareSendResponseList(arr: ReadableArray): List<PrepareSendResponse> {
     val list = ArrayList<PrepareSendResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSendResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1648,10 +1648,10 @@ fun readableMapOf(rate: Rate): ReadableMap =
 
 fun asRateList(arr: ReadableArray): List<Rate> {
     val list = ArrayList<Rate>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRate(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1691,10 +1691,10 @@ fun readableMapOf(receivePaymentRequest: ReceivePaymentRequest): ReadableMap =
 
 fun asReceivePaymentRequestList(arr: ReadableArray): List<ReceivePaymentRequest> {
     val list = ArrayList<ReceivePaymentRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1721,10 +1721,10 @@ fun readableMapOf(receivePaymentResponse: ReceivePaymentResponse): ReadableMap =
 
 fun asReceivePaymentResponseList(arr: ReadableArray): List<ReceivePaymentResponse> {
     val list = ArrayList<ReceivePaymentResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1763,10 +1763,10 @@ fun readableMapOf(recommendedFees: RecommendedFees): ReadableMap =
 
 fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     val list = ArrayList<RecommendedFees>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRecommendedFees(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1799,10 +1799,10 @@ fun readableMapOf(refundRequest: RefundRequest): ReadableMap =
 
 fun asRefundRequestList(arr: ReadableArray): List<RefundRequest> {
     val list = ArrayList<RefundRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1829,10 +1829,10 @@ fun readableMapOf(refundResponse: RefundResponse): ReadableMap =
 
 fun asRefundResponseList(arr: ReadableArray): List<RefundResponse> {
     val list = ArrayList<RefundResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1865,10 +1865,10 @@ fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
 
 fun asRefundableSwapList(arr: ReadableArray): List<RefundableSwap> {
     val list = ArrayList<RefundableSwap>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRefundableSwap(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1893,10 +1893,10 @@ fun readableMapOf(restoreRequest: RestoreRequest): ReadableMap =
 
 fun asRestoreRequestList(arr: ReadableArray): List<RestoreRequest> {
     val list = ArrayList<RestoreRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRestoreRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1923,10 +1923,10 @@ fun readableMapOf(routeHint: RouteHint): ReadableMap =
 
 fun asRouteHintList(arr: ReadableArray): List<RouteHint> {
     val list = ArrayList<RouteHint>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHint(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -1977,10 +1977,10 @@ fun readableMapOf(routeHintHop: RouteHintHop): ReadableMap =
 
 fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     val list = ArrayList<RouteHintHop>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHintHop(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2007,10 +2007,10 @@ fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap =
 
 fun asSendPaymentRequestList(arr: ReadableArray): List<SendPaymentRequest> {
     val list = ArrayList<SendPaymentRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2037,10 +2037,10 @@ fun readableMapOf(sendPaymentResponse: SendPaymentResponse): ReadableMap =
 
 fun asSendPaymentResponseList(arr: ReadableArray): List<SendPaymentResponse> {
     val list = ArrayList<SendPaymentResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2067,10 +2067,10 @@ fun readableMapOf(signMessageRequest: SignMessageRequest): ReadableMap =
 
 fun asSignMessageRequestList(arr: ReadableArray): List<SignMessageRequest> {
     val list = ArrayList<SignMessageRequest>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2097,10 +2097,10 @@ fun readableMapOf(signMessageResponse: SignMessageResponse): ReadableMap =
 
 fun asSignMessageResponseList(arr: ReadableArray): List<SignMessageResponse> {
     val list = ArrayList<SignMessageResponse>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2131,10 +2131,10 @@ fun readableMapOf(symbol: Symbol): ReadableMap =
 
 fun asSymbolList(arr: ReadableArray): List<Symbol> {
     val list = ArrayList<Symbol>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSymbol(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2167,10 +2167,10 @@ fun readableMapOf(urlSuccessActionData: UrlSuccessActionData): ReadableMap =
 
 fun asUrlSuccessActionDataList(arr: ReadableArray): List<UrlSuccessActionData> {
     val list = ArrayList<UrlSuccessActionData>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asUrlSuccessActionData(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2207,10 +2207,10 @@ fun readableMapOf(aesSuccessActionDataResult: AesSuccessActionDataResult): Reada
 
 fun asAesSuccessActionDataResultList(arr: ReadableArray): List<AesSuccessActionDataResult> {
     val list = ArrayList<AesSuccessActionDataResult>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataResult(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2220,10 +2220,10 @@ fun asBuyBitcoinProvider(type: String): BuyBitcoinProvider = BuyBitcoinProvider.
 
 fun asBuyBitcoinProviderList(arr: ReadableArray): List<BuyBitcoinProvider> {
     val list = ArrayList<BuyBitcoinProvider>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asBuyBitcoinProvider(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2316,10 +2316,10 @@ fun readableMapOf(inputType: InputType): ReadableMap? {
 
 fun asInputTypeList(arr: ReadableArray): List<InputType> {
     val list = ArrayList<InputType>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asInputType(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2329,10 +2329,10 @@ fun asLiquidNetwork(type: String): LiquidNetwork = LiquidNetwork.valueOf(camelTo
 
 fun asLiquidNetworkList(arr: ReadableArray): List<LiquidNetwork> {
     val list = ArrayList<LiquidNetwork>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asLiquidNetwork(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2367,10 +2367,10 @@ fun readableMapOf(lnUrlCallbackStatus: LnUrlCallbackStatus): ReadableMap? {
 
 fun asLnUrlCallbackStatusList(arr: ReadableArray): List<LnUrlCallbackStatus> {
     val list = ArrayList<LnUrlCallbackStatus>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlCallbackStatus(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2415,10 +2415,10 @@ fun readableMapOf(lnUrlPayResult: LnUrlPayResult): ReadableMap? {
 
 fun asLnUrlPayResultList(arr: ReadableArray): List<LnUrlPayResult> {
     val list = ArrayList<LnUrlPayResult>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayResult(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2463,10 +2463,10 @@ fun readableMapOf(lnUrlWithdrawResult: LnUrlWithdrawResult): ReadableMap? {
 
 fun asLnUrlWithdrawResultList(arr: ReadableArray): List<LnUrlWithdrawResult> {
     val list = ArrayList<LnUrlWithdrawResult>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawResult(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2476,10 +2476,10 @@ fun asNetwork(type: String): Network = Network.valueOf(camelToUpperSnakeCase(typ
 
 fun asNetworkList(arr: ReadableArray): List<Network> {
     val list = ArrayList<Network>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asNetwork(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2560,10 +2560,10 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
 
 fun asPaymentDetailsList(arr: ReadableArray): List<PaymentDetails> {
     val list = ArrayList<PaymentDetails>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPaymentDetails(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2573,10 +2573,10 @@ fun asPaymentMethod(type: String): PaymentMethod = PaymentMethod.valueOf(camelTo
 
 fun asPaymentMethodList(arr: ReadableArray): List<PaymentMethod> {
     val list = ArrayList<PaymentMethod>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asPaymentMethod(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2586,10 +2586,10 @@ fun asPaymentState(type: String): PaymentState = PaymentState.valueOf(camelToUpp
 
 fun asPaymentStateList(arr: ReadableArray): List<PaymentState> {
     val list = ArrayList<PaymentState>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asPaymentState(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2599,10 +2599,10 @@ fun asPaymentType(type: String): PaymentType = PaymentType.valueOf(camelToUpperS
 
 fun asPaymentTypeList(arr: ReadableArray): List<PaymentType> {
     val list = ArrayList<PaymentType>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is String -> list.add(asPaymentType(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2677,10 +2677,10 @@ fun readableMapOf(sdkEvent: SdkEvent): ReadableMap? {
 
 fun asSdkEventList(arr: ReadableArray): List<SdkEvent> {
     val list = ArrayList<SdkEvent>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSdkEvent(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2717,10 +2717,10 @@ fun readableMapOf(sendDestination: SendDestination): ReadableMap? {
 
 fun asSendDestinationList(arr: ReadableArray): List<SendDestination> {
     val list = ArrayList<SendDestination>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSendDestination(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2765,10 +2765,10 @@ fun readableMapOf(successActionProcessed: SuccessActionProcessed): ReadableMap? 
 
 fun asSuccessActionProcessedList(arr: ReadableArray): List<SuccessActionProcessed> {
     val list = ArrayList<SuccessActionProcessed>()
-    for (value in asArrayList(arr)) {
+    for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSuccessActionProcessed(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2816,7 +2816,7 @@ fun pushToArray(
         is UByte -> array.pushInt(value.toInt())
         is Array<*> -> array.pushArray(readableArrayOf(value.asIterable()))
         is List<*> -> array.pushArray(readableArrayOf(value))
-        else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        else -> throw SdkException.Generic(errUnexpectedType(value))
     }
 }
 
@@ -2857,21 +2857,6 @@ fun readableArrayOf(values: Iterable<*>?): ReadableArray {
     return array
 }
 
-fun asArrayList(arr: ReadableArray): ArrayList<Any> {
-    val arrayList = ArrayList<Any>()
-    for (i in 0..arr.size() - 1) {
-        when (arr.getType(i)) {
-            ReadableType.Boolean -> arrayList.add(arr.getBoolean(i))
-            ReadableType.Number -> arrayList.add(arr.getDouble(i))
-            ReadableType.String -> arrayList.add(arr.getString(i))
-            ReadableType.Map -> arrayList.add(arr.getMap(i))
-            ReadableType.Array -> arrayList.add(arr.getArray(i))
-            else -> throw SdkException.Generic("Could not convert object at index: $i")
-        }
-    }
-    return arrayList
-}
-
 fun asUByteList(arr: ReadableArray): List<UByte> {
     val list = ArrayList<UByte>()
     for (value in arr.toArrayList()) {
@@ -2879,7 +2864,7 @@ fun asUByteList(arr: ReadableArray): List<UByte> {
             is Double -> list.add(value.toInt().toUByte())
             is Int -> list.add(value.toUByte())
             is UByte -> list.add(value)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+            else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
     return list
@@ -2898,11 +2883,30 @@ fun errMissingMandatoryField(
     typeName: String,
 ): String = "Missing mandatory field $fieldName for type $typeName"
 
-fun errUnexpectedType(typeName: String): String = "Unexpected type $typeName"
+fun errUnexpectedType(type: Any?): String {
+    val typeName = if (type != null) type::class.java.name else "null"
+    return "Unexpected type $typeName"
+}
 
 fun errUnexpectedValue(fieldName: String): String = "Unexpected value for optional field $fieldName"
 
 fun camelToUpperSnakeCase(str: String): String {
     val pattern = "(?<=.)[A-Z]".toRegex()
     return str.replace(pattern, "_$0").uppercase()
+}
+
+internal fun ReadableArray.toList(): List<*> {
+    val arrayList = mutableListOf<Any?>()
+    for (i in 0 until size()) {
+        when (getType(i)) {
+            ReadableType.Null -> arrayList.add(null)
+            ReadableType.Boolean -> arrayList.add(getBoolean(i))
+            ReadableType.Number -> arrayList.add(getDouble(i))
+            ReadableType.String -> arrayList.add(getString(i))
+            ReadableType.Map -> arrayList.add(getMap(i))
+            ReadableType.Array -> arrayList.add(getArray(i))
+            else -> throw SdkException.Generic("Could not convert object at index: $i")
+        }
+    }
+    return arrayList
 }

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -27,7 +27,7 @@ fun readableMapOf(aesSuccessActionDataDecrypted: AesSuccessActionDataDecrypted):
 
 fun asAesSuccessActionDataDecryptedList(arr: ReadableArray): List<AesSuccessActionDataDecrypted> {
     val list = ArrayList<AesSuccessActionDataDecrypted>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataDecrypted(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -55,7 +55,7 @@ fun readableMapOf(backupRequest: BackupRequest): ReadableMap =
 
 fun asBackupRequestList(arr: ReadableArray): List<BackupRequest> {
     val list = ArrayList<BackupRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asBackupRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -94,7 +94,7 @@ fun readableMapOf(bitcoinAddressData: BitcoinAddressData): ReadableMap =
 
 fun asBitcoinAddressDataList(arr: ReadableArray): List<BitcoinAddressData> {
     val list = ArrayList<BitcoinAddressData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asBitcoinAddressData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -126,7 +126,7 @@ fun readableMapOf(buyBitcoinRequest: BuyBitcoinRequest): ReadableMap =
 
 fun asBuyBitcoinRequestList(arr: ReadableArray): List<BuyBitcoinRequest> {
     val list = ArrayList<BuyBitcoinRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asBuyBitcoinRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -162,7 +162,7 @@ fun readableMapOf(checkMessageRequest: CheckMessageRequest): ReadableMap =
 
 fun asCheckMessageRequestList(arr: ReadableArray): List<CheckMessageRequest> {
     val list = ArrayList<CheckMessageRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -192,7 +192,7 @@ fun readableMapOf(checkMessageResponse: CheckMessageResponse): ReadableMap =
 
 fun asCheckMessageResponseList(arr: ReadableArray): List<CheckMessageResponse> {
     val list = ArrayList<CheckMessageResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asCheckMessageResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -260,7 +260,7 @@ fun readableMapOf(config: Config): ReadableMap =
 
 fun asConfigList(arr: ReadableArray): List<Config> {
     val list = ArrayList<Config>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asConfig(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -293,7 +293,7 @@ fun readableMapOf(connectRequest: ConnectRequest): ReadableMap =
 
 fun asConnectRequestList(arr: ReadableArray): List<ConnectRequest> {
     val list = ArrayList<ConnectRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asConnectRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -338,7 +338,7 @@ fun readableMapOf(currencyInfo: CurrencyInfo): ReadableMap =
 
 fun asCurrencyInfoList(arr: ReadableArray): List<CurrencyInfo> {
     val list = ArrayList<CurrencyInfo>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asCurrencyInfo(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -371,7 +371,7 @@ fun readableMapOf(fiatCurrency: FiatCurrency): ReadableMap =
 
 fun asFiatCurrencyList(arr: ReadableArray): List<FiatCurrency> {
     val list = ArrayList<FiatCurrency>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asFiatCurrency(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -410,7 +410,7 @@ fun readableMapOf(getInfoResponse: GetInfoResponse): ReadableMap =
 
 fun asGetInfoResponseList(arr: ReadableArray): List<GetInfoResponse> {
     val list = ArrayList<GetInfoResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asGetInfoResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -483,7 +483,7 @@ fun readableMapOf(lnInvoice: LnInvoice): ReadableMap =
 
 fun asLnInvoiceList(arr: ReadableArray): List<LnInvoice> {
     val list = ArrayList<LnInvoice>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnInvoice(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -516,7 +516,7 @@ fun readableMapOf(lightningPaymentLimitsResponse: LightningPaymentLimitsResponse
 
 fun asLightningPaymentLimitsResponseList(arr: ReadableArray): List<LightningPaymentLimitsResponse> {
     val list = ArrayList<LightningPaymentLimitsResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLightningPaymentLimitsResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -552,7 +552,7 @@ fun readableMapOf(limits: Limits): ReadableMap =
 
 fun asLimitsList(arr: ReadableArray): List<Limits> {
     val list = ArrayList<Limits>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLimits(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -593,7 +593,7 @@ fun readableMapOf(liquidAddressData: LiquidAddressData): ReadableMap =
 
 fun asLiquidAddressDataList(arr: ReadableArray): List<LiquidAddressData> {
     val list = ArrayList<LiquidAddressData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLiquidAddressData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -645,7 +645,7 @@ fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap =
 
 fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
     val list = ArrayList<ListPaymentsRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asListPaymentsRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -683,7 +683,7 @@ fun readableMapOf(lnUrlAuthRequestData: LnUrlAuthRequestData): ReadableMap =
 
 fun asLnUrlAuthRequestDataList(arr: ReadableArray): List<LnUrlAuthRequestData> {
     val list = ArrayList<LnUrlAuthRequestData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlAuthRequestData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -713,7 +713,7 @@ fun readableMapOf(lnUrlErrorData: LnUrlErrorData): ReadableMap =
 
 fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     val list = ArrayList<LnUrlErrorData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlErrorData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -746,7 +746,7 @@ fun readableMapOf(lnUrlPayErrorData: LnUrlPayErrorData): ReadableMap =
 
 fun asLnUrlPayErrorDataList(arr: ReadableArray): List<LnUrlPayErrorData> {
     val list = ArrayList<LnUrlPayErrorData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayErrorData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -794,7 +794,7 @@ fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap =
 
 fun asLnUrlPayRequestList(arr: ReadableArray): List<LnUrlPayRequest> {
     val list = ArrayList<LnUrlPayRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -856,7 +856,7 @@ fun readableMapOf(lnUrlPayRequestData: LnUrlPayRequestData): ReadableMap =
 
 fun asLnUrlPayRequestDataList(arr: ReadableArray): List<LnUrlPayRequestData> {
     val list = ArrayList<LnUrlPayRequestData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayRequestData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -895,7 +895,7 @@ fun readableMapOf(lnUrlPaySuccessData: LnUrlPaySuccessData): ReadableMap =
 
 fun asLnUrlPaySuccessDataList(arr: ReadableArray): List<LnUrlPaySuccessData> {
     val list = ArrayList<LnUrlPaySuccessData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPaySuccessData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -930,7 +930,7 @@ fun readableMapOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest): ReadableMap =
 
 fun asLnUrlWithdrawRequestList(arr: ReadableArray): List<LnUrlWithdrawRequest> {
     val list = ArrayList<LnUrlWithdrawRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -972,7 +972,7 @@ fun readableMapOf(lnUrlWithdrawRequestData: LnUrlWithdrawRequestData): ReadableM
 
 fun asLnUrlWithdrawRequestDataList(arr: ReadableArray): List<LnUrlWithdrawRequestData> {
     val list = ArrayList<LnUrlWithdrawRequestData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawRequestData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1002,7 +1002,7 @@ fun readableMapOf(lnUrlWithdrawSuccessData: LnUrlWithdrawSuccessData): ReadableM
 
 fun asLnUrlWithdrawSuccessDataList(arr: ReadableArray): List<LnUrlWithdrawSuccessData> {
     val list = ArrayList<LnUrlWithdrawSuccessData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawSuccessData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1037,7 +1037,7 @@ fun readableMapOf(localeOverrides: LocaleOverrides): ReadableMap =
 
 fun asLocaleOverridesList(arr: ReadableArray): List<LocaleOverrides> {
     val list = ArrayList<LocaleOverrides>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLocaleOverrides(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1070,7 +1070,7 @@ fun readableMapOf(localizedName: LocalizedName): ReadableMap =
 
 fun asLocalizedNameList(arr: ReadableArray): List<LocalizedName> {
     val list = ArrayList<LocalizedName>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLocalizedName(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1103,7 +1103,7 @@ fun readableMapOf(logEntry: LogEntry): ReadableMap =
 
 fun asLogEntryList(arr: ReadableArray): List<LogEntry> {
     val list = ArrayList<LogEntry>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLogEntry(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1133,7 +1133,7 @@ fun readableMapOf(messageSuccessActionData: MessageSuccessActionData): ReadableM
 
 fun asMessageSuccessActionDataList(arr: ReadableArray): List<MessageSuccessActionData> {
     val list = ArrayList<MessageSuccessActionData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asMessageSuccessActionData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1166,7 +1166,7 @@ fun readableMapOf(onchainPaymentLimitsResponse: OnchainPaymentLimitsResponse): R
 
 fun asOnchainPaymentLimitsResponseList(arr: ReadableArray): List<OnchainPaymentLimitsResponse> {
     val list = ArrayList<OnchainPaymentLimitsResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asOnchainPaymentLimitsResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1199,7 +1199,7 @@ fun readableMapOf(payOnchainRequest: PayOnchainRequest): ReadableMap =
 
 fun asPayOnchainRequestList(arr: ReadableArray): List<PayOnchainRequest> {
     val list = ArrayList<PayOnchainRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPayOnchainRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1248,7 +1248,7 @@ fun readableMapOf(payment: Payment): ReadableMap =
 
 fun asPaymentList(arr: ReadableArray): List<Payment> {
     val list = ArrayList<Payment>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPayment(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1281,7 +1281,7 @@ fun readableMapOf(prepareBuyBitcoinRequest: PrepareBuyBitcoinRequest): ReadableM
 
 fun asPrepareBuyBitcoinRequestList(arr: ReadableArray): List<PrepareBuyBitcoinRequest> {
     val list = ArrayList<PrepareBuyBitcoinRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareBuyBitcoinRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1317,7 +1317,7 @@ fun readableMapOf(prepareBuyBitcoinResponse: PrepareBuyBitcoinResponse): Readabl
 
 fun asPrepareBuyBitcoinResponseList(arr: ReadableArray): List<PrepareBuyBitcoinResponse> {
     val list = ArrayList<PrepareBuyBitcoinResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareBuyBitcoinResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1358,7 +1358,7 @@ fun readableMapOf(preparePayOnchainRequest: PreparePayOnchainRequest): ReadableM
 
 fun asPreparePayOnchainRequestList(arr: ReadableArray): List<PreparePayOnchainRequest> {
     val list = ArrayList<PreparePayOnchainRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPreparePayOnchainRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1394,7 +1394,7 @@ fun readableMapOf(preparePayOnchainResponse: PreparePayOnchainResponse): Readabl
 
 fun asPreparePayOnchainResponseList(arr: ReadableArray): List<PreparePayOnchainResponse> {
     val list = ArrayList<PreparePayOnchainResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPreparePayOnchainResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1435,7 +1435,7 @@ fun readableMapOf(prepareReceiveRequest: PrepareReceiveRequest): ReadableMap =
 
 fun asPrepareReceiveRequestList(arr: ReadableArray): List<PrepareReceiveRequest> {
     val list = ArrayList<PrepareReceiveRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareReceiveRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1479,7 +1479,7 @@ fun readableMapOf(prepareReceiveResponse: PrepareReceiveResponse): ReadableMap =
 
 fun asPrepareReceiveResponseList(arr: ReadableArray): List<PrepareReceiveResponse> {
     val list = ArrayList<PrepareReceiveResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareReceiveResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1515,7 +1515,7 @@ fun readableMapOf(prepareRefundRequest: PrepareRefundRequest): ReadableMap =
 
 fun asPrepareRefundRequestList(arr: ReadableArray): List<PrepareRefundRequest> {
     val list = ArrayList<PrepareRefundRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1550,7 +1550,7 @@ fun readableMapOf(prepareRefundResponse: PrepareRefundResponse): ReadableMap =
 
 fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse> {
     val list = ArrayList<PrepareRefundResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareRefundResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1582,7 +1582,7 @@ fun readableMapOf(prepareSendRequest: PrepareSendRequest): ReadableMap =
 
 fun asPrepareSendRequestList(arr: ReadableArray): List<PrepareSendRequest> {
     val list = ArrayList<PrepareSendRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSendRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1615,7 +1615,7 @@ fun readableMapOf(prepareSendResponse: PrepareSendResponse): ReadableMap =
 
 fun asPrepareSendResponseList(arr: ReadableArray): List<PrepareSendResponse> {
     val list = ArrayList<PrepareSendResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPrepareSendResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1648,7 +1648,7 @@ fun readableMapOf(rate: Rate): ReadableMap =
 
 fun asRateList(arr: ReadableArray): List<Rate> {
     val list = ArrayList<Rate>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRate(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1691,7 +1691,7 @@ fun readableMapOf(receivePaymentRequest: ReceivePaymentRequest): ReadableMap =
 
 fun asReceivePaymentRequestList(arr: ReadableArray): List<ReceivePaymentRequest> {
     val list = ArrayList<ReceivePaymentRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1721,7 +1721,7 @@ fun readableMapOf(receivePaymentResponse: ReceivePaymentResponse): ReadableMap =
 
 fun asReceivePaymentResponseList(arr: ReadableArray): List<ReceivePaymentResponse> {
     val list = ArrayList<ReceivePaymentResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asReceivePaymentResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1763,7 +1763,7 @@ fun readableMapOf(recommendedFees: RecommendedFees): ReadableMap =
 
 fun asRecommendedFeesList(arr: ReadableArray): List<RecommendedFees> {
     val list = ArrayList<RecommendedFees>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRecommendedFees(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1799,7 +1799,7 @@ fun readableMapOf(refundRequest: RefundRequest): ReadableMap =
 
 fun asRefundRequestList(arr: ReadableArray): List<RefundRequest> {
     val list = ArrayList<RefundRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRefundRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1829,7 +1829,7 @@ fun readableMapOf(refundResponse: RefundResponse): ReadableMap =
 
 fun asRefundResponseList(arr: ReadableArray): List<RefundResponse> {
     val list = ArrayList<RefundResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRefundResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1865,7 +1865,7 @@ fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
 
 fun asRefundableSwapList(arr: ReadableArray): List<RefundableSwap> {
     val list = ArrayList<RefundableSwap>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRefundableSwap(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1893,7 +1893,7 @@ fun readableMapOf(restoreRequest: RestoreRequest): ReadableMap =
 
 fun asRestoreRequestList(arr: ReadableArray): List<RestoreRequest> {
     val list = ArrayList<RestoreRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRestoreRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1923,7 +1923,7 @@ fun readableMapOf(routeHint: RouteHint): ReadableMap =
 
 fun asRouteHintList(arr: ReadableArray): List<RouteHint> {
     val list = ArrayList<RouteHint>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRouteHint(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -1977,7 +1977,7 @@ fun readableMapOf(routeHintHop: RouteHintHop): ReadableMap =
 
 fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     val list = ArrayList<RouteHintHop>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asRouteHintHop(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2007,7 +2007,7 @@ fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap =
 
 fun asSendPaymentRequestList(arr: ReadableArray): List<SendPaymentRequest> {
     val list = ArrayList<SendPaymentRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2037,7 +2037,7 @@ fun readableMapOf(sendPaymentResponse: SendPaymentResponse): ReadableMap =
 
 fun asSendPaymentResponseList(arr: ReadableArray): List<SendPaymentResponse> {
     val list = ArrayList<SendPaymentResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSendPaymentResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2067,7 +2067,7 @@ fun readableMapOf(signMessageRequest: SignMessageRequest): ReadableMap =
 
 fun asSignMessageRequestList(arr: ReadableArray): List<SignMessageRequest> {
     val list = ArrayList<SignMessageRequest>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageRequest(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2097,7 +2097,7 @@ fun readableMapOf(signMessageResponse: SignMessageResponse): ReadableMap =
 
 fun asSignMessageResponseList(arr: ReadableArray): List<SignMessageResponse> {
     val list = ArrayList<SignMessageResponse>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSignMessageResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2131,7 +2131,7 @@ fun readableMapOf(symbol: Symbol): ReadableMap =
 
 fun asSymbolList(arr: ReadableArray): List<Symbol> {
     val list = ArrayList<Symbol>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSymbol(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2167,7 +2167,7 @@ fun readableMapOf(urlSuccessActionData: UrlSuccessActionData): ReadableMap =
 
 fun asUrlSuccessActionDataList(arr: ReadableArray): List<UrlSuccessActionData> {
     val list = ArrayList<UrlSuccessActionData>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asUrlSuccessActionData(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2207,7 +2207,7 @@ fun readableMapOf(aesSuccessActionDataResult: AesSuccessActionDataResult): Reada
 
 fun asAesSuccessActionDataResultList(arr: ReadableArray): List<AesSuccessActionDataResult> {
     val list = ArrayList<AesSuccessActionDataResult>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asAesSuccessActionDataResult(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2220,7 +2220,7 @@ fun asBuyBitcoinProvider(type: String): BuyBitcoinProvider = BuyBitcoinProvider.
 
 fun asBuyBitcoinProviderList(arr: ReadableArray): List<BuyBitcoinProvider> {
     val list = ArrayList<BuyBitcoinProvider>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asBuyBitcoinProvider(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2316,7 +2316,7 @@ fun readableMapOf(inputType: InputType): ReadableMap? {
 
 fun asInputTypeList(arr: ReadableArray): List<InputType> {
     val list = ArrayList<InputType>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asInputType(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2329,7 +2329,7 @@ fun asLiquidNetwork(type: String): LiquidNetwork = LiquidNetwork.valueOf(camelTo
 
 fun asLiquidNetworkList(arr: ReadableArray): List<LiquidNetwork> {
     val list = ArrayList<LiquidNetwork>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asLiquidNetwork(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2367,7 +2367,7 @@ fun readableMapOf(lnUrlCallbackStatus: LnUrlCallbackStatus): ReadableMap? {
 
 fun asLnUrlCallbackStatusList(arr: ReadableArray): List<LnUrlCallbackStatus> {
     val list = ArrayList<LnUrlCallbackStatus>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlCallbackStatus(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2415,7 +2415,7 @@ fun readableMapOf(lnUrlPayResult: LnUrlPayResult): ReadableMap? {
 
 fun asLnUrlPayResultList(arr: ReadableArray): List<LnUrlPayResult> {
     val list = ArrayList<LnUrlPayResult>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlPayResult(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2463,7 +2463,7 @@ fun readableMapOf(lnUrlWithdrawResult: LnUrlWithdrawResult): ReadableMap? {
 
 fun asLnUrlWithdrawResultList(arr: ReadableArray): List<LnUrlWithdrawResult> {
     val list = ArrayList<LnUrlWithdrawResult>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asLnUrlWithdrawResult(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2476,7 +2476,7 @@ fun asNetwork(type: String): Network = Network.valueOf(camelToUpperSnakeCase(typ
 
 fun asNetworkList(arr: ReadableArray): List<Network> {
     val list = ArrayList<Network>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asNetwork(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2560,7 +2560,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
 
 fun asPaymentDetailsList(arr: ReadableArray): List<PaymentDetails> {
     val list = ArrayList<PaymentDetails>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asPaymentDetails(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2573,7 +2573,7 @@ fun asPaymentMethod(type: String): PaymentMethod = PaymentMethod.valueOf(camelTo
 
 fun asPaymentMethodList(arr: ReadableArray): List<PaymentMethod> {
     val list = ArrayList<PaymentMethod>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asPaymentMethod(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2586,7 +2586,7 @@ fun asPaymentState(type: String): PaymentState = PaymentState.valueOf(camelToUpp
 
 fun asPaymentStateList(arr: ReadableArray): List<PaymentState> {
     val list = ArrayList<PaymentState>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asPaymentState(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2599,7 +2599,7 @@ fun asPaymentType(type: String): PaymentType = PaymentType.valueOf(camelToUpperS
 
 fun asPaymentTypeList(arr: ReadableArray): List<PaymentType> {
     val list = ArrayList<PaymentType>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is String -> list.add(asPaymentType(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2677,7 +2677,7 @@ fun readableMapOf(sdkEvent: SdkEvent): ReadableMap? {
 
 fun asSdkEventList(arr: ReadableArray): List<SdkEvent> {
     val list = ArrayList<SdkEvent>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSdkEvent(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2717,7 +2717,7 @@ fun readableMapOf(sendDestination: SendDestination): ReadableMap? {
 
 fun asSendDestinationList(arr: ReadableArray): List<SendDestination> {
     val list = ArrayList<SendDestination>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSendDestination(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2765,7 +2765,7 @@ fun readableMapOf(successActionProcessed: SuccessActionProcessed): ReadableMap? 
 
 fun asSuccessActionProcessedList(arr: ReadableArray): List<SuccessActionProcessed> {
     val list = ArrayList<SuccessActionProcessed>()
-    for (value in arr.toArrayList()) {
+    for (value in asArrayList(arr)) {
         when (value) {
             is ReadableMap -> list.add(asSuccessActionProcessed(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
@@ -2855,6 +2855,21 @@ fun readableArrayOf(values: Iterable<*>?): ReadableArray {
     }
 
     return array
+}
+
+fun asArrayList(arr: ReadableArray): ArrayList<Any> {
+    val arrayList = ArrayList<Any>()
+    for (i in 0..arr.size() - 1) {
+        when (arr.getType(i)) {
+            ReadableType.Boolean -> arrayList.add(arr.getBoolean(i))
+            ReadableType.Number -> arrayList.add(arr.getDouble(i))
+            ReadableType.String -> arrayList.add(arr.getString(i))
+            ReadableType.Map -> arrayList.add(arr.getMap(i))
+            ReadableType.Array -> arrayList.add(arr.getArray(i))
+            else -> throw SdkException.Generic("Could not convert object at index: $i")
+        }
+    }
+    return arrayList
 }
 
 fun asUByteList(arr: ReadableArray): List<UByte> {

--- a/packages/react-native/example/App.js
+++ b/packages/react-native/example/App.js
@@ -106,7 +106,7 @@ const App = () => {
                     let sendPaymentRes = await sendPayment({ prepareResponse: prepareSendRes })
                     addLine("sendPayment", JSON.stringify(sendPaymentRes))
                     // Once successfully paid an event of `paymentSucceeded` will be emitted.
-                    addLine("Payment", `${sendPaymentRes.payment}`)
+                    addLine("Payment", JSON.stringify(sendPaymentRes.payment))
                 }
             } catch (e) {
                 addLine("error", e.toString())

--- a/packages/react-native/example/ios/Podfile.lock
+++ b/packages/react-native/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - boost (1.76.0)
-  - breez_sdk_liquid (0.2.2-dev9):
-    - BreezSDKLiquid (= 0.2.2-dev9)
+  - breez_sdk_liquid (0.3.0):
+    - BreezSDKLiquid (= 0.3.0)
     - React-Core
-  - breez_sdk_liquidFFI (0.2.2-dev9)
-  - BreezSDKLiquid (0.2.2-dev9):
-    - breez_sdk_liquidFFI (= 0.2.2-dev9)
+  - breez_sdk_liquidFFI (0.3.0)
+  - BreezSDKLiquid (0.3.0):
+    - breez_sdk_liquidFFI (= 0.3.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.70.15)
@@ -558,9 +558,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 9fa78656d705f55b1220151d997e57e2a3f2cde0
-  breez_sdk_liquid: 9a0f8f1827dc3fd47f0319b34a657278e6a03f10
-  breez_sdk_liquidFFI: ba5620cdfd34d3cd2b3adf32c8ed1e3b61c80670
-  BreezSDKLiquid: d2a466cfdf36bdcfe8a80f7c62a79417bfe87409
+  breez_sdk_liquid: c19bb2739da6c57c4b9605fe4f8f89a03725e376
+  breez_sdk_liquidFFI: c85c235fb8177538d63f7902f86ff994bdc622a6
+  BreezSDKLiquid: 68dca0e9ba38647692f4950468f602ca756b5cd8
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 9cf707e46f9bd90816b7c91b2c1c8b8a2f549527
@@ -614,6 +614,6 @@ SPEC CHECKSUMS:
   Yoga: d6134eb3d6e3675afc1d6d65ccb3169b60e21980
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: aa18360f01c2d457ab24a8f42acc05ce22067077
+PODFILE CHECKSUM: 5345206b8527065b75f6fdb3eb493207c57cac73
 
 COCOAPODS: 1.15.2

--- a/packages/react-native/example/yarn.lock
+++ b/packages/react-native/example/yarn.lock
@@ -964,10 +964,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@breeztech/react-native-breez-sdk-liquid@0.2.2-dev9":
-  version "0.2.2-dev9"
-  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.2.2-dev9.tgz#11730805bedcdc9838cdbb975b03ae13e9741046"
-  integrity sha512-OLtLknG17jtX0rZYGXwf17kvXxR2+cRF0gupR8mxNFf5NLoVrBjHonXvf0x4tBzqohdVr67In5FhnCEhi2oc0g==
+"@breeztech/react-native-breez-sdk-liquid@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.3.0.tgz#bf12948a962664a02f86062a1150dfb0f434d3e1"
+  integrity sha512-dFST33/KSxS7a0zH88b4i0dyZcrcMmcWyB8RId2eay8tDc8HaGo84G+nQISRua+AwpilCHS9cGHAPL3vuqDynA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
This PR adds a function to replace ReadableArray.toArrayList() to prevent any nested objects being converted to HashMap instead of kept as ReadableMap.

Fixes #479 