### PR TITLE
Fix SDK checkout

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.sha }}
           path: build
 
       - name: Checkout breez-sdk-liquid-swift repo


### PR DESCRIPTION
This PR fixes the publish CI `publish-swift` to checkout the correct SDK branch