### PR TITLE
Chain swap cooperative refund: fix triggering of `refund_incoming_swap`

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -955,7 +955,10 @@ impl ChainSwapHandler {
                         RefundPending => match has_swap_expired {
                             true => {
                                 self.refund_outgoing_swap(&swap, true)
-                                    .or_else(|_| self.refund_outgoing_swap(&swap, false))
+                                    .or_else(|e| {
+                                        warn!("Failed to initiate cooperative refund, switching to non-cooperative: {e:?}");
+                                        self.refund_outgoing_swap(&swap, false)
+                                    })
                                     .await
                             }
                             false => self.refund_outgoing_swap(&swap, true).await,

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -808,8 +808,8 @@ impl ChainSwapHandler {
 
         let bitcoin_chain_service = self.bitcoin_chain_service.lock().await;
         let script_pk = swap_script
-            .to_address(self.config.network.into())
-            .map_err(|_| anyhow!("Could not retrieve address from swap script"))?
+            .to_address(self.config.network.as_bitcoin_chain())
+            .map_err(|e| anyhow!("Could not retrieve address from swap script: {e:?}"))?
             .script_pubkey();
         let utxos = bitcoin_chain_service.get_script_utxos(&script_pk).await?;
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1792,7 +1792,8 @@ impl LiquidSdk {
                 req.fee_rate_sat_per_vbyte,
                 true,
             )
-            .or_else(|_| {
+            .or_else(|e| {
+                warn!("Failed to initiate cooperative refund, switching to non-cooperative: {e:?}");
                 self.chain_swap_handler.refund_incoming_swap(
                     &req.swap_address,
                     &req.refund_address,

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -456,7 +456,10 @@ impl SendSwapHandler {
                 RefundPending => match has_swap_expired {
                     true => {
                         self.refund(swap, true)
-                            .or_else(|_| self.refund(swap, false))
+                            .or_else(|e| {
+                                warn!("Failed to initiate cooperative refund, switching to non-cooperative: {e:?}");
+                                self.refund(swap, false)
+                            })
                             .await
                     }
                     false => self.refund(swap, true).await,


### PR DESCRIPTION
This fixes the "Liquid chain used for Bitcoin operations" error, which came up when a refund was initiated.