### PR TITLE
Log exact error root cause when failing to lookup script address

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -864,7 +864,7 @@ impl ChainSwapHandler {
         let liquid_chain_service = self.liquid_chain_service.lock().await;
         let script_pk = swap_script
             .to_address(self.config.network.into())
-            .map_err(|_| anyhow!("Could not retrieve address from swap script"))?
+            .map_err(|e| anyhow!("Could not retrieve address from swap script: {e:?}"))?
             .to_unconfidential()
             .script_pubkey();
         let utxos = liquid_chain_service.get_script_utxos(&script_pk).await?;

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -388,7 +388,7 @@ impl SendSwapHandler {
         let liquid_chain_service = self.chain_service.lock().await;
         let script_pk = swap_script
             .to_address(self.config.network.into())
-            .map_err(|_| anyhow!("Could not retrieve address from swap script"))?
+            .map_err(|e| anyhow!("Could not retrieve address from swap script: {e:?}"))?
             .to_unconfidential()
             .script_pubkey();
         let utxos = liquid_chain_service.get_script_utxos(&script_pk).await?;


### PR DESCRIPTION
This PR ensures we log the root cause when we get "could not retrieve address from swap script" errors.