### PR TITLE
Add prepare_lnurl_pay

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.116"
+version = "0.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+checksum = "d52cec5fa9382154fe9671e8df93095b800c7d77abc66e2a5ef839d672521c5e"
 dependencies = [
  "bitcoin 0.29.2",
 ]
@@ -1803,14 +1803,14 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
+checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
- "lightning 0.0.116",
+ "lightning 0.0.118",
  "num-traits",
  "secp256k1 0.24.3",
 ]
@@ -2899,8 +2899,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.1-rc6"
-source = "git+https://github.com/breez/breez-sdk?branch=main#6b3d705214123c2de916b80380ce69d833adb925"
+version = "0.5.2"
+source = "git+https://github.com/breez/breez-sdk?branch=main#ce23e3298ff7de2dad4854e9dbc94840a570ef8e"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -2910,8 +2910,8 @@ dependencies = [
  "cbc",
  "elements",
  "hex",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning 0.0.118",
+ "lightning-invoice 0.26.0",
  "log",
  "prost",
  "querystring",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -570,7 +570,7 @@ pub(crate) async fn handle_command(
                     wait_confirmation!(
                         format!(
                             "Fees: {} sat. Are the fees acceptable? (y/N) ",
-                            prepare_response.prepare_send_response.fees_sat
+                            prepare_response.fees_sat
                         ),
                         "LNURL pay halted"
                     );

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.116"
+version = "0.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+checksum = "d52cec5fa9382154fe9671e8df93095b800c7d77abc66e2a5ef839d672521c5e"
 dependencies = [
  "bitcoin 0.29.2",
 ]
@@ -2006,14 +2006,14 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
+checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
- "lightning 0.0.116",
+ "lightning 0.0.118",
  "num-traits",
  "secp256k1 0.24.3",
 ]
@@ -3179,8 +3179,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.1-rc6"
-source = "git+https://github.com/breez/breez-sdk?branch=main#6b3d705214123c2de916b80380ce69d833adb925"
+version = "0.5.2"
+source = "git+https://github.com/breez/breez-sdk?branch=main#ce23e3298ff7de2dad4854e9dbc94840a570ef8e"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -3190,8 +3190,8 @@ dependencies = [
  "cbc",
  "elements",
  "hex",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning 0.0.118",
+ "lightning-invoice 0.26.0",
  "log",
  "prost",
  "querystring",

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -181,11 +181,6 @@ typedef struct wire_cst_send_destination {
   union SendDestinationKind kind;
 } wire_cst_send_destination;
 
-typedef struct wire_cst_prepare_send_response {
-  struct wire_cst_send_destination destination;
-  uint64_t fees_sat;
-} wire_cst_prepare_send_response;
-
 typedef struct wire_cst_aes_success_action_data {
   struct wire_cst_list_prim_u_8_strict *description;
   struct wire_cst_list_prim_u_8_strict *ciphertext;
@@ -226,7 +221,8 @@ typedef struct wire_cst_success_action {
 } wire_cst_success_action;
 
 typedef struct wire_cst_prepare_ln_url_pay_response {
-  struct wire_cst_prepare_send_response prepare_send_response;
+  struct wire_cst_send_destination destination;
+  uint64_t fees_sat;
   struct wire_cst_success_action *success_action;
 } wire_cst_prepare_ln_url_pay_response;
 
@@ -338,6 +334,11 @@ typedef struct wire_cst_refund_request {
 typedef struct wire_cst_restore_request {
   struct wire_cst_list_prim_u_8_strict *backup_path;
 } wire_cst_restore_request;
+
+typedef struct wire_cst_prepare_send_response {
+  struct wire_cst_send_destination destination;
+  uint64_t fees_sat;
+} wire_cst_prepare_send_response;
 
 typedef struct wire_cst_send_payment_request {
   struct wire_cst_prepare_send_response prepare_response;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -115,112 +115,6 @@ typedef struct wire_cst_ln_url_auth_request_data {
   struct wire_cst_list_prim_u_8_strict *url;
 } wire_cst_ln_url_auth_request_data;
 
-typedef struct wire_cst_ln_url_pay_request_data {
-  struct wire_cst_list_prim_u_8_strict *callback;
-  uint64_t min_sendable;
-  uint64_t max_sendable;
-  struct wire_cst_list_prim_u_8_strict *metadata_str;
-  uint16_t comment_allowed;
-  struct wire_cst_list_prim_u_8_strict *domain;
-  bool allows_nostr;
-  struct wire_cst_list_prim_u_8_strict *nostr_pubkey;
-  struct wire_cst_list_prim_u_8_strict *ln_address;
-} wire_cst_ln_url_pay_request_data;
-
-typedef struct wire_cst_ln_url_pay_request {
-  struct wire_cst_ln_url_pay_request_data data;
-  uint64_t amount_msat;
-  struct wire_cst_list_prim_u_8_strict *comment;
-  struct wire_cst_list_prim_u_8_strict *payment_label;
-  bool *validate_success_action_url;
-} wire_cst_ln_url_pay_request;
-
-typedef struct wire_cst_ln_url_withdraw_request_data {
-  struct wire_cst_list_prim_u_8_strict *callback;
-  struct wire_cst_list_prim_u_8_strict *k1;
-  struct wire_cst_list_prim_u_8_strict *default_description;
-  uint64_t min_withdrawable;
-  uint64_t max_withdrawable;
-} wire_cst_ln_url_withdraw_request_data;
-
-typedef struct wire_cst_ln_url_withdraw_request {
-  struct wire_cst_ln_url_withdraw_request_data data;
-  uint64_t amount_msat;
-  struct wire_cst_list_prim_u_8_strict *description;
-} wire_cst_ln_url_withdraw_request;
-
-typedef struct wire_cst_prepare_pay_onchain_response {
-  uint64_t receiver_amount_sat;
-  uint64_t claim_fees_sat;
-  uint64_t total_fees_sat;
-} wire_cst_prepare_pay_onchain_response;
-
-typedef struct wire_cst_pay_onchain_request {
-  struct wire_cst_list_prim_u_8_strict *address;
-  struct wire_cst_prepare_pay_onchain_response prepare_response;
-} wire_cst_pay_onchain_request;
-
-typedef struct wire_cst_prepare_buy_bitcoin_request {
-  int32_t provider;
-  uint64_t amount_sat;
-} wire_cst_prepare_buy_bitcoin_request;
-
-typedef struct wire_cst_PayOnchainAmount_Receiver {
-  uint64_t amount_sat;
-} wire_cst_PayOnchainAmount_Receiver;
-
-typedef union PayOnchainAmountKind {
-  struct wire_cst_PayOnchainAmount_Receiver Receiver;
-} PayOnchainAmountKind;
-
-typedef struct wire_cst_pay_onchain_amount {
-  int32_t tag;
-  union PayOnchainAmountKind kind;
-} wire_cst_pay_onchain_amount;
-
-typedef struct wire_cst_prepare_pay_onchain_request {
-  struct wire_cst_pay_onchain_amount amount;
-  uint32_t *fee_rate_sat_per_vbyte;
-} wire_cst_prepare_pay_onchain_request;
-
-typedef struct wire_cst_prepare_receive_request {
-  uint64_t *payer_amount_sat;
-  int32_t payment_method;
-} wire_cst_prepare_receive_request;
-
-typedef struct wire_cst_prepare_refund_request {
-  struct wire_cst_list_prim_u_8_strict *swap_address;
-  struct wire_cst_list_prim_u_8_strict *refund_address;
-  uint32_t fee_rate_sat_per_vbyte;
-} wire_cst_prepare_refund_request;
-
-typedef struct wire_cst_prepare_send_request {
-  struct wire_cst_list_prim_u_8_strict *destination;
-  uint64_t *amount_sat;
-} wire_cst_prepare_send_request;
-
-typedef struct wire_cst_prepare_receive_response {
-  int32_t payment_method;
-  uint64_t *payer_amount_sat;
-  uint64_t fees_sat;
-} wire_cst_prepare_receive_response;
-
-typedef struct wire_cst_receive_payment_request {
-  struct wire_cst_prepare_receive_response prepare_response;
-  struct wire_cst_list_prim_u_8_strict *description;
-  bool *use_description_hash;
-} wire_cst_receive_payment_request;
-
-typedef struct wire_cst_refund_request {
-  struct wire_cst_list_prim_u_8_strict *swap_address;
-  struct wire_cst_list_prim_u_8_strict *refund_address;
-  uint32_t fee_rate_sat_per_vbyte;
-} wire_cst_refund_request;
-
-typedef struct wire_cst_restore_request {
-  struct wire_cst_list_prim_u_8_strict *backup_path;
-} wire_cst_restore_request;
-
 typedef struct wire_cst_liquid_address_data {
   struct wire_cst_list_prim_u_8_strict *address;
   int32_t network;
@@ -291,6 +185,159 @@ typedef struct wire_cst_prepare_send_response {
   struct wire_cst_send_destination destination;
   uint64_t fees_sat;
 } wire_cst_prepare_send_response;
+
+typedef struct wire_cst_aes_success_action_data {
+  struct wire_cst_list_prim_u_8_strict *description;
+  struct wire_cst_list_prim_u_8_strict *ciphertext;
+  struct wire_cst_list_prim_u_8_strict *iv;
+} wire_cst_aes_success_action_data;
+
+typedef struct wire_cst_SuccessAction_Aes {
+  struct wire_cst_aes_success_action_data *data;
+} wire_cst_SuccessAction_Aes;
+
+typedef struct wire_cst_message_success_action_data {
+  struct wire_cst_list_prim_u_8_strict *message;
+} wire_cst_message_success_action_data;
+
+typedef struct wire_cst_SuccessAction_Message {
+  struct wire_cst_message_success_action_data *data;
+} wire_cst_SuccessAction_Message;
+
+typedef struct wire_cst_url_success_action_data {
+  struct wire_cst_list_prim_u_8_strict *description;
+  struct wire_cst_list_prim_u_8_strict *url;
+  bool matches_callback_domain;
+} wire_cst_url_success_action_data;
+
+typedef struct wire_cst_SuccessAction_Url {
+  struct wire_cst_url_success_action_data *data;
+} wire_cst_SuccessAction_Url;
+
+typedef union SuccessActionKind {
+  struct wire_cst_SuccessAction_Aes Aes;
+  struct wire_cst_SuccessAction_Message Message;
+  struct wire_cst_SuccessAction_Url Url;
+} SuccessActionKind;
+
+typedef struct wire_cst_success_action {
+  int32_t tag;
+  union SuccessActionKind kind;
+} wire_cst_success_action;
+
+typedef struct wire_cst_prepare_ln_url_pay_response {
+  struct wire_cst_prepare_send_response prepare_send_response;
+  struct wire_cst_success_action *success_action;
+} wire_cst_prepare_ln_url_pay_response;
+
+typedef struct wire_cst_ln_url_pay_request {
+  struct wire_cst_prepare_ln_url_pay_response prepare_response;
+} wire_cst_ln_url_pay_request;
+
+typedef struct wire_cst_ln_url_withdraw_request_data {
+  struct wire_cst_list_prim_u_8_strict *callback;
+  struct wire_cst_list_prim_u_8_strict *k1;
+  struct wire_cst_list_prim_u_8_strict *default_description;
+  uint64_t min_withdrawable;
+  uint64_t max_withdrawable;
+} wire_cst_ln_url_withdraw_request_data;
+
+typedef struct wire_cst_ln_url_withdraw_request {
+  struct wire_cst_ln_url_withdraw_request_data data;
+  uint64_t amount_msat;
+  struct wire_cst_list_prim_u_8_strict *description;
+} wire_cst_ln_url_withdraw_request;
+
+typedef struct wire_cst_prepare_pay_onchain_response {
+  uint64_t receiver_amount_sat;
+  uint64_t claim_fees_sat;
+  uint64_t total_fees_sat;
+} wire_cst_prepare_pay_onchain_response;
+
+typedef struct wire_cst_pay_onchain_request {
+  struct wire_cst_list_prim_u_8_strict *address;
+  struct wire_cst_prepare_pay_onchain_response prepare_response;
+} wire_cst_pay_onchain_request;
+
+typedef struct wire_cst_prepare_buy_bitcoin_request {
+  int32_t provider;
+  uint64_t amount_sat;
+} wire_cst_prepare_buy_bitcoin_request;
+
+typedef struct wire_cst_ln_url_pay_request_data {
+  struct wire_cst_list_prim_u_8_strict *callback;
+  uint64_t min_sendable;
+  uint64_t max_sendable;
+  struct wire_cst_list_prim_u_8_strict *metadata_str;
+  uint16_t comment_allowed;
+  struct wire_cst_list_prim_u_8_strict *domain;
+  bool allows_nostr;
+  struct wire_cst_list_prim_u_8_strict *nostr_pubkey;
+  struct wire_cst_list_prim_u_8_strict *ln_address;
+} wire_cst_ln_url_pay_request_data;
+
+typedef struct wire_cst_prepare_ln_url_pay_request {
+  struct wire_cst_ln_url_pay_request_data data;
+  uint64_t amount_msat;
+  struct wire_cst_list_prim_u_8_strict *comment;
+  bool *validate_success_action_url;
+} wire_cst_prepare_ln_url_pay_request;
+
+typedef struct wire_cst_PayOnchainAmount_Receiver {
+  uint64_t amount_sat;
+} wire_cst_PayOnchainAmount_Receiver;
+
+typedef union PayOnchainAmountKind {
+  struct wire_cst_PayOnchainAmount_Receiver Receiver;
+} PayOnchainAmountKind;
+
+typedef struct wire_cst_pay_onchain_amount {
+  int32_t tag;
+  union PayOnchainAmountKind kind;
+} wire_cst_pay_onchain_amount;
+
+typedef struct wire_cst_prepare_pay_onchain_request {
+  struct wire_cst_pay_onchain_amount amount;
+  uint32_t *fee_rate_sat_per_vbyte;
+} wire_cst_prepare_pay_onchain_request;
+
+typedef struct wire_cst_prepare_receive_request {
+  uint64_t *payer_amount_sat;
+  int32_t payment_method;
+} wire_cst_prepare_receive_request;
+
+typedef struct wire_cst_prepare_refund_request {
+  struct wire_cst_list_prim_u_8_strict *swap_address;
+  struct wire_cst_list_prim_u_8_strict *refund_address;
+  uint32_t fee_rate_sat_per_vbyte;
+} wire_cst_prepare_refund_request;
+
+typedef struct wire_cst_prepare_send_request {
+  struct wire_cst_list_prim_u_8_strict *destination;
+  uint64_t *amount_sat;
+} wire_cst_prepare_send_request;
+
+typedef struct wire_cst_prepare_receive_response {
+  int32_t payment_method;
+  uint64_t *payer_amount_sat;
+  uint64_t fees_sat;
+} wire_cst_prepare_receive_response;
+
+typedef struct wire_cst_receive_payment_request {
+  struct wire_cst_prepare_receive_response prepare_response;
+  struct wire_cst_list_prim_u_8_strict *description;
+  bool *use_description_hash;
+} wire_cst_receive_payment_request;
+
+typedef struct wire_cst_refund_request {
+  struct wire_cst_list_prim_u_8_strict *swap_address;
+  struct wire_cst_list_prim_u_8_strict *refund_address;
+  uint32_t fee_rate_sat_per_vbyte;
+} wire_cst_refund_request;
+
+typedef struct wire_cst_restore_request {
+  struct wire_cst_list_prim_u_8_strict *backup_path;
+} wire_cst_restore_request;
 
 typedef struct wire_cst_send_payment_request {
   struct wire_cst_prepare_send_response prepare_response;
@@ -447,19 +494,9 @@ typedef struct wire_cst_SuccessActionProcessed_Aes {
   struct wire_cst_aes_success_action_data_result *result;
 } wire_cst_SuccessActionProcessed_Aes;
 
-typedef struct wire_cst_message_success_action_data {
-  struct wire_cst_list_prim_u_8_strict *message;
-} wire_cst_message_success_action_data;
-
 typedef struct wire_cst_SuccessActionProcessed_Message {
   struct wire_cst_message_success_action_data *data;
 } wire_cst_SuccessActionProcessed_Message;
-
-typedef struct wire_cst_url_success_action_data {
-  struct wire_cst_list_prim_u_8_strict *description;
-  struct wire_cst_list_prim_u_8_strict *url;
-  bool matches_callback_domain;
-} wire_cst_url_success_action_data;
 
 typedef struct wire_cst_SuccessActionProcessed_Url {
   struct wire_cst_url_success_action_data *data;
@@ -999,6 +1036,10 @@ void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_buy_bit
                                                                                      uintptr_t that,
                                                                                      struct wire_cst_prepare_buy_bitcoin_request *req);
 
+void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(int64_t port_,
+                                                                                   uintptr_t that,
+                                                                                   struct wire_cst_prepare_ln_url_pay_request *req);
+
 void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_pay_onchain(int64_t port_,
                                                                                      uintptr_t that,
                                                                                      struct wire_cst_prepare_pay_onchain_request *req);
@@ -1071,6 +1112,8 @@ void frbgen_breez_liquid_rust_arc_increment_strong_count_RustOpaque_flutter_rust
 
 void frbgen_breez_liquid_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(const void *ptr);
 
+struct wire_cst_aes_success_action_data *frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data(void);
+
 struct wire_cst_aes_success_action_data_decrypted *frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_decrypted(void);
 
 struct wire_cst_aes_success_action_data_result *frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_result(void);
@@ -1127,6 +1170,8 @@ struct wire_cst_payment *frbgen_breez_liquid_cst_new_box_autoadd_payment(void);
 
 struct wire_cst_prepare_buy_bitcoin_request *frbgen_breez_liquid_cst_new_box_autoadd_prepare_buy_bitcoin_request(void);
 
+struct wire_cst_prepare_ln_url_pay_request *frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request(void);
+
 struct wire_cst_prepare_pay_onchain_request *frbgen_breez_liquid_cst_new_box_autoadd_prepare_pay_onchain_request(void);
 
 struct wire_cst_prepare_receive_request *frbgen_breez_liquid_cst_new_box_autoadd_prepare_receive_request(void);
@@ -1146,6 +1191,8 @@ struct wire_cst_sdk_event *frbgen_breez_liquid_cst_new_box_autoadd_sdk_event(voi
 struct wire_cst_send_payment_request *frbgen_breez_liquid_cst_new_box_autoadd_send_payment_request(void);
 
 struct wire_cst_sign_message_request *frbgen_breez_liquid_cst_new_box_autoadd_sign_message_request(void);
+
+struct wire_cst_success_action *frbgen_breez_liquid_cst_new_box_autoadd_success_action(void);
 
 struct wire_cst_success_action_processed *frbgen_breez_liquid_cst_new_box_autoadd_success_action_processed(void);
 
@@ -1178,6 +1225,7 @@ struct wire_cst_list_route_hint *frbgen_breez_liquid_cst_new_list_route_hint(int
 struct wire_cst_list_route_hint_hop *frbgen_breez_liquid_cst_new_list_route_hint_hop(int32_t len);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_decrypted);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_result);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_backup_request);
@@ -1206,6 +1254,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_buy_bitcoin_request);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_pay_onchain_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_receive_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_refund_request);
@@ -1216,6 +1265,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_sdk_event);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_send_payment_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_sign_message_request);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_success_action);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_success_action_processed);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_symbol);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_u_32);
@@ -1252,6 +1302,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_lnurl_withdraw);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_pay_onchain);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_buy_bitcoin);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_pay_onchain);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_receive_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_refund);

