### PR TITLE
Re-add convenience Flutter gen command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,14 +196,14 @@ jobs:
         working-directory: lib/bindings/langs/flutter/
         run: just frb
 
-      - name: Generate Dart/Flutter bindings
+      - name: Generate Dart/Flutter bindings & Softlink C Headers
         working-directory: lib/bindings/langs/flutter/
         run: just codegen
 
-      - name: Link C Headers
+      - name: Build iOS Framework & Softlink C Headers
         working-directory: lib/bindings/langs/flutter/
         if: ${{ success() || failure() }}
-        run: just link-headers
+        run: just build-ios-framework
 
       - name: Generate FFI bindings
         working-directory: lib/bindings/langs/flutter/

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -12,12 +12,12 @@ bootstrap frb='true' build='false':
 	just clean
 	@if {{frb}} == true; then just frb; fi
 	just init
-	just init-sdk
-	just codegen
-	@if {{build}} == true; then just build-uniffi; fi
-	just link-headers
-	just ffigen
+	@if {{build}} == true; then just build; fi
 	just check
+
+# (melos) Cleans the current workspace and all its packages of temporary pub & generated Melos IDE files.
+clean:
+	melos clean
 
 # Install flutter_rust_bridge_codegen dependencies
 frb:
@@ -27,21 +27,21 @@ frb:
 	dart pub global activate ffi
 	cargo install cargo-xcode
 
-# Generate bindings and softlink C headers
-gen:
-	just codegen
-	just link-headers
-	just ffigen
+# (melos) use instead of flutter pub get
+init *args:
+	dart pub global activate melos
+	melos bootstrap {{args}}
+	melos pub-upgrade
+	just init-sdk
 
-# Generate Dart/Flutter bindings
-codegen:
-	mkdir -p ../../../../packages/dart/lib/src
-	{{frb_bin}}
-	cd ../../../../packages/dart/lib/src && dart format -l 110 .
+# Install Breez Liquid SDK dependencies
+init-sdk:
+	brew install protobuf
 
-# Generate FFI bindings
-ffigen:
-	cd ../../../../packages/flutter/ && flutter pub run ffigen --config ffigen.yaml && dart format -l 110 ./lib/flutter_breez_liquid_bindings_generated.dart
+# Builds the uniFFI library & Generates Dart/Flutter bindings
+build:
+	just build-uniffi
+	just gen
 
 # Builds the uniFFI library
 build-uniffi:
@@ -56,54 +56,51 @@ build-uniffi-android:
 build-uniffi-swift:
 	bash scripts/build_uniffi_swift.sh
 
-# (melos) Run tests on packages in workspace
-test build='false':
-	just test-dart {{build}}
-# test-flutter {{build}}
+# Generate Dart/Flutter bindings & Softlinks C headers
+gen ios='true':
+	just codegen
+	@if {{ios}} == true; then just build-ios-framework; fi
+	just ffigen
 
-# (melos) Run tests on Dart packages in workspace
-test-dart build='true': 
-	@if {{build}} == true; then just build-uniffi; fi
-	melos test-dart
-
-# (melos) Run integration tests on Flutter packages in workspace
-#test-flutter build='true':
-#	@if {{build}} == true; then build; fi
-#	melos test-flutter
-
-# Softlinks library headers to ther expected locations
-link-headers:
+# Generate Dart/Flutter bindings & softlinks C headers
+codegen:
+	mkdir -p ../../../../packages/dart/lib/src
+	{{frb_bin}}
+	cd ../../../../packages/dart/lib/src && dart format -l 110 .
 	-ln -sf $(pwd)/breez_sdk_liquid/include/breez_sdk_liquid.h ../../../../packages/flutter/ios/Classes/breez_sdk_liquid.h
 	-ln -sf $(pwd)/breez_sdk_liquid/include/breez_sdk_liquid.h ../../../../packages/flutter/macos/Classes/breez_sdk_liquid.h
+
+# Builds the uniFFI framework & softlinks C headers
+build-ios-framework:
+	bash scripts/build_ios_framework.sh
 	-ln -sf $(pwd)/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h ../../../../packages/flutter/ios/Classes/breez_sdk_liquidFFI.h
 	-ln -sf $(pwd)/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h ../../../../packages/flutter/macos/Classes/breez_sdk_liquidFFI.h
 
-# (melos) use instead of flutter pub get
-init *args:
-	dart pub global activate melos
-	melos bootstrap {{args}}
-	melos pub-upgrade
-
-# Install Breez Liquid SDK dependencies
-init-sdk:
-	brew install protobuf
-
-# Update version number on podspec files & CMake scripts
-version:
-	bash scripts/version.sh
-
-# (melos) Generate docs for packages in workspace
-docs:
-	melos docs
-
-# (melos) Cleans the current workspace and all its packages of temporary pub & generated Melos IDE files.
-clean:
-	melos clean
+# Generate FFI bindings
+ffigen:
+	cd ../../../../packages/flutter/ && flutter pub run ffigen --config ffigen.yaml && dart format -l 110 ./lib/flutter_breez_liquid_bindings_generated.dart
 
 # (melos) Analyze & check the format of packages in workspace
 check:
 	melos analyze
 	melos check-format
