### PR TITLE
Fix the namespace conflict

### DIFF
--- a/lib/bindings/langs/android/lib/proguard-rules.pro
+++ b/lib/bindings/langs/android/lib/proguard-rules.pro
@@ -23,10 +23,10 @@
 # for JNA
 -dontwarn java.awt.*
 -keep class com.sun.jna.** { *; }
--keep class technology.breez.* { *; }
+-keep class technology.breez.liquid.* { *; }
 -keep class breez_sdk_liquid.** { *; }
 -keep class breez_sdk_liquid_notification.** { *; }
--keepclassmembers class * extends technology.breez.* { public *; }
+-keepclassmembers class * extends technology.breez.liquid.* { public *; }
 -keepclassmembers class * extends breez_sdk_liquid.** { public *; }
 -keepclassmembers class * extends breez_sdk_liquid_notification.** { public *; }
 -keepclassmembers class * extends com.sun.jna.** { public *; }

--- a/lib/bindings/langs/android/lib/src/main/AndroidManifest.xml
+++ b/lib/bindings/langs/android/lib/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="technology.breez">
+  package="technology.breez.liquid">
 
   <uses-permission android:name="android.permission.INTERNET" />
 

--- a/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/build.gradle.kts
+++ b/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/build.gradle.kts
@@ -79,7 +79,7 @@ kotlin {
 }
 
 android {
-    namespace = "technology.breez"
+    namespace = "technology.breez.liquid"
     compileSdk = 33
 
     defaultConfig {
@@ -95,7 +95,7 @@ android {
 
 val libraryVersion: String by project
 
-group = "technology.breez"
+group = "technology.breez.liquid"
 version = libraryVersion
 
 publishing {

--- a/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/consumer-rules.pro
+++ b/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/consumer-rules.pro
@@ -24,7 +24,7 @@
 -dontwarn java.awt.*
 -keep class com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
--keep class technology.breez.* { *; }
+-keep class technology.breez.liquid.* { *; }
 -keep class breez_sdk_liquid.** { *; }
--keepclassmembers class * extends technology.breez.* { public *; }
+-keepclassmembers class * extends technology.breez.liquid.* { public *; }
 -keepclassmembers class * extends breez_sdk_liquid.** { public *; }


### PR DESCRIPTION
> Duplicate class technology.breez.BuildConfig found in modules breez-sdk-0.5.2.aar -> jetified-breez-sdk-0.5.2-runtime (com.github.breez:breez-sdk:0.5.2) and breez-sdk-liquid-0.3.1-dev3.aar -> jetified-breez-sdk-liquid-0.3.1-dev3-runtime (com.github.breez:breez-sdk-liquid:0.3.1-dev3)

This PR fixes the namespace conflict between the Greenlight and Liquid SDK for Android and Kotlin Multi-Platform (and React Native).

Tested the build using:
```
    "@breeztech/react-native-breez-sdk": "^0.5.2",
    "@breeztech/react-native-breez-sdk-liquid": "0.3.1-dev4",
```
