### PR TITLE
Change short_channel_id to string

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.5.1-rc6"
-source = "git+https://github.com/breez/breez-sdk?branch=main#14715a7a178de28171de8d75f23b5d39a963fdb1"
+source = "git+https://github.com/breez/breez-sdk?branch=main#6b3d705214123c2de916b80380ce69d833adb925"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.5.1-rc6"
-source = "git+https://github.com/breez/breez-sdk?branch=main#14715a7a178de28171de8d75f23b5d39a963fdb1"
+source = "git+https://github.com/breez/breez-sdk?branch=main#6b3d705214123c2de916b80380ce69d833adb925"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -191,7 +191,7 @@ typedef struct wire_cst_SendDestination_LiquidAddress {
 
 typedef struct wire_cst_route_hint_hop {
   struct wire_cst_list_prim_u_8_strict *src_node_id;
-  uint64_t short_channel_id;
+  struct wire_cst_list_prim_u_8_strict *short_channel_id;
   uint32_t fees_base_msat;
   uint32_t fees_proportional_millionths;
   uint64_t cltv_expiry_delta;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -30,7 +30,7 @@ dictionary RouteHint {
 
 dictionary RouteHintHop {
      string src_node_id;
-     u64 short_channel_id;
+     string short_channel_id;
      u32 fees_base_msat;
      u32 fees_proportional_millionths;
      u64 cltv_expiry_delta;

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -306,7 +306,7 @@ pub struct _RouteHint {
 #[frb(mirror(RouteHintHop))]
 pub struct _RouteHintHop {
     pub src_node_id: String,
-    pub short_channel_id: u64,
+    pub short_channel_id: String,
     pub fees_base_msat: u32,
     pub fees_proportional_millionths: u32,
     pub cltv_expiry_delta: u64,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1812,7 +1812,7 @@ const _: fn() = || {
     {
         let RouteHintHop = None::<crate::bindings::RouteHintHop>.unwrap();
         let _: String = RouteHintHop.src_node_id;
-        let _: u64 = RouteHintHop.short_channel_id;
+        let _: String = RouteHintHop.short_channel_id;
         let _: u32 = RouteHintHop.fees_base_msat;
         let _: u32 = RouteHintHop.fees_proportional_millionths;
         let _: u64 = RouteHintHop.cltv_expiry_delta;
@@ -3523,7 +3523,7 @@ impl SseDecode for crate::bindings::RouteHintHop {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_srcNodeId = <String>::sse_decode(deserializer);
-        let mut var_shortChannelId = <u64>::sse_decode(deserializer);
+        let mut var_shortChannelId = <String>::sse_decode(deserializer);
         let mut var_feesBaseMsat = <u32>::sse_decode(deserializer);
         let mut var_feesProportionalMillionths = <u32>::sse_decode(deserializer);
         let mut var_cltvExpiryDelta = <u64>::sse_decode(deserializer);
@@ -6903,7 +6903,7 @@ impl SseEncode for crate::bindings::RouteHintHop {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.src_node_id, serializer);
-        <u64>::sse_encode(self.short_channel_id, serializer);
+        <String>::sse_encode(self.short_channel_id, serializer);
         <u32>::sse_encode(self.fees_base_msat, serializer);
         <u32>::sse_encode(self.fees_proportional_millionths, serializer);
         <u64>::sse_encode(self.cltv_expiry_delta, serializer);
@@ -9593,7 +9593,7 @@ mod io {
         fn new_with_null_ptr() -> Self {
             Self {
                 src_node_id: core::ptr::null_mut(),
-                short_channel_id: Default::default(),
+                short_channel_id: core::ptr::null_mut(),
                 fees_base_msat: Default::default(),
                 fees_proportional_millionths: Default::default(),
                 cltv_expiry_delta: Default::default(),
@@ -11374,7 +11374,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_route_hint_hop {
         src_node_id: *mut wire_cst_list_prim_u_8_strict,
-        short_channel_id: u64,
+        short_channel_id: *mut wire_cst_list_prim_u_8_strict,
         fees_base_msat: u32,
         fees_proportional_millionths: u32,
         cltv_expiry_delta: u64,

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -688,7 +688,7 @@ class RouteHint {
 
 class RouteHintHop {
   final String srcNodeId;
-  final BigInt shortChannelId;
+  final String shortChannelId;
   final int feesBaseMsat;
   final int feesProportionalMillionths;
   final BigInt cltvExpiryDelta;

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2570,7 +2570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return RouteHintHop(
       srcNodeId: dco_decode_String(arr[0]),
-      shortChannelId: dco_decode_u_64(arr[1]),
+      shortChannelId: dco_decode_String(arr[1]),
       feesBaseMsat: dco_decode_u_32(arr[2]),
       feesProportionalMillionths: dco_decode_u_32(arr[3]),
       cltvExpiryDelta: dco_decode_u_64(arr[4]),
@@ -4219,7 +4219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RouteHintHop sse_decode_route_hint_hop(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_srcNodeId = sse_decode_String(deserializer);
-    var var_shortChannelId = sse_decode_u_64(deserializer);
+    var var_shortChannelId = sse_decode_String(deserializer);
     var var_feesBaseMsat = sse_decode_u_32(deserializer);
     var var_feesProportionalMillionths = sse_decode_u_32(deserializer);
     var var_cltvExpiryDelta = sse_decode_u_64(deserializer);
@@ -5770,7 +5770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_route_hint_hop(RouteHintHop self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.srcNodeId, serializer);
-    sse_encode_u_64(self.shortChannelId, serializer);
+    sse_encode_String(self.shortChannelId, serializer);
     sse_encode_u_32(self.feesBaseMsat, serializer);
     sse_encode_u_32(self.feesProportionalMillionths, serializer);
     sse_encode_u_64(self.cltvExpiryDelta, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2558,7 +2558,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_route_hint_hop(RouteHintHop apiObj, wire_cst_route_hint_hop wireObj) {
     wireObj.src_node_id = cst_encode_String(apiObj.srcNodeId);
-    wireObj.short_channel_id = cst_encode_u_64(apiObj.shortChannelId);
+    wireObj.short_channel_id = cst_encode_String(apiObj.shortChannelId);
     wireObj.fees_base_msat = cst_encode_u_32(apiObj.feesBaseMsat);
     wireObj.fees_proportional_millionths = cst_encode_u_32(apiObj.feesProportionalMillionths);
     wireObj.cltv_expiry_delta = cst_encode_u_64(apiObj.cltvExpiryDelta);
@@ -4816,8 +4816,7 @@ final class wire_cst_SendDestination_LiquidAddress extends ffi.Struct {
 final class wire_cst_route_hint_hop extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> src_node_id;
 
-  @ffi.Uint64()
-  external int short_channel_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> short_channel_id;
 
   @ffi.Uint32()
   external int fees_base_msat;

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1657,8 +1657,7 @@ final class wire_cst_SendDestination_LiquidAddress extends ffi.Struct {
 final class wire_cst_route_hint_hop extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> src_node_id;
 
-  @ffi.Uint64()
-  external int short_channel_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> short_channel_id;
 
   @ffi.Uint32()
   external int fees_base_msat;

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1947,7 +1947,7 @@ fun asRouteHintHop(routeHintHop: ReadableMap): RouteHintHop? {
         return null
     }
     val srcNodeId = routeHintHop.getString("srcNodeId")!!
-    val shortChannelId = routeHintHop.getDouble("shortChannelId").toULong()
+    val shortChannelId = routeHintHop.getString("shortChannelId")!!
     val feesBaseMsat = routeHintHop.getInt("feesBaseMsat").toUInt()
     val feesProportionalMillionths = routeHintHop.getInt("feesProportionalMillionths").toUInt()
     val cltvExpiryDelta = routeHintHop.getDouble("cltvExpiryDelta").toULong()

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2234,7 +2234,7 @@ enum BreezSDKLiquidMapper {
         guard let srcNodeId = routeHintHop["srcNodeId"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "srcNodeId", typeName: "RouteHintHop"))
         }
-        guard let shortChannelId = routeHintHop["shortChannelId"] as? UInt64 else {
+        guard let shortChannelId = routeHintHop["shortChannelId"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "RouteHintHop"))
         }
         guard let feesBaseMsat = routeHintHop["feesBaseMsat"] as? UInt32 else {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -336,7 +336,7 @@ export interface RouteHint {
 
 export interface RouteHintHop {
     srcNodeId: string
-    shortChannelId: number
+    shortChannelId: string
     feesBaseMsat: number
     feesProportionalMillionths: number
     cltvExpiryDelta: number


### PR DESCRIPTION
This PR changes the `short_channel_id` of the `RouteHintHop` model to string in the format:
```
<BLOCK_HEIGHT>x<TX_INDEX>x<OUTPUT_INDEX>
```

Depends on https://github.com/breez/breez-sdk-greenlight/pull/1082 (CI errors until merged)

Fixes #480 