+
+# Update version number on podspec files & CMake scripts
+version:
+	bash scripts/version.sh
+
+# (melos) Run tests on packages in workspace
+test build='false':
+	just test-dart {{build}}
+
+# (melos) Run tests on Dart packages in workspace
+test-dart build='true': 
+	@if {{build}} == true; then just build; fi
+	melos test-dart
+
+# (melos) Generate docs for packages in workspace
+docs:
+	melos docs
 
 # Open melos.yaml
 melos:

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -27,7 +27,13 @@ frb:
 	dart pub global activate ffi
 	cargo install cargo-xcode
 
-# Generate Dart/Flutter bindings && softlink C headers
+# Generate bindings and softlink C headers
+gen:
+	just codegen
+	just link-headers
+	just ffigen
+
+# Generate Dart/Flutter bindings
 codegen:
 	mkdir -p ../../../../packages/dart/lib/src
 	{{frb_bin}}

--- a/lib/bindings/langs/flutter/scripts/build_ios_framework.sh
+++ b/lib/bindings/langs/flutter/scripts/build_ios_framework.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+cd ../..
+make init build-ios-framework
+# Clean existing framework & Sources dirs
+rm -rf ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework ../../packages/flutter/ios/Sources
+rm -rf ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework ../../packages/flutter/macos/Sources
+# Copy newly built framework & Sources dirs
+cp -r langs/swift/breez_sdk_liquidFFI.xcframework ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework
+cp -r langs/swift/breez_sdk_liquidFFI.xcframework ../../packages/flutter/macos/Frameworks/breez_sdk_liquidFFI.xcframework
+cp -r langs/swift/Sources ../../packages/flutter/ios/Sources
+cp -r langs/swift/Sources ../../packages/flutter/macos/Sources

--- a/lib/bindings/langs/flutter/scripts/build_uniffi_android.sh
+++ b/lib/bindings/langs/flutter/scripts/build_uniffi_android.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 cd ../..
 make init android
+# Clean existing library
 rm -r ../../packages/flutter/android/src/main/kotlin/breez_sdk_liquid*
+# Create target directories
 mkdir -p ../../packages/flutter/android/src/main/jniLibs/arm64-v8a
 mkdir -p ../../packages/flutter/android/src/main/jniLibs/armeabi-v7a
 mkdir -p ../../packages/flutter/android/src/main/jniLibs/x86
 mkdir -p ../../packages/flutter/android/src/main/jniLibs/x86_64
+# Copy libraries to target directories
 cp ffi/kotlin/jniLibs/arm64-v8a/*.so ../../packages/flutter/android/src/main/jniLibs/arm64-v8a/
 cp ffi/kotlin/jniLibs/armeabi-v7a/*.so ../../packages/flutter/android/src/main/jniLibs/armeabi-v7a/
 cp ffi/kotlin/jniLibs/x86/*.so ../../packages/flutter/android/src/main/jniLibs/x86/
 cp ffi/kotlin/jniLibs/x86_64/*.so ../../packages/flutter/android/src/main/jniLibs/x86_64/
+# Copy library contents & files
 cp -r langs/android/lib/src/main/kotlin ../../packages/flutter/android/src/main/
 cp -r ffi/kotlin/breez_sdk_liquid ../../packages/flutter/android/src/main/kotlin

--- a/lib/bindings/langs/flutter/scripts/build_uniffi_swift.sh
+++ b/lib/bindings/langs/flutter/scripts/build_uniffi_swift.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 cd ../..
-make init bindings-swift
-rm -rf ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework ../../packages/flutter/ios/Sources
-rm -rf ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework ../../packages/flutter/macos/Sources
-cp -r langs/swift/breez_sdk_liquidFFI.xcframework ../../packages/flutter/ios/Frameworks/breez_sdk_liquidFFI.xcframework
-cp -r langs/swift/breez_sdk_liquidFFI.xcframework ../../packages/flutter/macos/Frameworks/breez_sdk_liquidFFI.xcframework
-cp -r langs/swift/Sources ../../packages/flutter/ios/Sources
-cp -r langs/swift/Sources ../../packages/flutter/macos/Sources
+make init ios-universal darwin-universal

--- a/lib/bindings/makefile
+++ b/lib/bindings/makefile
@@ -114,7 +114,9 @@ swift-darwin: darwin-universal
 	cp ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ffi/swift-darwin
 	cd ffi/swift-darwin && "swiftc" "-emit-module" "-module-name" "breez_sdk_liquid_bindings" "-Xcc" "-fmodule-map-file=$(CURRENT_DIR)/ffi/swift-darwin/breez_sdk_liquidFFI.modulemap" "-I" "."  "-L" "." "-lbreez_sdk_liquid_bindings" breez_sdk_liquid.swift
 
-bindings-swift: ios-universal darwin-universal
+bindings-swift: ios-universal darwin-universal build-ios-framework
+
+build-ios-framework:
 	mkdir -p langs/swift/Sources/BreezSDKLiquid
 	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift -o langs/swift/Sources/BreezSDKLiquid
 	mv langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquid.swift langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquid.swift


### PR DESCRIPTION
Re-add the convenience Flutter `gen` command to generate code/FFI bindings and softlink C headers