### PR TITLE
Send: Fix double-lockup when payment is TimedOut

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1081,8 +1081,7 @@ impl LiquidSdk {
         let create_response = swap.get_boltz_create_response()?;
         self.try_lockup(&swap, &create_response).await?;
 
-        let accept_zero_conf = create_response.accept_zero_conf;
-        self.wait_for_payment(Swap::Send(swap), accept_zero_conf)
+        self.wait_for_payment(Swap::Send(swap), create_response.accept_zero_conf)
             .await
             .map(|payment| SendPaymentResponse { payment })
     }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2714,43 +2714,6 @@ mod tests {
                 assert_eq!(persisted_swap.state, PaymentState::Failed);
             }
 
-            // Verify that `InvoiceSet` correctly sets the state to `Pending` and
-            // assigns the `lockup_tx_id` to the payment
-            let persisted_swap = trigger_swap_update!(
-                "send",
-                NewSwapArgs::default().set_initial_payment_state(PaymentState::Created),
-                persister,
-                status_stream,
-                SubSwapStates::InvoiceSet,
-                None,
-                None
-            );
-            assert_eq!(persisted_swap.state, PaymentState::Pending);
-            assert!(persisted_swap.lockup_tx_id.is_some());
-
-            // Verify that, when `InvoiceSet` is received and the payment state is not `Created`,
-            // the payment state remains unchanged, and no lockup is broadcast
-            for payment_state in [
-                PaymentState::Pending,
-                PaymentState::TimedOut,
-                PaymentState::Complete,
-                PaymentState::Failed,
-                PaymentState::Refundable,
-                PaymentState::RefundPending,
-            ] {
-                let persisted_swap = trigger_swap_update!(
-                    "send",
-                    NewSwapArgs::default().set_initial_payment_state(payment_state),
-                    persister,
-                    status_stream,
-                    SubSwapStates::InvoiceSet,
-                    None,
-                    None
-                );
-                assert_eq!(persisted_swap.state, payment_state);
-                assert!(persisted_swap.lockup_tx_id.is_none());
-            }
-
             // Verify that `TransactionClaimPending` correctly sets the state to `Complete`
             // and stores the preimage
             let persisted_swap = trigger_swap_update!(

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -74,7 +74,10 @@ impl SendSwapHandler {
             // Boltz has locked the HTLC, we proceed with locking up the funds
             Ok(SubSwapStates::InvoiceSet) => {
                 match (swap.state, swap.lockup_tx_id.clone()) {
-                    (PaymentState::Created, None) | (PaymentState::TimedOut, None) => {
+                    (TimedOut, _) => {
+                        warn!("Send Swap {id} timed out, do not broadcast a lockup tx")
+                    }
+                    (PaymentState::Created, None) => {
                         let create_response = swap.get_boltz_create_response()?;
                         let lockup_tx = self.lockup_funds(id, &create_response).await?;
                         let lockup_tx_id = lockup_tx.txid().to_string();


### PR DESCRIPTION
Given the current event loop, TimedOut payments may cause lockups to be broadcast. 

This PR changes the send flow such that:
1. When a user calls `send_payment`, the lockup is broadcasted within that same thread _only if_ it hasn't been broadcasted beforehand
2. The background thread (Boltz status stream) does not execute lockups any longer

~**TODO:** Persist `lockup_tx_id` beforehand to ensure we don't broadcast twice in case the client closes the application before the new state is saved~