### PR TITLE
Bring remaining u32 amount types to u64

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/hydra-yse/boltz-rust?branch=yse-fee-calculation#09710fb508a2a188978f37c091ebb488331d627d"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#e431a04f4a2fa9e5d57a645eff278012a153b784"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
@@ -2760,7 +2760,6 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
- "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
@@ -3720,21 +3719,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "flate2",
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.12",
- "rustls-pki-types",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -3953,7 +3952,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/hydra-yse/boltz-rust?branch=yse-fee-calculation#09710fb508a2a188978f37c091ebb488331d627d"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#e431a04f4a2fa9e5d57a645eff278012a153b784"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
@@ -3054,7 +3054,6 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
- "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
@@ -4323,21 +4322,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "flate2",
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.12",
- "rustls-pki-types",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -14,7 +14,7 @@ frb = ["dep:flutter_rust_bridge"]
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", branch = "yse-fee-calculation" }
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
 chrono = "0.4"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.4.0", features = [

--- a/lib/core/src/buy.rs
+++ b/lib/core/src/buy.rs
@@ -54,7 +54,7 @@ impl BuyBitcoinApi for BuyBitcoinService {
                 self.moonpay_provider
                     .buy_bitcoin(
                         create_response.lockup_details.lockup_address,
-                        Some(create_response.lockup_details.amount as u64),
+                        Some(create_response.lockup_details.amount),
                         None,
                         redirect_url,
                     )

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -602,7 +602,7 @@ impl ChainSwapHandler {
                     .lowball_fee_rate_msat_per_vbyte()
                     .map(|v| v as f32),
                 &lockup_details.lockup_address,
-                lockup_details.amount as u64,
+                lockup_details.amount,
             )
             .await
         {
@@ -612,7 +612,7 @@ impl ChainSwapHandler {
                     .build_drain_tx(
                         None,
                         &lockup_details.lockup_address,
-                        Some(lockup_details.amount as u64),
+                        Some(lockup_details.amount),
                     )
                     .await
             }
@@ -1114,7 +1114,7 @@ impl ChainSwapHandler {
                 .unblind(&secp, liquid_swap_script.blinding_key.secret_key())?
                 .value;
         }
-        if value < claim_details.amount as u64 {
+        if value < claim_details.amount {
             return Err(anyhow!(
                 "Transaction value {value} sats is less than {} sats",
                 claim_details.amount
@@ -1159,7 +1159,7 @@ impl ChainSwapHandler {
             .filter(|tx_out| tx_out.script_pubkey == address.script_pubkey())
             .map(|tx_out| tx_out.value.to_sat())
             .sum();
-        if value < claim_details.amount as u64 {
+        if value < claim_details.amount {
             return Err(anyhow!(
                 "Transaction value {value} sats is less than {} sats",
                 claim_details.amount

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -226,7 +226,7 @@ pub(crate) struct InternalCreateReverseResponse {
     pub lockup_address: String,
     pub refund_public_key: String,
     pub timeout_block_height: u32,
-    pub onchain_amount: u32,
+    pub onchain_amount: u64,
     pub blinding_key: Option<String>,
 }
 impl InternalCreateReverseResponse {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1305,7 +1305,7 @@ impl LiquidSdk {
             claim_public_key: Some(claim_public_key),
             refund_public_key: Some(refund_public_key),
             user_lock_amount: None,
-            server_lock_amount: Some(server_lockup_amount_sat as u32), // TODO update our model
+            server_lock_amount: Some(server_lockup_amount_sat),
             pair_hash: Some(pair.hash),
             referral_id: None,
             webhook,
@@ -1594,7 +1594,7 @@ impl LiquidSdk {
         });
 
         let v2_req = CreateReverseRequest {
-            invoice_amount: payer_amount_sat as u32, // TODO update our model
+            invoice_amount: payer_amount_sat,
             from: "BTC".to_string(),
             to: "L-BTC".to_string(),
             preimage_hash: preimage.sha256,
@@ -1711,7 +1711,7 @@ impl LiquidSdk {
             preimage_hash: preimage.sha256,
             claim_public_key: Some(claim_public_key),
             refund_public_key: Some(refund_public_key),
-            user_lock_amount: Some(user_lockup_amount_sat as u32), // TODO update our model
+            user_lock_amount: Some(user_lockup_amount_sat),
             server_lock_amount: None,
             pair_hash: Some(pair.hash),
             referral_id: None,

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -32,7 +32,7 @@ pub(crate) fn new_send_swap(payment_state: Option<PaymentState>) -> SendSwap {
     let payment_hash = sha256::Hash::from_slice(&[0; 32][..]).expect("Expecting valid hash");
     let invoice = InvoiceBuilder::new(Currency::BitcoinTestnet)
         .description("Test invoice".into())
-        .payment_hash(payment_hash.clone())
+        .payment_hash(payment_hash)
         .payment_secret(PaymentSecret([42u8; 32]))
         .current_timestamp()
         .min_final_cltv_expiry_delta(144)


### PR DESCRIPTION
This PR fixes older TODOs about amount type conversions: some amounts and fees are `u64`, while others were `u32`.

Fixing this also simplifies the code for amountless swaps, which deals with `Option<u64>`.