### PR TITLE
Bump boltz client library

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=c140193dab075093e1cfdcc1dd608be8e828d1ef#c140193dab075093e1cfdcc1dd608be8e828d1ef"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f1c232ca5f37678d474f28536d0149319dbbb3c1#f1c232ca5f37678d474f28536d0149319dbbb3c1"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=c140193dab075093e1cfdcc1dd608be8e828d1ef#c140193dab075093e1cfdcc1dd608be8e828d1ef"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f1c232ca5f37678d474f28536d0149319dbbb3c1#f1c232ca5f37678d474f28536d0149319dbbb3c1"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -14,7 +14,7 @@ frb = ["dep:flutter_rust_bridge"]
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "c140193dab075093e1cfdcc1dd608be8e828d1ef" }
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f1c232ca5f37678d474f28536d0149319dbbb3c1" }
 chrono = "0.4"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.3.0", features = ["chrono"], optional = true }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -934,9 +934,9 @@ impl LiquidSdk {
         );
 
         match self.swapper.check_for_mrh(invoice)? {
-            // If we find a valid MRH, extract the BIP21 amount and address, then pay via onchain tx
-            Some((address, _amount_sat)) => {
-                info!("Found MRH for L-BTC address {address} and amount_sat {amount_sat}");
+            // If we find a valid MRH, extract the BIP21 address and pay to it via onchain tx
+            Some((address, _)) => {
+                info!("Found MRH for L-BTC address {address}, invoice amount_sat {amount_sat}");
                 self.pay_liquid(
                     LiquidAddressData {
                         address,

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -297,7 +297,10 @@ impl Swapper for MockSwapper {
         Box::new(MockStatusStream::new())
     }
 
-    fn check_for_mrh(&self, _invoice: &str) -> Result<Option<(String, f64)>, PaymentError> {
+    fn check_for_mrh(
+        &self,
+        _invoice: &str,
+    ) -> Result<Option<(String, boltz_client::bitcoin::Amount)>, PaymentError> {
         // Ok(Some(("".to_string(), 0.0)))
         unimplemented!()
     }


### PR DESCRIPTION
This PR bumps the `boltz-rust` library and adjusts the calls to some of the changed method signatures.