### PR TITLE
Reserved address pool

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.7.0"
-source = "git+https://github.com/dangeross/lwk?branch=savage-try-headers-subscribe#452bc5e07ab6b9a5fee8c2dae5c9e24d5e3cc9c5"
+source = "git+https://github.com/dangeross/lwk?branch=savage-full-scan-to-index#ccc2c70404e07e7c79cb28db460b005f13be931c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.7.0"
-source = "git+https://github.com/dangeross/lwk?branch=savage-try-headers-subscribe#452bc5e07ab6b9a5fee8c2dae5c9e24d5e3cc9c5"
+source = "git+https://github.com/dangeross/lwk?branch=savage-full-scan-to-index#ccc2c70404e07e7c79cb28db460b005f13be931c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -30,7 +30,7 @@ impl UniffiBindingLogger {
 impl log::Log for UniffiBindingLogger {
     fn enabled(&self, m: &Metadata) -> bool {
         // ignore the internal uniffi log to prevent infinite loop.
-        return m.level() <= Level::Trace && *m.target() != *"breez_sdk_liquid_bindings";
+        m.level() <= Level::Trace && *m.target() != *"breez_sdk_liquid_bindings"
     }
 
     fn log(&self, record: &Record) {

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -23,7 +23,7 @@ flutter_rust_bridge = { version = "=2.4.0", features = [
 log = { workspace = true }
 lwk_common = "0.7.0"
 lwk_signer = "0.7.0"
-lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-try-headers-subscribe" }
+lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-scan-to-index" }
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -186,6 +186,12 @@ impl From<anyhow::Error> for PaymentError {
     }
 }
 
+impl From<rusqlite::Error> for PaymentError {
+    fn from(_: rusqlite::Error) -> Self {
+        Self::PersistError
+    }
+}
+
 impl From<SdkError> for PaymentError {
     fn from(err: SdkError) -> Self {
         Self::Generic {

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -261,6 +261,16 @@ pub struct ConnectWithSignerRequest {
     pub config: Config,
 }
 
+/// A reserved address. Once an address is reserved, it can only be
+/// reallocated to another payment after the block height expiration.
+#[derive(Clone, Debug)]
+pub(crate) struct ReservedAddress {
+    /// The address that is reserved
+    pub(crate) address: String,
+    /// The block height that the address is reserved until
+    pub(crate) expiry_block_height: u32,
+}
+
 /// The send/receive methods supported by the SDK
 #[derive(Clone, Debug, EnumString, Serialize, Eq, PartialEq)]
 pub enum PaymentMethod {
@@ -600,7 +610,8 @@ impl FromSql for Direction {
 pub(crate) struct ChainSwap {
     pub(crate) id: String,
     pub(crate) direction: Direction,
-    pub(crate) claim_address: String,
+    /// The Bitcoin claim address is only set for Outgoing Chain Swaps
+    pub(crate) claim_address: Option<String>,
     pub(crate) lockup_address: String,
     pub(crate) timeout_block_height: u32,
     pub(crate) preimage: String,
@@ -823,8 +834,16 @@ pub(crate) struct ReceiveSwap {
     pub(crate) claim_fees_sat: u64,
     /// Persisted as soon as a claim tx is broadcast
     pub(crate) claim_tx_id: Option<String>,
+    /// Persisted only when the lockup tx is broadcast
+    pub(crate) lockup_tx_id: Option<String>,
+    /// The address reserved for a magic routing hint payment
+    pub(crate) mrh_address: String,
+    /// The script pubkey for a magic routing hint payment
+    pub(crate) mrh_script_pubkey: String,
+    /// Persisted only if a transaction is sent to the `mrh_address`
+    pub(crate) mrh_tx_id: Option<String>,
     /// Until the lockup tx is seen in the mempool, it contains the swap creation time.
-    /// Afterwards, it shows the lockup tx creation time.    
+    /// Afterwards, it shows the lockup tx creation time.
     pub(crate) created_at: u32,
     pub(crate) state: PaymentState,
 }

--- a/lib/core/src/persist/address.rs
+++ b/lib/core/src/persist/address.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use log::debug;
+use rusqlite::{Row, Transaction, TransactionBehavior};
+
+use crate::error::PaymentError;
+
+use super::{Persister, ReservedAddress};
+
+impl Persister {
+    pub(crate) fn next_expired_reserved_address(
+        &self,
+        tip: u32,
+    ) -> Result<Option<ReservedAddress>> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // Get the next expired reserved address
+        let query = Self::get_reserved_address_query(vec!["expiry_block_height < ?1".to_string()]);
+        let res = match tx.query_row(&query, [tip], Self::sql_row_to_reserved_address) {
+            Ok(reserved_address) => {
+                // Delete the reserved address
+                Self::delete_reserved_address_inner(&tx, &reserved_address.address)?;
+                Some(reserved_address)
+            }
+            Err(_) => None,
+        };
+        tx.commit()?;
+
+        Ok(res)
+    }
+
+    fn get_reserved_address_query(where_clauses: Vec<String>) -> String {
+        let mut where_clause_str = String::new();
+        if !where_clauses.is_empty() {
+            where_clause_str = String::from("WHERE ");
+            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
+        }
+
+        format!(
+            "
+            SELECT
+                address,
+                expiry_block_height
+            FROM reserved_addresses
+            {where_clause_str}
+            ORDER BY expiry_block_height ASC
+            LIMIT 1
+        "
+        )
+    }
+
+    pub(crate) fn insert_or_update_reserved_address(
+        &self,
+        address: &str,
+        expiry_block_height: u32,
+    ) -> Result<(), PaymentError> {
+        let con = self.get_connection()?;
+        con.execute(
+            "INSERT OR REPLACE INTO reserved_addresses (
+           address,
+           expiry_block_height
+        )
+        VALUES (?, ?)
+        ",
+            (&address, expiry_block_height),
+        )?;
+        debug!(
+            "Reserved address {} until block height {}",
+            address, expiry_block_height
+        );
+
+        Ok(())
+    }
+
+    pub(crate) fn delete_reserved_address(&self, address: &str) -> Result<(), PaymentError> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction()?;
+        Self::delete_reserved_address_inner(&tx, address)?;
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    fn delete_reserved_address_inner(tx: &Transaction, address: &str) -> Result<(), PaymentError> {
+        tx.execute(
+            "DELETE FROM reserved_addresses WHERE address = ?",
+            [address],
+        )?;
+
+        Ok(())
+    }
+
+    fn sql_row_to_reserved_address(row: &Row) -> rusqlite::Result<ReservedAddress> {
+        Ok(ReservedAddress {
+            address: row.get(0)?,
+            expiry_block_height: row.get(1)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use crate::test_utils::persist::new_persister;
+
+    #[test]
+    fn test_next_expired_reserved_address() -> Result<()> {
+        let (_temp_dir, storage) = new_persister()?;
+        let address = "tlq1pq2amlulhea6ltq7x3eu9atsc2nnrer7yt7xve363zxedqwu2mk6ctcyv9awl8xf28cythreqklt5q0qqwsxzlm6wu4z6d574adl9zh2zmr0h85gt534n";
+
+        storage.insert_or_update_reserved_address(&address, 100)?;
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(99)?;
+        // Under the expiry, not popped
+        assert!(maybe_reserved_address.is_none());
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(100)?;
+        // Equal to expiry, not popped
+        assert!(maybe_reserved_address.is_none());
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(101)?;
+        // Address expired, popped
+        assert!(maybe_reserved_address.is_some());
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(102)?;
+        // Address already popped
+        assert!(maybe_reserved_address.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_reserved_address() -> Result<()> {
+        let (_temp_dir, storage) = new_persister()?;
+        let address = "tlq1pq2amlulhea6ltq7x3eu9atsc2nnrer7yt7xve363zxedqwu2mk6ctcyv9awl8xf28cythreqklt5q0qqwsxzlm6wu4z6d574adl9zh2zmr0h85gt534n";
+
+        storage.insert_or_update_reserved_address(&address, 100)?;
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(99)?;
+        // Under the expiry, not popped
+        assert!(maybe_reserved_address.is_none());
+
+        storage.delete_reserved_address(&address)?;
+
+        let maybe_reserved_address = storage.next_expired_reserved_address(101)?;
+        // Over the expired, but already deleted
+        assert!(maybe_reserved_address.is_none());
+
+        Ok(())
+    }
+}

--- a/lib/core/src/persist/cache.rs
+++ b/lib/core/src/persist/cache.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use rusqlite::{Transaction, TransactionBehavior};
 use std::str::FromStr;
 
 use super::Persister;
@@ -6,10 +7,12 @@ use super::Persister;
 const KEY_SWAPPER_PROXY_URL: &str = "swapper_proxy_url";
 const KEY_IS_FIRST_SYNC_COMPLETE: &str = "is_first_sync_complete";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
+// TODO: The `last_derivation_index` needs to be synced
+const KEY_LAST_DERIVATION_INDEX: &str = "last_derivation_index";
 
 impl Persister {
-    pub fn get_cached_item(&self, key: &str) -> Result<Option<String>> {
-        let res = self.get_connection()?.query_row(
+    fn get_cached_item_inner(tx: &Transaction, key: &str) -> Result<Option<String>> {
+        let res = tx.query_row(
             "SELECT value FROM cached_items WHERE key = ?1",
             [key],
             |row| row.get(0),
@@ -17,19 +20,41 @@ impl Persister {
         Ok(res.ok())
     }
 
-    pub fn update_cached_item(&self, key: &str, value: String) -> Result<()> {
-        self.get_connection()?.execute(
+    fn update_cached_item_inner(tx: &Transaction, key: &str, value: String) -> Result<()> {
+        tx.execute(
             "INSERT OR REPLACE INTO cached_items (key, value) VALUES (?1,?2)",
             (key, value),
         )?;
         Ok(())
     }
 
-    #[allow(dead_code)]
-    pub fn delete_cached_item(&self, key: &str) -> Result<()> {
-        self.get_connection()?
-            .execute("DELETE FROM cached_items WHERE key = ?1", [key])?;
+    pub fn delete_cached_item_inner(tx: &Transaction, key: &str) -> Result<()> {
+        tx.execute("DELETE FROM cached_items WHERE key = ?1", [key])?;
         Ok(())
+    }
+
+    pub fn get_cached_item(&self, key: &str) -> Result<Option<String>> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction()?;
+        let res = Self::get_cached_item_inner(&tx, key);
+        tx.commit()?;
+        res
+    }
+
+    pub fn update_cached_item(&self, key: &str, value: String) -> Result<()> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction()?;
+        let res = Self::update_cached_item_inner(&tx, key, value);
+        tx.commit()?;
+        res
+    }
+
+    pub fn delete_cached_item(&self, key: &str) -> Result<()> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction()?;
+        let res = Self::delete_cached_item_inner(&tx, key);
+        tx.commit()?;
+        res
     }
 
     pub fn set_swapper_proxy_url(&self, swapper_proxy_url: String) -> Result<()> {
@@ -65,6 +90,38 @@ impl Persister {
     pub fn get_webhook_url(&self) -> Result<Option<String>> {
         self.get_cached_item(KEY_WEBHOOK_URL)
     }
+
+    pub fn set_last_derivation_index(&self, index: u32) -> Result<()> {
+        self.update_cached_item(KEY_LAST_DERIVATION_INDEX, index.to_string())
+    }
+
+    pub fn get_last_derivation_index(&self) -> Result<Option<u32>> {
+        self.get_cached_item(KEY_LAST_DERIVATION_INDEX)
+            .map(|maybe_str| maybe_str.and_then(|str| str.as_str().parse::<u32>().ok()))
+    }
+
+    pub fn next_derivation_index(&self) -> Result<Option<u32>> {
+        let mut con = self.get_connection()?;
+        let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let res = match Self::get_cached_item_inner(&tx, KEY_LAST_DERIVATION_INDEX)? {
+            Some(last_index_str) => {
+                let next_index = last_index_str
+                    .as_str()
+                    .parse::<u32>()
+                    .map(|index| index + 1)?;
+                Self::update_cached_item_inner(
+                    &tx,
+                    KEY_LAST_DERIVATION_INDEX,
+                    next_index.to_string(),
+                )?;
+                Some(next_index)
+            }
+            None => None,
+        };
+        tx.commit()?;
+
+        Ok(res)
+    }
 }
 
 #[cfg(test)]
@@ -84,6 +141,62 @@ mod tests {
         persister.delete_cached_item("key1")?;
         let item_value = persister.get_cached_item("key1")?;
         assert_eq!(item_value, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_last_derivation_index() -> Result<()> {
+        let (_temp_dir, persister) = new_persister()?;
+
+        let maybe_last_index = persister.get_last_derivation_index()?;
+        assert!(maybe_last_index.is_none());
+
+        persister.set_last_derivation_index(50)?;
+
+        let maybe_last_index = persister.get_last_derivation_index()?;
+        assert!(maybe_last_index.is_some());
+        assert_eq!(maybe_last_index, Some(50));
+
+        persister.set_last_derivation_index(51)?;
+
+        let maybe_last_index = persister.get_last_derivation_index()?;
+        assert!(maybe_last_index.is_some());
+        assert_eq!(maybe_last_index, Some(51));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_next_derivation_index() -> Result<()> {
+        let (_temp_dir, persister) = new_persister()?;
+
+        let maybe_next_index = persister.next_derivation_index()?;
+        assert!(maybe_next_index.is_none());
+
+        persister.set_last_derivation_index(50)?;
+
+        let maybe_next_index = persister.next_derivation_index()?;
+        assert!(maybe_next_index.is_some());
+        assert_eq!(maybe_next_index, Some(51));
+
+        let maybe_last_index = persister.get_last_derivation_index()?;
+        assert!(maybe_last_index.is_some());
+        assert_eq!(maybe_last_index, Some(51));
+
+        persister.set_last_derivation_index(52)?;
+
+        let maybe_next_index = persister.next_derivation_index()?;
+        assert!(maybe_next_index.is_some());
+        assert_eq!(maybe_next_index, Some(53));
+
+        let maybe_next_index = persister.next_derivation_index()?;
+        assert!(maybe_next_index.is_some());
+        assert_eq!(maybe_next_index, Some(54));
+
+        let maybe_last_index = persister.get_last_derivation_index()?;
+        assert!(maybe_last_index.is_some());
+        assert_eq!(maybe_last_index, Some(54));
 
         Ok(())
     }

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -259,8 +259,7 @@ impl Persister {
                 ":id": swap_id,
                 ":accept_zero_conf": accept_zero_conf,
             },
-        )
-        .map_err(|_| PaymentError::PersistError)?;
+        )?;
         Ok(())
     }
 
@@ -357,8 +356,7 @@ impl Persister {
                 ":refund_tx_id": refund_tx_id,
                 ":state": to_state,
             },
-        )
-        .map_err(|_| PaymentError::PersistError)?;
+        )?;
 
         Ok(())
     }

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -98,5 +98,90 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE receive_swaps ADD COLUMN payment_hash TEXT;
         ALTER TABLE send_swaps ADD COLUMN payment_hash TEXT;
         ",
+        "
+        CREATE TABLE IF NOT EXISTS reserved_addresses (
+            address TEXT NOT NULL PRIMARY KEY,
+            expiry_block_height INTEGER NOT NULL
+        ) STRICT;
+
+        ALTER TABLE receive_swaps ADD COLUMN mrh_address TEXT NOT NULL DEFAULT '';
+        ALTER TABLE receive_swaps ADD COLUMN mrh_script_pubkey TEXT NOT NULL DEFAULT '';
+        ALTER TABLE receive_swaps ADD COLUMN mrh_tx_id TEXT;
+        ",
+        "
+        ALTER TABLE chain_swaps RENAME TO old_chain_swaps;
+
+        CREATE TABLE IF NOT EXISTS chain_swaps (
+            id TEXT NOT NULL PRIMARY KEY,
+            direction INTEGER NOT NULL,
+            claim_address TEXT,
+            lockup_address TEXT NOT NULL,
+            timeout_block_height INTEGER NOT NULL,
+            preimage TEXT NOT NULL,
+            payer_amount_sat INTEGER NOT NULL,
+            receiver_amount_sat INTEGER NOT NULL,
+            accept_zero_conf INTEGER NOT NULL,
+            create_response_json TEXT NOT NULL,
+            claim_private_key TEXT NOT NULL,
+            refund_private_key TEXT NOT NULL,
+            server_lockup_tx_id TEXT,
+            user_lockup_tx_id TEXT,
+            claim_fees_sat INTEGER NOT NULL,
+            claim_tx_id TEXT,
+            refund_tx_id TEXT,
+            created_at INTEGER NOT NULL,
+            state INTEGER NOT NULL,
+            description TEXT,
+            id_hash TEXT
+        ) STRICT;
+
+        INSERT INTO chain_swaps (
+            id, 
+            direction,
+            claim_address,
+            lockup_address,
+            timeout_block_height,
+            preimage,
+            payer_amount_sat,
+            receiver_amount_sat,
+            accept_zero_conf,
+            create_response_json,
+            claim_private_key,
+            refund_private_key,
+            server_lockup_tx_id,
+            user_lockup_tx_id,
+            claim_fees_sat,
+            claim_tx_id,
+            refund_tx_id,
+            created_at,
+            state,
+            description,
+            id_hash
+        ) SELECT 
+            id, 
+            direction,
+            claim_address,
+            lockup_address,
+            timeout_block_height,
+            preimage,
+            payer_amount_sat,
+            receiver_amount_sat,
+            accept_zero_conf,
+            create_response_json,
+            claim_private_key,
+            refund_private_key,
+            server_lockup_tx_id,
+            user_lockup_tx_id,
+            claim_fees_sat,
+            claim_tx_id,
+            refund_tx_id,
+            created_at,
+            state,
+            description,
+            id_hash
+        FROM old_chain_swaps;
+
+        DROP TABLE old_chain_swaps;
+        ",
     ]
 }

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -25,12 +25,12 @@ impl Persister {
                 claim_private_key,
                 invoice,
                 payment_hash,
-                description,
                 payer_amount_sat,
                 receiver_amount_sat,
                 created_at,
                 claim_fees_sat,
-                claim_tx_id,
+                mrh_address,
+                mrh_script_pubkey,
                 state
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -44,14 +44,30 @@ impl Persister {
             &receive_swap.claim_private_key,
             &receive_swap.invoice,
             &receive_swap.payment_hash,
-            &receive_swap.description,
             &receive_swap.payer_amount_sat,
             &receive_swap.receiver_amount_sat,
             &receive_swap.created_at,
             &receive_swap.claim_fees_sat,
-            &receive_swap.claim_tx_id,
+            &receive_swap.mrh_address,
+            &receive_swap.mrh_script_pubkey,
             &receive_swap.state,
         ))?;
+
+        con.execute(
+            "UPDATE receive_swaps
+            SET
+                description = :description,
+                claim_tx_id = :claim_tx_id,
+                mrh_tx_id = :mrh_tx_id
+            WHERE
+                id = :id",
+            named_params! {
+                ":id": &receive_swap.id,
+                ":description": &receive_swap.description,
+                ":claim_tx_id": &receive_swap.claim_tx_id,
+                ":mrh_tx_id": &receive_swap.mrh_tx_id,
+            },
+        )?;
 
         Ok(())
     }
@@ -77,6 +93,10 @@ impl Persister {
                 rs.receiver_amount_sat,
                 rs.claim_fees_sat,
                 rs.claim_tx_id,
+                rs.lockup_tx_id,
+                rs.mrh_address,
+                rs.mrh_script_pubkey,
+                rs.mrh_tx_id,
                 rs.created_at,
                 rs.state
             FROM receive_swaps AS rs
@@ -118,8 +138,12 @@ impl Persister {
             receiver_amount_sat: row.get(8)?,
             claim_fees_sat: row.get(9)?,
             claim_tx_id: row.get(10)?,
-            created_at: row.get(11)?,
-            state: row.get(12)?,
+            lockup_tx_id: row.get(11)?,
+            mrh_address: row.get(12)?,
+            mrh_script_pubkey: row.get(13)?,
+            mrh_tx_id: row.get(14)?,
+            created_at: row.get(15)?,
+            state: row.get(16)?,
         })
     }
 
@@ -161,6 +185,28 @@ impl Persister {
                 Self::sql_row_to_receive_swap,
             )?
             .map(|i| i.unwrap())
+            .collect();
+        Ok(res)
+    }
+
+    /// Ongoing Receive Swaps with no claim or lockup transactions, indexed by mrh_script_pubkey
+    pub(crate) fn list_ongoing_receive_swaps_by_mrh_script_pubkey(
+        &self,
+    ) -> Result<HashMap<String, ReceiveSwap>> {
+        let con: Connection = self.get_connection()?;
+        let res = self
+            .list_ongoing_receive_swaps(&con)?
+            .iter()
+            .filter_map(|swap| {
+                match (
+                    swap.lockup_tx_id.clone(),
+                    swap.claim_tx_id.clone(),
+                    swap.mrh_script_pubkey.is_empty(),
+                ) {
+                    (None, None, false) => Some((swap.mrh_script_pubkey.clone(), swap.clone())),
+                    _ => None,
+                }
+            })
             .collect();
         Ok(res)
     }
@@ -232,6 +278,8 @@ impl Persister {
         to_state: PaymentState,
         claim_tx_id: Option<&str>,
         lockup_tx_id: Option<&str>,
+        mrh_tx_id: Option<&str>,
+        mrh_amount_sat: Option<u64>,
     ) -> Result<(), PaymentError> {
         // Do not overwrite claim_tx_id or lockup_tx_id
         let con: Connection = self.get_connection()?;
@@ -248,6 +296,13 @@ impl Persister {
                         WHEN lockup_tx_id IS NULL THEN :lockup_tx_id
                         ELSE lockup_tx_id
                     END,
+                mrh_tx_id = 
+                    CASE
+                        WHEN mrh_tx_id IS NULL THEN :mrh_tx_id
+                        ELSE mrh_tx_id
+                    END,
+                payer_amount_sat = COALESCE(:mrh_amount_sat, payer_amount_sat),
+                receiver_amount_sat = COALESCE(:mrh_amount_sat, receiver_amount_sat),
                 state = :state
             WHERE
                 id = :id",
@@ -255,10 +310,11 @@ impl Persister {
                 ":id": swap_id,
                 ":lockup_tx_id": lockup_tx_id,
                 ":claim_tx_id": claim_tx_id,
+                ":mrh_tx_id": mrh_tx_id,
+                ":mrh_amount_sat": mrh_amount_sat,
                 ":state": to_state,
             },
-        )
-        .map_err(|_| PaymentError::PersistError)?;
+        )?;
 
         Ok(())
     }
@@ -364,7 +420,14 @@ mod tests {
         let new_state = PaymentState::Pending;
         let claim_tx_id = Some("claim_tx_id");
 
-        storage.try_handle_receive_swap_update(&receive_swap.id, new_state, claim_tx_id, None)?;
+        storage.try_handle_receive_swap_update(
+            &receive_swap.id,
+            new_state,
+            claim_tx_id,
+            None,
+            None,
+            None,
+        )?;
 
         let updated_receive_swap = storage
             .fetch_receive_swap_by_id(&receive_swap.id)?

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -71,8 +71,7 @@ impl Persister {
                 ":from_state": from_state,
                 ":to_state": to_state,
             },
-        )
-        .map_err(|_| PaymentError::PersistError)?;
+        )?;
 
         Ok(())
     }
@@ -236,8 +235,7 @@ impl Persister {
                 ":refund_tx_id": refund_tx_id,
                 ":state": to_state,
             },
-        )
-        .map_err(|_| PaymentError::PersistError)?;
+        )?;
 
         Ok(())
     }

--- a/lib/core/src/swapper/boltz/bitcoin.rs
+++ b/lib/core/src/swapper/boltz/bitcoin.rs
@@ -101,12 +101,13 @@ impl BoltzSwapper {
     pub(crate) fn new_outgoing_chain_claim_tx(
         &self,
         swap: &ChainSwap,
+        claim_address: String,
     ) -> Result<Transaction, PaymentError> {
         let claim_keypair = swap.get_claim_keypair()?;
         let claim_swap_script = swap.get_claim_swap_script()?.as_bitcoin_script()?;
         let claim_tx_wrapper = BtcSwapTx::new_claim(
             claim_swap_script,
-            swap.claim_address.clone(),
+            claim_address,
             &self.bitcoin_electrum_config,
             self.boltz_url.clone(),
             swap.id.clone(),

--- a/lib/core/src/swapper/boltz/liquid.rs
+++ b/lib/core/src/swapper/boltz/liquid.rs
@@ -72,12 +72,13 @@ impl BoltzSwapper {
     pub(crate) fn new_incoming_chain_claim_tx(
         &self,
         swap: &ChainSwap,
+        claim_address: String,
     ) -> Result<Transaction, PaymentError> {
         let claim_keypair = swap.get_claim_keypair()?;
         let swap_script = swap.get_claim_swap_script()?.as_liquid_script()?;
         let claim_tx_wrapper = LBtcSwapTx::new_claim(
             swap_script,
-            swap.claim_address.clone(),
+            claim_address,
             &self.liquid_electrum_config,
             self.boltz_url.clone(),
             swap.id.clone(),

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -53,7 +53,7 @@ pub(crate) fn new_chain_swap(
         Direction::Incoming => ChainSwap {
             id: generate_random_string(4),
             direction,
-            claim_address: "tlq1qq0nn497zr4l6nfq84pxzqwme87n7kz09lvnx94t7ecw045dvjr09s9s6ens46nt7qcrmx673vq6gkss50qhpcxywt3r5a44j2".to_string(),
+            claim_address: None,
             lockup_address: "tb1p7cftn5u3ndt8ln0m6hruwyhsz8kc5sxt557ua03qcew0z29u5paqh8f7uu".to_string(),
             timeout_block_height: 2868778,
             preimage: "bbce422d96c0386c3a6c1b1fe11fc7be3fdd871c6855db6ab2e319e96ec19c78".to_string(),
@@ -116,7 +116,7 @@ pub(crate) fn new_chain_swap(
         Direction::Outgoing => ChainSwap {
             id: generate_random_string(4),
             direction,
-            claim_address: "14DeLtifrayJXAWft3qhPbdY4HVJUgMyx1".to_string(),
+            claim_address: Some("14DeLtifrayJXAWft3qhPbdY4HVJUgMyx1".to_string()),
             lockup_address: "tlq1pqg4e5r5a59gdl26ud6s7gna3mchqs20ycwl2lp67ejzy69fl7dwccwx9nqtr6ef848k7vpmvmdhsyeq2wp3vtn3gnlenhd0wrasv4qvr2dk0nz5tu0rw".to_string(),
             timeout_block_height: 1481523,
             preimage: "a95a028483df6112c15fdef513d9d8255ff0951d5c0856f85cf9c98352a0f71a".to_string(),

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -103,6 +103,10 @@ pub(crate) fn new_receive_swap(payment_state: Option<PaymentState>) -> ReceiveSw
         receiver_amount_sat: 587,
         claim_fees_sat: 200,
         claim_tx_id: None,
+        lockup_tx_id: None,
+        mrh_address: "tlq1pq2amlulhea6ltq7x3eu9atsc2nnrer7yt7xve363zxedqwu2mk6ctcyv9awl8xf28cythreqklt5q0qqwsxzlm6wu4z6d574adl9zh2zmr0h85gt534n".to_string(),
+        mrh_script_pubkey: "tex1qnkznyyxwnxnkk0j94cnvq27h24jk6sqf0te55x".to_string(),
+        mrh_tx_id: None,
         created_at: utils::now(),
         state: payment_state.unwrap_or(PaymentState::Created),
     }


### PR DESCRIPTION
This PR:
- Adds addresses allocated to swaps to a reserved pool of addresses until the swap expires
- Gets the next unused address from either an expired reserved address or the next index from the cached derivation index
- Caches the last used derivation index
- Associates a magic routing hint address to the reverse swap, which then when paid via this address, is linked to the reverse swap (if the address is unused, it will be reallocated after expiry)

TODO:
- [x] Adjust the `payer_amount_sat` and `receiver_amount_sat` if paid via magic routing hint to set the payment fees to 0 (both should equal tx amount)
- [x] Patch LWK to allow an "up to index" full scan to prevent gap limit errors

QUESTIONS:
- Should a payment created using a LiquidAddress method expire?

Fixes #523