### PR TITLE
Propagate signer interface changes

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2214,7 +2214,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -2226,9 +2236,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.7",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2522,6 +2545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2900,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=387e37f8ce48ee841762b945137e2c6b4b4b5cfa#387e37f8ce48ee841762b945137e2c6b4b4b5cfa"
+source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -2921,6 +2953,7 @@ dependencies = [
  "serde_json",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tonic",
  "tonic-build",
  "url",
@@ -3142,6 +3175,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -3410,7 +3452,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot 0.12.3",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -3867,7 +3911,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=387e37f8ce48ee841762b945137e2c6b4b4b5cfa#387e37f8ce48ee841762b945137e2c6b4b4b5cfa"
+source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -3201,6 +3201,7 @@ dependencies = [
  "serde_json",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tonic",
  "tonic-build",
  "url",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -27,7 +27,7 @@ lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-s
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "387e37f8ce48ee841762b945137e2c6b4b4b5cfa", features = ["liquid"]}
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "441a9fd50c32098b2887e960c8a4bcc5956da1af", features = ["liquid"]}
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 strum = "0.25"

--- a/lib/core/src/lnurl/auth.rs
+++ b/lib/core/src/lnurl/auth.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use sdk_common::{
     bitcoin::util::bip32::{ChildNumber, DerivationPath},
     prelude::{LnUrlResult, LnurlAuthSigner},
@@ -17,8 +18,9 @@ impl SdkLnurlAuthSigner {
     }
 }
 
+#[async_trait]
 impl LnurlAuthSigner for SdkLnurlAuthSigner {
-    fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
+    async fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
         let derivation: DerivationPath = derivation_path.to_vec().into();
         self.signer
             .derive_xpub(derivation.to_string())
@@ -26,7 +28,11 @@ impl LnurlAuthSigner for SdkLnurlAuthSigner {
             .map(|xpub| xpub.to_vec())
     }
 
-    fn sign_ecdsa(&self, msg: &[u8], derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
+    async fn sign_ecdsa(
+        &self,
+        msg: &[u8],
+        derivation_path: &[ChildNumber],
+    ) -> LnUrlResult<Vec<u8>> {
         let derivation: DerivationPath = derivation_path.to_vec().into();
         self.signer
             .sign_ecdsa(msg.to_vec(), derivation.to_string())
@@ -34,7 +40,7 @@ impl LnurlAuthSigner for SdkLnurlAuthSigner {
             .map(|s: Vec<u8>| s.to_vec())
     }
 
-    fn hmac_sha256(
+    async fn hmac_sha256(
         &self,
         key_derivation_path: &[ChildNumber],
         input: &[u8],


### PR DESCRIPTION
This PR bumps `sdk-common` to the latest version and propagates the changes introduced in https://github.com/breez/breez-sdk-greenlight/commit/a247b9508695a41a513d7fd1ff71a2d84844b73c , namely making the methods `async`.