--- a/lib/bindings/langs/flutter/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h
@@ -101,6 +101,8 @@ RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_pay_oncha
 );
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_buy_bitcoin(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_pay_onchain(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_receive_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
@@ -326,6 +328,9 @@ uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_pay_o
     
 );
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_buy_bitcoin(void
+    
+);
+uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay(void
     
 );
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_pay_onchain(void

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -100,6 +100,13 @@ dictionary LnUrlErrorData {
 };
 
 [Enum]
+interface SuccessAction {
+    Aes(AesSuccessActionData data);
+    Message(MessageSuccessActionData data);
+    Url(UrlSuccessActionData data);
+};
+
+[Enum]
 interface SuccessActionProcessed {
     Aes(AesSuccessActionDataResult result);
     Message(MessageSuccessActionData data);
@@ -110,6 +117,12 @@ interface SuccessActionProcessed {
 interface AesSuccessActionDataResult {
     Decrypted(AesSuccessActionDataDecrypted data);
     ErrorStatus(string reason);
+};
+
+dictionary AesSuccessActionData {
+    string description;
+    string ciphertext;
+    string iv;
 };
 
 dictionary AesSuccessActionDataDecrypted {
@@ -130,14 +143,6 @@ dictionary UrlSuccessActionData {
 dictionary LnUrlPayErrorData {
     string payment_hash;
     string reason;
-};
-
-dictionary LnUrlPayRequest {
-    LnUrlPayRequestData data;
-    u64 amount_msat;
-    string? comment = null;
-    string? payment_label = null;
-    boolean? validate_success_action_url = null;
 };
 
 [Error]
@@ -342,6 +347,22 @@ dictionary CheckMessageRequest {
 
 dictionary CheckMessageResponse {
     boolean is_valid;
+};
+
+dictionary PrepareLnUrlPayRequest {
+    LnUrlPayRequestData data;
+    u64 amount_msat;
+    string? comment = null;
+    boolean? validate_success_action_url = null;
+};
+
+dictionary PrepareLnUrlPayResponse {
+    PrepareSendResponse prepare_send_response;
+    SuccessAction? success_action = null;
+};
+
+dictionary LnUrlPayRequest {
+    PrepareLnUrlPayResponse prepare_response;
 };
 
 dictionary PrepareSendRequest {
@@ -669,6 +690,9 @@ interface BindingLiquidSdk {
 
     [Throws=SdkError]
     void disconnect();
+
+    [Throws=LnUrlPayError]
+    PrepareLnUrlPayResponse prepare_lnurl_pay(PrepareLnUrlPayRequest req);
 
     [Throws=LnUrlPayError]
     LnUrlPayResult lnurl_pay(LnUrlPayRequest req);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -357,7 +357,8 @@ dictionary PrepareLnUrlPayRequest {
 };
 
 dictionary PrepareLnUrlPayResponse {
-    PrepareSendResponse prepare_send_response;
+    SendDestination destination;
+    u64 fees_sat;
     SuccessAction? success_action = null;
 };
 

--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -159,7 +159,15 @@ impl BindingLiquidSdk {
         rt().block_on(self.sdk.get_payment(&req))
     }
 
-    pub fn lnurl_pay(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
+    pub fn prepare_lnurl_pay(
+        &self,
+        req: PrepareLnUrlPayRequest,
+    ) -> Result<PrepareLnUrlPayResponse, LnUrlPayError> {
+        rt().block_on(self.sdk.prepare_lnurl_pay(req))
+            .map_err(Into::into)
+    }
+
+    pub fn lnurl_pay(&self, req: model::LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
         rt().block_on(self.sdk.lnurl_pay(req)).map_err(Into::into)
     }
 

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -183,9 +183,16 @@ impl BindingLiquidSdk {
         self.sdk.get_payment(&req).await
     }
 
+    pub async fn prepare_lnurl_pay(
+        &self,
+        req: PrepareLnUrlPayRequest,
+    ) -> Result<PrepareLnUrlPayResponse, duplicates::LnUrlPayError> {
+        self.sdk.prepare_lnurl_pay(req).await.map_err(Into::into)
+    }
+
     pub async fn lnurl_pay(
         &self,
-        req: LnUrlPayRequest,
+        req: crate::model::LnUrlPayRequest,
     ) -> Result<LnUrlPayResult, duplicates::LnUrlPayError> {
         self.sdk.lnurl_pay(req).await.map_err(Into::into)
     }
@@ -367,13 +374,11 @@ pub struct _LnUrlPayRequestData {
     pub ln_address: Option<String>,
 }
 
-#[frb(mirror(LnUrlPayRequest))]
-pub struct _LnUrlPayRequest {
-    pub data: LnUrlPayRequestData,
-    pub amount_msat: u64,
-    pub comment: Option<String>,
-    pub payment_label: Option<String>,
-    pub validate_success_action_url: Option<bool>,
+#[frb(mirror(SuccessAction))]
+pub enum _SuccessAction {
+    Aes { data: AesSuccessActionData },
+    Message { data: MessageSuccessActionData },
+    Url { data: UrlSuccessActionData },
 }
 
 #[frb(mirror(SuccessActionProcessed))]
@@ -381,6 +386,13 @@ pub enum _SuccessActionProcessed {
     Aes { result: AesSuccessActionDataResult },
     Message { data: MessageSuccessActionData },
     Url { data: UrlSuccessActionData },
+}
+
+#[frb(mirror(AesSuccessActionData))]
+pub struct _AesSuccessActionData {
+    pub description: String,
+    pub ciphertext: String,
+    pub iv: String,
 }
 
 #[frb(mirror(AesSuccessActionDataResult))]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3541,12 +3541,13 @@ impl SseDecode for crate::model::PrepareLnUrlPayRequest {
 impl SseDecode for crate::model::PrepareLnUrlPayResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_prepareSendResponse =
-            <crate::model::PrepareSendResponse>::sse_decode(deserializer);
+        let mut var_destination = <crate::model::SendDestination>::sse_decode(deserializer);
+        let mut var_feesSat = <u64>::sse_decode(deserializer);
         let mut var_successAction =
             <Option<crate::bindings::SuccessAction>>::sse_decode(deserializer);
         return crate::model::PrepareLnUrlPayResponse {
-            prepare_send_response: var_prepareSendResponse,
+            destination: var_destination,
+            fees_sat: var_feesSat,
             success_action: var_successAction,
         };
     }
@@ -5479,7 +5480,8 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::PrepareLnUrlPayRequest>
 impl flutter_rust_bridge::IntoDart for crate::model::PrepareLnUrlPayResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.prepare_send_response.into_into_dart().into_dart(),
+            self.destination.into_into_dart().into_dart(),
+            self.fees_sat.into_into_dart().into_dart(),
             self.success_action.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -7301,7 +7303,8 @@ impl SseEncode for crate::model::PrepareLnUrlPayRequest {
 impl SseEncode for crate::model::PrepareLnUrlPayResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::model::PrepareSendResponse>::sse_encode(self.prepare_send_response, serializer);
+        <crate::model::SendDestination>::sse_encode(self.destination, serializer);
+        <u64>::sse_encode(self.fees_sat, serializer);
         <Option<crate::bindings::SuccessAction>>::sse_encode(self.success_action, serializer);
     }
 }
@@ -9065,7 +9068,8 @@ mod io {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::PrepareLnUrlPayResponse {
             crate::model::PrepareLnUrlPayResponse {
-                prepare_send_response: self.prepare_send_response.cst_decode(),
+                destination: self.destination.cst_decode(),
+                fees_sat: self.fees_sat.cst_decode(),
                 success_action: self.success_action.cst_decode(),
             }
         }
@@ -10142,7 +10146,8 @@ mod io {
     impl NewWithNullPtr for wire_cst_prepare_ln_url_pay_response {
         fn new_with_null_ptr() -> Self {
             Self {
-                prepare_send_response: Default::default(),
+                destination: Default::default(),
+                fees_sat: Default::default(),
                 success_action: core::ptr::null_mut(),
             }
         }
@@ -12198,7 +12203,8 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_ln_url_pay_response {
-        prepare_send_response: wire_cst_prepare_send_response,
+        destination: wire_cst_send_destination,
+        fees_sat: u64,
         success_action: *mut wire_cst_success_action,
     }
     #[repr(C)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.4.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1147354100;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 425220482;
 
 // Section: executor
 
@@ -724,7 +724,7 @@ fn wire__crate__bindings__BindingLiquidSdk_lnurl_pay_impl(
     that: impl CstDecode<
         RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>,
     >,
-    req: impl CstDecode<crate::bindings::LnUrlPayRequest>,
+    req: impl CstDecode<crate::model::LnUrlPayRequest>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::DcoCodec, _, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -901,6 +901,55 @@ fn wire__crate__bindings__BindingLiquidSdk_prepare_buy_bitcoin_impl(
                         }
                         let api_that_guard = api_that_guard.unwrap();
                         let output_ok = crate::bindings::BindingLiquidSdk::prepare_buy_bitcoin(
+                            &*api_that_guard,
+                            api_req,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>,
+    >,
+    req: impl CstDecode<crate::model::PrepareLnUrlPayRequest>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::DcoCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "BindingLiquidSdk_prepare_lnurl_pay",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            let api_req = req.cst_decode();
+            move |context| async move {
+                transform_result_dco::<_, _, crate::bindings::duplicates::LnUrlPayError>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::bindings::BindingLiquidSdk::prepare_lnurl_pay(
                             &*api_that_guard,
                             api_req,
                         )
@@ -1697,6 +1746,12 @@ fn wire__crate__bindings__parse_invoice_impl(
 #[allow(clippy::unnecessary_literal_unwrap)]
 const _: fn() = || {
     {
+        let AesSuccessActionData = None::<crate::bindings::AesSuccessActionData>.unwrap();
+        let _: String = AesSuccessActionData.description;
+        let _: String = AesSuccessActionData.ciphertext;
+        let _: String = AesSuccessActionData.iv;
+    }
+    {
         let AesSuccessActionDataDecrypted =
             None::<crate::bindings::AesSuccessActionDataDecrypted>.unwrap();
         let _: String = AesSuccessActionDataDecrypted.description;
@@ -1803,14 +1858,6 @@ const _: fn() = || {
         let _: String = LnUrlPayErrorData.reason;
     }
     {
-        let LnUrlPayRequest = None::<crate::bindings::LnUrlPayRequest>.unwrap();
-        let _: crate::bindings::LnUrlPayRequestData = LnUrlPayRequest.data;
-        let _: u64 = LnUrlPayRequest.amount_msat;
-        let _: Option<String> = LnUrlPayRequest.comment;
-        let _: Option<String> = LnUrlPayRequest.payment_label;
-        let _: Option<bool> = LnUrlPayRequest.validate_success_action_url;
-    }
-    {
         let LnUrlPayRequestData = None::<crate::bindings::LnUrlPayRequestData>.unwrap();
         let _: String = LnUrlPayRequestData.callback;
         let _: u64 = LnUrlPayRequestData.min_sendable;
@@ -1869,6 +1916,17 @@ const _: fn() = || {
         let _: u64 = RouteHintHop.cltv_expiry_delta;
         let _: Option<u64> = RouteHintHop.htlc_minimum_msat;
         let _: Option<u64> = RouteHintHop.htlc_maximum_msat;
+    }
+    match None::<crate::bindings::SuccessAction>.unwrap() {
+        crate::bindings::SuccessAction::Aes { data } => {
+            let _: crate::bindings::AesSuccessActionData = data;
+        }
+        crate::bindings::SuccessAction::Message { data } => {
+            let _: crate::bindings::MessageSuccessActionData = data;
+        }
+        crate::bindings::SuccessAction::Url { data } => {
+            let _: crate::bindings::UrlSuccessActionData = data;
+        }
     }
     match None::<crate::bindings::SuccessActionProcessed>.unwrap() {
         crate::bindings::SuccessActionProcessed::Aes { result } => {
@@ -2072,6 +2130,20 @@ impl SseDecode for String {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <Vec<u8>>::sse_decode(deserializer);
         return String::from_utf8(inner).unwrap();
+    }
+}
+
+impl SseDecode for crate::bindings::AesSuccessActionData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_description = <String>::sse_decode(deserializer);
+        let mut var_ciphertext = <String>::sse_decode(deserializer);
+        let mut var_iv = <String>::sse_decode(deserializer);
+        return crate::bindings::AesSuccessActionData {
+            description: var_description,
+            ciphertext: var_ciphertext,
+            iv: var_iv,
+        };
     }
 }
 
@@ -2792,20 +2864,13 @@ impl SseDecode for crate::bindings::LnUrlPayErrorData {
     }
 }
 
-impl SseDecode for crate::bindings::LnUrlPayRequest {
+impl SseDecode for crate::model::LnUrlPayRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_data = <crate::bindings::LnUrlPayRequestData>::sse_decode(deserializer);
-        let mut var_amountMsat = <u64>::sse_decode(deserializer);
-        let mut var_comment = <Option<String>>::sse_decode(deserializer);
-        let mut var_paymentLabel = <Option<String>>::sse_decode(deserializer);
-        let mut var_validateSuccessActionUrl = <Option<bool>>::sse_decode(deserializer);
-        return crate::bindings::LnUrlPayRequest {
-            data: var_data,
-            amount_msat: var_amountMsat,
-            comment: var_comment,
-            payment_label: var_paymentLabel,
-            validate_success_action_url: var_validateSuccessActionUrl,
+        let mut var_prepareResponse =
+            <crate::model::PrepareLnUrlPayResponse>::sse_decode(deserializer);
+        return crate::model::LnUrlPayRequest {
+            prepare_response: var_prepareResponse,
         };
     }
 }
@@ -3118,6 +3183,17 @@ impl SseDecode for Option<crate::model::Payment> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::model::Payment>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::bindings::SuccessAction> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::bindings::SuccessAction>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -3442,6 +3518,36 @@ impl SseDecode for crate::model::PrepareBuyBitcoinResponse {
             provider: var_provider,
             amount_sat: var_amountSat,
             fees_sat: var_feesSat,
+        };
+    }
+}
+
+impl SseDecode for crate::model::PrepareLnUrlPayRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_data = <crate::bindings::LnUrlPayRequestData>::sse_decode(deserializer);
+        let mut var_amountMsat = <u64>::sse_decode(deserializer);
+        let mut var_comment = <Option<String>>::sse_decode(deserializer);
+        let mut var_validateSuccessActionUrl = <Option<bool>>::sse_decode(deserializer);
+        return crate::model::PrepareLnUrlPayRequest {
+            data: var_data,
+            amount_msat: var_amountMsat,
+            comment: var_comment,
+            validate_success_action_url: var_validateSuccessActionUrl,
+        };
+    }
+}
+
+impl SseDecode for crate::model::PrepareLnUrlPayResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_prepareSendResponse =
+            <crate::model::PrepareSendResponse>::sse_decode(deserializer);
+        let mut var_successAction =
+            <Option<crate::bindings::SuccessAction>>::sse_decode(deserializer);
+        return crate::model::PrepareLnUrlPayResponse {
+            prepare_send_response: var_prepareSendResponse,
+            success_action: var_successAction,
         };
     }
 }
@@ -3825,6 +3931,33 @@ impl SseDecode for crate::model::SignMessageResponse {
     }
 }
 
+impl SseDecode for crate::bindings::SuccessAction {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_data =
+                    <crate::bindings::AesSuccessActionData>::sse_decode(deserializer);
+                return crate::bindings::SuccessAction::Aes { data: var_data };
+            }
+            1 => {
+                let mut var_data =
+                    <crate::bindings::MessageSuccessActionData>::sse_decode(deserializer);
+                return crate::bindings::SuccessAction::Message { data: var_data };
+            }
+            2 => {
+                let mut var_data =
+                    <crate::bindings::UrlSuccessActionData>::sse_decode(deserializer);
+                return crate::bindings::SuccessAction::Url { data: var_data };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::bindings::SuccessActionProcessed {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3964,6 +4097,28 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<BindingLiquidSdk>> for Binding
     }
 }
 
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::AesSuccessActionData> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.description.into_into_dart().into_dart(),
+            self.0.ciphertext.into_into_dart().into_dart(),
+            self.0.iv.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::bindings::AesSuccessActionData>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::AesSuccessActionData>>
+    for crate::bindings::AesSuccessActionData
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::AesSuccessActionData> {
+        self.into()
+    }
+}
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::AesSuccessActionDataDecrypted> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
@@ -4668,30 +4823,17 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LnUrlPayError
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LnUrlPayRequest> {
+impl flutter_rust_bridge::IntoDart for crate::model::LnUrlPayRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.0.data.into_into_dart().into_dart(),
-            self.0.amount_msat.into_into_dart().into_dart(),
-            self.0.comment.into_into_dart().into_dart(),
-            self.0.payment_label.into_into_dart().into_dart(),
-            self.0
-                .validate_success_action_url
-                .into_into_dart()
-                .into_dart(),
-        ]
-        .into_dart()
+        [self.prepare_response.into_into_dart().into_dart()].into_dart()
     }
 }
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<crate::bindings::LnUrlPayRequest>
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::model::LnUrlPayRequest {}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::LnUrlPayRequest>
+    for crate::model::LnUrlPayRequest
 {
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LnUrlPayRequest>>
-    for crate::bindings::LnUrlPayRequest
-{
-    fn into_into_dart(self) -> FrbWrapper<crate::bindings::LnUrlPayRequest> {
-        self.into()
+    fn into_into_dart(self) -> crate::model::LnUrlPayRequest {
+        self
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -5309,6 +5451,52 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::PrepareBuyBitcoinResponse>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::PrepareLnUrlPayRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.data.into_into_dart().into_dart(),
+            self.amount_msat.into_into_dart().into_dart(),
+            self.comment.into_into_dart().into_dart(),
+            self.validate_success_action_url
+                .into_into_dart()
+                .into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::model::PrepareLnUrlPayRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::PrepareLnUrlPayRequest>
+    for crate::model::PrepareLnUrlPayRequest
+{
+    fn into_into_dart(self) -> crate::model::PrepareLnUrlPayRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::PrepareLnUrlPayResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.prepare_send_response.into_into_dart().into_dart(),
+            self.success_action.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::model::PrepareLnUrlPayResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::PrepareLnUrlPayResponse>
+    for crate::model::PrepareLnUrlPayResponse
+{
+    fn into_into_dart(self) -> crate::model::PrepareLnUrlPayResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::model::PreparePayOnchainRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -5825,6 +6013,36 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::SignMessageResponse>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::SuccessAction> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self.0 {
+            crate::bindings::SuccessAction::Aes { data } => {
+                [0.into_dart(), data.into_into_dart().into_dart()].into_dart()
+            }
+            crate::bindings::SuccessAction::Message { data } => {
+                [1.into_dart(), data.into_into_dart().into_dart()].into_dart()
+            }
+            crate::bindings::SuccessAction::Url { data } => {
+                [2.into_dart(), data.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::bindings::SuccessAction>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::SuccessAction>>
+    for crate::bindings::SuccessAction
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::SuccessAction> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::SuccessActionProcessed> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self.0 {
@@ -5947,6 +6165,15 @@ impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<u8>>::sse_encode(self.into_bytes(), serializer);
+    }
+}
+
+impl SseEncode for crate::bindings::AesSuccessActionData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.description, serializer);
+        <String>::sse_encode(self.ciphertext, serializer);
+        <String>::sse_encode(self.iv, serializer);
     }
 }
 
@@ -6503,14 +6730,10 @@ impl SseEncode for crate::bindings::LnUrlPayErrorData {
     }
 }
 
-impl SseEncode for crate::bindings::LnUrlPayRequest {
+impl SseEncode for crate::model::LnUrlPayRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::bindings::LnUrlPayRequestData>::sse_encode(self.data, serializer);
-        <u64>::sse_encode(self.amount_msat, serializer);
-        <Option<String>>::sse_encode(self.comment, serializer);
-        <Option<String>>::sse_encode(self.payment_label, serializer);
-        <Option<bool>>::sse_encode(self.validate_success_action_url, serializer);
+        <crate::model::PrepareLnUrlPayResponse>::sse_encode(self.prepare_response, serializer);
     }
 }
 
@@ -6756,6 +6979,16 @@ impl SseEncode for Option<crate::model::Payment> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::model::Payment>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::bindings::SuccessAction> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::bindings::SuccessAction>::sse_encode(value, serializer);
         }
     }
 }
@@ -7055,6 +7288,24 @@ impl SseEncode for crate::model::PrepareBuyBitcoinResponse {
     }
 }
 
+impl SseEncode for crate::model::PrepareLnUrlPayRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::bindings::LnUrlPayRequestData>::sse_encode(self.data, serializer);
+        <u64>::sse_encode(self.amount_msat, serializer);
+        <Option<String>>::sse_encode(self.comment, serializer);
+        <Option<bool>>::sse_encode(self.validate_success_action_url, serializer);
+    }
+}
+
+impl SseEncode for crate::model::PrepareLnUrlPayResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::model::PrepareSendResponse>::sse_encode(self.prepare_send_response, serializer);
+        <Option<crate::bindings::SuccessAction>>::sse_encode(self.success_action, serializer);
+    }
+}
+
 impl SseEncode for crate::model::PreparePayOnchainRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7320,6 +7571,29 @@ impl SseEncode for crate::model::SignMessageResponse {
     }
 }
 
+impl SseEncode for crate::bindings::SuccessAction {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::bindings::SuccessAction::Aes { data } => {
+                <i32>::sse_encode(0, serializer);
+                <crate::bindings::AesSuccessActionData>::sse_encode(data, serializer);
+            }
+            crate::bindings::SuccessAction::Message { data } => {
+                <i32>::sse_encode(1, serializer);
+                <crate::bindings::MessageSuccessActionData>::sse_encode(data, serializer);
+            }
+            crate::bindings::SuccessAction::Url { data } => {
+                <i32>::sse_encode(2, serializer);
+                <crate::bindings::UrlSuccessActionData>::sse_encode(data, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::bindings::SuccessActionProcessed {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7493,6 +7767,16 @@ mod io {
             String::from_utf8(vec).unwrap()
         }
     }
+    impl CstDecode<crate::bindings::AesSuccessActionData> for wire_cst_aes_success_action_data {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::AesSuccessActionData {
+            crate::bindings::AesSuccessActionData {
+                description: self.description.cst_decode(),
+                ciphertext: self.ciphertext.cst_decode(),
+                iv: self.iv.cst_decode(),
+            }
+        }
+    }
     impl CstDecode<crate::bindings::AesSuccessActionDataDecrypted>
         for wire_cst_aes_success_action_data_decrypted
     {
@@ -7552,6 +7836,13 @@ mod io {
                 label: self.label.cst_decode(),
                 message: self.message.cst_decode(),
             }
+        }
+    }
+    impl CstDecode<crate::bindings::AesSuccessActionData> for *mut wire_cst_aes_success_action_data {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::AesSuccessActionData {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::bindings::AesSuccessActionData>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::bindings::AesSuccessActionDataDecrypted>
@@ -7682,11 +7973,11 @@ mod io {
             CstDecode::<crate::bindings::LnUrlPayErrorData>::cst_decode(*wrap).into()
         }
     }
-    impl CstDecode<crate::bindings::LnUrlPayRequest> for *mut wire_cst_ln_url_pay_request {
+    impl CstDecode<crate::model::LnUrlPayRequest> for *mut wire_cst_ln_url_pay_request {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::bindings::LnUrlPayRequest {
+        fn cst_decode(self) -> crate::model::LnUrlPayRequest {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
-            CstDecode::<crate::bindings::LnUrlPayRequest>::cst_decode(*wrap).into()
+            CstDecode::<crate::model::LnUrlPayRequest>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::bindings::LnUrlPayRequestData> for *mut wire_cst_ln_url_pay_request_data {
@@ -7761,6 +8052,13 @@ mod io {
             CstDecode::<crate::model::PrepareBuyBitcoinRequest>::cst_decode(*wrap).into()
         }
     }
+    impl CstDecode<crate::model::PrepareLnUrlPayRequest> for *mut wire_cst_prepare_ln_url_pay_request {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::PrepareLnUrlPayRequest {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::model::PrepareLnUrlPayRequest>::cst_decode(*wrap).into()
+        }
+    }
     impl CstDecode<crate::model::PreparePayOnchainRequest>
         for *mut wire_cst_prepare_pay_onchain_request
     {
@@ -7831,6 +8129,13 @@ mod io {
         fn cst_decode(self) -> crate::model::SignMessageRequest {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
             CstDecode::<crate::model::SignMessageRequest>::cst_decode(*wrap).into()
+        }
+    }
+    impl CstDecode<crate::bindings::SuccessAction> for *mut wire_cst_success_action {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::SuccessAction {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::bindings::SuccessAction>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::bindings::SuccessActionProcessed> for *mut wire_cst_success_action_processed {
@@ -8359,15 +8664,11 @@ mod io {
             }
         }
     }
-    impl CstDecode<crate::bindings::LnUrlPayRequest> for wire_cst_ln_url_pay_request {
+    impl CstDecode<crate::model::LnUrlPayRequest> for wire_cst_ln_url_pay_request {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::bindings::LnUrlPayRequest {
-            crate::bindings::LnUrlPayRequest {
-                data: self.data.cst_decode(),
-                amount_msat: self.amount_msat.cst_decode(),
-                comment: self.comment.cst_decode(),
-                payment_label: self.payment_label.cst_decode(),
-                validate_success_action_url: self.validate_success_action_url.cst_decode(),
+        fn cst_decode(self) -> crate::model::LnUrlPayRequest {
+            crate::model::LnUrlPayRequest {
+                prepare_response: self.prepare_response.cst_decode(),
             }
         }
     }
@@ -8749,6 +9050,26 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::model::PrepareLnUrlPayRequest> for wire_cst_prepare_ln_url_pay_request {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::PrepareLnUrlPayRequest {
+            crate::model::PrepareLnUrlPayRequest {
+                data: self.data.cst_decode(),
+                amount_msat: self.amount_msat.cst_decode(),
+                comment: self.comment.cst_decode(),
+                validate_success_action_url: self.validate_success_action_url.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::model::PrepareLnUrlPayResponse> for wire_cst_prepare_ln_url_pay_response {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::PrepareLnUrlPayResponse {
+            crate::model::PrepareLnUrlPayResponse {
+                prepare_send_response: self.prepare_send_response.cst_decode(),
+                success_action: self.success_action.cst_decode(),
+            }
+        }
+    }
     impl CstDecode<crate::model::PreparePayOnchainRequest> for wire_cst_prepare_pay_onchain_request {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::PreparePayOnchainRequest {
@@ -9041,6 +9362,32 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::bindings::SuccessAction> for wire_cst_success_action {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::SuccessAction {
+            match self.tag {
+                0 => {
+                    let ans = unsafe { self.kind.Aes };
+                    crate::bindings::SuccessAction::Aes {
+                        data: ans.data.cst_decode(),
+                    }
+                }
+                1 => {
+                    let ans = unsafe { self.kind.Message };
+                    crate::bindings::SuccessAction::Message {
+                        data: ans.data.cst_decode(),
+                    }
+                }
+                2 => {
+                    let ans = unsafe { self.kind.Url };
+                    crate::bindings::SuccessAction::Url {
+                        data: ans.data.cst_decode(),
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<crate::bindings::SuccessActionProcessed> for wire_cst_success_action_processed {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::bindings::SuccessActionProcessed {
@@ -9086,6 +9433,20 @@ mod io {
                 url: self.url.cst_decode(),
                 matches_callback_domain: self.matches_callback_domain.cst_decode(),
             }
+        }
+    }
+    impl NewWithNullPtr for wire_cst_aes_success_action_data {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                description: core::ptr::null_mut(),
+                ciphertext: core::ptr::null_mut(),
+                iv: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_aes_success_action_data {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
         }
     }
     impl NewWithNullPtr for wire_cst_aes_success_action_data_decrypted {
@@ -9477,11 +9838,7 @@ mod io {
     impl NewWithNullPtr for wire_cst_ln_url_pay_request {
         fn new_with_null_ptr() -> Self {
             Self {
-                data: Default::default(),
-                amount_msat: Default::default(),
-                comment: core::ptr::null_mut(),
-                payment_label: core::ptr::null_mut(),
-                validate_success_action_url: core::ptr::null_mut(),
+                prepare_response: Default::default(),
             }
         }
     }
@@ -9763,6 +10120,34 @@ mod io {
         }
     }
     impl Default for wire_cst_prepare_buy_bitcoin_response {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_prepare_ln_url_pay_request {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                data: Default::default(),
+                amount_msat: Default::default(),
+                comment: core::ptr::null_mut(),
+                validate_success_action_url: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_prepare_ln_url_pay_request {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_prepare_ln_url_pay_response {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                prepare_send_response: Default::default(),
+                success_action: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_prepare_ln_url_pay_response {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -10099,6 +10484,19 @@ mod io {
             Self::new_with_null_ptr()
         }
     }
+    impl NewWithNullPtr for wire_cst_success_action {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: SuccessActionKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_success_action {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
     impl NewWithNullPtr for wire_cst_success_action_processed {
         fn new_with_null_ptr() -> Self {
             Self {
@@ -10303,6 +10701,15 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(
+        port_: i64,
+        that: usize,
+        req: *mut wire_cst_prepare_ln_url_pay_request,
+    ) {
+        wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay_impl(port_, that, req)
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_pay_onchain(
         port_: i64,
         that: usize,
@@ -10486,6 +10893,14 @@ mod io {
         unsafe {
             StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>::decrement_strong_count(ptr as _);
         }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data(
+    ) -> *mut wire_cst_aes_success_action_data {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_aes_success_action_data::new_with_null_ptr(),
+        )
     }
 
     #[no_mangle]
@@ -10704,6 +11119,14 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request(
+    ) -> *mut wire_cst_prepare_ln_url_pay_request {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_prepare_ln_url_pay_request::new_with_null_ptr(),
+        )
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_prepare_pay_onchain_request(
     ) -> *mut wire_cst_prepare_pay_onchain_request {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
@@ -10778,6 +11201,14 @@ mod io {
     ) -> *mut wire_cst_sign_message_request {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
             wire_cst_sign_message_request::new_with_null_ptr(),
+        )
+    }
+
+    #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_success_action(
+    ) -> *mut wire_cst_success_action {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_success_action::new_with_null_ptr(),
         )
     }
 
@@ -10944,6 +11375,13 @@ mod io {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
     }
 
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_aes_success_action_data {
+        description: *mut wire_cst_list_prim_u_8_strict,
+        ciphertext: *mut wire_cst_list_prim_u_8_strict,
+        iv: *mut wire_cst_list_prim_u_8_strict,
+    }
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_aes_success_action_data_decrypted {
@@ -11413,11 +11851,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_ln_url_pay_request {
-        data: wire_cst_ln_url_pay_request_data,
-        amount_msat: u64,
-        comment: *mut wire_cst_list_prim_u_8_strict,
-        payment_label: *mut wire_cst_list_prim_u_8_strict,
-        validate_success_action_url: *mut bool,
+        prepare_response: wire_cst_prepare_ln_url_pay_response,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -11755,6 +12189,20 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_prepare_ln_url_pay_request {
+        data: wire_cst_ln_url_pay_request_data,
+        amount_msat: u64,
+        comment: *mut wire_cst_list_prim_u_8_strict,
+        validate_success_action_url: *mut bool,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_prepare_ln_url_pay_response {
+        prepare_send_response: wire_cst_prepare_send_response,
+        success_action: *mut wire_cst_success_action,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_pay_onchain_request {
         amount: wire_cst_pay_onchain_amount,
         fee_rate_sat_per_vbyte: *mut u32,
@@ -11984,6 +12432,35 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_sign_message_response {
         signature: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_success_action {
+        tag: i32,
+        kind: SuccessActionKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union SuccessActionKind {
+        Aes: wire_cst_SuccessAction_Aes,
+        Message: wire_cst_SuccessAction_Message,
+        Url: wire_cst_SuccessAction_Url,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_SuccessAction_Aes {
+        data: *mut wire_cst_aes_success_action_data,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_SuccessAction_Message {
+        data: *mut wire_cst_message_success_action_data,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_SuccessAction_Url {
+        data: *mut wire_cst_url_success_action_data,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1390,8 +1390,10 @@ pub struct PrepareLnUrlPayRequest {
 /// Returned when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
 #[derive(Debug, Serialize)]
 pub struct PrepareLnUrlPayResponse {
-    /// The response from preparing the payment which includes `fees_sat`
-    pub prepare_send_response: PrepareSendResponse,
+    /// The destination of the payment
+    pub destination: SendDestination,
+    /// The fees in satoshis to send the payment
+    pub fees_sat: u64,
     /// The unprocessed LUD-09 success action. This will be processed and decrypted if
     /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
     pub success_action: Option<SuccessAction>,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1373,6 +1373,37 @@ impl From<SwapTree> for InternalSwapTree {
     }
 }
 
+/// An argument when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
+#[derive(Debug, Serialize)]
+pub struct PrepareLnUrlPayRequest {
+    /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
+    pub data: LnUrlPayRequestData,
+    /// The amount in millisatoshis for this payment
+    pub amount_msat: u64,
+    /// An optional comment for this payment
+    pub comment: Option<String>,
+    /// Validates that, if there is a URL success action, the URL domain matches
+    /// the LNURL callback domain. Defaults to `true`
+    pub validate_success_action_url: Option<bool>,
+}
+
+/// Returned when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
+#[derive(Debug, Serialize)]
+pub struct PrepareLnUrlPayResponse {
+    /// The response from preparing the payment which includes `fees_sat`
+    pub prepare_send_response: PrepareSendResponse,
+    /// The unprocessed LUD-09 success action. This will be processed and decrypted if
+    /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
+    pub success_action: Option<SuccessAction>,
+}
+
+/// An argument when calling [crate::sdk::LiquidSdk::lnurl_pay].
+#[derive(Debug, Serialize)]
+pub struct LnUrlPayRequest {
+    /// The response from calling [crate::sdk::LiquidSdk::prepare_lnurl_pay]
+    pub prepare_response: PrepareLnUrlPayResponse,
+}
+
 /// Contains the result of the entire LNURL-pay interaction, as reported by the LNURL endpoint.
 ///
 /// * `EndpointSuccess` indicates the payment is complete. The endpoint may return a `SuccessActionProcessed`,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2178,7 +2178,7 @@ impl LiquidSdk {
                 Err(LnUrlPayError::Generic { err: data.reason })
             }
             ValidatedCallbackResponse::EndpointSuccess { data } => {
-                let prepare_send_response = self
+                let prepare_response = self
                     .prepare_send_payment(&PrepareSendRequest {
                         destination: data.pr.clone(),
                         amount_sat: None,
@@ -2186,8 +2186,9 @@ impl LiquidSdk {
                     .await?;
 
                 Ok(PrepareLnUrlPayResponse {
+                    destination: prepare_response.destination,
+                    fees_sat: prepare_response.fees_sat,
                     success_action: data.success_action,
-                    prepare_send_response,
                 })
             }
         }
@@ -2212,7 +2213,10 @@ impl LiquidSdk {
         let prepare_response = req.prepare_response;
         let payment = self
             .send_payment(&SendPaymentRequest {
-                prepare_response: prepare_response.prepare_send_response,
+                prepare_response: PrepareSendResponse {
+                    destination: prepare_response.destination,
+                    fees_sat: prepare_response.fees_sat,
+                },
             })
             .await?
             .payment;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2138,13 +2138,33 @@ impl LiquidSdk {
         self.persister.restore_from_backup(backup_path)
     }
 
-    /// Second step of LNURL-pay. The first step is [parse], which also validates the LNURL destination
-    /// and generates the [LnUrlPayRequest] payload needed here.
+    /// Prepares to pay to an LNURL encoded pay request or lightning address.
+    ///
+    /// This is the second step of LNURL-pay flow. The first step is [parse], which also validates the LNURL
+    /// destination and generates the [LnUrlPayRequest] payload needed here.
     ///
     /// This call will validate the `amount_msat` and `comment` parameters of `req` against the parameters
-    /// of the LNURL endpoint (`req_data`). If they match the endpoint requirements, the LNURL payment
-    /// is made.
-    pub async fn lnurl_pay(&self, req: LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
+    /// of the LNURL endpoint (`req_data`). If they match the endpoint requirements, a [PrepareSendResponse] is
+    /// prepared for the invoice. If the receiver has encoded a Magic Routing Hint in the invoice, the
+    /// [PrepareSendResponse]'s `fees_sat` will reflect this.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - the [PrepareLnUrlPayRequest] containing:
+    ///     * `data` - the [LnUrlPayRequestData] returned by [parse]
+    ///     * `amount_msat` - the amount in millisatoshis for this payment
+    ///     * `comment` - an optional comment for this payment
+    ///     * `validate_success_action_url` - validates that, if there is a URL success action, the URL domain matches
+    ///       the LNURL callback domain. Defaults to 'true'
+    ///
+    /// # Returns
+    /// Returns a [PrepareLnUrlPayResponse] containing:
+    ///     * `prepare_send_response` - the prepared [PrepareSendResponse] for the retreived invoice
+    ///     * `success_action` - the optional unprocessed LUD-09 success action
+    pub async fn prepare_lnurl_pay(
+        &self,
+        req: PrepareLnUrlPayRequest,
+    ) -> Result<PrepareLnUrlPayResponse, LnUrlPayError> {
         match validate_lnurl_pay(
             req.amount_msat,
             &req.comment,
@@ -2154,71 +2174,93 @@ impl LiquidSdk {
         )
         .await?
         {
-            ValidatedCallbackResponse::EndpointError { data: e } => {
-                Ok(LnUrlPayResult::EndpointError { data: e })
+            ValidatedCallbackResponse::EndpointError { data } => {
+                Err(LnUrlPayError::Generic { err: data.reason })
             }
-            ValidatedCallbackResponse::EndpointSuccess { data: cb } => {
-                let prepare_response = self
+            ValidatedCallbackResponse::EndpointSuccess { data } => {
+                let prepare_send_response = self
                     .prepare_send_payment(&PrepareSendRequest {
-                        destination: cb.pr.clone(),
+                        destination: data.pr.clone(),
                         amount_sat: None,
                     })
                     .await?;
 
-                let payment = self
-                    .send_payment(&SendPaymentRequest { prepare_response })
-                    .await?
-                    .payment;
-
-                let maybe_sa_processed: Option<SuccessActionProcessed> = match cb.success_action {
-                    Some(sa) => {
-                        let processed_sa = match sa {
-                            // For AES, we decrypt the contents on the fly
-                            SuccessAction::Aes(data) => {
-                                let PaymentDetails::Lightning { preimage, .. } = &payment.details
-                                else {
-                                    return Err(LnUrlPayError::Generic {
-                                        err: format!("Invalid payment type: expected type `PaymentDetails::Lightning`, got payment details {:?}.", payment.details),
-                                    });
-                                };
-
-                                let preimage_str =
-                                    preimage.clone().ok_or(LnUrlPayError::Generic {
-                                        err: "Payment successful but no preimage found".to_string(),
-                                    })?;
-                                let preimage =
-                                    sha256::Hash::from_str(&preimage_str).map_err(|_| {
-                                        LnUrlPayError::Generic {
-                                            err: "Invalid preimage".to_string(),
-                                        }
-                                    })?;
-                                let preimage_arr: [u8; 32] = preimage.into_32();
-                                let result = match (data, &preimage_arr).try_into() {
-                                    Ok(data) => AesSuccessActionDataResult::Decrypted { data },
-                                    Err(e) => AesSuccessActionDataResult::ErrorStatus {
-                                        reason: e.to_string(),
-                                    },
-                                };
-                                SuccessActionProcessed::Aes { result }
-                            }
-                            SuccessAction::Message(data) => {
-                                SuccessActionProcessed::Message { data }
-                            }
-                            SuccessAction::Url(data) => SuccessActionProcessed::Url { data },
-                        };
-                        Some(processed_sa)
-                    }
-                    None => None,
-                };
-
-                Ok(LnUrlPayResult::EndpointSuccess {
-                    data: model::LnUrlPaySuccessData {
-                        payment,
-                        success_action: maybe_sa_processed,
-                    },
+                Ok(PrepareLnUrlPayResponse {
+                    success_action: data.success_action,
+                    prepare_send_response,
                 })
             }
         }
+    }
+
+    /// Pay to an LNURL encoded pay request or lightning address.
+    ///
+    /// The final step of LNURL-pay flow, called after preparing the payment with [LiquidSdk::prepare_lnurl_pay].
+    /// This call sends the payment using the [PrepareLnUrlPayResponse]'s `prepare_send_response` either via
+    /// Lightning or directly to a Liquid address if a Magic Routing Hint is included in the invoice.
+    /// Once the payment is made, the [PrepareLnUrlPayResponse]'s `success_action` is processed decrypting
+    /// the AES data if needed.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - the [LnUrlPayRequest] containing:
+    ///     * `prepare_response` - the [PrepareLnUrlPayResponse] returned by [LiquidSdk::prepare_lnurl_pay]
+    pub async fn lnurl_pay(
+        &self,
+        req: model::LnUrlPayRequest,
+    ) -> Result<LnUrlPayResult, LnUrlPayError> {
+        let prepare_response = req.prepare_response;
+        let payment = self
+            .send_payment(&SendPaymentRequest {
+                prepare_response: prepare_response.prepare_send_response,
+            })
+            .await?
+            .payment;
+
+        let maybe_sa_processed: Option<SuccessActionProcessed> = match prepare_response
+            .success_action
+        {
+            Some(sa) => {
+                let processed_sa = match sa {
+                    // For AES, we decrypt the contents on the fly
+                    SuccessAction::Aes { data } => {
+                        let PaymentDetails::Lightning { preimage, .. } = &payment.details else {
+                            return Err(LnUrlPayError::Generic {
+                                        err: format!("Invalid payment type: expected type `PaymentDetails::Lightning`, got payment details {:?}.", payment.details),
+                                    });
+                        };
+
+                        let preimage_str = preimage.clone().ok_or(LnUrlPayError::Generic {
+                            err: "Payment successful but no preimage found".to_string(),
+                        })?;
+                        let preimage = sha256::Hash::from_str(&preimage_str).map_err(|_| {
+                            LnUrlPayError::Generic {
+                                err: "Invalid preimage".to_string(),
+                            }
+                        })?;
+                        let preimage_arr: [u8; 32] = preimage.into_32();
+                        let result = match (data, &preimage_arr).try_into() {
+                            Ok(data) => AesSuccessActionDataResult::Decrypted { data },
+                            Err(e) => AesSuccessActionDataResult::ErrorStatus {
+                                reason: e.to_string(),
+                            },
+                        };
+                        SuccessActionProcessed::Aes { result }
+                    }
+                    SuccessAction::Message { data } => SuccessActionProcessed::Message { data },
+                    SuccessAction::Url { data } => SuccessActionProcessed::Url { data },
+                };
+                Some(processed_sa)
+            }
+            None => None,
+        };
+
+        Ok(LnUrlPayResult::EndpointSuccess {
+            data: model::LnUrlPaySuccessData {
+                payment,
+                success_action: maybe_sa_processed,
+            },
+        })
     }
 
     /// Second step of LNURL-withdraw. The first step is [parse], which also validates the LNURL destination

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -69,6 +69,8 @@ abstract class BindingLiquidSdk implements RustOpaqueInterface {
 
   Future<PrepareBuyBitcoinResponse> prepareBuyBitcoin({required PrepareBuyBitcoinRequest req});
 
+  Future<PrepareLnUrlPayResponse> prepareLnurlPay({required PrepareLnUrlPayRequest req});
+
   Future<PreparePayOnchainResponse> preparePayOnchain({required PreparePayOnchainRequest req});
 
   Future<PrepareReceiveResponse> prepareReceivePayment({required PrepareReceiveRequest req});
@@ -96,6 +98,30 @@ abstract class BindingLiquidSdk implements RustOpaqueInterface {
   Future<void> sync();
 
   Future<void> unregisterWebhook();
+}
+
+class AesSuccessActionData {
+  final String description;
+  final String ciphertext;
+  final String iv;
+
+  const AesSuccessActionData({
+    required this.description,
+    required this.ciphertext,
+    required this.iv,
+  });
+
+  @override
+  int get hashCode => description.hashCode ^ ciphertext.hashCode ^ iv.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AesSuccessActionData &&
+          runtimeType == other.runtimeType &&
+          description == other.description &&
+          ciphertext == other.ciphertext &&
+          iv == other.iv;
 }
 
 class AesSuccessActionDataDecrypted {
@@ -441,41 +467,6 @@ class LnUrlPayErrorData {
           reason == other.reason;
 }
 
-class LnUrlPayRequest {
-  final LnUrlPayRequestData data;
-  final BigInt amountMsat;
-  final String? comment;
-  final String? paymentLabel;
-  final bool? validateSuccessActionUrl;
-
-  const LnUrlPayRequest({
-    required this.data,
-    required this.amountMsat,
-    this.comment,
-    this.paymentLabel,
-    this.validateSuccessActionUrl,
-  });
-
-  @override
-  int get hashCode =>
-      data.hashCode ^
-      amountMsat.hashCode ^
-      comment.hashCode ^
-      paymentLabel.hashCode ^
-      validateSuccessActionUrl.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is LnUrlPayRequest &&
-          runtimeType == other.runtimeType &&
-          data == other.data &&
-          amountMsat == other.amountMsat &&
-          comment == other.comment &&
-          paymentLabel == other.paymentLabel &&
-          validateSuccessActionUrl == other.validateSuccessActionUrl;
-}
-
 class LnUrlPayRequestData {
   final String callback;
   final BigInt minSendable;
@@ -729,6 +720,21 @@ class RouteHintHop {
           cltvExpiryDelta == other.cltvExpiryDelta &&
           htlcMinimumMsat == other.htlcMinimumMsat &&
           htlcMaximumMsat == other.htlcMaximumMsat;
+}
+
+@freezed
+sealed class SuccessAction with _$SuccessAction {
+  const SuccessAction._();
+
+  const factory SuccessAction.aes({
+    required AesSuccessActionData data,
+  }) = SuccessAction_Aes;
+  const factory SuccessAction.message({
+    required MessageSuccessActionData data,
+  }) = SuccessAction_Message;
+  const factory SuccessAction.url({
+    required UrlSuccessActionData data,
+  }) = SuccessAction_Url;
 }
 
 @freezed

--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -932,6 +932,271 @@ abstract class InputType_LnUrlError extends InputType {
 }
 
 /// @nodoc
+mixin _$SuccessAction {
+  Object get data => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SuccessActionCopyWith<$Res> {
+  factory $SuccessActionCopyWith(SuccessAction value, $Res Function(SuccessAction) then) =
+      _$SuccessActionCopyWithImpl<$Res, SuccessAction>;
+}
+
+/// @nodoc
+class _$SuccessActionCopyWithImpl<$Res, $Val extends SuccessAction> implements $SuccessActionCopyWith<$Res> {
+  _$SuccessActionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$SuccessAction_AesImplCopyWith<$Res> {
+  factory _$$SuccessAction_AesImplCopyWith(
+          _$SuccessAction_AesImpl value, $Res Function(_$SuccessAction_AesImpl) then) =
+      __$$SuccessAction_AesImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({AesSuccessActionData data});
+}
+
+/// @nodoc
+class __$$SuccessAction_AesImplCopyWithImpl<$Res>
+    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_AesImpl>
+    implements _$$SuccessAction_AesImplCopyWith<$Res> {
+  __$$SuccessAction_AesImplCopyWithImpl(
+      _$SuccessAction_AesImpl _value, $Res Function(_$SuccessAction_AesImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$SuccessAction_AesImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as AesSuccessActionData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessAction_AesImpl extends SuccessAction_Aes {
+  const _$SuccessAction_AesImpl({required this.data}) : super._();
+
+  @override
+  final AesSuccessActionData data;
+
+  @override
+  String toString() {
+    return 'SuccessAction.aes(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessAction_AesImpl &&
+            (identical(other.data, data) || other.data == data));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessAction_AesImplCopyWith<_$SuccessAction_AesImpl> get copyWith =>
+      __$$SuccessAction_AesImplCopyWithImpl<_$SuccessAction_AesImpl>(this, _$identity);
+}
+
+abstract class SuccessAction_Aes extends SuccessAction {
+  const factory SuccessAction_Aes({required final AesSuccessActionData data}) = _$SuccessAction_AesImpl;
+  const SuccessAction_Aes._() : super._();
+
+  @override
+  AesSuccessActionData get data;
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessAction_AesImplCopyWith<_$SuccessAction_AesImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SuccessAction_MessageImplCopyWith<$Res> {
+  factory _$$SuccessAction_MessageImplCopyWith(
+          _$SuccessAction_MessageImpl value, $Res Function(_$SuccessAction_MessageImpl) then) =
+      __$$SuccessAction_MessageImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({MessageSuccessActionData data});
+}
+
+/// @nodoc
+class __$$SuccessAction_MessageImplCopyWithImpl<$Res>
+    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_MessageImpl>
+    implements _$$SuccessAction_MessageImplCopyWith<$Res> {
+  __$$SuccessAction_MessageImplCopyWithImpl(
+      _$SuccessAction_MessageImpl _value, $Res Function(_$SuccessAction_MessageImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$SuccessAction_MessageImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as MessageSuccessActionData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessAction_MessageImpl extends SuccessAction_Message {
+  const _$SuccessAction_MessageImpl({required this.data}) : super._();
+
+  @override
+  final MessageSuccessActionData data;
+
+  @override
+  String toString() {
+    return 'SuccessAction.message(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessAction_MessageImpl &&
+            (identical(other.data, data) || other.data == data));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessAction_MessageImplCopyWith<_$SuccessAction_MessageImpl> get copyWith =>
+      __$$SuccessAction_MessageImplCopyWithImpl<_$SuccessAction_MessageImpl>(this, _$identity);
+}
+
+abstract class SuccessAction_Message extends SuccessAction {
+  const factory SuccessAction_Message({required final MessageSuccessActionData data}) =
+      _$SuccessAction_MessageImpl;
+  const SuccessAction_Message._() : super._();
+
+  @override
+  MessageSuccessActionData get data;
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessAction_MessageImplCopyWith<_$SuccessAction_MessageImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SuccessAction_UrlImplCopyWith<$Res> {
+  factory _$$SuccessAction_UrlImplCopyWith(
+          _$SuccessAction_UrlImpl value, $Res Function(_$SuccessAction_UrlImpl) then) =
+      __$$SuccessAction_UrlImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({UrlSuccessActionData data});
+}
+
+/// @nodoc
+class __$$SuccessAction_UrlImplCopyWithImpl<$Res>
+    extends _$SuccessActionCopyWithImpl<$Res, _$SuccessAction_UrlImpl>
+    implements _$$SuccessAction_UrlImplCopyWith<$Res> {
+  __$$SuccessAction_UrlImplCopyWithImpl(
+      _$SuccessAction_UrlImpl _value, $Res Function(_$SuccessAction_UrlImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$SuccessAction_UrlImpl(
+      data: null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as UrlSuccessActionData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessAction_UrlImpl extends SuccessAction_Url {
+  const _$SuccessAction_UrlImpl({required this.data}) : super._();
+
+  @override
+  final UrlSuccessActionData data;
+
+  @override
+  String toString() {
+    return 'SuccessAction.url(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessAction_UrlImpl &&
+            (identical(other.data, data) || other.data == data));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data);
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessAction_UrlImplCopyWith<_$SuccessAction_UrlImpl> get copyWith =>
+      __$$SuccessAction_UrlImplCopyWithImpl<_$SuccessAction_UrlImpl>(this, _$identity);
+}
+
+abstract class SuccessAction_Url extends SuccessAction {
+  const factory SuccessAction_Url({required final UrlSuccessActionData data}) = _$SuccessAction_UrlImpl;
+  const SuccessAction_Url._() : super._();
+
+  @override
+  UrlSuccessActionData get data;
+
+  /// Create a copy of SuccessAction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessAction_UrlImplCopyWith<_$SuccessAction_UrlImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$SuccessActionProcessed {}
 
 /// @nodoc

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2550,10 +2550,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareLnUrlPayResponse dco_decode_prepare_ln_url_pay_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return PrepareLnUrlPayResponse(
-      prepareSendResponse: dco_decode_prepare_send_response(arr[0]),
-      successAction: dco_decode_opt_box_autoadd_success_action(arr[1]),
+      destination: dco_decode_send_destination(arr[0]),
+      feesSat: dco_decode_u_64(arr[1]),
+      successAction: dco_decode_opt_box_autoadd_success_action(arr[2]),
     );
   }
 
@@ -4400,10 +4401,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PrepareLnUrlPayResponse sse_decode_prepare_ln_url_pay_response(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_prepareSendResponse = sse_decode_prepare_send_response(deserializer);
+    var var_destination = sse_decode_send_destination(deserializer);
+    var var_feesSat = sse_decode_u_64(deserializer);
     var var_successAction = sse_decode_opt_box_autoadd_success_action(deserializer);
     return PrepareLnUrlPayResponse(
-        prepareSendResponse: var_prepareSendResponse, successAction: var_successAction);
+        destination: var_destination, feesSat: var_feesSat, successAction: var_successAction);
   }
 
   @protected
@@ -6134,7 +6136,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_prepare_ln_url_pay_response(PrepareLnUrlPayResponse self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_prepare_send_response(self.prepareSendResponse, serializer);
+    sse_encode_send_destination(self.destination, serializer);
+    sse_encode_u_64(self.feesSat, serializer);
     sse_encode_opt_box_autoadd_success_action(self.successAction, serializer);
   }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -65,7 +65,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.4.0';
 
   @override
-  int get rustContentHash => 1147354100;
+  int get rustContentHash => 425220482;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'breez_sdk_liquid',
@@ -124,6 +124,9 @@ abstract class RustLibApi extends BaseApi {
 
   Future<PrepareBuyBitcoinResponse> crateBindingsBindingLiquidSdkPrepareBuyBitcoin(
       {required BindingLiquidSdk that, required PrepareBuyBitcoinRequest req});
+
+  Future<PrepareLnUrlPayResponse> crateBindingsBindingLiquidSdkPrepareLnurlPay(
+      {required BindingLiquidSdk that, required PrepareLnUrlPayRequest req});
 
   Future<PreparePayOnchainResponse> crateBindingsBindingLiquidSdkPreparePayOnchain(
       {required BindingLiquidSdk that, required PreparePayOnchainRequest req});
@@ -669,6 +672,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateBindingsBindingLiquidSdkPrepareBuyBitcoinConstMeta => const TaskConstMeta(
         debugName: "BindingLiquidSdk_prepare_buy_bitcoin",
+        argNames: ["that", "req"],
+      );
+
+  @override
+  Future<PrepareLnUrlPayResponse> crateBindingsBindingLiquidSdkPrepareLnurlPay(
+      {required BindingLiquidSdk that, required PrepareLnUrlPayRequest req}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        var arg0 =
+            cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(
+                that);
+        var arg1 = cst_encode_box_autoadd_prepare_ln_url_pay_request(req);
+        return wire.wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(port_, arg0, arg1);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_prepare_ln_url_pay_response,
+        decodeErrorData: dco_decode_ln_url_pay_error,
+      ),
+      constMeta: kCrateBindingsBindingLiquidSdkPrepareLnurlPayConstMeta,
+      argValues: [that, req],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateBindingsBindingLiquidSdkPrepareLnurlPayConstMeta => const TaskConstMeta(
+        debugName: "BindingLiquidSdk_prepare_lnurl_pay",
         argNames: ["that", "req"],
       );
 
@@ -1219,6 +1248,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AesSuccessActionData dco_decode_aes_success_action_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return AesSuccessActionData(
+      description: dco_decode_String(arr[0]),
+      ciphertext: dco_decode_String(arr[1]),
+      iv: dco_decode_String(arr[2]),
+    );
+  }
+
+  @protected
   AesSuccessActionDataDecrypted dco_decode_aes_success_action_data_decrypted(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -1284,6 +1325,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   bool dco_decode_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as bool;
+  }
+
+  @protected
+  AesSuccessActionData dco_decode_box_autoadd_aes_success_action_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_aes_success_action_data(raw);
   }
 
   @protected
@@ -1455,6 +1502,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PrepareLnUrlPayRequest dco_decode_box_autoadd_prepare_ln_url_pay_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_prepare_ln_url_pay_request(raw);
+  }
+
+  @protected
   PreparePayOnchainRequest dco_decode_box_autoadd_prepare_pay_onchain_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_prepare_pay_onchain_request(raw);
@@ -1512,6 +1565,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SignMessageRequest dco_decode_box_autoadd_sign_message_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_sign_message_request(raw);
+  }
+
+  @protected
+  SuccessAction dco_decode_box_autoadd_success_action(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_success_action(raw);
   }
 
   @protected
@@ -2014,13 +2073,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LnUrlPayRequest dco_decode_ln_url_pay_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return LnUrlPayRequest(
-      data: dco_decode_ln_url_pay_request_data(arr[0]),
-      amountMsat: dco_decode_u_64(arr[1]),
-      comment: dco_decode_opt_String(arr[2]),
-      paymentLabel: dco_decode_opt_String(arr[3]),
-      validateSuccessActionUrl: dco_decode_opt_box_autoadd_bool(arr[4]),
+      prepareResponse: dco_decode_prepare_ln_url_pay_response(arr[0]),
     );
   }
 
@@ -2256,6 +2311,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SuccessAction? dco_decode_opt_box_autoadd_success_action(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_success_action(raw);
+  }
+
+  @protected
   SuccessActionProcessed? dco_decode_opt_box_autoadd_success_action_processed(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_success_action_processed(raw);
@@ -2469,6 +2530,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       provider: dco_decode_buy_bitcoin_provider(arr[0]),
       amountSat: dco_decode_u_64(arr[1]),
       feesSat: dco_decode_u_64(arr[2]),
+    );
+  }
+
+  @protected
+  PrepareLnUrlPayRequest dco_decode_prepare_ln_url_pay_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return PrepareLnUrlPayRequest(
+      data: dco_decode_ln_url_pay_request_data(arr[0]),
+      amountMsat: dco_decode_u_64(arr[1]),
+      comment: dco_decode_opt_String(arr[2]),
+      validateSuccessActionUrl: dco_decode_opt_box_autoadd_bool(arr[3]),
+    );
+  }
+
+  @protected
+  PrepareLnUrlPayResponse dco_decode_prepare_ln_url_pay_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return PrepareLnUrlPayResponse(
+      prepareSendResponse: dco_decode_prepare_send_response(arr[0]),
+      successAction: dco_decode_opt_box_autoadd_success_action(arr[1]),
     );
   }
 
@@ -2795,6 +2880,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SuccessAction dco_decode_success_action(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return SuccessAction_Aes(
+          data: dco_decode_box_autoadd_aes_success_action_data(raw[1]),
+        );
+      case 1:
+        return SuccessAction_Message(
+          data: dco_decode_box_autoadd_message_success_action_data(raw[1]),
+        );
+      case 2:
+        return SuccessAction_Url(
+          data: dco_decode_box_autoadd_url_success_action_data(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   SuccessActionProcessed dco_decode_success_action_processed(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -2929,6 +3035,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AesSuccessActionData sse_decode_aes_success_action_data(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_description = sse_decode_String(deserializer);
+    var var_ciphertext = sse_decode_String(deserializer);
+    var var_iv = sse_decode_String(deserializer);
+    return AesSuccessActionData(description: var_description, ciphertext: var_ciphertext, iv: var_iv);
+  }
+
+  @protected
   AesSuccessActionDataDecrypted sse_decode_aes_success_action_data_decrypted(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_description = sse_decode_String(deserializer);
@@ -2987,6 +3102,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   bool sse_decode_bool(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint8() != 0;
+  }
+
+  @protected
+  AesSuccessActionData sse_decode_box_autoadd_aes_success_action_data(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_aes_success_action_data(deserializer));
   }
 
   @protected
@@ -3160,6 +3281,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PrepareLnUrlPayRequest sse_decode_box_autoadd_prepare_ln_url_pay_request(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_prepare_ln_url_pay_request(deserializer));
+  }
+
+  @protected
   PreparePayOnchainRequest sse_decode_box_autoadd_prepare_pay_onchain_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_prepare_pay_onchain_request(deserializer));
@@ -3217,6 +3344,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SignMessageRequest sse_decode_box_autoadd_sign_message_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_sign_message_request(deserializer));
+  }
+
+  @protected
+  SuccessAction sse_decode_box_autoadd_success_action(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_success_action(deserializer));
   }
 
   @protected
@@ -3756,17 +3889,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LnUrlPayRequest sse_decode_ln_url_pay_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_data = sse_decode_ln_url_pay_request_data(deserializer);
-    var var_amountMsat = sse_decode_u_64(deserializer);
-    var var_comment = sse_decode_opt_String(deserializer);
-    var var_paymentLabel = sse_decode_opt_String(deserializer);
-    var var_validateSuccessActionUrl = sse_decode_opt_box_autoadd_bool(deserializer);
-    return LnUrlPayRequest(
-        data: var_data,
-        amountMsat: var_amountMsat,
-        comment: var_comment,
-        paymentLabel: var_paymentLabel,
-        validateSuccessActionUrl: var_validateSuccessActionUrl);
+    var var_prepareResponse = sse_decode_prepare_ln_url_pay_response(deserializer);
+    return LnUrlPayRequest(prepareResponse: var_prepareResponse);
   }
 
   @protected
@@ -3999,6 +4123,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_payment(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  SuccessAction? sse_decode_opt_box_autoadd_success_action(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_success_action(deserializer));
     } else {
       return null;
     }
@@ -4246,6 +4381,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_amountSat = sse_decode_u_64(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
     return PrepareBuyBitcoinResponse(provider: var_provider, amountSat: var_amountSat, feesSat: var_feesSat);
+  }
+
+  @protected
+  PrepareLnUrlPayRequest sse_decode_prepare_ln_url_pay_request(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_data = sse_decode_ln_url_pay_request_data(deserializer);
+    var var_amountMsat = sse_decode_u_64(deserializer);
+    var var_comment = sse_decode_opt_String(deserializer);
+    var var_validateSuccessActionUrl = sse_decode_opt_box_autoadd_bool(deserializer);
+    return PrepareLnUrlPayRequest(
+        data: var_data,
+        amountMsat: var_amountMsat,
+        comment: var_comment,
+        validateSuccessActionUrl: var_validateSuccessActionUrl);
+  }
+
+  @protected
+  PrepareLnUrlPayResponse sse_decode_prepare_ln_url_pay_response(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_prepareSendResponse = sse_decode_prepare_send_response(deserializer);
+    var var_successAction = sse_decode_opt_box_autoadd_success_action(deserializer);
+    return PrepareLnUrlPayResponse(
+        prepareSendResponse: var_prepareSendResponse, successAction: var_successAction);
   }
 
   @protected
@@ -4526,6 +4684,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SuccessAction sse_decode_success_action(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_data = sse_decode_box_autoadd_aes_success_action_data(deserializer);
+        return SuccessAction_Aes(data: var_data);
+      case 1:
+        var var_data = sse_decode_box_autoadd_message_success_action_data(deserializer);
+        return SuccessAction_Message(data: var_data);
+      case 2:
+        var var_data = sse_decode_box_autoadd_url_success_action_data(deserializer);
+        return SuccessAction_Url(data: var_data);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   SuccessActionProcessed sse_decode_success_action_processed(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4760,6 +4938,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_aes_success_action_data(AesSuccessActionData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.description, serializer);
+    sse_encode_String(self.ciphertext, serializer);
+    sse_encode_String(self.iv, serializer);
+  }
+
+  @protected
   void sse_encode_aes_success_action_data_decrypted(
       AesSuccessActionDataDecrypted self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -4808,6 +4994,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_bool(bool self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putUint8(self ? 1 : 0);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_aes_success_action_data(AesSuccessActionData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_aes_success_action_data(self, serializer);
   }
 
   @protected
@@ -4985,6 +5177,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_prepare_ln_url_pay_request(
+      PrepareLnUrlPayRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_prepare_ln_url_pay_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_prepare_pay_onchain_request(
       PreparePayOnchainRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5043,6 +5242,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_box_autoadd_sign_message_request(SignMessageRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_sign_message_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_success_action(SuccessAction self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_success_action(self, serializer);
   }
 
   @protected
@@ -5483,11 +5688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_ln_url_pay_request(LnUrlPayRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_ln_url_pay_request_data(self.data, serializer);
-    sse_encode_u_64(self.amountMsat, serializer);
-    sse_encode_opt_String(self.comment, serializer);
-    sse_encode_opt_String(self.paymentLabel, serializer);
-    sse_encode_opt_box_autoadd_bool(self.validateSuccessActionUrl, serializer);
+    sse_encode_prepare_ln_url_pay_response(self.prepareResponse, serializer);
   }
 
   @protected
@@ -5687,6 +5888,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_payment(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_success_action(SuccessAction? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_success_action(self, serializer);
     }
   }
 
@@ -5909,6 +6120,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_buy_bitcoin_provider(self.provider, serializer);
     sse_encode_u_64(self.amountSat, serializer);
     sse_encode_u_64(self.feesSat, serializer);
+  }
+
+  @protected
+  void sse_encode_prepare_ln_url_pay_request(PrepareLnUrlPayRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ln_url_pay_request_data(self.data, serializer);
+    sse_encode_u_64(self.amountMsat, serializer);
+    sse_encode_opt_String(self.comment, serializer);
+    sse_encode_opt_box_autoadd_bool(self.validateSuccessActionUrl, serializer);
+  }
+
+  @protected
+  void sse_encode_prepare_ln_url_pay_response(PrepareLnUrlPayResponse self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_prepare_send_response(self.prepareSendResponse, serializer);
+    sse_encode_opt_box_autoadd_success_action(self.successAction, serializer);
   }
 
   @protected
@@ -6136,6 +6363,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_success_action(SuccessAction self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case SuccessAction_Aes(data: final data):
+        sse_encode_i_32(0, serializer);
+        sse_encode_box_autoadd_aes_success_action_data(data, serializer);
+      case SuccessAction_Message(data: final data):
+        sse_encode_i_32(1, serializer);
+        sse_encode_box_autoadd_message_success_action_data(data, serializer);
+      case SuccessAction_Url(data: final data):
+        sse_encode_i_32(2, serializer);
+        sse_encode_box_autoadd_url_success_action_data(data, serializer);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   void sse_encode_success_action_processed(SuccessActionProcessed self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
@@ -6291,6 +6536,9 @@ class BindingLiquidSdkImpl extends RustOpaque implements BindingLiquidSdk {
 
   Future<PrepareBuyBitcoinResponse> prepareBuyBitcoin({required PrepareBuyBitcoinRequest req}) =>
       RustLib.instance.api.crateBindingsBindingLiquidSdkPrepareBuyBitcoin(that: this, req: req);
+
+  Future<PrepareLnUrlPayResponse> prepareLnurlPay({required PrepareLnUrlPayRequest req}) =>
+      RustLib.instance.api.crateBindingsBindingLiquidSdkPrepareLnurlPay(that: this, req: req);
 
   Future<PreparePayOnchainResponse> preparePayOnchain({required PreparePayOnchainRequest req}) =>
       RustLib.instance.api.crateBindingsBindingLiquidSdkPreparePayOnchain(that: this, req: req);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -51,6 +51,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  AesSuccessActionData dco_decode_aes_success_action_data(dynamic raw);
+
+  @protected
   AesSuccessActionDataDecrypted dco_decode_aes_success_action_data_decrypted(dynamic raw);
 
   @protected
@@ -67,6 +70,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   bool dco_decode_bool(dynamic raw);
+
+  @protected
+  AesSuccessActionData dco_decode_box_autoadd_aes_success_action_data(dynamic raw);
 
   @protected
   AesSuccessActionDataDecrypted dco_decode_box_autoadd_aes_success_action_data_decrypted(dynamic raw);
@@ -153,6 +159,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PrepareBuyBitcoinRequest dco_decode_box_autoadd_prepare_buy_bitcoin_request(dynamic raw);
 
   @protected
+  PrepareLnUrlPayRequest dco_decode_box_autoadd_prepare_ln_url_pay_request(dynamic raw);
+
+  @protected
   PreparePayOnchainRequest dco_decode_box_autoadd_prepare_pay_onchain_request(dynamic raw);
 
   @protected
@@ -181,6 +190,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignMessageRequest dco_decode_box_autoadd_sign_message_request(dynamic raw);
+
+  @protected
+  SuccessAction dco_decode_box_autoadd_success_action(dynamic raw);
 
   @protected
   SuccessActionProcessed dco_decode_box_autoadd_success_action_processed(dynamic raw);
@@ -369,6 +381,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Payment? dco_decode_opt_box_autoadd_payment(dynamic raw);
 
   @protected
+  SuccessAction? dco_decode_opt_box_autoadd_success_action(dynamic raw);
+
+  @protected
   SuccessActionProcessed? dco_decode_opt_box_autoadd_success_action_processed(dynamic raw);
 
   @protected
@@ -412,6 +427,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PrepareBuyBitcoinResponse dco_decode_prepare_buy_bitcoin_response(dynamic raw);
+
+  @protected
+  PrepareLnUrlPayRequest dco_decode_prepare_ln_url_pay_request(dynamic raw);
+
+  @protected
+  PrepareLnUrlPayResponse dco_decode_prepare_ln_url_pay_response(dynamic raw);
 
   @protected
   PreparePayOnchainRequest dco_decode_prepare_pay_onchain_request(dynamic raw);
@@ -489,6 +510,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   SignMessageResponse dco_decode_sign_message_response(dynamic raw);
 
   @protected
+  SuccessAction dco_decode_success_action(dynamic raw);
+
+  @protected
   SuccessActionProcessed dco_decode_success_action_processed(dynamic raw);
 
   @protected
@@ -542,6 +566,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  AesSuccessActionData sse_decode_aes_success_action_data(SseDeserializer deserializer);
+
+  @protected
   AesSuccessActionDataDecrypted sse_decode_aes_success_action_data_decrypted(SseDeserializer deserializer);
 
   @protected
@@ -558,6 +585,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   bool sse_decode_bool(SseDeserializer deserializer);
+
+  @protected
+  AesSuccessActionData sse_decode_box_autoadd_aes_success_action_data(SseDeserializer deserializer);
 
   @protected
   AesSuccessActionDataDecrypted sse_decode_box_autoadd_aes_success_action_data_decrypted(
@@ -646,6 +676,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PrepareBuyBitcoinRequest sse_decode_box_autoadd_prepare_buy_bitcoin_request(SseDeserializer deserializer);
 
   @protected
+  PrepareLnUrlPayRequest sse_decode_box_autoadd_prepare_ln_url_pay_request(SseDeserializer deserializer);
+
+  @protected
   PreparePayOnchainRequest sse_decode_box_autoadd_prepare_pay_onchain_request(SseDeserializer deserializer);
 
   @protected
@@ -674,6 +707,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignMessageRequest sse_decode_box_autoadd_sign_message_request(SseDeserializer deserializer);
+
+  @protected
+  SuccessAction sse_decode_box_autoadd_success_action(SseDeserializer deserializer);
 
   @protected
   SuccessActionProcessed sse_decode_box_autoadd_success_action_processed(SseDeserializer deserializer);
@@ -862,6 +898,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Payment? sse_decode_opt_box_autoadd_payment(SseDeserializer deserializer);
 
   @protected
+  SuccessAction? sse_decode_opt_box_autoadd_success_action(SseDeserializer deserializer);
+
+  @protected
   SuccessActionProcessed? sse_decode_opt_box_autoadd_success_action_processed(SseDeserializer deserializer);
 
   @protected
@@ -905,6 +944,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PrepareBuyBitcoinResponse sse_decode_prepare_buy_bitcoin_response(SseDeserializer deserializer);
+
+  @protected
+  PrepareLnUrlPayRequest sse_decode_prepare_ln_url_pay_request(SseDeserializer deserializer);
+
+  @protected
+  PrepareLnUrlPayResponse sse_decode_prepare_ln_url_pay_response(SseDeserializer deserializer);
 
   @protected
   PreparePayOnchainRequest sse_decode_prepare_pay_onchain_request(SseDeserializer deserializer);
@@ -982,6 +1027,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   SignMessageResponse sse_decode_sign_message_response(SseDeserializer deserializer);
 
   @protected
+  SuccessAction sse_decode_success_action(SseDeserializer deserializer);
+
+  @protected
   SuccessActionProcessed sse_decode_success_action_processed(SseDeserializer deserializer);
 
   @protected
@@ -1040,6 +1088,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_String(String raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_list_prim_u_8_strict(utf8.encoder.convert(raw));
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_aes_success_action_data> cst_encode_box_autoadd_aes_success_action_data(
+      AesSuccessActionData raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_aes_success_action_data();
+    cst_api_fill_to_wire_aes_success_action_data(raw, ptr.ref);
+    return ptr;
   }
 
   @protected
@@ -1283,6 +1340,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_prepare_ln_url_pay_request> cst_encode_box_autoadd_prepare_ln_url_pay_request(
+      PrepareLnUrlPayRequest raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_prepare_ln_url_pay_request();
+    cst_api_fill_to_wire_prepare_ln_url_pay_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_prepare_pay_onchain_request> cst_encode_box_autoadd_prepare_pay_onchain_request(
       PreparePayOnchainRequest raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1366,6 +1432,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_sign_message_request();
     cst_api_fill_to_wire_sign_message_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_success_action> cst_encode_box_autoadd_success_action(SuccessAction raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_success_action();
+    cst_api_fill_to_wire_success_action(raw, ptr.ref);
     return ptr;
   }
 
@@ -1543,6 +1617,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_success_action> cst_encode_opt_box_autoadd_success_action(SuccessAction? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_success_action(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_cst_success_action_processed> cst_encode_opt_box_autoadd_success_action_processed(
       SuccessActionProcessed? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1583,6 +1663,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int cst_encode_usize(BigInt raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw.toSigned(64).toInt();
+  }
+
+  @protected
+  void cst_api_fill_to_wire_aes_success_action_data(
+      AesSuccessActionData apiObj, wire_cst_aes_success_action_data wireObj) {
+    wireObj.description = cst_encode_String(apiObj.description);
+    wireObj.ciphertext = cst_encode_String(apiObj.ciphertext);
+    wireObj.iv = cst_encode_String(apiObj.iv);
   }
 
   @protected
@@ -1628,6 +1716,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.amountSat);
     wireObj.label = cst_encode_opt_String(apiObj.label);
     wireObj.message = cst_encode_opt_String(apiObj.message);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_aes_success_action_data(
+      AesSuccessActionData apiObj, ffi.Pointer<wire_cst_aes_success_action_data> wireObj) {
+    cst_api_fill_to_wire_aes_success_action_data(apiObj, wireObj.ref);
   }
 
   @protected
@@ -1786,6 +1880,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_prepare_ln_url_pay_request(
+      PrepareLnUrlPayRequest apiObj, ffi.Pointer<wire_cst_prepare_ln_url_pay_request> wireObj) {
+    cst_api_fill_to_wire_prepare_ln_url_pay_request(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_prepare_pay_onchain_request(
       PreparePayOnchainRequest apiObj, ffi.Pointer<wire_cst_prepare_pay_onchain_request> wireObj) {
     cst_api_fill_to_wire_prepare_pay_onchain_request(apiObj, wireObj.ref);
@@ -1842,6 +1942,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_box_autoadd_sign_message_request(
       SignMessageRequest apiObj, ffi.Pointer<wire_cst_sign_message_request> wireObj) {
     cst_api_fill_to_wire_sign_message_request(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_success_action(
+      SuccessAction apiObj, ffi.Pointer<wire_cst_success_action> wireObj) {
+    cst_api_fill_to_wire_success_action(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2198,11 +2304,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_ln_url_pay_request(LnUrlPayRequest apiObj, wire_cst_ln_url_pay_request wireObj) {
-    cst_api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
-    wireObj.amount_msat = cst_encode_u_64(apiObj.amountMsat);
-    wireObj.comment = cst_encode_opt_String(apiObj.comment);
-    wireObj.payment_label = cst_encode_opt_String(apiObj.paymentLabel);
-    wireObj.validate_success_action_url = cst_encode_opt_box_autoadd_bool(apiObj.validateSuccessActionUrl);
+    cst_api_fill_to_wire_prepare_ln_url_pay_response(apiObj.prepareResponse, wireObj.prepare_response);
   }
 
   @protected
@@ -2569,6 +2671,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_prepare_ln_url_pay_request(
+      PrepareLnUrlPayRequest apiObj, wire_cst_prepare_ln_url_pay_request wireObj) {
+    cst_api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
+    wireObj.amount_msat = cst_encode_u_64(apiObj.amountMsat);
+    wireObj.comment = cst_encode_opt_String(apiObj.comment);
+    wireObj.validate_success_action_url = cst_encode_opt_box_autoadd_bool(apiObj.validateSuccessActionUrl);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_prepare_ln_url_pay_response(
+      PrepareLnUrlPayResponse apiObj, wire_cst_prepare_ln_url_pay_response wireObj) {
+    cst_api_fill_to_wire_prepare_send_response(apiObj.prepareSendResponse, wireObj.prepare_send_response);
+    wireObj.success_action = cst_encode_opt_box_autoadd_success_action(apiObj.successAction);
+  }
+
+  @protected
   void cst_api_fill_to_wire_prepare_pay_onchain_request(
       PreparePayOnchainRequest apiObj, wire_cst_prepare_pay_onchain_request wireObj) {
     cst_api_fill_to_wire_pay_onchain_amount(apiObj.amount, wireObj.amount);
@@ -2806,6 +2924,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_success_action(SuccessAction apiObj, wire_cst_success_action wireObj) {
+    if (apiObj is SuccessAction_Aes) {
+      var pre_data = cst_encode_box_autoadd_aes_success_action_data(apiObj.data);
+      wireObj.tag = 0;
+      wireObj.kind.Aes.data = pre_data;
+      return;
+    }
+    if (apiObj is SuccessAction_Message) {
+      var pre_data = cst_encode_box_autoadd_message_success_action_data(apiObj.data);
+      wireObj.tag = 1;
+      wireObj.kind.Message.data = pre_data;
+      return;
+    }
+    if (apiObj is SuccessAction_Url) {
+      var pre_data = cst_encode_box_autoadd_url_success_action_data(apiObj.data);
+      wireObj.tag = 2;
+      wireObj.kind.Url.data = pre_data;
+      return;
+    }
+  }
+
+  @protected
   void cst_api_fill_to_wire_success_action_processed(
       SuccessActionProcessed apiObj, wire_cst_success_action_processed wireObj) {
     if (apiObj is SuccessActionProcessed_Aes) {
@@ -2920,6 +3060,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_aes_success_action_data(AesSuccessActionData self, SseSerializer serializer);
+
+  @protected
   void sse_encode_aes_success_action_data_decrypted(
       AesSuccessActionDataDecrypted self, SseSerializer serializer);
 
@@ -2937,6 +3080,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_aes_success_action_data(AesSuccessActionData self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_aes_success_action_data_decrypted(
@@ -3029,6 +3175,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PrepareBuyBitcoinRequest self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_prepare_ln_url_pay_request(
+      PrepareLnUrlPayRequest self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_prepare_pay_onchain_request(
       PreparePayOnchainRequest self, SseSerializer serializer);
 
@@ -3058,6 +3208,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_sign_message_request(SignMessageRequest self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_success_action(SuccessAction self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_success_action_processed(SuccessActionProcessed self, SseSerializer serializer);
@@ -3248,6 +3401,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_opt_box_autoadd_payment(Payment? self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_success_action(SuccessAction? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_box_autoadd_success_action_processed(
       SuccessActionProcessed? self, SseSerializer serializer);
 
@@ -3292,6 +3448,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_prepare_buy_bitcoin_response(PrepareBuyBitcoinResponse self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_prepare_ln_url_pay_request(PrepareLnUrlPayRequest self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_prepare_ln_url_pay_response(PrepareLnUrlPayResponse self, SseSerializer serializer);
 
   @protected
   void sse_encode_prepare_pay_onchain_request(PreparePayOnchainRequest self, SseSerializer serializer);
@@ -3367,6 +3529,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_sign_message_response(SignMessageResponse self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_success_action(SuccessAction self, SseSerializer serializer);
 
   @protected
   void sse_encode_success_action_processed(SuccessActionProcessed self, SseSerializer serializer);
@@ -3775,6 +3940,26 @@ class RustLibWire implements BaseWire {
       _wire__crate__bindings__BindingLiquidSdk_prepare_buy_bitcoinPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_buy_bitcoin_request>)>();
 
+  void wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(
+    int port_,
+    int that,
+    ffi.Pointer<wire_cst_prepare_ln_url_pay_request> req,
+  ) {
+    return _wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(
+      port_,
+      that,
+      req,
+    );
+  }
+
+  late final _wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_payPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.UintPtr, ffi.Pointer<wire_cst_prepare_ln_url_pay_request>)>>(
+      'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay');
+  late final _wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay =
+      _wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_payPtr
+          .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_ln_url_pay_request>)>();
+
   void wire__crate__bindings__BindingLiquidSdk_prepare_pay_onchain(
     int port_,
     int that,
@@ -4168,6 +4353,16 @@ class RustLibWire implements BaseWire {
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdkPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
+  ffi.Pointer<wire_cst_aes_success_action_data> cst_new_box_autoadd_aes_success_action_data() {
+    return _cst_new_box_autoadd_aes_success_action_data();
+  }
+
+  late final _cst_new_box_autoadd_aes_success_action_dataPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_aes_success_action_data> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data');
+  late final _cst_new_box_autoadd_aes_success_action_data = _cst_new_box_autoadd_aes_success_action_dataPtr
+      .asFunction<ffi.Pointer<wire_cst_aes_success_action_data> Function()>();
+
   ffi.Pointer<wire_cst_aes_success_action_data_decrypted>
       cst_new_box_autoadd_aes_success_action_data_decrypted() {
     return _cst_new_box_autoadd_aes_success_action_data_decrypted();
@@ -4463,6 +4658,17 @@ class RustLibWire implements BaseWire {
       _cst_new_box_autoadd_prepare_buy_bitcoin_requestPtr
           .asFunction<ffi.Pointer<wire_cst_prepare_buy_bitcoin_request> Function()>();
 
+  ffi.Pointer<wire_cst_prepare_ln_url_pay_request> cst_new_box_autoadd_prepare_ln_url_pay_request() {
+    return _cst_new_box_autoadd_prepare_ln_url_pay_request();
+  }
+
+  late final _cst_new_box_autoadd_prepare_ln_url_pay_requestPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_prepare_ln_url_pay_request> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request');
+  late final _cst_new_box_autoadd_prepare_ln_url_pay_request =
+      _cst_new_box_autoadd_prepare_ln_url_pay_requestPtr
+          .asFunction<ffi.Pointer<wire_cst_prepare_ln_url_pay_request> Function()>();
+
   ffi.Pointer<wire_cst_prepare_pay_onchain_request> cst_new_box_autoadd_prepare_pay_onchain_request() {
     return _cst_new_box_autoadd_prepare_pay_onchain_request();
   }
@@ -4563,6 +4769,16 @@ class RustLibWire implements BaseWire {
           'frbgen_breez_liquid_cst_new_box_autoadd_sign_message_request');
   late final _cst_new_box_autoadd_sign_message_request = _cst_new_box_autoadd_sign_message_requestPtr
       .asFunction<ffi.Pointer<wire_cst_sign_message_request> Function()>();
+
+  ffi.Pointer<wire_cst_success_action> cst_new_box_autoadd_success_action() {
+    return _cst_new_box_autoadd_success_action();
+  }
+
+  late final _cst_new_box_autoadd_success_actionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_success_action> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_success_action');
+  late final _cst_new_box_autoadd_success_action =
+      _cst_new_box_autoadd_success_actionPtr.asFunction<ffi.Pointer<wire_cst_success_action> Function()>();
 
   ffi.Pointer<wire_cst_success_action_processed> cst_new_box_autoadd_success_action_processed() {
     return _cst_new_box_autoadd_success_action_processed();
@@ -4882,166 +5098,6 @@ final class wire_cst_ln_url_auth_request_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
 }
 
-final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  @ffi.Uint64()
-  external int min_sendable;
-
-  @ffi.Uint64()
-  external int max_sendable;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
-
-  @ffi.Uint16()
-  external int comment_allowed;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
-
-  @ffi.Bool()
-  external bool allows_nostr;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
-}
-
-final class wire_cst_ln_url_pay_request extends ffi.Struct {
-  external wire_cst_ln_url_pay_request_data data;
-
-  @ffi.Uint64()
-  external int amount_msat;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_label;
-
-  external ffi.Pointer<ffi.Bool> validate_success_action_url;
-}
-
-final class wire_cst_ln_url_withdraw_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> k1;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> default_description;
-
-  @ffi.Uint64()
-  external int min_withdrawable;
-
-  @ffi.Uint64()
-  external int max_withdrawable;
-}
-
-final class wire_cst_ln_url_withdraw_request extends ffi.Struct {
-  external wire_cst_ln_url_withdraw_request_data data;
-
-  @ffi.Uint64()
-  external int amount_msat;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-}
-
-final class wire_cst_prepare_pay_onchain_response extends ffi.Struct {
-  @ffi.Uint64()
-  external int receiver_amount_sat;
-
-  @ffi.Uint64()
-  external int claim_fees_sat;
-
-  @ffi.Uint64()
-  external int total_fees_sat;
-}
-
-final class wire_cst_pay_onchain_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
-
-  external wire_cst_prepare_pay_onchain_response prepare_response;
-}
-
-final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
-  @ffi.Int32()
-  external int provider;
-
-  @ffi.Uint64()
-  external int amount_sat;
-}
-
-final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_sat;
-}
-
-final class PayOnchainAmountKind extends ffi.Union {
-  external wire_cst_PayOnchainAmount_Receiver Receiver;
-}
-
-final class wire_cst_pay_onchain_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external PayOnchainAmountKind kind;
-}
-
-final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
-  external wire_cst_pay_onchain_amount amount;
-
-  external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_prepare_receive_request extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
-
-  @ffi.Int32()
-  external int payment_method;
-}
-
-final class wire_cst_prepare_refund_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
-
-  @ffi.Uint32()
-  external int fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_prepare_send_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
-
-  external ffi.Pointer<ffi.Uint64> amount_sat;
-}
-
-final class wire_cst_prepare_receive_response extends ffi.Struct {
-  @ffi.Int32()
-  external int payment_method;
-
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
-
-  @ffi.Uint64()
-  external int fees_sat;
-}
-
-final class wire_cst_receive_payment_request extends ffi.Struct {
-  external wire_cst_prepare_receive_response prepare_response;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<ffi.Bool> use_description_hash;
-}
-
-final class wire_cst_refund_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
-
-  @ffi.Uint32()
-  external int fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_restore_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
-}
-
 final class wire_cst_liquid_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -5150,6 +5206,222 @@ final class wire_cst_prepare_send_response extends ffi.Struct {
 
   @ffi.Uint64()
   external int fees_sat;
+}
+
+final class wire_cst_aes_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ciphertext;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iv;
+}
+
+final class wire_cst_SuccessAction_Aes extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data> data;
+}
+
+final class wire_cst_message_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
+}
+
+final class wire_cst_SuccessAction_Message extends ffi.Struct {
+  external ffi.Pointer<wire_cst_message_success_action_data> data;
+}
+
+final class wire_cst_url_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
+
+  @ffi.Bool()
+  external bool matches_callback_domain;
+}
+
+final class wire_cst_SuccessAction_Url extends ffi.Struct {
+  external ffi.Pointer<wire_cst_url_success_action_data> data;
+}
+
+final class SuccessActionKind extends ffi.Union {
+  external wire_cst_SuccessAction_Aes Aes;
+
+  external wire_cst_SuccessAction_Message Message;
+
+  external wire_cst_SuccessAction_Url Url;
+}
+
+final class wire_cst_success_action extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SuccessActionKind kind;
+}
+
+final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
+  external wire_cst_prepare_send_response prepare_send_response;
+
+  external ffi.Pointer<wire_cst_success_action> success_action;
+}
+
+final class wire_cst_ln_url_pay_request extends ffi.Struct {
+  external wire_cst_prepare_ln_url_pay_response prepare_response;
+}
+
+final class wire_cst_ln_url_withdraw_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> k1;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> default_description;
+
+  @ffi.Uint64()
+  external int min_withdrawable;
+
+  @ffi.Uint64()
+  external int max_withdrawable;
+}
+
+final class wire_cst_ln_url_withdraw_request extends ffi.Struct {
+  external wire_cst_ln_url_withdraw_request_data data;
+
+  @ffi.Uint64()
+  external int amount_msat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+}
+
+final class wire_cst_prepare_pay_onchain_response extends ffi.Struct {
+  @ffi.Uint64()
+  external int receiver_amount_sat;
+
+  @ffi.Uint64()
+  external int claim_fees_sat;
+
+  @ffi.Uint64()
+  external int total_fees_sat;
+}
+
+final class wire_cst_pay_onchain_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
+
+  external wire_cst_prepare_pay_onchain_response prepare_response;
+}
+
+final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
+  @ffi.Int32()
+  external int provider;
+
+  @ffi.Uint64()
+  external int amount_sat;
+}
+
+final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  @ffi.Uint64()
+  external int min_sendable;
+
+  @ffi.Uint64()
+  external int max_sendable;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
+
+  @ffi.Uint16()
+  external int comment_allowed;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
+
+  @ffi.Bool()
+  external bool allows_nostr;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+}
+
+final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
+  external wire_cst_ln_url_pay_request_data data;
+
+  @ffi.Uint64()
+  external int amount_msat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
+
+  external ffi.Pointer<ffi.Bool> validate_success_action_url;
+}
+
+final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_sat;
+}
+
+final class PayOnchainAmountKind extends ffi.Union {
+  external wire_cst_PayOnchainAmount_Receiver Receiver;
+}
+
+final class wire_cst_pay_onchain_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external PayOnchainAmountKind kind;
+}
+
+final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
+  external wire_cst_pay_onchain_amount amount;
+
+  external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_prepare_receive_request extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+
+  @ffi.Int32()
+  external int payment_method;
+}
+
+final class wire_cst_prepare_refund_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
+
+  @ffi.Uint32()
+  external int fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_prepare_send_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
+
+  external ffi.Pointer<ffi.Uint64> amount_sat;
+}
+
+final class wire_cst_prepare_receive_response extends ffi.Struct {
+  @ffi.Int32()
+  external int payment_method;
+
+  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+
+  @ffi.Uint64()
+  external int fees_sat;
+}
+
+final class wire_cst_receive_payment_request extends ffi.Struct {
+  external wire_cst_prepare_receive_response prepare_response;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Bool> use_description_hash;
+}
+
+final class wire_cst_refund_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
+
+  @ffi.Uint32()
+  external int fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_restore_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
 }
 
 final class wire_cst_send_payment_request extends ffi.Struct {
@@ -5362,21 +5634,8 @@ final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
   external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
 }
 
-final class wire_cst_message_success_action_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
-}
-
 final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
   external ffi.Pointer<wire_cst_message_success_action_data> data;
-}
-
-final class wire_cst_url_success_action_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
-
-  @ffi.Bool()
-  external bool matches_callback_domain;
 }
 
 final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2682,7 +2682,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_prepare_ln_url_pay_response(
       PrepareLnUrlPayResponse apiObj, wire_cst_prepare_ln_url_pay_response wireObj) {
-    cst_api_fill_to_wire_prepare_send_response(apiObj.prepareSendResponse, wireObj.prepare_send_response);
+    cst_api_fill_to_wire_send_destination(apiObj.destination, wireObj.destination);
+    wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
     wireObj.success_action = cst_encode_opt_box_autoadd_success_action(apiObj.successAction);
   }
 
@@ -5201,13 +5202,6 @@ final class wire_cst_send_destination extends ffi.Struct {
   external SendDestinationKind kind;
 }
 
-final class wire_cst_prepare_send_response extends ffi.Struct {
-  external wire_cst_send_destination destination;
-
-  @ffi.Uint64()
-  external int fees_sat;
-}
-
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -5257,7 +5251,10 @@ final class wire_cst_success_action extends ffi.Struct {
 }
 
 final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
-  external wire_cst_prepare_send_response prepare_send_response;
+  external wire_cst_send_destination destination;
+
+  @ffi.Uint64()
+  external int fees_sat;
 
   external ffi.Pointer<wire_cst_success_action> success_action;
 }
@@ -5422,6 +5419,13 @@ final class wire_cst_refund_request extends ffi.Struct {
 
 final class wire_cst_restore_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
+}
+
+final class wire_cst_prepare_send_response extends ffi.Struct {
+  external wire_cst_send_destination destination;
+
+  @ffi.Uint64()
+  external int fees_sat;
 }
 
 final class wire_cst_send_payment_request extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -364,6 +364,26 @@ class ListPaymentsRequest {
           details == other.details;
 }
 
+/// An argument when calling [crate::sdk::LiquidSdk::lnurl_pay].
+class LnUrlPayRequest {
+  /// The response from calling [crate::sdk::LiquidSdk::prepare_lnurl_pay]
+  final PrepareLnUrlPayResponse prepareResponse;
+
+  const LnUrlPayRequest({
+    required this.prepareResponse,
+  });
+
+  @override
+  int get hashCode => prepareResponse.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LnUrlPayRequest &&
+          runtimeType == other.runtimeType &&
+          prepareResponse == other.prepareResponse;
+}
+
 @freezed
 sealed class LnUrlPayResult with _$LnUrlPayResult {
   const LnUrlPayResult._();
@@ -746,6 +766,69 @@ class PrepareBuyBitcoinResponse {
           provider == other.provider &&
           amountSat == other.amountSat &&
           feesSat == other.feesSat;
+}
+
+/// An argument when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
+class PrepareLnUrlPayRequest {
+  /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
+  final LnUrlPayRequestData data;
+
+  /// The amount in millisatoshis for this payment
+  final BigInt amountMsat;
+
+  /// An optional comment for this payment
+  final String? comment;
+
+  /// Validates that, if there is a URL success action, the URL domain matches
+  /// the LNURL callback domain. Defaults to `true`
+  final bool? validateSuccessActionUrl;
+
+  const PrepareLnUrlPayRequest({
+    required this.data,
+    required this.amountMsat,
+    this.comment,
+    this.validateSuccessActionUrl,
+  });
+
+  @override
+  int get hashCode =>
+      data.hashCode ^ amountMsat.hashCode ^ comment.hashCode ^ validateSuccessActionUrl.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PrepareLnUrlPayRequest &&
+          runtimeType == other.runtimeType &&
+          data == other.data &&
+          amountMsat == other.amountMsat &&
+          comment == other.comment &&
+          validateSuccessActionUrl == other.validateSuccessActionUrl;
+}
+
+/// Returned when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
+class PrepareLnUrlPayResponse {
+  /// The response from preparing the payment which includes `fees_sat`
+  final PrepareSendResponse prepareSendResponse;
+
+  /// The unprocessed LUD-09 success action. This will be processed and decrypted if
+  /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
+  final SuccessAction? successAction;
+
+  const PrepareLnUrlPayResponse({
+    required this.prepareSendResponse,
+    this.successAction,
+  });
+
+  @override
+  int get hashCode => prepareSendResponse.hashCode ^ successAction.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PrepareLnUrlPayResponse &&
+          runtimeType == other.runtimeType &&
+          prepareSendResponse == other.prepareSendResponse &&
+          successAction == other.successAction;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -807,27 +807,32 @@ class PrepareLnUrlPayRequest {
 
 /// Returned when calling [crate::sdk::LiquidSdk::prepare_lnurl_pay].
 class PrepareLnUrlPayResponse {
-  /// The response from preparing the payment which includes `fees_sat`
-  final PrepareSendResponse prepareSendResponse;
+  /// The destination of the payment
+  final SendDestination destination;
+
+  /// The fees in satoshis to send the payment
+  final BigInt feesSat;
 
   /// The unprocessed LUD-09 success action. This will be processed and decrypted if
   /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
   final SuccessAction? successAction;
 
   const PrepareLnUrlPayResponse({
-    required this.prepareSendResponse,
+    required this.destination,
+    required this.feesSat,
     this.successAction,
   });
 
   @override
-  int get hashCode => prepareSendResponse.hashCode ^ successAction.hashCode;
+  int get hashCode => destination.hashCode ^ feesSat.hashCode ^ successAction.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PrepareLnUrlPayResponse &&
           runtimeType == other.runtimeType &&
-          prepareSendResponse == other.prepareSendResponse &&
+          destination == other.destination &&
+          feesSat == other.feesSat &&
           successAction == other.successAction;
 }
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -3890,13 +3890,6 @@ final class wire_cst_send_destination extends ffi.Struct {
   external SendDestinationKind kind;
 }
 
-final class wire_cst_prepare_send_response extends ffi.Struct {
-  external wire_cst_send_destination destination;
-
-  @ffi.Uint64()
-  external int fees_sat;
-}
-
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -3946,7 +3939,10 @@ final class wire_cst_success_action extends ffi.Struct {
 }
 
 final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
-  external wire_cst_prepare_send_response prepare_send_response;
+  external wire_cst_send_destination destination;
+
+  @ffi.Uint64()
+  external int fees_sat;
 
   external ffi.Pointer<wire_cst_success_action> success_action;
 }
@@ -4111,6 +4107,13 @@ final class wire_cst_refund_request extends ffi.Struct {
 
 final class wire_cst_restore_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
+}
+
+final class wire_cst_prepare_send_response extends ffi.Struct {
+  external wire_cst_send_destination destination;
+
+  @ffi.Uint64()
+  external int fees_sat;
 }
 
 final class wire_cst_send_payment_request extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -387,6 +387,26 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_buy_bitcoinPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_buy_bitcoin_request>)>();
 
+  void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(
+    int port_,
+    int that,
+    ffi.Pointer<wire_cst_prepare_ln_url_pay_request> req,
+  ) {
+    return _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay(
+      port_,
+      that,
+      req,
+    );
+  }
+
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_payPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.UintPtr, ffi.Pointer<wire_cst_prepare_ln_url_pay_request>)>>(
+      'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay');
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_pay =
+      _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_lnurl_payPtr
+          .asFunction<void Function(int, int, ffi.Pointer<wire_cst_prepare_ln_url_pay_request>)>();
+
   void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_prepare_pay_onchain(
     int port_,
     int that,
@@ -790,6 +810,18 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdkPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
+  ffi.Pointer<wire_cst_aes_success_action_data>
+      frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_dataPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_aes_success_action_data> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data =
+      _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_dataPtr
+          .asFunction<ffi.Pointer<wire_cst_aes_success_action_data> Function()>();
+
   ffi.Pointer<wire_cst_aes_success_action_data_decrypted>
       frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_decrypted() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_decrypted();
@@ -1118,6 +1150,18 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_prepare_buy_bitcoin_requestPtr
           .asFunction<ffi.Pointer<wire_cst_prepare_buy_bitcoin_request> Function()>();
 
+  ffi.Pointer<wire_cst_prepare_ln_url_pay_request>
+      frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_requestPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_prepare_ln_url_pay_request> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_request =
+      _frbgen_breez_liquid_cst_new_box_autoadd_prepare_ln_url_pay_requestPtr
+          .asFunction<ffi.Pointer<wire_cst_prepare_ln_url_pay_request> Function()>();
+
   ffi.Pointer<wire_cst_prepare_pay_onchain_request>
       frbgen_breez_liquid_cst_new_box_autoadd_prepare_pay_onchain_request() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_prepare_pay_onchain_request();
@@ -1231,6 +1275,17 @@ class FlutterBreezLiquidBindings {
   late final _frbgen_breez_liquid_cst_new_box_autoadd_sign_message_request =
       _frbgen_breez_liquid_cst_new_box_autoadd_sign_message_requestPtr
           .asFunction<ffi.Pointer<wire_cst_sign_message_request> Function()>();
+
+  ffi.Pointer<wire_cst_success_action> frbgen_breez_liquid_cst_new_box_autoadd_success_action() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_success_action();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_success_actionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_success_action> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_success_action');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_success_action =
+      _frbgen_breez_liquid_cst_new_box_autoadd_success_actionPtr
+          .asFunction<ffi.Pointer<wire_cst_success_action> Function()>();
 
   ffi.Pointer<wire_cst_success_action_processed>
       frbgen_breez_liquid_cst_new_box_autoadd_success_action_processed() {
@@ -1806,6 +1861,26 @@ class FlutterBreezLiquidBindings {
       'uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_buy_bitcoin');
   late final _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_buy_bitcoin =
       _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_buy_bitcoinPtr
+          .asFunction<RustBuffer Function(ffi.Pointer<ffi.Void>, RustBuffer, ffi.Pointer<RustCallStatus>)>();
+
+  RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay(
+    ffi.Pointer<ffi.Void> ptr,
+    RustBuffer req,
+    ffi.Pointer<RustCallStatus> out_status,
+  ) {
+    return _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay(
+      ptr,
+      req,
+      out_status,
+    );
+  }
+
+  late final _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_payPtr = _lookup<
+          ffi.NativeFunction<
+              RustBuffer Function(ffi.Pointer<ffi.Void>, RustBuffer, ffi.Pointer<RustCallStatus>)>>(
+      'uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay');
+  late final _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay =
+      _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_payPtr
           .asFunction<RustBuffer Function(ffi.Pointer<ffi.Void>, RustBuffer, ffi.Pointer<RustCallStatus>)>();
 
   RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_pay_onchain(
@@ -3384,6 +3459,17 @@ class FlutterBreezLiquidBindings {
       _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_buy_bitcoinPtr
           .asFunction<int Function()>();
 
+  int uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay() {
+    return _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay();
+  }
+
+  late final _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_payPtr =
+      _lookup<ffi.NativeFunction<ffi.Uint16 Function()>>(
+          'uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay');
+  late final _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay =
+      _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_payPtr
+          .asFunction<int Function()>();
+
   int uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_pay_onchain() {
     return _uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_pay_onchain();
   }
@@ -3701,166 +3787,6 @@ final class wire_cst_ln_url_auth_request_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
 }
 
-final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  @ffi.Uint64()
-  external int min_sendable;
-
-  @ffi.Uint64()
-  external int max_sendable;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
-
-  @ffi.Uint16()
-  external int comment_allowed;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
-
-  @ffi.Bool()
-  external bool allows_nostr;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
-}
-
-final class wire_cst_ln_url_pay_request extends ffi.Struct {
-  external wire_cst_ln_url_pay_request_data data;
-
-  @ffi.Uint64()
-  external int amount_msat;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_label;
-
-  external ffi.Pointer<ffi.Bool> validate_success_action_url;
-}
-
-final class wire_cst_ln_url_withdraw_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> k1;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> default_description;
-
-  @ffi.Uint64()
-  external int min_withdrawable;
-
-  @ffi.Uint64()
-  external int max_withdrawable;
-}
-
-final class wire_cst_ln_url_withdraw_request extends ffi.Struct {
-  external wire_cst_ln_url_withdraw_request_data data;
-
-  @ffi.Uint64()
-  external int amount_msat;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-}
-
-final class wire_cst_prepare_pay_onchain_response extends ffi.Struct {
-  @ffi.Uint64()
-  external int receiver_amount_sat;
-
-  @ffi.Uint64()
-  external int claim_fees_sat;
-
-  @ffi.Uint64()
-  external int total_fees_sat;
-}
-
-final class wire_cst_pay_onchain_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
-
-  external wire_cst_prepare_pay_onchain_response prepare_response;
-}
-
-final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
-  @ffi.Int32()
-  external int provider;
-
-  @ffi.Uint64()
-  external int amount_sat;
-}
-
-final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_sat;
-}
-
-final class PayOnchainAmountKind extends ffi.Union {
-  external wire_cst_PayOnchainAmount_Receiver Receiver;
-}
-
-final class wire_cst_pay_onchain_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external PayOnchainAmountKind kind;
-}
-
-final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
-  external wire_cst_pay_onchain_amount amount;
-
-  external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_prepare_receive_request extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
-
-  @ffi.Int32()
-  external int payment_method;
-}
-
-final class wire_cst_prepare_refund_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
-
-  @ffi.Uint32()
-  external int fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_prepare_send_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
-
-  external ffi.Pointer<ffi.Uint64> amount_sat;
-}
-
-final class wire_cst_prepare_receive_response extends ffi.Struct {
-  @ffi.Int32()
-  external int payment_method;
-
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
-
-  @ffi.Uint64()
-  external int fees_sat;
-}
-
-final class wire_cst_receive_payment_request extends ffi.Struct {
-  external wire_cst_prepare_receive_response prepare_response;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<ffi.Bool> use_description_hash;
-}
-
-final class wire_cst_refund_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
-
-  @ffi.Uint32()
-  external int fee_rate_sat_per_vbyte;
-}
-
-final class wire_cst_restore_request extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
-}
-
 final class wire_cst_liquid_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -3969,6 +3895,222 @@ final class wire_cst_prepare_send_response extends ffi.Struct {
 
   @ffi.Uint64()
   external int fees_sat;
+}
+
+final class wire_cst_aes_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ciphertext;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iv;
+}
+
+final class wire_cst_SuccessAction_Aes extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data> data;
+}
+
+final class wire_cst_message_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
+}
+
+final class wire_cst_SuccessAction_Message extends ffi.Struct {
+  external ffi.Pointer<wire_cst_message_success_action_data> data;
+}
+
+final class wire_cst_url_success_action_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
+
+  @ffi.Bool()
+  external bool matches_callback_domain;
+}
+
+final class wire_cst_SuccessAction_Url extends ffi.Struct {
+  external ffi.Pointer<wire_cst_url_success_action_data> data;
+}
+
+final class SuccessActionKind extends ffi.Union {
+  external wire_cst_SuccessAction_Aes Aes;
+
+  external wire_cst_SuccessAction_Message Message;
+
+  external wire_cst_SuccessAction_Url Url;
+}
+
+final class wire_cst_success_action extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SuccessActionKind kind;
+}
+
+final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
+  external wire_cst_prepare_send_response prepare_send_response;
+
+  external ffi.Pointer<wire_cst_success_action> success_action;
+}
+
+final class wire_cst_ln_url_pay_request extends ffi.Struct {
+  external wire_cst_prepare_ln_url_pay_response prepare_response;
+}
+
+final class wire_cst_ln_url_withdraw_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> k1;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> default_description;
+
+  @ffi.Uint64()
+  external int min_withdrawable;
+
+  @ffi.Uint64()
+  external int max_withdrawable;
+}
+
+final class wire_cst_ln_url_withdraw_request extends ffi.Struct {
+  external wire_cst_ln_url_withdraw_request_data data;
+
+  @ffi.Uint64()
+  external int amount_msat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+}
+
+final class wire_cst_prepare_pay_onchain_response extends ffi.Struct {
+  @ffi.Uint64()
+  external int receiver_amount_sat;
+
+  @ffi.Uint64()
+  external int claim_fees_sat;
+
+  @ffi.Uint64()
+  external int total_fees_sat;
+}
+
+final class wire_cst_pay_onchain_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
+
+  external wire_cst_prepare_pay_onchain_response prepare_response;
+}
+
+final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
+  @ffi.Int32()
+  external int provider;
+
+  @ffi.Uint64()
+  external int amount_sat;
+}
+
+final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  @ffi.Uint64()
+  external int min_sendable;
+
+  @ffi.Uint64()
+  external int max_sendable;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
+
+  @ffi.Uint16()
+  external int comment_allowed;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
+
+  @ffi.Bool()
+  external bool allows_nostr;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+}
+
+final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
+  external wire_cst_ln_url_pay_request_data data;
+
+  @ffi.Uint64()
+  external int amount_msat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
+
+  external ffi.Pointer<ffi.Bool> validate_success_action_url;
+}
+
+final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_sat;
+}
+
+final class PayOnchainAmountKind extends ffi.Union {
+  external wire_cst_PayOnchainAmount_Receiver Receiver;
+}
+
+final class wire_cst_pay_onchain_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external PayOnchainAmountKind kind;
+}
+
+final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
+  external wire_cst_pay_onchain_amount amount;
+
+  external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_prepare_receive_request extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+
+  @ffi.Int32()
+  external int payment_method;
+}
+
+final class wire_cst_prepare_refund_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
+
+  @ffi.Uint32()
+  external int fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_prepare_send_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
+
+  external ffi.Pointer<ffi.Uint64> amount_sat;
+}
+
+final class wire_cst_prepare_receive_response extends ffi.Struct {
+  @ffi.Int32()
+  external int payment_method;
+
+  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+
+  @ffi.Uint64()
+  external int fees_sat;
+}
+
+final class wire_cst_receive_payment_request extends ffi.Struct {
+  external wire_cst_prepare_receive_response prepare_response;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Bool> use_description_hash;
+}
+
+final class wire_cst_refund_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_address;
+
+  @ffi.Uint32()
+  external int fee_rate_sat_per_vbyte;
+}
+
+final class wire_cst_restore_request extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> backup_path;
 }
 
 final class wire_cst_send_payment_request extends ffi.Struct {
@@ -4181,21 +4323,8 @@ final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
   external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
 }
 
-final class wire_cst_message_success_action_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
-}
-
 final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
   external ffi.Pointer<wire_cst_message_success_action_data> data;
-}
-
-final class wire_cst_url_success_action_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
-
-  @ffi.Bool()
-  external bool matches_callback_domain;
 }
 
 final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3,6 +3,42 @@ import breez_sdk_liquid.*
 import com.facebook.react.bridge.*
 import java.util.*
 
+fun asAesSuccessActionData(aesSuccessActionData: ReadableMap): AesSuccessActionData? {
+    if (!validateMandatoryFields(
+            aesSuccessActionData,
+            arrayOf(
+                "description",
+                "ciphertext",
+                "iv",
+            ),
+        )
+    ) {
+        return null
+    }
+    val description = aesSuccessActionData.getString("description")!!
+    val ciphertext = aesSuccessActionData.getString("ciphertext")!!
+    val iv = aesSuccessActionData.getString("iv")!!
+    return AesSuccessActionData(description, ciphertext, iv)
+}
+
+fun readableMapOf(aesSuccessActionData: AesSuccessActionData): ReadableMap =
+    readableMapOf(
+        "description" to aesSuccessActionData.description,
+        "ciphertext" to aesSuccessActionData.ciphertext,
+        "iv" to aesSuccessActionData.iv,
+    )
+
+fun asAesSuccessActionDataList(arr: ReadableArray): List<AesSuccessActionData> {
+    val list = ArrayList<AesSuccessActionData>()
+    for (value in arr.toList()) {
+        when (value) {
+            is ReadableMap -> list.add(asAesSuccessActionData(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType(value))
+        }
+    }
+    return list
+}
+
 fun asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: ReadableMap): AesSuccessActionDataDecrypted? {
     if (!validateMandatoryFields(
             aesSuccessActionDataDecrypted,
@@ -771,37 +807,19 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
     if (!validateMandatoryFields(
             lnUrlPayRequest,
             arrayOf(
-                "data",
-                "amountMsat",
+                "prepareResponse",
             ),
         )
     ) {
         return null
     }
-    val data = lnUrlPayRequest.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
-    val amountMsat = lnUrlPayRequest.getDouble("amountMsat").toULong()
-    val comment = if (hasNonNullKey(lnUrlPayRequest, "comment")) lnUrlPayRequest.getString("comment") else null
-    val paymentLabel = if (hasNonNullKey(lnUrlPayRequest, "paymentLabel")) lnUrlPayRequest.getString("paymentLabel") else null
-    val validateSuccessActionUrl =
-        if (hasNonNullKey(
-                lnUrlPayRequest,
-                "validateSuccessActionUrl",
-            )
-        ) {
-            lnUrlPayRequest.getBoolean("validateSuccessActionUrl")
-        } else {
-            null
-        }
-    return LnUrlPayRequest(data, amountMsat, comment, paymentLabel, validateSuccessActionUrl)
+    val prepareResponse = lnUrlPayRequest.getMap("prepareResponse")?.let { asPrepareLnUrlPayResponse(it) }!!
+    return LnUrlPayRequest(prepareResponse)
 }
 
 fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap =
     readableMapOf(
-        "data" to readableMapOf(lnUrlPayRequest.data),
-        "amountMsat" to lnUrlPayRequest.amountMsat,
-        "comment" to lnUrlPayRequest.comment,
-        "paymentLabel" to lnUrlPayRequest.paymentLabel,
-        "validateSuccessActionUrl" to lnUrlPayRequest.validateSuccessActionUrl,
+        "prepareResponse" to readableMapOf(lnUrlPayRequest.prepareResponse),
     )
 
 fun asLnUrlPayRequestList(arr: ReadableArray): List<LnUrlPayRequest> {
@@ -1332,6 +1350,91 @@ fun asPrepareBuyBitcoinResponseList(arr: ReadableArray): List<PrepareBuyBitcoinR
     for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asPrepareBuyBitcoinResponse(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType(value))
+        }
+    }
+    return list
+}
+
+fun asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: ReadableMap): PrepareLnUrlPayRequest? {
+    if (!validateMandatoryFields(
+            prepareLnUrlPayRequest,
+            arrayOf(
+                "data",
+                "amountMsat",
+            ),
+        )
+    ) {
+        return null
+    }
+    val data = prepareLnUrlPayRequest.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
+    val amountMsat = prepareLnUrlPayRequest.getDouble("amountMsat").toULong()
+    val comment = if (hasNonNullKey(prepareLnUrlPayRequest, "comment")) prepareLnUrlPayRequest.getString("comment") else null
+    val validateSuccessActionUrl =
+        if (hasNonNullKey(
+                prepareLnUrlPayRequest,
+                "validateSuccessActionUrl",
+            )
+        ) {
+            prepareLnUrlPayRequest.getBoolean("validateSuccessActionUrl")
+        } else {
+            null
+        }
+    return PrepareLnUrlPayRequest(data, amountMsat, comment, validateSuccessActionUrl)
+}
+
+fun readableMapOf(prepareLnUrlPayRequest: PrepareLnUrlPayRequest): ReadableMap =
+    readableMapOf(
+        "data" to readableMapOf(prepareLnUrlPayRequest.data),
+        "amountMsat" to prepareLnUrlPayRequest.amountMsat,
+        "comment" to prepareLnUrlPayRequest.comment,
+        "validateSuccessActionUrl" to prepareLnUrlPayRequest.validateSuccessActionUrl,
+    )
+
+fun asPrepareLnUrlPayRequestList(arr: ReadableArray): List<PrepareLnUrlPayRequest> {
+    val list = ArrayList<PrepareLnUrlPayRequest>()
+    for (value in arr.toList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPrepareLnUrlPayRequest(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType(value))
+        }
+    }
+    return list
+}
+
+fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUrlPayResponse? {
+    if (!validateMandatoryFields(
+            prepareLnUrlPayResponse,
+            arrayOf(
+                "prepareSendResponse",
+            ),
+        )
+    ) {
+        return null
+    }
+    val prepareSendResponse = prepareLnUrlPayResponse.getMap("prepareSendResponse")?.let { asPrepareSendResponse(it) }!!
+    val successAction =
+        if (hasNonNullKey(prepareLnUrlPayResponse, "successAction")) {
+            prepareLnUrlPayResponse.getMap("successAction")?.let {
+                asSuccessAction(it)
+            }
+        } else {
+            null
+        }
+    return PrepareLnUrlPayResponse(prepareSendResponse, successAction)
+}
+
+fun readableMapOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse): ReadableMap =
+    readableMapOf(
+        "prepareSendResponse" to readableMapOf(prepareLnUrlPayResponse.prepareSendResponse),
+        "successAction" to prepareLnUrlPayResponse.successAction?.let { readableMapOf(it) },
+    )
+
+fun asPrepareLnUrlPayResponseList(arr: ReadableArray): List<PrepareLnUrlPayResponse> {
+    val list = ArrayList<PrepareLnUrlPayResponse>()
+    for (value in arr.toList()) {
+        when (value) {
+            is ReadableMap -> list.add(asPrepareLnUrlPayResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }
@@ -2844,6 +2947,54 @@ fun asSendDestinationList(arr: ReadableArray): List<SendDestination> {
     for (value in arr.toList()) {
         when (value) {
             is ReadableMap -> list.add(asSendDestination(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType(value))
+        }
+    }
+    return list
+}
+
+fun asSuccessAction(successAction: ReadableMap): SuccessAction? {
+    val type = successAction.getString("type")
+
+    if (type == "aes") {
+        val data = successAction.getMap("data")?.let { asAesSuccessActionData(it) }!!
+        return SuccessAction.Aes(data)
+    }
+    if (type == "message") {
+        val data = successAction.getMap("data")?.let { asMessageSuccessActionData(it) }!!
+        return SuccessAction.Message(data)
+    }
+    if (type == "url") {
+        val data = successAction.getMap("data")?.let { asUrlSuccessActionData(it) }!!
+        return SuccessAction.Url(data)
+    }
+    return null
+}
+
+fun readableMapOf(successAction: SuccessAction): ReadableMap? {
+    val map = Arguments.createMap()
+    when (successAction) {
+        is SuccessAction.Aes -> {
+            pushToMap(map, "type", "aes")
+            pushToMap(map, "data", readableMapOf(successAction.data))
+        }
+        is SuccessAction.Message -> {
+            pushToMap(map, "type", "message")
+            pushToMap(map, "data", readableMapOf(successAction.data))
+        }
+        is SuccessAction.Url -> {
+            pushToMap(map, "type", "url")
+            pushToMap(map, "data", readableMapOf(successAction.data))
+        }
+    }
+    return map
+}
+
+fun asSuccessActionList(arr: ReadableArray): List<SuccessAction> {
+    val list = ArrayList<SuccessAction>()
+    for (value in arr.toList()) {
+        when (value) {
+            is ReadableMap -> list.add(asSuccessAction(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1406,13 +1406,15 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
     if (!validateMandatoryFields(
             prepareLnUrlPayResponse,
             arrayOf(
-                "prepareSendResponse",
+                "destination",
+                "feesSat",
             ),
         )
     ) {
         return null
     }
-    val prepareSendResponse = prepareLnUrlPayResponse.getMap("prepareSendResponse")?.let { asPrepareSendResponse(it) }!!
+    val destination = prepareLnUrlPayResponse.getMap("destination")?.let { asSendDestination(it) }!!
+    val feesSat = prepareLnUrlPayResponse.getDouble("feesSat").toULong()
     val successAction =
         if (hasNonNullKey(prepareLnUrlPayResponse, "successAction")) {
             prepareLnUrlPayResponse.getMap("successAction")?.let {
@@ -1421,12 +1423,13 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
         } else {
             null
         }
-    return PrepareLnUrlPayResponse(prepareSendResponse, successAction)
+    return PrepareLnUrlPayResponse(destination, feesSat, successAction)
 }
 
 fun readableMapOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse): ReadableMap =
     readableMapOf(
-        "prepareSendResponse" to readableMapOf(prepareLnUrlPayResponse.prepareSendResponse),
+        "destination" to readableMapOf(prepareLnUrlPayResponse.destination),
+        "feesSat" to prepareLnUrlPayResponse.feesSat,
         "successAction" to prepareLnUrlPayResponse.successAction?.let { readableMapOf(it) },
     )
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidModule.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidModule.kt
@@ -551,6 +551,24 @@ class BreezSDKLiquidModule(
     }
 
     @ReactMethod
+    fun prepareLnurlPay(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                val prepareLnUrlPayRequest =
+                    asPrepareLnUrlPayRequest(req)
+                        ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "PrepareLnUrlPayRequest")) }
+                val res = getBindingLiquidSdk().prepareLnurlPay(prepareLnUrlPayRequest)
+                promise.resolve(readableMapOf(res))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun lnurlPay(
         req: ReadableMap,
         promise: Promise,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2,6 +2,45 @@ import BreezSDKLiquid
 import Foundation
 
 enum BreezSDKLiquidMapper {
+    static func asAesSuccessActionData(aesSuccessActionData: [String: Any?]) throws -> AesSuccessActionData {
+        guard let description = aesSuccessActionData["description"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionData"))
+        }
+        guard let ciphertext = aesSuccessActionData["ciphertext"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ciphertext", typeName: "AesSuccessActionData"))
+        }
+        guard let iv = aesSuccessActionData["iv"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "iv", typeName: "AesSuccessActionData"))
+        }
+
+        return AesSuccessActionData(description: description, ciphertext: ciphertext, iv: iv)
+    }
+
+    static func dictionaryOf(aesSuccessActionData: AesSuccessActionData) -> [String: Any?] {
+        return [
+            "description": aesSuccessActionData.description,
+            "ciphertext": aesSuccessActionData.ciphertext,
+            "iv": aesSuccessActionData.iv,
+        ]
+    }
+
+    static func asAesSuccessActionDataList(arr: [Any]) throws -> [AesSuccessActionData] {
+        var list = [AesSuccessActionData]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var aesSuccessActionData = try asAesSuccessActionData(aesSuccessActionData: val)
+                list.append(aesSuccessActionData)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionData"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(aesSuccessActionDataList: [AesSuccessActionData]) -> [Any] {
+        return aesSuccessActionDataList.map { v -> [String: Any?] in return dictionaryOf(aesSuccessActionData: v) }
+    }
+
     static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
         guard let description = aesSuccessActionDataDecrypted["description"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionDataDecrypted"))
@@ -920,46 +959,17 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asLnUrlPayRequest(lnUrlPayRequest: [String: Any?]) throws -> LnUrlPayRequest {
-        guard let dataTmp = lnUrlPayRequest["data"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayRequest"))
+        guard let prepareResponseTmp = lnUrlPayRequest["prepareResponse"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "LnUrlPayRequest"))
         }
-        let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
+        let prepareResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: prepareResponseTmp)
 
-        guard let amountMsat = lnUrlPayRequest["amountMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlPayRequest"))
-        }
-        var comment: String?
-        if hasNonNilKey(data: lnUrlPayRequest, key: "comment") {
-            guard let commentTmp = lnUrlPayRequest["comment"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "comment"))
-            }
-            comment = commentTmp
-        }
-        var paymentLabel: String?
-        if hasNonNilKey(data: lnUrlPayRequest, key: "paymentLabel") {
-            guard let paymentLabelTmp = lnUrlPayRequest["paymentLabel"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "paymentLabel"))
-            }
-            paymentLabel = paymentLabelTmp
-        }
-        var validateSuccessActionUrl: Bool?
-        if hasNonNilKey(data: lnUrlPayRequest, key: "validateSuccessActionUrl") {
-            guard let validateSuccessActionUrlTmp = lnUrlPayRequest["validateSuccessActionUrl"] as? Bool else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "validateSuccessActionUrl"))
-            }
-            validateSuccessActionUrl = validateSuccessActionUrlTmp
-        }
-
-        return LnUrlPayRequest(data: data, amountMsat: amountMsat, comment: comment, paymentLabel: paymentLabel, validateSuccessActionUrl: validateSuccessActionUrl)
+        return LnUrlPayRequest(prepareResponse: prepareResponse)
     }
 
     static func dictionaryOf(lnUrlPayRequest: LnUrlPayRequest) -> [String: Any?] {
         return [
-            "data": dictionaryOf(lnUrlPayRequestData: lnUrlPayRequest.data),
-            "amountMsat": lnUrlPayRequest.amountMsat,
-            "comment": lnUrlPayRequest.comment == nil ? nil : lnUrlPayRequest.comment,
-            "paymentLabel": lnUrlPayRequest.paymentLabel == nil ? nil : lnUrlPayRequest.paymentLabel,
-            "validateSuccessActionUrl": lnUrlPayRequest.validateSuccessActionUrl == nil ? nil : lnUrlPayRequest.validateSuccessActionUrl,
+            "prepareResponse": dictionaryOf(prepareLnUrlPayResponse: lnUrlPayRequest.prepareResponse),
         ]
     }
 
@@ -1581,6 +1591,97 @@ enum BreezSDKLiquidMapper {
 
     static func arrayOf(prepareBuyBitcoinResponseList: [PrepareBuyBitcoinResponse]) -> [Any] {
         return prepareBuyBitcoinResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareBuyBitcoinResponse: v) }
+    }
+
+    static func asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: [String: Any?]) throws -> PrepareLnUrlPayRequest {
+        guard let dataTmp = prepareLnUrlPayRequest["data"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayRequest"))
+        }
+        let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
+
+        guard let amountMsat = prepareLnUrlPayRequest["amountMsat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "PrepareLnUrlPayRequest"))
+        }
+        var comment: String?
+        if hasNonNilKey(data: prepareLnUrlPayRequest, key: "comment") {
+            guard let commentTmp = prepareLnUrlPayRequest["comment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "comment"))
+            }
+            comment = commentTmp
+        }
+        var validateSuccessActionUrl: Bool?
+        if hasNonNilKey(data: prepareLnUrlPayRequest, key: "validateSuccessActionUrl") {
+            guard let validateSuccessActionUrlTmp = prepareLnUrlPayRequest["validateSuccessActionUrl"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "validateSuccessActionUrl"))
+            }
+            validateSuccessActionUrl = validateSuccessActionUrlTmp
+        }
+
+        return PrepareLnUrlPayRequest(data: data, amountMsat: amountMsat, comment: comment, validateSuccessActionUrl: validateSuccessActionUrl)
+    }
+
+    static func dictionaryOf(prepareLnUrlPayRequest: PrepareLnUrlPayRequest) -> [String: Any?] {
+        return [
+            "data": dictionaryOf(lnUrlPayRequestData: prepareLnUrlPayRequest.data),
+            "amountMsat": prepareLnUrlPayRequest.amountMsat,
+            "comment": prepareLnUrlPayRequest.comment == nil ? nil : prepareLnUrlPayRequest.comment,
+            "validateSuccessActionUrl": prepareLnUrlPayRequest.validateSuccessActionUrl == nil ? nil : prepareLnUrlPayRequest.validateSuccessActionUrl,
+        ]
+    }
+
+    static func asPrepareLnUrlPayRequestList(arr: [Any]) throws -> [PrepareLnUrlPayRequest] {
+        var list = [PrepareLnUrlPayRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var prepareLnUrlPayRequest = try asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: val)
+                list.append(prepareLnUrlPayRequest)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayRequest"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(prepareLnUrlPayRequestList: [PrepareLnUrlPayRequest]) -> [Any] {
+        return prepareLnUrlPayRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareLnUrlPayRequest: v) }
+    }
+
+    static func asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: [String: Any?]) throws -> PrepareLnUrlPayResponse {
+        guard let prepareSendResponseTmp = prepareLnUrlPayResponse["prepareSendResponse"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareSendResponse", typeName: "PrepareLnUrlPayResponse"))
+        }
+        let prepareSendResponse = try asPrepareSendResponse(prepareSendResponse: prepareSendResponseTmp)
+
+        var successAction: SuccessAction?
+        if let successActionTmp = prepareLnUrlPayResponse["successAction"] as? [String: Any?] {
+            successAction = try asSuccessAction(successAction: successActionTmp)
+        }
+
+        return PrepareLnUrlPayResponse(prepareSendResponse: prepareSendResponse, successAction: successAction)
+    }
+
+    static func dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
+        return [
+            "prepareSendResponse": dictionaryOf(prepareSendResponse: prepareLnUrlPayResponse.prepareSendResponse),
+            "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),
+        ]
+    }
+
+    static func asPrepareLnUrlPayResponseList(arr: [Any]) throws -> [PrepareLnUrlPayResponse] {
+        var list = [PrepareLnUrlPayResponse]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var prepareLnUrlPayResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: val)
+                list.append(prepareLnUrlPayResponse)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayResponse"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(prepareLnUrlPayResponseList: [PrepareLnUrlPayResponse]) -> [Any] {
+        return prepareLnUrlPayResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareLnUrlPayResponse: v) }
     }
 
     static func asPreparePayOnchainRequest(preparePayOnchainRequest: [String: Any?]) throws -> PreparePayOnchainRequest {
@@ -3665,6 +3766,81 @@ enum BreezSDKLiquidMapper {
                 list.append(sendDestination)
             } else {
                 throw SdkError.Generic(message: errUnexpectedType(typeName: "SendDestination"))
+            }
+        }
+        return list
+    }
+
+    static func asSuccessAction(successAction: [String: Any?]) throws -> SuccessAction {
+        let type = successAction["type"] as! String
+        if type == "aes" {
+            guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+            }
+            let _data = try asAesSuccessActionData(aesSuccessActionData: dataTmp)
+
+            return SuccessAction.aes(data: _data)
+        }
+        if type == "message" {
+            guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+            }
+            let _data = try asMessageSuccessActionData(messageSuccessActionData: dataTmp)
+
+            return SuccessAction.message(data: _data)
+        }
+        if type == "url" {
+            guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+            }
+            let _data = try asUrlSuccessActionData(urlSuccessActionData: dataTmp)
+
+            return SuccessAction.url(data: _data)
+        }
+
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessAction")
+    }
+
+    static func dictionaryOf(successAction: SuccessAction) -> [String: Any?] {
+        switch successAction {
+        case let .aes(
+            data
+        ):
+            return [
+                "type": "aes",
+                "data": dictionaryOf(aesSuccessActionData: data),
+            ]
+
+        case let .message(
+            data
+        ):
+            return [
+                "type": "message",
+                "data": dictionaryOf(messageSuccessActionData: data),
+            ]
+
+        case let .url(
+            data
+        ):
+            return [
+                "type": "url",
+                "data": dictionaryOf(urlSuccessActionData: data),
+            ]
+        }
+    }
+
+    static func arrayOf(successActionList: [SuccessAction]) -> [Any] {
+        return successActionList.map { v -> [String: Any?] in return dictionaryOf(successAction: v) }
+    }
+
+    static func asSuccessActionList(arr: [Any]) throws -> [SuccessAction] {
+        var list = [SuccessAction]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var successAction = try asSuccessAction(successAction: val)
+                list.append(successAction)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessAction"))
             }
         }
         return list

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1647,22 +1647,26 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: [String: Any?]) throws -> PrepareLnUrlPayResponse {
-        guard let prepareSendResponseTmp = prepareLnUrlPayResponse["prepareSendResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareSendResponse", typeName: "PrepareLnUrlPayResponse"))
+        guard let destinationTmp = prepareLnUrlPayResponse["destination"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareLnUrlPayResponse"))
         }
-        let prepareSendResponse = try asPrepareSendResponse(prepareSendResponse: prepareSendResponseTmp)
+        let destination = try asSendDestination(sendDestination: destinationTmp)
 
+        guard let feesSat = prepareLnUrlPayResponse["feesSat"] as? UInt64 else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareLnUrlPayResponse"))
+        }
         var successAction: SuccessAction?
         if let successActionTmp = prepareLnUrlPayResponse["successAction"] as? [String: Any?] {
             successAction = try asSuccessAction(successAction: successActionTmp)
         }
 
-        return PrepareLnUrlPayResponse(prepareSendResponse: prepareSendResponse, successAction: successAction)
+        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, successAction: successAction)
     }
 
     static func dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
         return [
-            "prepareSendResponse": dictionaryOf(prepareSendResponse: prepareLnUrlPayResponse.prepareSendResponse),
+            "destination": dictionaryOf(sendDestination: prepareLnUrlPayResponse.destination),
+            "feesSat": prepareLnUrlPayResponse.feesSat,
             "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),
         ]
     }

--- a/packages/react-native/ios/RNBreezSDKLiquid.m
+++ b/packages/react-native/ios/RNBreezSDKLiquid.m
@@ -181,6 +181,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    prepareLnurlPay: (NSDictionary*)req
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     lnurlPay: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject

--- a/packages/react-native/ios/RNBreezSDKLiquid.swift
+++ b/packages/react-native/ios/RNBreezSDKLiquid.swift
@@ -416,6 +416,17 @@ class RNBreezSDKLiquid: RCTEventEmitter {
         }
     }
 
+    @objc(prepareLnurlPay:resolve:reject:)
+    func prepareLnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            let prepareLnUrlPayRequest = try BreezSDKLiquidMapper.asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: req)
+            var res = try getBindingLiquidSdk().prepareLnurlPay(req: prepareLnUrlPayRequest)
+            resolve(BreezSDKLiquidMapper.dictionaryOf(prepareLnUrlPayResponse: res))
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(lnurlPay:resolve:reject:)
     func lnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -19,6 +19,12 @@ const BreezSDKLiquid = NativeModules.RNBreezSDKLiquid
 
 const BreezSDKLiquidEmitter = new NativeEventEmitter(BreezSDKLiquid)
 
+export interface AesSuccessActionData {
+    description: string
+    ciphertext: string
+    iv: string
+}
+
 export interface AesSuccessActionDataDecrypted {
     description: string
     plaintext: string
@@ -151,11 +157,7 @@ export interface LnUrlPayErrorData {
 }
 
 export interface LnUrlPayRequest {
-    data: LnUrlPayRequestData
-    amountMsat: number
-    comment?: string
-    paymentLabel?: string
-    validateSuccessActionUrl?: boolean
+    prepareResponse: PrepareLnUrlPayResponse
 }
 
 export interface LnUrlPayRequestData {
@@ -243,6 +245,18 @@ export interface PrepareBuyBitcoinResponse {
     provider: BuyBitcoinProvider
     amountSat: number
     feesSat: number
+}
+
+export interface PrepareLnUrlPayRequest {
+    data: LnUrlPayRequestData
+    amountMsat: number
+    comment?: string
+    validateSuccessActionUrl?: boolean
+}
+
+export interface PrepareLnUrlPayResponse {
+    prepareSendResponse: PrepareSendResponse
+    successAction?: SuccessAction
 }
 
 export interface PreparePayOnchainRequest {
@@ -618,6 +632,23 @@ export type SendDestination = {
     invoice: LnInvoice
 }
 
+export enum SuccessActionVariant {
+    AES = "aes",
+    MESSAGE = "message",
+    URL = "url"
+}
+
+export type SuccessAction = {
+    type: SuccessActionVariant.AES,
+    data: AesSuccessActionData
+} | {
+    type: SuccessActionVariant.MESSAGE,
+    data: MessageSuccessActionData
+} | {
+    type: SuccessActionVariant.URL,
+    data: UrlSuccessActionData
+}
+
 export enum SuccessActionProcessedVariant {
     AES = "aes",
     MESSAGE = "message",
@@ -794,6 +825,11 @@ export const restore = async (req: RestoreRequest): Promise<void> => {
 
 export const disconnect = async (): Promise<void> => {
     await BreezSDKLiquid.disconnect()
+}
+
+export const prepareLnurlPay = async (req: PrepareLnUrlPayRequest): Promise<PrepareLnUrlPayResponse> => {
+    const response = await BreezSDKLiquid.prepareLnurlPay(req)
+    return response
 }
 
 export const lnurlPay = async (req: LnUrlPayRequest): Promise<LnUrlPayResult> => {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -255,7 +255,8 @@ export interface PrepareLnUrlPayRequest {
 }
 
 export interface PrepareLnUrlPayResponse {
-    prepareSendResponse: PrepareSendResponse
+    destination: SendDestination
+    feesSat: number
     successAction?: SuccessAction
 }
 


### PR DESCRIPTION
This PR adds a `prepare_lnurl_pay()` interface method as a step before `lnurl_pay()` to calculate the fees involved with the payment, whether it is a payment via Lightning or paid directly to a Liquid address using the Magic Route Hint retrieved in the invoice.

Depends on https://github.com/breez/breez-sdk-greenlight/pull/1104 (CI tests will be broken)

Fixes #468 