### PR TITLE
Add support for paying to BOLT12

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#fa01549242a786f3fc9ccffa134e47ba462838db"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#a8a7057320aca4f5b03708a11de0ea66dc931d80"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +400,12 @@ name = "bech32"
 version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip21"
@@ -440,12 +462,29 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "base64 0.21.7",
  "bech32 0.10.0-beta",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "hex-conservative 0.1.2",
  "hex_lit",
  "secp256k1 0.28.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
@@ -458,10 +497,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -484,9 +544,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -539,7 +609,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#8b8bddeb362b6d62ae92ed9a6cb759e1d0506a12"
+source = "git+https://github.com/ok300/boltz-rust?branch=ok300-support-bolt12#5e5181552e822ce2b6c2b6642f903acba3118b16"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
@@ -588,6 +658,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "lightning 0.0.125",
  "log",
  "lwk_common",
  "lwk_signer",
@@ -1423,6 +1494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,7 +1879,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
 dependencies = [
  "bitcoin 0.30.2",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-invoice 0.32.0",
+ "lightning-types",
 ]
 
 [[package]]
@@ -1827,6 +1919,28 @@ dependencies = [
  "lightning 0.0.122",
  "num-traits",
  "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -1981,7 +2095,7 @@ checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin 0.31.2",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
 ]
 
 [[package]]
@@ -2993,6 +3107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3139,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -3996,7 +4129,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#a8a7057320aca4f5b03708a11de0ea66dc931d80"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#11c6812c81407881a014390cb3da68cea169bcf1"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#12dea61af7b74be972a957aa53402d9eccc6530f"
+source = "git+https://github.com/breez/breez-sdk?rev=5955216ec4ed003972b4473a77207dfb744da882#5955216ec4ed003972b4473a77207dfb744da882"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#53ba77bce27b49a5c9b47698b5ce3cbded975572"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#12dea61af7b74be972a957aa53402d9eccc6530f"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3045,8 +3045,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
+version = "0.6.2"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#fa01549242a786f3fc9ccffa134e47ba462838db"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#11c6812c81407881a014390cb3da68cea169bcf1"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#3ffe4458d81e4d8f9c5d287e1b5dacf9735ec3d3"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#caf483b6eebf860e079c239858f2900c82302955"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#53ba77bce27b49a5c9b47698b5ce3cbded975572"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#3ffe4458d81e4d8f9c5d287e1b5dacf9735ec3d3"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#caf483b6eebf860e079c239858f2900c82302955"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/ok300/boltz-rust?branch=ok300-support-bolt12#5e5181552e822ce2b6c2b6642f903acba3118b16"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#19e01071f5722c21f80ae9b34edef5c3972e9e0b"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -327,7 +327,7 @@ pub(crate) async fn handle_command(
                 (None, Some(offer), None) => match amount_sat {
                     Some(_) => Ok(offer),
                     None => Err(anyhow!(
-                        "Must specify either a BOLT11 invoice, a BOLT12 offer or a direct/BIP21 address."
+                        "Must specify an amount for a BOLT12 offer."
                     ))
                 },
                 (None, None, Some(address)) => Ok(address),

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -21,7 +21,7 @@ use serde_json::to_string_pretty;
 pub(crate) enum Command {
     /// Send a payment directly or via a swap
     SendPayment {
-        /// Invoice which has to be paid (BOLT11 or BOLT12)
+        /// Invoice which has to be paid (BOLT11)
         #[arg(long)]
         invoice: Option<String>,
 

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#caf483b6eebf860e079c239858f2900c82302955"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#53ba77bce27b49a5c9b47698b5ce3cbded975572"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#3ffe4458d81e4d8f9c5d287e1b5dacf9735ec3d3"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#caf483b6eebf860e079c239858f2900c82302955"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3293,8 +3293,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
+version = "0.6.2"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#fa01549242a786f3fc9ccffa134e47ba462838db"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#11c6812c81407881a014390cb3da68cea169bcf1"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#8da4455e4a5a077e40c440d6c875236d666fffb0"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#53ba77bce27b49a5c9b47698b5ce3cbded975572"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#12dea61af7b74be972a957aa53402d9eccc6530f"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#a8a7057320aca4f5b03708a11de0ea66dc931d80"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#11c6812c81407881a014390cb3da68cea169bcf1"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#fa01549242a786f3fc9ccffa134e47ba462838db"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#a8a7057320aca4f5b03708a11de0ea66dc931d80"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#8da4455e4a5a077e40c440d6c875236d666fffb0"
+source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#3ffe4458d81e4d8f9c5d287e1b5dacf9735ec3d3"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -189,6 +189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +436,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +483,12 @@ name = "bech32"
 version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bincode"
@@ -554,12 +576,29 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "base64 0.21.7",
  "bech32 0.10.0-beta",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "hex-conservative 0.1.2",
  "hex_lit",
  "secp256k1 0.28.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
@@ -572,10 +611,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -598,9 +658,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -653,7 +723,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#8b8bddeb362b6d62ae92ed9a6cb759e1d0506a12"
+source = "git+https://github.com/ok300/boltz-rust?branch=ok300-support-bolt12#5e5181552e822ce2b6c2b6642f903acba3118b16"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
@@ -687,6 +757,7 @@ dependencies = [
  "glob",
  "hex",
  "lazy_static",
+ "lightning 0.0.125",
  "log",
  "lwk_common",
  "lwk_signer",
@@ -1607,6 +1678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,7 +2082,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
 dependencies = [
  "bitcoin 0.30.2",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-invoice 0.32.0",
+ "lightning-types",
 ]
 
 [[package]]
@@ -2030,6 +2122,28 @@ dependencies = [
  "lightning 0.0.122",
  "num-traits",
  "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -2194,7 +2308,7 @@ checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin 0.31.2",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
 ]
 
 [[package]]
@@ -3241,6 +3355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,6 +3387,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/ok300/boltz-rust?branch=ok300-support-bolt12#5e5181552e822ce2b6c2b6642f903acba3118b16"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#19e01071f5722c21f80ae9b34edef5c3972e9e0b"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?branch=ok300-sdk-common-parse-bolt12-offer#12dea61af7b74be972a957aa53402d9eccc6530f"
+source = "git+https://github.com/breez/breez-sdk?rev=5955216ec4ed003972b4473a77207dfb744da882#5955216ec4ed003972b4473a77207dfb744da882"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -480,6 +480,25 @@ typedef struct wire_cst_aes_success_action_data_result {
   union AesSuccessActionDataResultKind kind;
 } wire_cst_aes_success_action_data_result;
 
+typedef struct wire_cst_Amount_Bitcoin {
+  uint64_t amount_msat;
+} wire_cst_Amount_Bitcoin;
+
+typedef struct wire_cst_Amount_Currency {
+  struct wire_cst_list_prim_u_8_strict *iso4217_code;
+  uint64_t fractional_amount;
+} wire_cst_Amount_Currency;
+
+typedef union AmountKind {
+  struct wire_cst_Amount_Bitcoin Bitcoin;
+  struct wire_cst_Amount_Currency Currency;
+} AmountKind;
+
+typedef struct wire_cst_amount {
+  int32_t tag;
+  union AmountKind kind;
+} wire_cst_amount;
+
 typedef struct wire_cst_bitcoin_address_data {
   struct wire_cst_list_prim_u_8_strict *address;
   int32_t network;
@@ -487,6 +506,21 @@ typedef struct wire_cst_bitcoin_address_data {
   struct wire_cst_list_prim_u_8_strict *label;
   struct wire_cst_list_prim_u_8_strict *message;
 } wire_cst_bitcoin_address_data;
+
+typedef struct wire_cst_list_String {
+  struct wire_cst_list_prim_u_8_strict **ptr;
+  int32_t len;
+} wire_cst_list_String;
+
+typedef struct wire_cst_ln_offer {
+  struct wire_cst_list_prim_u_8_strict *bolt12;
+  struct wire_cst_list_String *chains;
+  struct wire_cst_amount *amount;
+  struct wire_cst_list_prim_u_8_strict *description;
+  uint64_t *absolute_expiry;
+  struct wire_cst_list_prim_u_8_strict *issuer;
+  struct wire_cst_list_prim_u_8_strict *signing_pubkey;
+} wire_cst_ln_offer;
 
 typedef struct wire_cst_ln_url_error_data {
   struct wire_cst_list_prim_u_8_strict *reason;
@@ -628,7 +662,7 @@ typedef struct wire_cst_InputType_Bolt11 {
 } wire_cst_InputType_Bolt11;
 
 typedef struct wire_cst_InputType_Bolt12Offer {
-  struct wire_cst_list_prim_u_8_strict *offer;
+  struct wire_cst_ln_offer *offer;
 } wire_cst_InputType_Bolt12Offer;
 
 typedef struct wire_cst_InputType_NodeId {
@@ -1131,6 +1165,8 @@ struct wire_cst_aes_success_action_data_decrypted *frbgen_breez_liquid_cst_new_b
 
 struct wire_cst_aes_success_action_data_result *frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_result(void);
 
+struct wire_cst_amount *frbgen_breez_liquid_cst_new_box_autoadd_amount(void);
+
 struct wire_cst_backup_request *frbgen_breez_liquid_cst_new_box_autoadd_backup_request(void);
 
 struct wire_cst_binding_event_listener *frbgen_breez_liquid_cst_new_box_autoadd_binding_event_listener(void);
@@ -1156,6 +1192,8 @@ struct wire_cst_list_payment_details *frbgen_breez_liquid_cst_new_box_autoadd_li
 struct wire_cst_list_payments_request *frbgen_breez_liquid_cst_new_box_autoadd_list_payments_request(void);
 
 struct wire_cst_ln_invoice *frbgen_breez_liquid_cst_new_box_autoadd_ln_invoice(void);
+
+struct wire_cst_ln_offer *frbgen_breez_liquid_cst_new_box_autoadd_ln_offer(void);
 
 struct wire_cst_ln_url_auth_request_data *frbgen_breez_liquid_cst_new_box_autoadd_ln_url_auth_request_data(void);
 
@@ -1219,6 +1257,8 @@ uint64_t *frbgen_breez_liquid_cst_new_box_autoadd_u_64(uint64_t value);
 
 struct wire_cst_url_success_action_data *frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data(void);
 
+struct wire_cst_list_String *frbgen_breez_liquid_cst_new_list_String(int32_t len);
+
 struct wire_cst_list_fiat_currency *frbgen_breez_liquid_cst_new_list_fiat_currency(int32_t len);
 
 struct wire_cst_list_locale_overrides *frbgen_breez_liquid_cst_new_list_locale_overrides(int32_t len);
@@ -1243,6 +1283,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_decrypted);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_result);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_backup_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_binding_event_listener);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_bitcoin_address_data);
@@ -1256,6 +1297,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_list_payment_details);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_list_payments_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_invoice);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_offer);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_auth_request_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_error_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data);
@@ -1287,6 +1329,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_u_32);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_u_64);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_String);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_fiat_currency);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_locale_overrides);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_localized_name);

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -173,6 +173,7 @@ typedef struct wire_cst_SendDestination_Bolt11 {
 
 typedef struct wire_cst_SendDestination_Bolt12 {
   struct wire_cst_list_prim_u_8_strict *offer;
+  uint64_t receiver_amount_sat;
 } wire_cst_SendDestination_Bolt12;
 
 typedef union SendDestinationKind {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -407,6 +407,7 @@ typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *description;
   struct wire_cst_list_prim_u_8_strict *preimage;
   struct wire_cst_list_prim_u_8_strict *bolt11;
+  struct wire_cst_list_prim_u_8_strict *bolt12_offer;
   struct wire_cst_list_prim_u_8_strict *payment_hash;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -195,6 +195,15 @@ typedef struct wire_cst_amount {
   union AmountKind kind;
 } wire_cst_amount;
 
+typedef struct wire_cst_ln_offer_blinded_path {
+  struct wire_cst_list_String *blinded_hops;
+} wire_cst_ln_offer_blinded_path;
+
+typedef struct wire_cst_list_ln_offer_blinded_path {
+  struct wire_cst_ln_offer_blinded_path *ptr;
+  int32_t len;
+} wire_cst_list_ln_offer_blinded_path;
+
 typedef struct wire_cst_ln_offer {
   struct wire_cst_list_prim_u_8_strict *offer;
   struct wire_cst_list_String *chains;
@@ -203,6 +212,7 @@ typedef struct wire_cst_ln_offer {
   uint64_t *absolute_expiry;
   struct wire_cst_list_prim_u_8_strict *issuer;
   struct wire_cst_list_prim_u_8_strict *signing_pubkey;
+  struct wire_cst_list_ln_offer_blinded_path *paths;
 } wire_cst_ln_offer;
 
 typedef struct wire_cst_SendDestination_Bolt12 {
@@ -1261,6 +1271,8 @@ struct wire_cst_list_String *frbgen_breez_liquid_cst_new_list_String(int32_t len
 
 struct wire_cst_list_fiat_currency *frbgen_breez_liquid_cst_new_list_fiat_currency(int32_t len);
 
+struct wire_cst_list_ln_offer_blinded_path *frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path(int32_t len);
+
 struct wire_cst_list_locale_overrides *frbgen_breez_liquid_cst_new_list_locale_overrides(int32_t len);
 
 struct wire_cst_list_localized_name *frbgen_breez_liquid_cst_new_list_localized_name(int32_t len);
@@ -1331,6 +1343,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_String);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_fiat_currency);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_locale_overrides);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_localized_name);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_payment);

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -198,7 +198,7 @@ typedef struct wire_cst_amount {
 typedef struct wire_cst_ln_offer {
   struct wire_cst_list_prim_u_8_strict *bolt12;
   struct wire_cst_list_String *chains;
-  struct wire_cst_amount *amount;
+  struct wire_cst_amount *min_amount;
   struct wire_cst_list_prim_u_8_strict *description;
   uint64_t *absolute_expiry;
   struct wire_cst_list_prim_u_8_strict *issuer;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -171,9 +171,14 @@ typedef struct wire_cst_SendDestination_Bolt11 {
   struct wire_cst_ln_invoice *invoice;
 } wire_cst_SendDestination_Bolt11;
 
+typedef struct wire_cst_SendDestination_Bolt12 {
+  struct wire_cst_list_prim_u_8_strict *invoice;
+} wire_cst_SendDestination_Bolt12;
+
 typedef union SendDestinationKind {
   struct wire_cst_SendDestination_LiquidAddress LiquidAddress;
   struct wire_cst_SendDestination_Bolt11 Bolt11;
+  struct wire_cst_SendDestination_Bolt12 Bolt12;
 } SendDestinationKind;
 
 typedef struct wire_cst_send_destination {
@@ -1108,7 +1113,7 @@ WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__default_config(i
 void frbgen_breez_liquid_wire__crate__bindings__parse(int64_t port_,
                                                       struct wire_cst_list_prim_u_8_strict *input);
 
-WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_invoice(struct wire_cst_list_prim_u_8_strict *input);
+WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_bolt11_invoice(struct wire_cst_list_prim_u_8_strict *input);
 
 void frbgen_breez_liquid_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(const void *ptr);
 
@@ -1324,7 +1329,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__connect);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__default_config);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse);
-    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse_invoice);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse_bolt11_invoice);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     return dummy_var;
 }

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -172,7 +172,7 @@ typedef struct wire_cst_SendDestination_Bolt11 {
 } wire_cst_SendDestination_Bolt11;
 
 typedef struct wire_cst_SendDestination_Bolt12 {
-  struct wire_cst_list_prim_u_8_strict *invoice;
+  struct wire_cst_list_prim_u_8_strict *offer;
 } wire_cst_SendDestination_Bolt12;
 
 typedef union SendDestinationKind {
@@ -626,6 +626,10 @@ typedef struct wire_cst_InputType_Bolt11 {
   struct wire_cst_ln_invoice *invoice;
 } wire_cst_InputType_Bolt11;
 
+typedef struct wire_cst_InputType_Bolt12 {
+  struct wire_cst_list_prim_u_8_strict *offer;
+} wire_cst_InputType_Bolt12;
+
 typedef struct wire_cst_InputType_NodeId {
   struct wire_cst_list_prim_u_8_strict *node_id;
 } wire_cst_InputType_NodeId;
@@ -654,6 +658,7 @@ typedef union InputTypeKind {
   struct wire_cst_InputType_BitcoinAddress BitcoinAddress;
   struct wire_cst_InputType_LiquidAddress LiquidAddress;
   struct wire_cst_InputType_Bolt11 Bolt11;
+  struct wire_cst_InputType_Bolt12 Bolt12;
   struct wire_cst_InputType_NodeId NodeId;
   struct wire_cst_InputType_Url Url;
   struct wire_cst_InputType_LnUrlPay LnUrlPay;
@@ -1113,7 +1118,7 @@ WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__default_config(i
 void frbgen_breez_liquid_wire__crate__bindings__parse(int64_t port_,
                                                       struct wire_cst_list_prim_u_8_strict *input);
 
-WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_bolt11_invoice(struct wire_cst_list_prim_u_8_strict *input);
+WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__parse_invoice(struct wire_cst_list_prim_u_8_strict *input);
 
 void frbgen_breez_liquid_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(const void *ptr);
 
@@ -1329,7 +1334,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__connect);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__default_config);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse);
-    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse_bolt11_invoice);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__parse_invoice);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     return dummy_var;
 }

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -196,7 +196,7 @@ typedef struct wire_cst_amount {
 } wire_cst_amount;
 
 typedef struct wire_cst_ln_offer {
-  struct wire_cst_list_prim_u_8_strict *bolt12;
+  struct wire_cst_list_prim_u_8_strict *offer;
   struct wire_cst_list_String *chains;
   struct wire_cst_amount *min_amount;
   struct wire_cst_list_prim_u_8_strict *description;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -171,8 +171,42 @@ typedef struct wire_cst_SendDestination_Bolt11 {
   struct wire_cst_ln_invoice *invoice;
 } wire_cst_SendDestination_Bolt11;
 
+typedef struct wire_cst_list_String {
+  struct wire_cst_list_prim_u_8_strict **ptr;
+  int32_t len;
+} wire_cst_list_String;
+
+typedef struct wire_cst_Amount_Bitcoin {
+  uint64_t amount_msat;
+} wire_cst_Amount_Bitcoin;
+
+typedef struct wire_cst_Amount_Currency {
+  struct wire_cst_list_prim_u_8_strict *iso4217_code;
+  uint64_t fractional_amount;
+} wire_cst_Amount_Currency;
+
+typedef union AmountKind {
+  struct wire_cst_Amount_Bitcoin Bitcoin;
+  struct wire_cst_Amount_Currency Currency;
+} AmountKind;
+
+typedef struct wire_cst_amount {
+  int32_t tag;
+  union AmountKind kind;
+} wire_cst_amount;
+
+typedef struct wire_cst_ln_offer {
+  struct wire_cst_list_prim_u_8_strict *bolt12;
+  struct wire_cst_list_String *chains;
+  struct wire_cst_amount *amount;
+  struct wire_cst_list_prim_u_8_strict *description;
+  uint64_t *absolute_expiry;
+  struct wire_cst_list_prim_u_8_strict *issuer;
+  struct wire_cst_list_prim_u_8_strict *signing_pubkey;
+} wire_cst_ln_offer;
+
 typedef struct wire_cst_SendDestination_Bolt12 {
-  struct wire_cst_list_prim_u_8_strict *offer;
+  struct wire_cst_ln_offer *offer;
   uint64_t receiver_amount_sat;
 } wire_cst_SendDestination_Bolt12;
 
@@ -480,25 +514,6 @@ typedef struct wire_cst_aes_success_action_data_result {
   union AesSuccessActionDataResultKind kind;
 } wire_cst_aes_success_action_data_result;
 
-typedef struct wire_cst_Amount_Bitcoin {
-  uint64_t amount_msat;
-} wire_cst_Amount_Bitcoin;
-
-typedef struct wire_cst_Amount_Currency {
-  struct wire_cst_list_prim_u_8_strict *iso4217_code;
-  uint64_t fractional_amount;
-} wire_cst_Amount_Currency;
-
-typedef union AmountKind {
-  struct wire_cst_Amount_Bitcoin Bitcoin;
-  struct wire_cst_Amount_Currency Currency;
-} AmountKind;
-
-typedef struct wire_cst_amount {
-  int32_t tag;
-  union AmountKind kind;
-} wire_cst_amount;
-
 typedef struct wire_cst_bitcoin_address_data {
   struct wire_cst_list_prim_u_8_strict *address;
   int32_t network;
@@ -506,21 +521,6 @@ typedef struct wire_cst_bitcoin_address_data {
   struct wire_cst_list_prim_u_8_strict *label;
   struct wire_cst_list_prim_u_8_strict *message;
 } wire_cst_bitcoin_address_data;
-
-typedef struct wire_cst_list_String {
-  struct wire_cst_list_prim_u_8_strict **ptr;
-  int32_t len;
-} wire_cst_list_String;
-
-typedef struct wire_cst_ln_offer {
-  struct wire_cst_list_prim_u_8_strict *bolt12;
-  struct wire_cst_list_String *chains;
-  struct wire_cst_amount *amount;
-  struct wire_cst_list_prim_u_8_strict *description;
-  uint64_t *absolute_expiry;
-  struct wire_cst_list_prim_u_8_strict *issuer;
-  struct wire_cst_list_prim_u_8_strict *signing_pubkey;
-} wire_cst_ln_offer;
 
 typedef struct wire_cst_ln_url_error_data {
   struct wire_cst_list_prim_u_8_strict *reason;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -627,9 +627,9 @@ typedef struct wire_cst_InputType_Bolt11 {
   struct wire_cst_ln_invoice *invoice;
 } wire_cst_InputType_Bolt11;
 
-typedef struct wire_cst_InputType_Bolt12 {
+typedef struct wire_cst_InputType_Bolt12Offer {
   struct wire_cst_list_prim_u_8_strict *offer;
-} wire_cst_InputType_Bolt12;
+} wire_cst_InputType_Bolt12Offer;
 
 typedef struct wire_cst_InputType_NodeId {
   struct wire_cst_list_prim_u_8_strict *node_id;
@@ -659,7 +659,7 @@ typedef union InputTypeKind {
   struct wire_cst_InputType_BitcoinAddress BitcoinAddress;
   struct wire_cst_InputType_LiquidAddress LiquidAddress;
   struct wire_cst_InputType_Bolt11 Bolt11;
-  struct wire_cst_InputType_Bolt12 Bolt12;
+  struct wire_cst_InputType_Bolt12Offer Bolt12Offer;
   struct wire_cst_InputType_NodeId NodeId;
   struct wire_cst_InputType_Url Url;
   struct wire_cst_InputType_LnUrlPay LnUrlPay;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -53,7 +53,7 @@ class SwapUpdatedTask : TaskProtocol {
             switch details {
             case let .bitcoin(swapId, _, _, _):
                 return swapId
-            case let .lightning(swapId, _, _, _, _, _, _):
+            case let .lightning(swapId, _, _, _, _, _, _, _):
                 return swapId
             default:
                 break

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -533,7 +533,7 @@ interface GetPaymentRequest {
 
 [Enum]
 interface PaymentDetails {
-    Lightning(string swap_id, string description, string? preimage, string? bolt11, string? payment_hash, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Lightning(string swap_id, string description, string? preimage, string? bolt11, string? bolt12_offer, string? payment_hash, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
     Bitcoin(string swap_id, string description, string? refund_tx_id, u64? refund_tx_amount_sat);
 };

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -381,7 +381,7 @@ dictionary PrepareSendRequest {
 interface SendDestination {
     LiquidAddress(LiquidAddressData address_data);
     Bolt11(LNInvoice invoice);
-    Bolt12(string offer);
+    Bolt12(string offer, u64 receiver_amount_sat);
 };
 
 dictionary PrepareSendResponse {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -45,7 +45,7 @@ interface Amount {
 };
 
 dictionary LNOffer {
-    string bolt12;
+    string offer;
     sequence<string> chains;
     string? description;
     string? signing_pubkey;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -43,6 +43,7 @@ interface InputType {
     BitcoinAddress(BitcoinAddressData address);
     LiquidAddress(LiquidAddressData address);
     Bolt11(LNInvoice invoice);
+    Bolt12(string offer);
     NodeId(string node_id);
     Url(string url);
     LnUrlPay(LnUrlPayRequestData data);
@@ -380,7 +381,7 @@ dictionary PrepareSendRequest {
 interface SendDestination {
     LiquidAddress(LiquidAddressData address_data);
     Bolt11(LNInvoice invoice);
-    Bolt12(string invoice);
+    Bolt12(string offer);
 };
 
 dictionary PrepareSendResponse {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -380,6 +380,7 @@ dictionary PrepareSendRequest {
 interface SendDestination {
     LiquidAddress(LiquidAddressData address_data);
     Bolt11(LNInvoice invoice);
+    Bolt12(string invoice);
 };
 
 dictionary PrepareSendResponse {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -43,7 +43,7 @@ interface InputType {
     BitcoinAddress(BitcoinAddressData address);
     LiquidAddress(LiquidAddressData address);
     Bolt11(LNInvoice invoice);
-    Bolt12(string offer);
+    Bolt12Offer(string offer);
     NodeId(string node_id);
     Url(string url);
     LnUrlPay(LnUrlPayRequestData data);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -44,9 +44,14 @@ interface Amount {
     Currency(string iso4217_code, u64 fractional_amount);
 };
 
+dictionary LNOfferBlindedPath {
+    sequence<string> blinded_hops;
+};
+
 dictionary LNOffer {
     string offer;
     sequence<string> chains;
+    sequence<LNOfferBlindedPath> paths;
     string? description;
     string? signing_pubkey;
     Amount? min_amount;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -49,7 +49,7 @@ dictionary LNOffer {
     sequence<string> chains;
     string? description;
     string? signing_pubkey;
-    Amount? amount;
+    Amount? min_amount;
     u64? absolute_expiry;
     string? issuer;
 };

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -39,11 +39,27 @@ dictionary RouteHintHop {
 };
 
 [Enum]
+interface Amount {
+    Bitcoin(u64 amount_msat);
+    Currency(string iso4217_code, u64 fractional_amount);
+};
+
+dictionary LNOffer {
+    string bolt12;
+    sequence<string> chains;
+    string? description;
+    string? signing_pubkey;
+    Amount? amount;
+    u64? absolute_expiry;
+    string? issuer;
+};
+
+[Enum]
 interface InputType {
     BitcoinAddress(BitcoinAddressData address);
     LiquidAddress(LiquidAddressData address);
     Bolt11(LNInvoice invoice);
-    Bolt12Offer(string offer);
+    Bolt12Offer(LNOffer offer);
     NodeId(string node_id);
     Url(string url);
     LnUrlPay(LnUrlPayRequestData data);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -397,7 +397,7 @@ dictionary PrepareSendRequest {
 interface SendDestination {
     LiquidAddress(LiquidAddressData address_data);
     Bolt11(LNInvoice invoice);
-    Bolt12(string offer, u64 receiver_amount_sat);
+    Bolt12(LNOffer offer, u64 receiver_amount_sat);
 };
 
 dictionary PrepareSendResponse {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -44,14 +44,14 @@ interface Amount {
     Currency(string iso4217_code, u64 fractional_amount);
 };
 
-dictionary LNOfferBlindedPath {
+dictionary LnOfferBlindedPath {
     sequence<string> blinded_hops;
 };
 
 dictionary LNOffer {
     string offer;
     sequence<string> chains;
-    sequence<LNOfferBlindedPath> paths;
+    sequence<LnOfferBlindedPath> paths;
     string? description;
     string? signing_pubkey;
     Amount? min_amount;

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -30,7 +30,8 @@ lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-s
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "441a9fd50c32098b2887e960c8a4bcc5956da1af", features = ["liquid"]}
+#sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "441a9fd50c32098b2887e960c8a4bcc5956da1af", features = ["liquid"]}
+sdk-common = { git = "https://github.com/breez/breez-sdk", branch = "ok300-sdk-common-parse-bolt12-offer", features = ["liquid"]}
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 strum = "0.25"

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -14,8 +14,7 @@ frb = ["dep:flutter_rust_bridge"]
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-#boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
-boltz-client = { git = "https://github.com/ok300/boltz-rust", branch = "ok300-support-bolt12" }
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
 chrono = "0.4"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.4.0", features = [

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -14,12 +14,15 @@ frb = ["dep:flutter_rust_bridge"]
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
+#boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
+boltz-client = { git = "https://github.com/ok300/boltz-rust", branch = "ok300-support-bolt12" }
 chrono = "0.4"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.4.0", features = [
   "chrono",
 ], optional = true }
+# We need at least lightning v0.0.125 for the Bolt12 structs. The lightning version from sdk-common is too old (v0.0.118, matching vls-core).
+lightning = "0.0.125"
 log = { workspace = true }
 lwk_common = "0.7.0"
 lwk_signer = "0.7.0"

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -29,8 +29,7 @@ lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-s
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
-#sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "441a9fd50c32098b2887e960c8a4bcc5956da1af", features = ["liquid"]}
-sdk-common = { git = "https://github.com/breez/breez-sdk", branch = "ok300-sdk-common-parse-bolt12-offer", features = ["liquid"]}
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "5955216ec4ed003972b4473a77207dfb744da882", features = ["liquid"]}
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 strum = "0.25"

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -340,8 +340,8 @@ pub enum _Amount {
     },
 }
 
-#[frb(mirror(LNOfferBlindedPath))]
-pub struct _LNOfferBlindedPath {
+#[frb(mirror(LnOfferBlindedPath))]
+pub struct _LnOfferBlindedPath {
     pub blinded_hops: Vec<String>,
 }
 
@@ -354,7 +354,7 @@ pub struct _LNOffer {
     pub absolute_expiry: Option<u64>,
     pub issuer: Option<String>,
     pub signing_pubkey: Option<String>,
-    pub paths: Vec<LNOfferBlindedPath>,
+    pub paths: Vec<LnOfferBlindedPath>,
 }
 
 #[frb(mirror(InputType))]

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -334,6 +334,7 @@ pub enum _InputType {
     BitcoinAddress { address: BitcoinAddressData },
     LiquidAddress { address: LiquidAddressData },
     Bolt11 { invoice: LNInvoice },
+    Bolt12 { offer: String },
     NodeId { node_id: String },
     Url { url: String },
     LnUrlPay { data: LnUrlPayRequestData },

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -334,7 +334,7 @@ pub enum _InputType {
     BitcoinAddress { address: BitcoinAddressData },
     LiquidAddress { address: LiquidAddressData },
     Bolt11 { invoice: LNInvoice },
-    Bolt12 { offer: String },
+    Bolt12Offer { offer: String },
     NodeId { node_id: String },
     Url { url: String },
     LnUrlPay { data: LnUrlPayRequestData },

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -329,7 +329,6 @@ pub struct _RouteHintHop {
     pub htlc_maximum_msat: Option<u64>,
 }
 
-
 #[frb(mirror(Amount))]
 pub enum _Amount {
     Bitcoin {

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -342,7 +342,7 @@ pub enum _Amount {
 
 #[frb(mirror(LNOffer))]
 pub struct _LNOffer {
-    pub bolt12: String,
+    pub offer: String,
     pub chains: Vec<String>,
     pub min_amount: Option<Amount>,
     pub description: Option<String>,

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -340,6 +340,11 @@ pub enum _Amount {
     },
 }
 
+#[frb(mirror(LNOfferBlindedPath))]
+pub struct _LNOfferBlindedPath {
+    pub blinded_hops: Vec<String>,
+}
+
 #[frb(mirror(LNOffer))]
 pub struct _LNOffer {
     pub offer: String,
@@ -349,6 +354,7 @@ pub struct _LNOffer {
     pub absolute_expiry: Option<u64>,
     pub issuer: Option<String>,
     pub signing_pubkey: Option<String>,
+    pub paths: Vec<LNOfferBlindedPath>,
 }
 
 #[frb(mirror(InputType))]

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -344,7 +344,7 @@ pub enum _Amount {
 pub struct _LNOffer {
     pub bolt12: String,
     pub chains: Vec<String>,
-    pub amount: Option<Amount>,
+    pub min_amount: Option<Amount>,
     pub description: Option<String>,
     pub absolute_expiry: Option<u64>,
     pub issuer: Option<String>,

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -329,12 +329,35 @@ pub struct _RouteHintHop {
     pub htlc_maximum_msat: Option<u64>,
 }
 
+
+#[frb(mirror(Amount))]
+pub enum _Amount {
+    Bitcoin {
+        amount_msat: u64,
+    },
+    Currency {
+        iso4217_code: String,
+        fractional_amount: u64,
+    },
+}
+
+#[frb(mirror(LNOffer))]
+pub struct _LNOffer {
+    pub bolt12: String,
+    pub chains: Vec<String>,
+    pub amount: Option<Amount>,
+    pub description: Option<String>,
+    pub absolute_expiry: Option<u64>,
+    pub issuer: Option<String>,
+    pub signing_pubkey: Option<String>,
+}
+
 #[frb(mirror(InputType))]
 pub enum _InputType {
     BitcoinAddress { address: BitcoinAddressData },
     LiquidAddress { address: LiquidAddressData },
     Bolt11 { invoice: LNInvoice },
-    Bolt12Offer { offer: String },
+    Bolt12Offer { offer: LNOffer },
     NodeId { node_id: String },
     Url { url: String },
     LnUrlPay { data: LnUrlPayRequestData },

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1765,6 +1765,18 @@ const _: fn() = || {
             let _: String = reason;
         }
     }
+    match None::<crate::bindings::Amount>.unwrap() {
+        crate::bindings::Amount::Bitcoin { amount_msat } => {
+            let _: u64 = amount_msat;
+        }
+        crate::bindings::Amount::Currency {
+            iso4217_code,
+            fractional_amount,
+        } => {
+            let _: String = iso4217_code;
+            let _: u64 = fractional_amount;
+        }
+    }
     {
         let BitcoinAddressData = None::<crate::bindings::BitcoinAddressData>.unwrap();
         let _: String = BitcoinAddressData.address;
@@ -1799,7 +1811,7 @@ const _: fn() = || {
             let _: crate::bindings::LNInvoice = invoice;
         }
         crate::bindings::InputType::Bolt12Offer { offer } => {
-            let _: String = offer;
+            let _: crate::bindings::LNOffer = offer;
         }
         crate::bindings::InputType::NodeId { node_id } => {
             let _: String = node_id;
@@ -1843,6 +1855,16 @@ const _: fn() = || {
         let _: Vec<crate::bindings::RouteHint> = LNInvoice.routing_hints;
         let _: Vec<u8> = LNInvoice.payment_secret;
         let _: u64 = LNInvoice.min_final_cltv_expiry_delta;
+    }
+    {
+        let LNOffer = None::<crate::bindings::LNOffer>.unwrap();
+        let _: String = LNOffer.bolt12;
+        let _: Vec<String> = LNOffer.chains;
+        let _: Option<crate::bindings::Amount> = LNOffer.amount;
+        let _: Option<String> = LNOffer.description;
+        let _: Option<u64> = LNOffer.absolute_expiry;
+        let _: Option<String> = LNOffer.issuer;
+        let _: Option<String> = LNOffer.signing_pubkey;
     }
     {
         let LnUrlAuthRequestData = None::<crate::bindings::LnUrlAuthRequestData>.unwrap();
@@ -2185,6 +2207,32 @@ impl SseDecode for crate::bindings::AesSuccessActionDataResult {
     }
 }
 
+impl SseDecode for crate::bindings::Amount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_amountMsat = <u64>::sse_decode(deserializer);
+                return crate::bindings::Amount::Bitcoin {
+                    amount_msat: var_amountMsat,
+                };
+            }
+            1 => {
+                let mut var_iso4217Code = <String>::sse_decode(deserializer);
+                let mut var_fractionalAmount = <u64>::sse_decode(deserializer);
+                return crate::bindings::Amount::Currency {
+                    iso4217_code: var_iso4217Code,
+                    fractional_amount: var_fractionalAmount,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::model::BackupRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2435,7 +2483,7 @@ impl SseDecode for crate::bindings::InputType {
                 };
             }
             3 => {
-                let mut var_offer = <String>::sse_decode(deserializer);
+                let mut var_offer = <crate::bindings::LNOffer>::sse_decode(deserializer);
                 return crate::bindings::InputType::Bolt12Offer { offer: var_offer };
             }
             4 => {
@@ -2528,6 +2576,18 @@ impl SseDecode for crate::model::LiquidNetwork {
             1 => crate::model::LiquidNetwork::Testnet,
             _ => unreachable!("Invalid variant for LiquidNetwork: {}", inner),
         };
+    }
+}
+
+impl SseDecode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
     }
 }
 
@@ -2723,6 +2783,28 @@ impl SseDecode for crate::bindings::LNInvoice {
             routing_hints: var_routingHints,
             payment_secret: var_paymentSecret,
             min_final_cltv_expiry_delta: var_minFinalCltvExpiryDelta,
+        };
+    }
+}
+
+impl SseDecode for crate::bindings::LNOffer {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bolt12 = <String>::sse_decode(deserializer);
+        let mut var_chains = <Vec<String>>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::bindings::Amount>>::sse_decode(deserializer);
+        let mut var_description = <Option<String>>::sse_decode(deserializer);
+        let mut var_absoluteExpiry = <Option<u64>>::sse_decode(deserializer);
+        let mut var_issuer = <Option<String>>::sse_decode(deserializer);
+        let mut var_signingPubkey = <Option<String>>::sse_decode(deserializer);
+        return crate::bindings::LNOffer {
+            bolt12: var_bolt12,
+            chains: var_chains,
+            amount: var_amount,
+            description: var_description,
+            absolute_expiry: var_absoluteExpiry,
+            issuer: var_issuer,
+            signing_pubkey: var_signingPubkey,
         };
     }
 }
@@ -3148,6 +3230,17 @@ impl SseDecode for Option<String> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::bindings::Amount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::bindings::Amount>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -4197,6 +4290,39 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::AesSuccessAct
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::Amount> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self.0 {
+            crate::bindings::Amount::Bitcoin { amount_msat } => {
+                [0.into_dart(), amount_msat.into_into_dart().into_dart()].into_dart()
+            }
+            crate::bindings::Amount::Currency {
+                iso4217_code,
+                fractional_amount,
+            } => [
+                1.into_dart(),
+                iso4217_code.into_into_dart().into_dart(),
+                fractional_amount.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::bindings::Amount>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::Amount>>
+    for crate::bindings::Amount
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::Amount> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::model::BackupRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.backup_path.into_into_dart().into_dart()].into_dart()
@@ -4681,6 +4807,32 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNInvoice>>
     for crate::bindings::LNInvoice
 {
     fn into_into_dart(self) -> FrbWrapper<crate::bindings::LNInvoice> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOffer> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bolt12.into_into_dart().into_dart(),
+            self.0.chains.into_into_dart().into_dart(),
+            self.0.amount.into_into_dart().into_dart(),
+            self.0.description.into_into_dart().into_dart(),
+            self.0.absolute_expiry.into_into_dart().into_dart(),
+            self.0.issuer.into_into_dart().into_dart(),
+            self.0.signing_pubkey.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::bindings::LNOffer>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNOffer>>
+    for crate::bindings::LNOffer
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::LNOffer> {
         self.into()
     }
 }
@@ -6242,6 +6394,29 @@ impl SseEncode for crate::bindings::AesSuccessActionDataResult {
     }
 }
 
+impl SseEncode for crate::bindings::Amount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::bindings::Amount::Bitcoin { amount_msat } => {
+                <i32>::sse_encode(0, serializer);
+                <u64>::sse_encode(amount_msat, serializer);
+            }
+            crate::bindings::Amount::Currency {
+                iso4217_code,
+                fractional_amount,
+            } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(iso4217_code, serializer);
+                <u64>::sse_encode(fractional_amount, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::model::BackupRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6422,7 +6597,7 @@ impl SseEncode for crate::bindings::InputType {
             }
             crate::bindings::InputType::Bolt12Offer { offer } => {
                 <i32>::sse_encode(3, serializer);
-                <String>::sse_encode(offer, serializer);
+                <crate::bindings::LNOffer>::sse_encode(offer, serializer);
             }
             crate::bindings::InputType::NodeId { node_id } => {
                 <i32>::sse_encode(4, serializer);
@@ -6497,6 +6672,16 @@ impl SseEncode for crate::model::LiquidNetwork {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <String>::sse_encode(item, serializer);
+        }
     }
 }
 
@@ -6646,6 +6831,19 @@ impl SseEncode for crate::bindings::LNInvoice {
         <Vec<crate::bindings::RouteHint>>::sse_encode(self.routing_hints, serializer);
         <Vec<u8>>::sse_encode(self.payment_secret, serializer);
         <u64>::sse_encode(self.min_final_cltv_expiry_delta, serializer);
+    }
+}
+
+impl SseEncode for crate::bindings::LNOffer {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bolt12, serializer);
+        <Vec<String>>::sse_encode(self.chains, serializer);
+        <Option<crate::bindings::Amount>>::sse_encode(self.amount, serializer);
+        <Option<String>>::sse_encode(self.description, serializer);
+        <Option<u64>>::sse_encode(self.absolute_expiry, serializer);
+        <Option<String>>::sse_encode(self.issuer, serializer);
+        <Option<String>>::sse_encode(self.signing_pubkey, serializer);
     }
 }
 
@@ -6982,6 +7180,16 @@ impl SseEncode for Option<String> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::bindings::Amount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::bindings::Amount>::sse_encode(value, serializer);
         }
     }
 }
@@ -7872,6 +8080,27 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::bindings::Amount> for wire_cst_amount {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::Amount {
+            match self.tag {
+                0 => {
+                    let ans = unsafe { self.kind.Bitcoin };
+                    crate::bindings::Amount::Bitcoin {
+                        amount_msat: ans.amount_msat.cst_decode(),
+                    }
+                }
+                1 => {
+                    let ans = unsafe { self.kind.Currency };
+                    crate::bindings::Amount::Currency {
+                        iso4217_code: ans.iso4217_code.cst_decode(),
+                        fractional_amount: ans.fractional_amount.cst_decode(),
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<crate::model::BackupRequest> for wire_cst_backup_request {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::BackupRequest {
@@ -7923,6 +8152,13 @@ mod io {
         fn cst_decode(self) -> crate::bindings::AesSuccessActionDataResult {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
             CstDecode::<crate::bindings::AesSuccessActionDataResult>::cst_decode(*wrap).into()
+        }
+    }
+    impl CstDecode<crate::bindings::Amount> for *mut wire_cst_amount {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::Amount {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::bindings::Amount>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::model::BackupRequest> for *mut wire_cst_backup_request {
@@ -8012,6 +8248,13 @@ mod io {
         fn cst_decode(self) -> crate::bindings::LNInvoice {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
             CstDecode::<crate::bindings::LNInvoice>::cst_decode(*wrap).into()
+        }
+    }
+    impl CstDecode<crate::bindings::LNOffer> for *mut wire_cst_ln_offer {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::LNOffer {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::bindings::LNOffer>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::bindings::LnUrlAuthRequestData> for *mut wire_cst_ln_url_auth_request_data {
@@ -8443,6 +8686,16 @@ mod io {
             }
         }
     }
+    impl CstDecode<Vec<String>> for *mut wire_cst_list_String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<String> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
     impl CstDecode<Vec<crate::bindings::FiatCurrency>> for *mut wire_cst_list_fiat_currency {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<crate::bindings::FiatCurrency> {
@@ -8591,6 +8844,20 @@ mod io {
                 routing_hints: self.routing_hints.cst_decode(),
                 payment_secret: self.payment_secret.cst_decode(),
                 min_final_cltv_expiry_delta: self.min_final_cltv_expiry_delta.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::bindings::LNOffer> for wire_cst_ln_offer {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::LNOffer {
+            crate::bindings::LNOffer {
+                bolt12: self.bolt12.cst_decode(),
+                chains: self.chains.cst_decode(),
+                amount: self.amount.cst_decode(),
+                description: self.description.cst_decode(),
+                absolute_expiry: self.absolute_expiry.cst_decode(),
+                issuer: self.issuer.cst_decode(),
+                signing_pubkey: self.signing_pubkey.cst_decode(),
             }
         }
     }
@@ -9559,6 +9826,19 @@ mod io {
             Self::new_with_null_ptr()
         }
     }
+    impl NewWithNullPtr for wire_cst_amount {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: AmountKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_amount {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
     impl NewWithNullPtr for wire_cst_backup_request {
         fn new_with_null_ptr() -> Self {
             Self {
@@ -9837,6 +10117,24 @@ mod io {
         }
     }
     impl Default for wire_cst_ln_invoice {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_ln_offer {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                bolt12: core::ptr::null_mut(),
+                chains: core::ptr::null_mut(),
+                amount: core::ptr::null_mut(),
+                description: core::ptr::null_mut(),
+                absolute_expiry: core::ptr::null_mut(),
+                issuer: core::ptr::null_mut(),
+                signing_pubkey: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_ln_offer {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -11006,6 +11304,11 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_amount() -> *mut wire_cst_amount {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_amount::new_with_null_ptr())
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_backup_request(
     ) -> *mut wire_cst_backup_request {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
@@ -11101,6 +11404,11 @@ mod io {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
             wire_cst_ln_invoice::new_with_null_ptr(),
         )
+    }
+
+    #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_ln_offer() -> *mut wire_cst_ln_offer {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_ln_offer::new_with_null_ptr())
     }
 
     #[no_mangle]
@@ -11338,6 +11646,20 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_list_String(
+        len: i32,
+    ) -> *mut wire_cst_list_String {
+        let wrap = wire_cst_list_String {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <*mut wire_cst_list_prim_u_8_strict>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_list_fiat_currency(
         len: i32,
     ) -> *mut wire_cst_list_fiat_currency {
@@ -11507,6 +11829,30 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_amount {
+        tag: i32,
+        kind: AmountKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union AmountKind {
+        Bitcoin: wire_cst_Amount_Bitcoin,
+        Currency: wire_cst_Amount_Currency,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_Amount_Bitcoin {
+        amount_msat: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_Amount_Currency {
+        iso4217_code: *mut wire_cst_list_prim_u_8_strict,
+        fractional_amount: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_backup_request {
         backup_path: *mut wire_cst_list_prim_u_8_strict,
     }
@@ -11643,7 +11989,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_InputType_Bolt12Offer {
-        offer: *mut wire_cst_list_prim_u_8_strict,
+        offer: *mut wire_cst_ln_offer,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -11697,6 +12043,12 @@ mod io {
         amount_sat: *mut u64,
         label: *mut wire_cst_list_prim_u_8_strict,
         message: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_String {
+        ptr: *mut *mut wire_cst_list_prim_u_8_strict,
+        len: i32,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -11806,6 +12158,17 @@ mod io {
         routing_hints: *mut wire_cst_list_route_hint,
         payment_secret: *mut wire_cst_list_prim_u_8_strict,
         min_final_cltv_expiry_delta: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_ln_offer {
+        bolt12: *mut wire_cst_list_prim_u_8_strict,
+        chains: *mut wire_cst_list_String,
+        amount: *mut wire_cst_amount,
+        description: *mut wire_cst_list_prim_u_8_strict,
+        absolute_expiry: *mut u64,
+        issuer: *mut wire_cst_list_prim_u_8_strict,
+        signing_pubkey: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3999,7 +3999,7 @@ impl SseDecode for crate::model::SendDestination {
                 };
             }
             2 => {
-                let mut var_offer = <String>::sse_decode(deserializer);
+                let mut var_offer = <crate::bindings::LNOffer>::sse_decode(deserializer);
                 let mut var_receiverAmountSat = <u64>::sse_decode(deserializer);
                 return crate::model::SendDestination::Bolt12 {
                     offer: var_offer,
@@ -7803,7 +7803,7 @@ impl SseEncode for crate::model::SendDestination {
                 receiver_amount_sat,
             } => {
                 <i32>::sse_encode(2, serializer);
-                <String>::sse_encode(offer, serializer);
+                <crate::bindings::LNOffer>::sse_encode(offer, serializer);
                 <u64>::sse_encode(receiver_amount_sat, serializer);
             }
             _ => {
@@ -12882,7 +12882,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_SendDestination_Bolt12 {
-        offer: *mut wire_cst_list_prim_u_8_strict,
+        offer: *mut wire_cst_ln_offer,
         receiver_amount_sat: u64,
     }
     #[repr(C)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3469,6 +3469,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_description = <String>::sse_decode(deserializer);
                 let mut var_preimage = <Option<String>>::sse_decode(deserializer);
                 let mut var_bolt11 = <Option<String>>::sse_decode(deserializer);
+                let mut var_bolt12Offer = <Option<String>>::sse_decode(deserializer);
                 let mut var_paymentHash = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
@@ -3477,6 +3478,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     description: var_description,
                     preimage: var_preimage,
                     bolt11: var_bolt11,
+                    bolt12_offer: var_bolt12Offer,
                     payment_hash: var_paymentHash,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
@@ -5470,6 +5472,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 description,
                 preimage,
                 bolt11,
+                bolt12_offer,
                 payment_hash,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -5479,6 +5482,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 description.into_into_dart().into_dart(),
                 preimage.into_into_dart().into_dart(),
                 bolt11.into_into_dart().into_dart(),
+                bolt12_offer.into_into_dart().into_dart(),
                 payment_hash.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
@@ -7420,6 +7424,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 description,
                 preimage,
                 bolt11,
+                bolt12_offer,
                 payment_hash,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -7429,6 +7434,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <String>::sse_encode(description, serializer);
                 <Option<String>>::sse_encode(preimage, serializer);
                 <Option<String>>::sse_encode(bolt11, serializer);
+                <Option<String>>::sse_encode(bolt12_offer, serializer);
                 <Option<String>>::sse_encode(payment_hash, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
@@ -9357,6 +9363,7 @@ mod io {
                         description: ans.description.cst_decode(),
                         preimage: ans.preimage.cst_decode(),
                         bolt11: ans.bolt11.cst_decode(),
+                        bolt12_offer: ans.bolt12_offer.cst_decode(),
                         payment_hash: ans.payment_hash.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
@@ -12675,6 +12682,7 @@ mod io {
         description: *mut wire_cst_list_prim_u_8_strict,
         preimage: *mut wire_cst_list_prim_u_8_strict,
         bolt11: *mut wire_cst_list_prim_u_8_strict,
+        bolt12_offer: *mut wire_cst_list_prim_u_8_strict,
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3896,7 +3896,11 @@ impl SseDecode for crate::model::SendDestination {
             }
             2 => {
                 let mut var_offer = <String>::sse_decode(deserializer);
-                return crate::model::SendDestination::Bolt12 { offer: var_offer };
+                let mut var_receiverAmountSat = <u64>::sse_decode(deserializer);
+                return crate::model::SendDestination::Bolt12 {
+                    offer: var_offer,
+                    receiver_amount_sat: var_receiverAmountSat,
+                };
             }
             _ => {
                 unimplemented!("");
@@ -5949,9 +5953,15 @@ impl flutter_rust_bridge::IntoDart for crate::model::SendDestination {
             crate::model::SendDestination::Bolt11 { invoice } => {
                 [1.into_dart(), invoice.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SendDestination::Bolt12 { offer } => {
-                [2.into_dart(), offer.into_into_dart().into_dart()].into_dart()
-            }
+            crate::model::SendDestination::Bolt12 {
+                offer,
+                receiver_amount_sat,
+            } => [
+                2.into_dart(),
+                offer.into_into_dart().into_dart(),
+                receiver_amount_sat.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -7564,9 +7574,13 @@ impl SseEncode for crate::model::SendDestination {
                 <i32>::sse_encode(1, serializer);
                 <crate::bindings::LNInvoice>::sse_encode(invoice, serializer);
             }
-            crate::model::SendDestination::Bolt12 { offer } => {
+            crate::model::SendDestination::Bolt12 {
+                offer,
+                receiver_amount_sat,
+            } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(offer, serializer);
+                <u64>::sse_encode(receiver_amount_sat, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -9370,6 +9384,7 @@ mod io {
                     let ans = unsafe { self.kind.Bolt12 };
                     crate::model::SendDestination::Bolt12 {
                         offer: ans.offer.cst_decode(),
+                        receiver_amount_sat: ans.receiver_amount_sat.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -12474,6 +12489,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_SendDestination_Bolt12 {
         offer: *mut wire_cst_list_prim_u_8_strict,
+        receiver_amount_sat: u64,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1865,6 +1865,11 @@ const _: fn() = || {
         let _: Option<u64> = LNOffer.absolute_expiry;
         let _: Option<String> = LNOffer.issuer;
         let _: Option<String> = LNOffer.signing_pubkey;
+        let _: Vec<crate::bindings::LNOfferBlindedPath> = LNOffer.paths;
+    }
+    {
+        let LNOfferBlindedPath = None::<crate::bindings::LNOfferBlindedPath>.unwrap();
+        let _: Vec<String> = LNOfferBlindedPath.blinded_hops;
     }
     {
         let LnUrlAuthRequestData = None::<crate::bindings::LnUrlAuthRequestData>.unwrap();
@@ -2603,6 +2608,20 @@ impl SseDecode for Vec<crate::bindings::FiatCurrency> {
     }
 }
 
+impl SseDecode for Vec<crate::bindings::LNOfferBlindedPath> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::bindings::LNOfferBlindedPath>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::bindings::LocaleOverrides> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2797,6 +2816,7 @@ impl SseDecode for crate::bindings::LNOffer {
         let mut var_absoluteExpiry = <Option<u64>>::sse_decode(deserializer);
         let mut var_issuer = <Option<String>>::sse_decode(deserializer);
         let mut var_signingPubkey = <Option<String>>::sse_decode(deserializer);
+        let mut var_paths = <Vec<crate::bindings::LNOfferBlindedPath>>::sse_decode(deserializer);
         return crate::bindings::LNOffer {
             offer: var_offer,
             chains: var_chains,
@@ -2805,6 +2825,17 @@ impl SseDecode for crate::bindings::LNOffer {
             absolute_expiry: var_absoluteExpiry,
             issuer: var_issuer,
             signing_pubkey: var_signingPubkey,
+            paths: var_paths,
+        };
+    }
+}
+
+impl SseDecode for crate::bindings::LNOfferBlindedPath {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_blindedHops = <Vec<String>>::sse_decode(deserializer);
+        return crate::bindings::LNOfferBlindedPath {
+            blinded_hops: var_blindedHops,
         };
     }
 }
@@ -4821,6 +4852,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOffer> {
             self.0.absolute_expiry.into_into_dart().into_dart(),
             self.0.issuer.into_into_dart().into_dart(),
             self.0.signing_pubkey.into_into_dart().into_dart(),
+            self.0.paths.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4833,6 +4865,23 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNOffer>>
     for crate::bindings::LNOffer
 {
     fn into_into_dart(self) -> FrbWrapper<crate::bindings::LNOffer> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOfferBlindedPath> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.0.blinded_hops.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::bindings::LNOfferBlindedPath>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNOfferBlindedPath>>
+    for crate::bindings::LNOfferBlindedPath
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::LNOfferBlindedPath> {
         self.into()
     }
 }
@@ -6695,6 +6744,16 @@ impl SseEncode for Vec<crate::bindings::FiatCurrency> {
     }
 }
 
+impl SseEncode for Vec<crate::bindings::LNOfferBlindedPath> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::bindings::LNOfferBlindedPath>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::bindings::LocaleOverrides> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6844,6 +6903,14 @@ impl SseEncode for crate::bindings::LNOffer {
         <Option<u64>>::sse_encode(self.absolute_expiry, serializer);
         <Option<String>>::sse_encode(self.issuer, serializer);
         <Option<String>>::sse_encode(self.signing_pubkey, serializer);
+        <Vec<crate::bindings::LNOfferBlindedPath>>::sse_encode(self.paths, serializer);
+    }
+}
+
+impl SseEncode for crate::bindings::LNOfferBlindedPath {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<String>>::sse_encode(self.blinded_hops, serializer);
     }
 }
 
@@ -8706,6 +8773,18 @@ mod io {
             vec.into_iter().map(CstDecode::cst_decode).collect()
         }
     }
+    impl CstDecode<Vec<crate::bindings::LNOfferBlindedPath>>
+        for *mut wire_cst_list_ln_offer_blinded_path
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::bindings::LNOfferBlindedPath> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
     impl CstDecode<Vec<crate::bindings::LocaleOverrides>> for *mut wire_cst_list_locale_overrides {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<crate::bindings::LocaleOverrides> {
@@ -8858,6 +8937,15 @@ mod io {
                 absolute_expiry: self.absolute_expiry.cst_decode(),
                 issuer: self.issuer.cst_decode(),
                 signing_pubkey: self.signing_pubkey.cst_decode(),
+                paths: self.paths.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::bindings::LNOfferBlindedPath> for wire_cst_ln_offer_blinded_path {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::bindings::LNOfferBlindedPath {
+            crate::bindings::LNOfferBlindedPath {
+                blinded_hops: self.blinded_hops.cst_decode(),
             }
         }
     }
@@ -10131,10 +10219,23 @@ mod io {
                 absolute_expiry: core::ptr::null_mut(),
                 issuer: core::ptr::null_mut(),
                 signing_pubkey: core::ptr::null_mut(),
+                paths: core::ptr::null_mut(),
             }
         }
     }
     impl Default for wire_cst_ln_offer {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_ln_offer_blinded_path {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                blinded_hops: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_ln_offer_blinded_path {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -11674,6 +11775,20 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path(
+        len: i32,
+    ) -> *mut wire_cst_list_ln_offer_blinded_path {
+        let wrap = wire_cst_list_ln_offer_blinded_path {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_ln_offer_blinded_path>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_list_locale_overrides(
         len: i32,
     ) -> *mut wire_cst_list_locale_overrides {
@@ -12058,6 +12173,12 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_list_ln_offer_blinded_path {
+        ptr: *mut wire_cst_ln_offer_blinded_path,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_list_locale_overrides {
         ptr: *mut wire_cst_locale_overrides,
         len: i32,
@@ -12169,6 +12290,12 @@ mod io {
         absolute_expiry: *mut u64,
         issuer: *mut wire_cst_list_prim_u_8_strict,
         signing_pubkey: *mut wire_cst_list_prim_u_8_strict,
+        paths: *mut wire_cst_list_ln_offer_blinded_path,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_ln_offer_blinded_path {
+        blinded_hops: *mut wire_cst_list_String,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1860,7 +1860,7 @@ const _: fn() = || {
         let LNOffer = None::<crate::bindings::LNOffer>.unwrap();
         let _: String = LNOffer.bolt12;
         let _: Vec<String> = LNOffer.chains;
-        let _: Option<crate::bindings::Amount> = LNOffer.amount;
+        let _: Option<crate::bindings::Amount> = LNOffer.min_amount;
         let _: Option<String> = LNOffer.description;
         let _: Option<u64> = LNOffer.absolute_expiry;
         let _: Option<String> = LNOffer.issuer;
@@ -2792,7 +2792,7 @@ impl SseDecode for crate::bindings::LNOffer {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_bolt12 = <String>::sse_decode(deserializer);
         let mut var_chains = <Vec<String>>::sse_decode(deserializer);
-        let mut var_amount = <Option<crate::bindings::Amount>>::sse_decode(deserializer);
+        let mut var_minAmount = <Option<crate::bindings::Amount>>::sse_decode(deserializer);
         let mut var_description = <Option<String>>::sse_decode(deserializer);
         let mut var_absoluteExpiry = <Option<u64>>::sse_decode(deserializer);
         let mut var_issuer = <Option<String>>::sse_decode(deserializer);
@@ -2800,7 +2800,7 @@ impl SseDecode for crate::bindings::LNOffer {
         return crate::bindings::LNOffer {
             bolt12: var_bolt12,
             chains: var_chains,
-            amount: var_amount,
+            min_amount: var_minAmount,
             description: var_description,
             absolute_expiry: var_absoluteExpiry,
             issuer: var_issuer,
@@ -4816,7 +4816,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOffer> {
         [
             self.0.bolt12.into_into_dart().into_dart(),
             self.0.chains.into_into_dart().into_dart(),
-            self.0.amount.into_into_dart().into_dart(),
+            self.0.min_amount.into_into_dart().into_dart(),
             self.0.description.into_into_dart().into_dart(),
             self.0.absolute_expiry.into_into_dart().into_dart(),
             self.0.issuer.into_into_dart().into_dart(),
@@ -6839,7 +6839,7 @@ impl SseEncode for crate::bindings::LNOffer {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.bolt12, serializer);
         <Vec<String>>::sse_encode(self.chains, serializer);
-        <Option<crate::bindings::Amount>>::sse_encode(self.amount, serializer);
+        <Option<crate::bindings::Amount>>::sse_encode(self.min_amount, serializer);
         <Option<String>>::sse_encode(self.description, serializer);
         <Option<u64>>::sse_encode(self.absolute_expiry, serializer);
         <Option<String>>::sse_encode(self.issuer, serializer);
@@ -8853,7 +8853,7 @@ mod io {
             crate::bindings::LNOffer {
                 bolt12: self.bolt12.cst_decode(),
                 chains: self.chains.cst_decode(),
-                amount: self.amount.cst_decode(),
+                min_amount: self.min_amount.cst_decode(),
                 description: self.description.cst_decode(),
                 absolute_expiry: self.absolute_expiry.cst_decode(),
                 issuer: self.issuer.cst_decode(),
@@ -10126,7 +10126,7 @@ mod io {
             Self {
                 bolt12: core::ptr::null_mut(),
                 chains: core::ptr::null_mut(),
-                amount: core::ptr::null_mut(),
+                min_amount: core::ptr::null_mut(),
                 description: core::ptr::null_mut(),
                 absolute_expiry: core::ptr::null_mut(),
                 issuer: core::ptr::null_mut(),
@@ -12164,7 +12164,7 @@ mod io {
     pub struct wire_cst_ln_offer {
         bolt12: *mut wire_cst_list_prim_u_8_strict,
         chains: *mut wire_cst_list_String,
-        amount: *mut wire_cst_amount,
+        min_amount: *mut wire_cst_amount,
         description: *mut wire_cst_list_prim_u_8_strict,
         absolute_expiry: *mut u64,
         issuer: *mut wire_cst_list_prim_u_8_strict,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1798,7 +1798,7 @@ const _: fn() = || {
         crate::bindings::InputType::Bolt11 { invoice } => {
             let _: crate::bindings::LNInvoice = invoice;
         }
-        crate::bindings::InputType::Bolt12 { offer } => {
+        crate::bindings::InputType::Bolt12Offer { offer } => {
             let _: String = offer;
         }
         crate::bindings::InputType::NodeId { node_id } => {
@@ -2436,7 +2436,7 @@ impl SseDecode for crate::bindings::InputType {
             }
             3 => {
                 let mut var_offer = <String>::sse_decode(deserializer);
-                return crate::bindings::InputType::Bolt12 { offer: var_offer };
+                return crate::bindings::InputType::Bolt12Offer { offer: var_offer };
             }
             4 => {
                 let mut var_nodeId = <String>::sse_decode(deserializer);
@@ -4468,7 +4468,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::InputType> {
             crate::bindings::InputType::Bolt11 { invoice } => {
                 [2.into_dart(), invoice.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::InputType::Bolt12 { offer } => {
+            crate::bindings::InputType::Bolt12Offer { offer } => {
                 [3.into_dart(), offer.into_into_dart().into_dart()].into_dart()
             }
             crate::bindings::InputType::NodeId { node_id } => {
@@ -6414,7 +6414,7 @@ impl SseEncode for crate::bindings::InputType {
                 <i32>::sse_encode(2, serializer);
                 <crate::bindings::LNInvoice>::sse_encode(invoice, serializer);
             }
-            crate::bindings::InputType::Bolt12 { offer } => {
+            crate::bindings::InputType::Bolt12Offer { offer } => {
                 <i32>::sse_encode(3, serializer);
                 <String>::sse_encode(offer, serializer);
             }
@@ -8341,8 +8341,8 @@ mod io {
                     }
                 }
                 3 => {
-                    let ans = unsafe { self.kind.Bolt12 };
-                    crate::bindings::InputType::Bolt12 {
+                    let ans = unsafe { self.kind.Bolt12Offer };
+                    crate::bindings::InputType::Bolt12Offer {
                         offer: ans.offer.cst_decode(),
                     }
                 }
@@ -11585,7 +11585,7 @@ mod io {
         BitcoinAddress: wire_cst_InputType_BitcoinAddress,
         LiquidAddress: wire_cst_InputType_LiquidAddress,
         Bolt11: wire_cst_InputType_Bolt11,
-        Bolt12: wire_cst_InputType_Bolt12,
+        Bolt12Offer: wire_cst_InputType_Bolt12Offer,
         NodeId: wire_cst_InputType_NodeId,
         Url: wire_cst_InputType_Url,
         LnUrlPay: wire_cst_InputType_LnUrlPay,
@@ -11611,7 +11611,7 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_InputType_Bolt12 {
+    pub struct wire_cst_InputType_Bolt12Offer {
         offer: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1798,6 +1798,9 @@ const _: fn() = || {
         crate::bindings::InputType::Bolt11 { invoice } => {
             let _: crate::bindings::LNInvoice = invoice;
         }
+        crate::bindings::InputType::Bolt12 { offer } => {
+            let _: String = offer;
+        }
         crate::bindings::InputType::NodeId { node_id } => {
             let _: String = node_id;
         }
@@ -2432,30 +2435,34 @@ impl SseDecode for crate::bindings::InputType {
                 };
             }
             3 => {
+                let mut var_offer = <String>::sse_decode(deserializer);
+                return crate::bindings::InputType::Bolt12 { offer: var_offer };
+            }
+            4 => {
                 let mut var_nodeId = <String>::sse_decode(deserializer);
                 return crate::bindings::InputType::NodeId {
                     node_id: var_nodeId,
                 };
             }
-            4 => {
+            5 => {
                 let mut var_url = <String>::sse_decode(deserializer);
                 return crate::bindings::InputType::Url { url: var_url };
             }
-            5 => {
+            6 => {
                 let mut var_data = <crate::bindings::LnUrlPayRequestData>::sse_decode(deserializer);
                 return crate::bindings::InputType::LnUrlPay { data: var_data };
             }
-            6 => {
+            7 => {
                 let mut var_data =
                     <crate::bindings::LnUrlWithdrawRequestData>::sse_decode(deserializer);
                 return crate::bindings::InputType::LnUrlWithdraw { data: var_data };
             }
-            7 => {
+            8 => {
                 let mut var_data =
                     <crate::bindings::LnUrlAuthRequestData>::sse_decode(deserializer);
                 return crate::bindings::InputType::LnUrlAuth { data: var_data };
             }
-            8 => {
+            9 => {
                 let mut var_data = <crate::bindings::LnUrlErrorData>::sse_decode(deserializer);
                 return crate::bindings::InputType::LnUrlError { data: var_data };
             }
@@ -3887,6 +3894,10 @@ impl SseDecode for crate::model::SendDestination {
                     invoice: var_invoice,
                 };
             }
+            2 => {
+                let mut var_offer = <String>::sse_decode(deserializer);
+                return crate::model::SendDestination::Bolt12 { offer: var_offer };
+            }
             _ => {
                 unimplemented!("");
             }
@@ -4453,23 +4464,26 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::InputType> {
             crate::bindings::InputType::Bolt11 { invoice } => {
                 [2.into_dart(), invoice.into_into_dart().into_dart()].into_dart()
             }
+            crate::bindings::InputType::Bolt12 { offer } => {
+                [3.into_dart(), offer.into_into_dart().into_dart()].into_dart()
+            }
             crate::bindings::InputType::NodeId { node_id } => {
-                [3.into_dart(), node_id.into_into_dart().into_dart()].into_dart()
+                [4.into_dart(), node_id.into_into_dart().into_dart()].into_dart()
             }
             crate::bindings::InputType::Url { url } => {
-                [4.into_dart(), url.into_into_dart().into_dart()].into_dart()
+                [5.into_dart(), url.into_into_dart().into_dart()].into_dart()
             }
             crate::bindings::InputType::LnUrlPay { data } => {
-                [5.into_dart(), data.into_into_dart().into_dart()].into_dart()
-            }
-            crate::bindings::InputType::LnUrlWithdraw { data } => {
                 [6.into_dart(), data.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::InputType::LnUrlAuth { data } => {
+            crate::bindings::InputType::LnUrlWithdraw { data } => {
                 [7.into_dart(), data.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::InputType::LnUrlError { data } => {
+            crate::bindings::InputType::LnUrlAuth { data } => {
                 [8.into_dart(), data.into_into_dart().into_dart()].into_dart()
+            }
+            crate::bindings::InputType::LnUrlError { data } => {
+                [9.into_dart(), data.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -5935,6 +5949,9 @@ impl flutter_rust_bridge::IntoDart for crate::model::SendDestination {
             crate::model::SendDestination::Bolt11 { invoice } => {
                 [1.into_dart(), invoice.into_into_dart().into_dart()].into_dart()
             }
+            crate::model::SendDestination::Bolt12 { offer } => {
+                [2.into_dart(), offer.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -6387,28 +6404,32 @@ impl SseEncode for crate::bindings::InputType {
                 <i32>::sse_encode(2, serializer);
                 <crate::bindings::LNInvoice>::sse_encode(invoice, serializer);
             }
-            crate::bindings::InputType::NodeId { node_id } => {
+            crate::bindings::InputType::Bolt12 { offer } => {
                 <i32>::sse_encode(3, serializer);
+                <String>::sse_encode(offer, serializer);
+            }
+            crate::bindings::InputType::NodeId { node_id } => {
+                <i32>::sse_encode(4, serializer);
                 <String>::sse_encode(node_id, serializer);
             }
             crate::bindings::InputType::Url { url } => {
-                <i32>::sse_encode(4, serializer);
+                <i32>::sse_encode(5, serializer);
                 <String>::sse_encode(url, serializer);
             }
             crate::bindings::InputType::LnUrlPay { data } => {
-                <i32>::sse_encode(5, serializer);
+                <i32>::sse_encode(6, serializer);
                 <crate::bindings::LnUrlPayRequestData>::sse_encode(data, serializer);
             }
             crate::bindings::InputType::LnUrlWithdraw { data } => {
-                <i32>::sse_encode(6, serializer);
+                <i32>::sse_encode(7, serializer);
                 <crate::bindings::LnUrlWithdrawRequestData>::sse_encode(data, serializer);
             }
             crate::bindings::InputType::LnUrlAuth { data } => {
-                <i32>::sse_encode(7, serializer);
+                <i32>::sse_encode(8, serializer);
                 <crate::bindings::LnUrlAuthRequestData>::sse_encode(data, serializer);
             }
             crate::bindings::InputType::LnUrlError { data } => {
-                <i32>::sse_encode(8, serializer);
+                <i32>::sse_encode(9, serializer);
                 <crate::bindings::LnUrlErrorData>::sse_encode(data, serializer);
             }
             _ => {
@@ -7543,6 +7564,10 @@ impl SseEncode for crate::model::SendDestination {
                 <i32>::sse_encode(1, serializer);
                 <crate::bindings::LNInvoice>::sse_encode(invoice, serializer);
             }
+            crate::model::SendDestination::Bolt12 { offer } => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(offer, serializer);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -8302,36 +8327,42 @@ mod io {
                     }
                 }
                 3 => {
+                    let ans = unsafe { self.kind.Bolt12 };
+                    crate::bindings::InputType::Bolt12 {
+                        offer: ans.offer.cst_decode(),
+                    }
+                }
+                4 => {
                     let ans = unsafe { self.kind.NodeId };
                     crate::bindings::InputType::NodeId {
                         node_id: ans.node_id.cst_decode(),
                     }
                 }
-                4 => {
+                5 => {
                     let ans = unsafe { self.kind.Url };
                     crate::bindings::InputType::Url {
                         url: ans.url.cst_decode(),
                     }
                 }
-                5 => {
+                6 => {
                     let ans = unsafe { self.kind.LnUrlPay };
                     crate::bindings::InputType::LnUrlPay {
                         data: ans.data.cst_decode(),
                     }
                 }
-                6 => {
+                7 => {
                     let ans = unsafe { self.kind.LnUrlWithdraw };
                     crate::bindings::InputType::LnUrlWithdraw {
                         data: ans.data.cst_decode(),
                     }
                 }
-                7 => {
+                8 => {
                     let ans = unsafe { self.kind.LnUrlAuth };
                     crate::bindings::InputType::LnUrlAuth {
                         data: ans.data.cst_decode(),
                     }
                 }
-                8 => {
+                9 => {
                     let ans = unsafe { self.kind.LnUrlError };
                     crate::bindings::InputType::LnUrlError {
                         data: ans.data.cst_decode(),
@@ -9333,6 +9364,12 @@ mod io {
                     let ans = unsafe { self.kind.Bolt11 };
                     crate::model::SendDestination::Bolt11 {
                         invoice: ans.invoice.cst_decode(),
+                    }
+                }
+                2 => {
+                    let ans = unsafe { self.kind.Bolt12 };
+                    crate::model::SendDestination::Bolt12 {
+                        offer: ans.offer.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -11533,6 +11570,7 @@ mod io {
         BitcoinAddress: wire_cst_InputType_BitcoinAddress,
         LiquidAddress: wire_cst_InputType_LiquidAddress,
         Bolt11: wire_cst_InputType_Bolt11,
+        Bolt12: wire_cst_InputType_Bolt12,
         NodeId: wire_cst_InputType_NodeId,
         Url: wire_cst_InputType_Url,
         LnUrlPay: wire_cst_InputType_LnUrlPay,
@@ -11555,6 +11593,11 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_InputType_Bolt11 {
         invoice: *mut wire_cst_ln_invoice,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_InputType_Bolt12 {
+        offer: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -12414,6 +12457,7 @@ mod io {
     pub union SendDestinationKind {
         LiquidAddress: wire_cst_SendDestination_LiquidAddress,
         Bolt11: wire_cst_SendDestination_Bolt11,
+        Bolt12: wire_cst_SendDestination_Bolt12,
         nil__: (),
     }
     #[repr(C)]
@@ -12425,6 +12469,11 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_SendDestination_Bolt11 {
         invoice: *mut wire_cst_ln_invoice,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_SendDestination_Bolt12 {
+        offer: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1858,7 +1858,7 @@ const _: fn() = || {
     }
     {
         let LNOffer = None::<crate::bindings::LNOffer>.unwrap();
-        let _: String = LNOffer.bolt12;
+        let _: String = LNOffer.offer;
         let _: Vec<String> = LNOffer.chains;
         let _: Option<crate::bindings::Amount> = LNOffer.min_amount;
         let _: Option<String> = LNOffer.description;
@@ -2790,7 +2790,7 @@ impl SseDecode for crate::bindings::LNInvoice {
 impl SseDecode for crate::bindings::LNOffer {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_bolt12 = <String>::sse_decode(deserializer);
+        let mut var_offer = <String>::sse_decode(deserializer);
         let mut var_chains = <Vec<String>>::sse_decode(deserializer);
         let mut var_minAmount = <Option<crate::bindings::Amount>>::sse_decode(deserializer);
         let mut var_description = <Option<String>>::sse_decode(deserializer);
@@ -2798,7 +2798,7 @@ impl SseDecode for crate::bindings::LNOffer {
         let mut var_issuer = <Option<String>>::sse_decode(deserializer);
         let mut var_signingPubkey = <Option<String>>::sse_decode(deserializer);
         return crate::bindings::LNOffer {
-            bolt12: var_bolt12,
+            offer: var_offer,
             chains: var_chains,
             min_amount: var_minAmount,
             description: var_description,
@@ -4814,7 +4814,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNInvoice>>
 impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOffer> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.0.bolt12.into_into_dart().into_dart(),
+            self.0.offer.into_into_dart().into_dart(),
             self.0.chains.into_into_dart().into_dart(),
             self.0.min_amount.into_into_dart().into_dart(),
             self.0.description.into_into_dart().into_dart(),
@@ -6837,7 +6837,7 @@ impl SseEncode for crate::bindings::LNInvoice {
 impl SseEncode for crate::bindings::LNOffer {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.bolt12, serializer);
+        <String>::sse_encode(self.offer, serializer);
         <Vec<String>>::sse_encode(self.chains, serializer);
         <Option<crate::bindings::Amount>>::sse_encode(self.min_amount, serializer);
         <Option<String>>::sse_encode(self.description, serializer);
@@ -8851,7 +8851,7 @@ mod io {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::bindings::LNOffer {
             crate::bindings::LNOffer {
-                bolt12: self.bolt12.cst_decode(),
+                offer: self.offer.cst_decode(),
                 chains: self.chains.cst_decode(),
                 min_amount: self.min_amount.cst_decode(),
                 description: self.description.cst_decode(),
@@ -10124,7 +10124,7 @@ mod io {
     impl NewWithNullPtr for wire_cst_ln_offer {
         fn new_with_null_ptr() -> Self {
             Self {
-                bolt12: core::ptr::null_mut(),
+                offer: core::ptr::null_mut(),
                 chains: core::ptr::null_mut(),
                 min_amount: core::ptr::null_mut(),
                 description: core::ptr::null_mut(),
@@ -12162,7 +12162,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_ln_offer {
-        bolt12: *mut wire_cst_list_prim_u_8_strict,
+        offer: *mut wire_cst_list_prim_u_8_strict,
         chains: *mut wire_cst_list_String,
         min_amount: *mut wire_cst_amount,
         description: *mut wire_cst_list_prim_u_8_strict,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1865,11 +1865,11 @@ const _: fn() = || {
         let _: Option<u64> = LNOffer.absolute_expiry;
         let _: Option<String> = LNOffer.issuer;
         let _: Option<String> = LNOffer.signing_pubkey;
-        let _: Vec<crate::bindings::LNOfferBlindedPath> = LNOffer.paths;
+        let _: Vec<crate::bindings::LnOfferBlindedPath> = LNOffer.paths;
     }
     {
-        let LNOfferBlindedPath = None::<crate::bindings::LNOfferBlindedPath>.unwrap();
-        let _: Vec<String> = LNOfferBlindedPath.blinded_hops;
+        let LnOfferBlindedPath = None::<crate::bindings::LnOfferBlindedPath>.unwrap();
+        let _: Vec<String> = LnOfferBlindedPath.blinded_hops;
     }
     {
         let LnUrlAuthRequestData = None::<crate::bindings::LnUrlAuthRequestData>.unwrap();
@@ -2608,13 +2608,13 @@ impl SseDecode for Vec<crate::bindings::FiatCurrency> {
     }
 }
 
-impl SseDecode for Vec<crate::bindings::LNOfferBlindedPath> {
+impl SseDecode for Vec<crate::bindings::LnOfferBlindedPath> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut len_ = <i32>::sse_decode(deserializer);
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
-            ans_.push(<crate::bindings::LNOfferBlindedPath>::sse_decode(
+            ans_.push(<crate::bindings::LnOfferBlindedPath>::sse_decode(
                 deserializer,
             ));
         }
@@ -2816,7 +2816,7 @@ impl SseDecode for crate::bindings::LNOffer {
         let mut var_absoluteExpiry = <Option<u64>>::sse_decode(deserializer);
         let mut var_issuer = <Option<String>>::sse_decode(deserializer);
         let mut var_signingPubkey = <Option<String>>::sse_decode(deserializer);
-        let mut var_paths = <Vec<crate::bindings::LNOfferBlindedPath>>::sse_decode(deserializer);
+        let mut var_paths = <Vec<crate::bindings::LnOfferBlindedPath>>::sse_decode(deserializer);
         return crate::bindings::LNOffer {
             offer: var_offer,
             chains: var_chains,
@@ -2830,11 +2830,11 @@ impl SseDecode for crate::bindings::LNOffer {
     }
 }
 
-impl SseDecode for crate::bindings::LNOfferBlindedPath {
+impl SseDecode for crate::bindings::LnOfferBlindedPath {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_blindedHops = <Vec<String>>::sse_decode(deserializer);
-        return crate::bindings::LNOfferBlindedPath {
+        return crate::bindings::LnOfferBlindedPath {
             blinded_hops: var_blindedHops,
         };
     }
@@ -4871,19 +4871,19 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNOffer>>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LNOfferBlindedPath> {
+impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::bindings::LnOfferBlindedPath> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.0.blinded_hops.into_into_dart().into_dart()].into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<crate::bindings::LNOfferBlindedPath>
+    for FrbWrapper<crate::bindings::LnOfferBlindedPath>
 {
 }
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LNOfferBlindedPath>>
-    for crate::bindings::LNOfferBlindedPath
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LnOfferBlindedPath>>
+    for crate::bindings::LnOfferBlindedPath
 {
-    fn into_into_dart(self) -> FrbWrapper<crate::bindings::LNOfferBlindedPath> {
+    fn into_into_dart(self) -> FrbWrapper<crate::bindings::LnOfferBlindedPath> {
         self.into()
     }
 }
@@ -6748,12 +6748,12 @@ impl SseEncode for Vec<crate::bindings::FiatCurrency> {
     }
 }
 
-impl SseEncode for Vec<crate::bindings::LNOfferBlindedPath> {
+impl SseEncode for Vec<crate::bindings::LnOfferBlindedPath> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
-            <crate::bindings::LNOfferBlindedPath>::sse_encode(item, serializer);
+            <crate::bindings::LnOfferBlindedPath>::sse_encode(item, serializer);
         }
     }
 }
@@ -6907,11 +6907,11 @@ impl SseEncode for crate::bindings::LNOffer {
         <Option<u64>>::sse_encode(self.absolute_expiry, serializer);
         <Option<String>>::sse_encode(self.issuer, serializer);
         <Option<String>>::sse_encode(self.signing_pubkey, serializer);
-        <Vec<crate::bindings::LNOfferBlindedPath>>::sse_encode(self.paths, serializer);
+        <Vec<crate::bindings::LnOfferBlindedPath>>::sse_encode(self.paths, serializer);
     }
 }
 
-impl SseEncode for crate::bindings::LNOfferBlindedPath {
+impl SseEncode for crate::bindings::LnOfferBlindedPath {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<String>>::sse_encode(self.blinded_hops, serializer);
@@ -8779,11 +8779,11 @@ mod io {
             vec.into_iter().map(CstDecode::cst_decode).collect()
         }
     }
-    impl CstDecode<Vec<crate::bindings::LNOfferBlindedPath>>
+    impl CstDecode<Vec<crate::bindings::LnOfferBlindedPath>>
         for *mut wire_cst_list_ln_offer_blinded_path
     {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> Vec<crate::bindings::LNOfferBlindedPath> {
+        fn cst_decode(self) -> Vec<crate::bindings::LnOfferBlindedPath> {
             let vec = unsafe {
                 let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
                 flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
@@ -8947,10 +8947,10 @@ mod io {
             }
         }
     }
-    impl CstDecode<crate::bindings::LNOfferBlindedPath> for wire_cst_ln_offer_blinded_path {
+    impl CstDecode<crate::bindings::LnOfferBlindedPath> for wire_cst_ln_offer_blinded_path {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::bindings::LNOfferBlindedPath {
-            crate::bindings::LNOfferBlindedPath {
+        fn cst_decode(self) -> crate::bindings::LnOfferBlindedPath {
+            crate::bindings::LnOfferBlindedPath {
                 blinded_hops: self.blinded_hops.cst_decode(),
             }
         }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -345,7 +345,7 @@ pub struct OnchainPaymentLimitsResponse {
 #[derive(Debug, Serialize, Clone)]
 pub struct PrepareSendRequest {
     /// The destination we intend to pay to.
-    /// Supports BIP21 URIs, BOLT11 invoices and Liquid addresses
+    /// Supports BIP21 URIs, BOLT11 invoices, BOLT12 offers and Liquid addresses
     pub destination: String,
 
     /// Should only be set when paying directly onchain or to a BIP21 URI
@@ -361,6 +361,9 @@ pub enum SendDestination {
     },
     Bolt11 {
         invoice: LNInvoice,
+    },
+    Bolt12 {
+        offer: String,
     },
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1308,18 +1308,17 @@ impl Payment {
             // If it's a chain swap instead, we use the `claim_address` field from the swap data (either pure Bitcoin or Liquid address).
             // Otherwise, we specify the Liquid address (BIP21 or pure), set in `payment_details.address`.
             destination: match &swap {
-                Some(
-                    PaymentSwapData {
-                        swap_type: PaymentSwapType::Receive,
-                        bolt11,
-                        ..
-                    }
-                    | PaymentSwapData {
-                        swap_type: PaymentSwapType::Send,
-                        bolt11,
-                        ..
-                    },
-                ) => bolt11.clone(),
+                Some(PaymentSwapData {
+                    swap_type: PaymentSwapType::Receive,
+                    bolt11,
+                    ..
+                }) => bolt11.clone(),
+                Some(PaymentSwapData {
+                    swap_type: PaymentSwapType::Send,
+                    bolt11,
+                    bolt12_offer,
+                    ..
+                }) => bolt11.clone().or(bolt12_offer.clone()),
                 Some(PaymentSwapData {
                     swap_type: PaymentSwapType::Chain,
                     claim_address,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -743,7 +743,10 @@ impl ChainSwap {
 #[derive(Clone, Debug)]
 pub(crate) struct SendSwap {
     pub(crate) id: String,
+    /// Bolt11 or Bolt12 invoice. This is determined by whether `bolt12_offer` is set or not.
     pub(crate) invoice: String,
+    /// The bolt12 offer, if this swap sends to a Bolt12 offer
+    pub(crate) bolt12_offer: Option<String>,
     pub(crate) payment_hash: Option<String>,
     pub(crate) description: Option<String>,
     pub(crate) preimage: Option<String>,
@@ -1115,6 +1118,7 @@ pub struct PaymentSwapData {
 
     pub preimage: Option<String>,
     pub bolt11: Option<String>,
+    pub bolt12_offer: Option<String>,
     pub payment_hash: Option<String>,
     pub description: String,
 
@@ -1149,10 +1153,12 @@ pub enum PaymentDetails {
         /// In case of a Send swap, this is the preimage of the paid invoice (proof of payment).
         preimage: Option<String>,
 
-        /// Represents the invoice associated with a payment
+        /// Represents the Bolt11 invoice associated with a payment
         /// In the case of a Send payment, this is the invoice paid by the swapper
         /// In the case of a Receive payment, this is the invoice paid by the user
         bolt11: Option<String>,
+
+        bolt12_offer: Option<String>,
 
         /// The payment hash of the invoice
         payment_hash: Option<String>,
@@ -1282,6 +1288,7 @@ impl Payment {
                 swap_id: swap.swap_id,
                 preimage: swap.preimage,
                 bolt11: swap.bolt11,
+                bolt12_offer: swap.bolt12_offer,
                 payment_hash: swap.payment_hash,
                 description: swap.description,
                 refund_tx_id: swap.refund_tx_id,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -364,6 +364,7 @@ pub enum SendDestination {
     },
     Bolt12 {
         offer: String,
+        receiver_amount_sat: u64,
     },
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -363,7 +363,7 @@ pub enum SendDestination {
         invoice: LNInvoice,
     },
     Bolt12 {
-        offer: String,
+        offer: LNOffer,
         receiver_amount_sat: u64,
     },
 }

--- a/lib/core/src/persist/address.rs
+++ b/lib/core/src/persist/address.rs
@@ -108,7 +108,7 @@ mod tests {
         let (_temp_dir, storage) = new_persister()?;
         let address = "tlq1pq2amlulhea6ltq7x3eu9atsc2nnrer7yt7xve363zxedqwu2mk6ctcyv9awl8xf28cythreqklt5q0qqwsxzlm6wu4z6d574adl9zh2zmr0h85gt534n";
 
-        storage.insert_or_update_reserved_address(&address, 100)?;
+        storage.insert_or_update_reserved_address(address, 100)?;
 
         let maybe_reserved_address = storage.next_expired_reserved_address(99)?;
         // Under the expiry, not popped
@@ -134,13 +134,13 @@ mod tests {
         let (_temp_dir, storage) = new_persister()?;
         let address = "tlq1pq2amlulhea6ltq7x3eu9atsc2nnrer7yt7xve363zxedqwu2mk6ctcyv9awl8xf28cythreqklt5q0qqwsxzlm6wu4z6d574adl9zh2zmr0h85gt534n";
 
-        storage.insert_or_update_reserved_address(&address, 100)?;
+        storage.insert_or_update_reserved_address(address, 100)?;
 
         let maybe_reserved_address = storage.next_expired_reserved_address(99)?;
         // Under the expiry, not popped
         assert!(maybe_reserved_address.is_none());
 
-        storage.delete_reserved_address(&address)?;
+        storage.delete_reserved_address(address)?;
 
         let maybe_reserved_address = storage.next_expired_reserved_address(101)?;
         // Over the expired, but already deleted

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -183,5 +183,63 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
 
         DROP TABLE old_chain_swaps;
         ",
+        // Add bolt12_offer column for Send Swaps
+        "
+        ALTER TABLE send_swaps RENAME TO send_swaps_old;
+
+        CREATE TABLE send_swaps (
+            id TEXT NOT NULL PRIMARY KEY,
+            invoice TEXT NOT NULL UNIQUE,
+            bolt12_offer TEXT,
+            preimage TEXT,
+            payer_amount_sat INTEGER NOT NULL,
+            receiver_amount_sat INTEGER NOT NULL,
+            create_response_json TEXT NOT NULL,
+            refund_private_key TEXT NOT NULL,
+            lockup_tx_id TEXT,
+            refund_tx_id TEXT,
+            created_at INTEGER NOT NULL,
+            state INTEGER NOT NULL,
+            description TEXT,
+            id_hash TEXT,
+            payment_hash TEXT
+        ) STRICT;
+
+        INSERT INTO send_swaps (
+            id,
+            invoice,
+            bolt12_offer,
+            preimage,
+            payer_amount_sat,
+            receiver_amount_sat,
+            create_response_json,
+            refund_private_key,
+            lockup_tx_id,
+            refund_tx_id,
+            created_at,
+            state,
+            description,
+            id_hash,
+            payment_hash
+        ) SELECT
+            id,
+            invoice,
+            NULL,
+            preimage,
+            payer_amount_sat,
+            receiver_amount_sat,
+            create_response_json,
+            refund_private_key,
+            lockup_tx_id,
+            refund_tx_id,
+            created_at,
+            state,
+            description,
+            id_hash,
+            payment_hash
+        FROM send_swaps_old;
+
+        DROP TABLE send_swaps_old;
+        ",
     ]
 }

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -183,63 +183,6 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
 
         DROP TABLE old_chain_swaps;
         ",
-        // Add bolt12_offer column for Send Swaps
-        "
-        ALTER TABLE send_swaps RENAME TO send_swaps_old;
-
-        CREATE TABLE send_swaps (
-            id TEXT NOT NULL PRIMARY KEY,
-            invoice TEXT NOT NULL UNIQUE,
-            bolt12_offer TEXT,
-            preimage TEXT,
-            payer_amount_sat INTEGER NOT NULL,
-            receiver_amount_sat INTEGER NOT NULL,
-            create_response_json TEXT NOT NULL,
-            refund_private_key TEXT NOT NULL,
-            lockup_tx_id TEXT,
-            refund_tx_id TEXT,
-            created_at INTEGER NOT NULL,
-            state INTEGER NOT NULL,
-            description TEXT,
-            id_hash TEXT,
-            payment_hash TEXT
-        ) STRICT;
-
-        INSERT INTO send_swaps (
-            id,
-            invoice,
-            bolt12_offer,
-            preimage,
-            payer_amount_sat,
-            receiver_amount_sat,
-            create_response_json,
-            refund_private_key,
-            lockup_tx_id,
-            refund_tx_id,
-            created_at,
-            state,
-            description,
-            id_hash,
-            payment_hash
-        ) SELECT
-            id,
-            invoice,
-            NULL,
-            preimage,
-            payer_amount_sat,
-            receiver_amount_sat,
-            create_response_json,
-            refund_private_key,
-            lockup_tx_id,
-            refund_tx_id,
-            created_at,
-            state,
-            description,
-            id_hash,
-            payment_hash
-        FROM send_swaps_old;
-
-        DROP TABLE send_swaps_old;
-        ",
+        "ALTER TABLE send_swaps ADD COLUMN bolt12_offer TEXT;",
     ]
 }

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -180,6 +180,7 @@ impl Persister {
                 ss.id,
                 ss.created_at,
                 ss.invoice,
+                ss.bolt12_offer,
                 ss.payment_hash,
                 ss.description,
                 ss.preimage,
@@ -256,29 +257,30 @@ impl Persister {
         let maybe_send_swap_id: Option<String> = row.get(14)?;
         let maybe_send_swap_created_at: Option<u32> = row.get(15)?;
         let maybe_send_swap_invoice: Option<String> = row.get(16)?;
-        let maybe_send_swap_payment_hash: Option<String> = row.get(17)?;
-        let maybe_send_swap_description: Option<String> = row.get(18)?;
-        let maybe_send_swap_preimage: Option<String> = row.get(19)?;
-        let maybe_send_swap_refund_tx_id: Option<String> = row.get(20)?;
-        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(21)?;
-        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(22)?;
-        let maybe_send_swap_state: Option<PaymentState> = row.get(23)?;
+        let maybe_send_swap_bolt12_offer: Option<String> = row.get(17)?;
+        let maybe_send_swap_payment_hash: Option<String> = row.get(18)?;
+        let maybe_send_swap_description: Option<String> = row.get(19)?;
+        let maybe_send_swap_preimage: Option<String> = row.get(20)?;
+        let maybe_send_swap_refund_tx_id: Option<String> = row.get(21)?;
+        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(22)?;
+        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(23)?;
+        let maybe_send_swap_state: Option<PaymentState> = row.get(24)?;
 
-        let maybe_chain_swap_id: Option<String> = row.get(24)?;
-        let maybe_chain_swap_created_at: Option<u32> = row.get(25)?;
-        let maybe_chain_swap_direction: Option<Direction> = row.get(26)?;
-        let maybe_chain_swap_preimage: Option<String> = row.get(27)?;
-        let maybe_chain_swap_description: Option<String> = row.get(28)?;
-        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(29)?;
-        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(30)?;
-        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(31)?;
-        let maybe_chain_swap_claim_address: Option<String> = row.get(32)?;
-        let maybe_chain_swap_state: Option<PaymentState> = row.get(33)?;
+        let maybe_chain_swap_id: Option<String> = row.get(25)?;
+        let maybe_chain_swap_created_at: Option<u32> = row.get(26)?;
+        let maybe_chain_swap_direction: Option<Direction> = row.get(27)?;
+        let maybe_chain_swap_preimage: Option<String> = row.get(28)?;
+        let maybe_chain_swap_description: Option<String> = row.get(29)?;
+        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(30)?;
+        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(31)?;
+        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(32)?;
+        let maybe_chain_swap_claim_address: Option<String> = row.get(33)?;
+        let maybe_chain_swap_state: Option<PaymentState> = row.get(34)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(34)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(35)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(35)?;
-        let maybe_payment_details_description: Option<String> = row.get(36)?;
+        let maybe_payment_details_destination: Option<String> = row.get(36)?;
+        let maybe_payment_details_description: Option<String> = row.get(37)?;
 
         let (swap, payment_type) = match maybe_receive_swap_id {
             Some(receive_swap_id) => (
@@ -288,6 +290,7 @@ impl Persister {
                     created_at: maybe_receive_swap_created_at.unwrap_or(utils::now()),
                     preimage: None,
                     bolt11: maybe_receive_swap_invoice.clone(),
+                    bolt12_offer: None, // Bolt12 not supported for Receive Swaps
                     payment_hash: maybe_receive_swap_payment_hash,
                     description: maybe_receive_swap_description.unwrap_or_else(|| {
                         maybe_receive_swap_invoice
@@ -310,7 +313,11 @@ impl Persister {
                         swap_type: PaymentSwapType::Send,
                         created_at: maybe_send_swap_created_at.unwrap_or(utils::now()),
                         preimage: maybe_send_swap_preimage,
-                        bolt11: maybe_send_swap_invoice.clone(),
+                        bolt11: match maybe_send_swap_bolt12_offer.is_some() {
+                            true => None, // We don't expose the Bolt12 invoice
+                            false => maybe_send_swap_invoice,
+                        },
+                        bolt12_offer: maybe_send_swap_bolt12_offer,
                         payment_hash: maybe_send_swap_payment_hash,
                         description: maybe_send_swap_description
                             .unwrap_or("Lightning payment".to_string()),
@@ -331,6 +338,7 @@ impl Persister {
                             created_at: maybe_chain_swap_created_at.unwrap_or(utils::now()),
                             preimage: maybe_chain_swap_preimage,
                             bolt11: None,
+                            bolt12_offer: None, // Bolt12 not supported for Chain Swaps
                             payment_hash: None,
                             description: maybe_chain_swap_description
                                 .unwrap_or("Bitcoin transfer".to_string()),
@@ -357,6 +365,7 @@ impl Persister {
                     swap_type: PaymentSwapType::Receive,
                     swap_id,
                     bolt11,
+                    bolt12_offer,
                     payment_hash,
                     refund_tx_id,
                     preimage,
@@ -367,6 +376,7 @@ impl Persister {
                     swap_type: PaymentSwapType::Send,
                     swap_id,
                     bolt11,
+                    bolt12_offer,
                     payment_hash,
                     preimage,
                     refund_tx_id,
@@ -377,6 +387,7 @@ impl Persister {
                 swap_id,
                 preimage,
                 bolt11,
+                bolt12_offer,
                 payment_hash,
                 refund_tx_id,
                 refund_tx_amount_sat,

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -312,11 +312,14 @@ impl Persister {
                         preimage: maybe_send_swap_preimage,
                         bolt11: maybe_send_swap_invoice.clone(),
                         payment_hash: maybe_send_swap_payment_hash,
-                        description: maybe_send_swap_description.unwrap_or_else(|| {
-                            maybe_send_swap_invoice
-                                .and_then(|bolt11| get_invoice_description!(bolt11))
-                                .unwrap_or("Lightning payment".to_string())
-                        }),
+
+                        description: "Lightning payment".to_string(),
+                        // TODO Should not assume this is bolt11
+                        // description: maybe_send_swap_description.unwrap_or_else(|| {
+                        //     maybe_send_swap_invoice
+                        //         .and_then(|bolt11| get_invoice_description!(bolt11))
+                        //         .unwrap_or("Lightning payment".to_string())
+                        // }),
                         payer_amount_sat: maybe_send_swap_payer_amount_sat.unwrap_or(0),
                         receiver_amount_sat: maybe_send_swap_receiver_amount_sat.unwrap_or(0),
                         refund_tx_id: maybe_send_swap_refund_tx_id,

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -312,14 +312,8 @@ impl Persister {
                         preimage: maybe_send_swap_preimage,
                         bolt11: maybe_send_swap_invoice.clone(),
                         payment_hash: maybe_send_swap_payment_hash,
-
-                        description: "Lightning payment".to_string(),
-                        // TODO Should not assume this is bolt11
-                        // description: maybe_send_swap_description.unwrap_or_else(|| {
-                        //     maybe_send_swap_invoice
-                        //         .and_then(|bolt11| get_invoice_description!(bolt11))
-                        //         .unwrap_or("Lightning payment".to_string())
-                        // }),
+                        description: maybe_send_swap_description
+                            .unwrap_or("Lightning payment".to_string()),
                         payer_amount_sat: maybe_send_swap_payer_amount_sat.unwrap_or(0),
                         receiver_amount_sat: maybe_send_swap_receiver_amount_sat.unwrap_or(0),
                         refund_tx_id: maybe_send_swap_refund_tx_id,

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -21,6 +21,7 @@ impl Persister {
                 id,
                 id_hash,
                 invoice,
+                bolt12_offer,
                 payment_hash,
                 description,
                 payer_amount_sat,
@@ -32,13 +33,14 @@ impl Persister {
                 created_at,
                 state
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )?;
         let id_hash = sha256::Hash::hash(send_swap.id.as_bytes()).to_hex();
         _ = stmt.execute((
             &send_swap.id,
             &id_hash,
             &send_swap.invoice,
+            &send_swap.bolt12_offer,
             &send_swap.payment_hash,
             &send_swap.description,
             &send_swap.payer_amount_sat,
@@ -88,6 +90,7 @@ impl Persister {
             SELECT
                 id,
                 invoice,
+                bolt12_offer,
                 payment_hash,
                 description,
                 preimage,
@@ -126,17 +129,18 @@ impl Persister {
         Ok(SendSwap {
             id: row.get(0)?,
             invoice: row.get(1)?,
-            payment_hash: row.get(2)?,
-            description: row.get(3)?,
-            preimage: row.get(4)?,
-            payer_amount_sat: row.get(5)?,
-            receiver_amount_sat: row.get(6)?,
-            create_response_json: row.get(7)?,
-            refund_private_key: row.get(8)?,
-            lockup_tx_id: row.get(9)?,
-            refund_tx_id: row.get(10)?,
-            created_at: row.get(11)?,
-            state: row.get(12)?,
+            bolt12_offer: row.get(2)?,
+            payment_hash: row.get(3)?,
+            description: row.get(4)?,
+            preimage: row.get(5)?,
+            payer_amount_sat: row.get(6)?,
+            receiver_amount_sat: row.get(7)?,
+            create_response_json: row.get(8)?,
+            refund_private_key: row.get(9)?,
+            lockup_tx_id: row.get(10)?,
+            refund_tx_id: row.get(11)?,
+            created_at: row.get(12)?,
+            state: row.get(13)?,
         })
     }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2595,7 +2595,7 @@ impl LiquidSdk {
                         .collect(),
                     // TODO This conversion (between lightning-v0.0.125 to -v0.0.118 Amount types)
                     //      won't be needed when Liquid SDK uses the same lightning crate version as sdk-common
-                    amount: offer.amount().map(|amount| match amount {
+                    min_amount: offer.amount().map(|amount| match amount {
                         ::lightning::offers::offer::Amount::Bitcoin { amount_msats } => {
                             Amount::Bitcoin {
                                 amount_msat: amount_msats,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1046,8 +1046,6 @@ impl LiquidSdk {
             PaymentError::InsufficientFunds
         );
 
-        // TODO CHeck for MRH (if present, pay via Liquid)
-
         self.send_payment_via_swap(
             invoice,
             &invoice_parsed.payment_hash().to_string(),

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -641,12 +641,6 @@ impl LiquidSdk {
             receiver_amount_sat == user_specified_receiver_amount_sat,
             PaymentError::invalid_invoice("Invalid Bolt12 invoice amount")
         );
-        if let Some(Amount::Bitcoin { amount_msat }) = &offer.min_amount {
-            ensure_sdk!(
-                receiver_amount_sat >= amount_msat / 1_000,
-                PaymentError::invalid_invoice("Invalid Bolt12 invoice amount: below offer minimum")
-            );
-        }
 
         Ok(invoice_parsed)
     }
@@ -916,6 +910,14 @@ impl LiquidSdk {
                         "Expected PayAmount of type Receiver when processing a Bolt12 offer",
                     )),
                 }?;
+                if let Some(Amount::Bitcoin { amount_msat }) = &offer.min_amount {
+                    ensure_sdk!(
+                        receiver_amount_sat >= amount_msat / 1_000,
+                        PaymentError::invalid_invoice(
+                            "Invalid receiver amount: below offer minimum"
+                        )
+                    );
+                }
 
                 let lbtc_pair = self.validate_submarine_pairs(receiver_amount_sat)?;
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -788,7 +788,7 @@ impl LiquidSdk {
                 };
                 payment_destination = SendDestination::Bolt11 { invoice };
             }
-            Ok(InputType::Bolt12 { offer }) => {
+            Ok(InputType::Bolt12Offer { offer }) => {
                 let amount_sat = req
                     .amount_sat
                     .ok_or_else(|| anyhow!("Expected amount when processing BOLT12 offer"))?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -706,7 +706,7 @@ impl LiquidSdk {
     /// # Arguments
     ///
     /// * `req` - the [PrepareSendRequest] containing:
-    ///     * `destination` - Either a Liquid BIP21 URI/address. a BOLT11 invoice or a BOLT12 offer
+    ///     * `destination` - Either a Liquid BIP21 URI/address, a BOLT11 invoice or a BOLT12 offer
     ///     * `amount_sat` - Should only be specified when paying directly onchain or via amount-less BIP21
     ///
     /// # Returns

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2680,14 +2680,14 @@ impl LiquidSdk {
                     paths: offer
                         .paths()
                         .iter()
-                        .map(|path| LNOfferBlindedPath {
+                        .map(|path| LnOfferBlindedPath {
                             blinded_hops: path
                                 .blinded_hops()
                                 .iter()
                                 .map(|hop| hop.blinded_node_id.to_hex())
                                 .collect(),
                         })
-                        .collect::<Vec<LNOfferBlindedPath>>(),
+                        .collect::<Vec<LnOfferBlindedPath>>(),
                 },
             });
         }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1034,7 +1034,6 @@ impl LiquidSdk {
         invoice: &str,
         fees_sat: u64,
     ) -> Result<SendPaymentResponse, PaymentError> {
-        // TODO Ensure it's not self-transfer
         // TODO Validate invoice
 
         let invoice_parsed = utils::parse_bolt12_invoice(invoice)?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -860,7 +860,7 @@ impl LiquidSdk {
                 };
                 payment_destination = SendDestination::Bolt11 { invoice };
             }
-            Ok(InputType::Bolt12Offer { offer }) => {
+            Ok(InputType::Bolt12Offer { offer: _ }) => {
                 receiver_amount_sat = match req.amount {
                     Some(PayAmount::Receiver { amount_sat }) => Ok(amount_sat),
                     _ => Err(PaymentError::amount_missing(
@@ -877,7 +877,7 @@ impl LiquidSdk {
                 fees_sat = boltz_fees_total + lockup_fees_sat;
 
                 payment_destination = SendDestination::Bolt12 {
-                    offer,
+                    offer: req.destination.clone(),
                     receiver_amount_sat,
                 };
             }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1067,6 +1067,7 @@ impl LiquidSdk {
             None => {
                 self.send_payment_via_swap(
                     invoice,
+                    None,
                     &bolt11_invoice.payment_hash().to_string(),
                     description,
                     amount_sat,
@@ -1096,6 +1097,7 @@ impl LiquidSdk {
 
         self.send_payment_via_swap(
             invoice_str,
+            Some(offer.offer.clone()),
             &invoice.payment_hash().to_string(),
             invoice.description().map(|desc| desc.to_string()),
             receiver_amount_sat,
@@ -1163,9 +1165,12 @@ impl LiquidSdk {
     }
 
     /// Performs a Send Payment by doing a swap (create it, fund it, track it, etc).
+    ///
+    /// If `bolt12_offer` is set, `invoice` refers to a Bolt12 invoice, otherwise it's a Bolt11 one.
     async fn send_payment_via_swap(
         &self,
         invoice: &str,
+        bolt12_offer: Option<String>,
         payment_hash: &str,
         description: Option<String>,
         receiver_amount_sat: u64,
@@ -1233,6 +1238,7 @@ impl LiquidSdk {
                 let swap = SendSwap {
                     id: swap_id.clone(),
                     invoice: invoice.to_string(),
+                    bolt12_offer,
                     payment_hash: Some(payment_hash.to_string()),
                     description,
                     preimage: None,

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -413,4 +413,10 @@ impl Swapper for BoltzSwapper {
         )
         .map_err(Into::into)
     }
+
+    fn get_bolt12_invoice(&self, offer: &str, amount_sat: u64) -> Result<String, PaymentError> {
+        let invoice_res = self.client.get_bolt12_invoice(offer, amount_sat)?;
+        info!("Received BOLT12 invoice response: {invoice_res:?}");
+        Ok(invoice_res.invoice)
+    }
 }

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -104,6 +104,8 @@ pub trait Swapper: Send + Sync {
         &self,
         invoice: &str,
     ) -> Result<Option<(String, boltz_client::bitcoin::Amount)>, PaymentError>;
+
+    fn get_bolt12_invoice(&self, offer: &str, amount_sat: u64) -> Result<String, PaymentError>;
 }
 
 #[async_trait]

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -42,6 +42,7 @@ pub(crate) fn new_send_swap(payment_state: Option<PaymentState>) -> SendSwap {
     SendSwap {
         id: generate_random_string(4),
         invoice: invoice.to_string(),
+        bolt12_offer: None,
         payment_hash: Some(payment_hash.to_string()),
         description: Some("Send to BTC lightning".to_string()),
         preimage: None,

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -309,4 +309,8 @@ impl Swapper for MockSwapper {
         // Ok(Some(("".to_string(), 0.0)))
         unimplemented!()
     }
+
+    fn get_bolt12_invoice(&self, _offer: &str, _amount_sat: u64) -> Result<String, PaymentError> {
+        unimplemented!()
+    }
 }

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -427,6 +427,7 @@ class LNOffer {
   final BigInt? absoluteExpiry;
   final String? issuer;
   final String? signingPubkey;
+  final List<LNOfferBlindedPath> paths;
 
   const LNOffer({
     required this.offer,
@@ -436,6 +437,7 @@ class LNOffer {
     this.absoluteExpiry,
     this.issuer,
     this.signingPubkey,
+    required this.paths,
   });
 
   @override
@@ -446,7 +448,8 @@ class LNOffer {
       description.hashCode ^
       absoluteExpiry.hashCode ^
       issuer.hashCode ^
-      signingPubkey.hashCode;
+      signingPubkey.hashCode ^
+      paths.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -459,7 +462,24 @@ class LNOffer {
           description == other.description &&
           absoluteExpiry == other.absoluteExpiry &&
           issuer == other.issuer &&
-          signingPubkey == other.signingPubkey;
+          signingPubkey == other.signingPubkey &&
+          paths == other.paths;
+}
+
+class LNOfferBlindedPath {
+  final List<String> blindedHops;
+
+  const LNOfferBlindedPath({
+    required this.blindedHops,
+  });
+
+  @override
+  int get hashCode => blindedHops.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LNOfferBlindedPath && runtimeType == other.runtimeType && blindedHops == other.blindedHops;
 }
 
 class LnUrlAuthRequestData {

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -281,9 +281,9 @@ sealed class InputType with _$InputType {
   const factory InputType.bolt11({
     required LNInvoice invoice,
   }) = InputType_Bolt11;
-  const factory InputType.bolt12({
+  const factory InputType.bolt12Offer({
     required String offer,
-  }) = InputType_Bolt12;
+  }) = InputType_Bolt12Offer;
   const factory InputType.nodeId({
     required String nodeId,
   }) = InputType_NodeId;

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -281,6 +281,9 @@ sealed class InputType with _$InputType {
   const factory InputType.bolt11({
     required LNInvoice invoice,
   }) = InputType_Bolt11;
+  const factory InputType.bolt12({
+    required String offer,
+  }) = InputType_Bolt12;
   const factory InputType.nodeId({
     required String nodeId,
   }) = InputType_NodeId;

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -420,7 +420,7 @@ class LNInvoice {
 }
 
 class LNOffer {
-  final String bolt12;
+  final String offer;
   final List<String> chains;
   final Amount? minAmount;
   final String? description;
@@ -429,7 +429,7 @@ class LNOffer {
   final String? signingPubkey;
 
   const LNOffer({
-    required this.bolt12,
+    required this.offer,
     required this.chains,
     this.minAmount,
     this.description,
@@ -440,7 +440,7 @@ class LNOffer {
 
   @override
   int get hashCode =>
-      bolt12.hashCode ^
+      offer.hashCode ^
       chains.hashCode ^
       minAmount.hashCode ^
       description.hashCode ^
@@ -453,7 +453,7 @@ class LNOffer {
       identical(this, other) ||
       other is LNOffer &&
           runtimeType == other.runtimeType &&
-          bolt12 == other.bolt12 &&
+          offer == other.offer &&
           chains == other.chains &&
           minAmount == other.minAmount &&
           description == other.description &&

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -427,7 +427,7 @@ class LNOffer {
   final BigInt? absoluteExpiry;
   final String? issuer;
   final String? signingPubkey;
-  final List<LNOfferBlindedPath> paths;
+  final List<LnOfferBlindedPath> paths;
 
   const LNOffer({
     required this.offer,
@@ -466,10 +466,10 @@ class LNOffer {
           paths == other.paths;
 }
 
-class LNOfferBlindedPath {
+class LnOfferBlindedPath {
   final List<String> blindedHops;
 
-  const LNOfferBlindedPath({
+  const LnOfferBlindedPath({
     required this.blindedHops,
   });
 
@@ -479,7 +479,7 @@ class LNOfferBlindedPath {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is LNOfferBlindedPath && runtimeType == other.runtimeType && blindedHops == other.blindedHops;
+      other is LnOfferBlindedPath && runtimeType == other.runtimeType && blindedHops == other.blindedHops;
 }
 
 class LnUrlAuthRequestData {

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -422,7 +422,7 @@ class LNInvoice {
 class LNOffer {
   final String bolt12;
   final List<String> chains;
-  final Amount? amount;
+  final Amount? minAmount;
   final String? description;
   final BigInt? absoluteExpiry;
   final String? issuer;
@@ -431,7 +431,7 @@ class LNOffer {
   const LNOffer({
     required this.bolt12,
     required this.chains,
-    this.amount,
+    this.minAmount,
     this.description,
     this.absoluteExpiry,
     this.issuer,
@@ -442,7 +442,7 @@ class LNOffer {
   int get hashCode =>
       bolt12.hashCode ^
       chains.hashCode ^
-      amount.hashCode ^
+      minAmount.hashCode ^
       description.hashCode ^
       absoluteExpiry.hashCode ^
       issuer.hashCode ^
@@ -455,7 +455,7 @@ class LNOffer {
           runtimeType == other.runtimeType &&
           bolt12 == other.bolt12 &&
           chains == other.chains &&
-          amount == other.amount &&
+          minAmount == other.minAmount &&
           description == other.description &&
           absoluteExpiry == other.absoluteExpiry &&
           issuer == other.issuer &&

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -157,6 +157,19 @@ sealed class AesSuccessActionDataResult with _$AesSuccessActionDataResult {
   }) = AesSuccessActionDataResult_ErrorStatus;
 }
 
+@freezed
+sealed class Amount with _$Amount {
+  const Amount._();
+
+  const factory Amount.bitcoin({
+    required BigInt amountMsat,
+  }) = Amount_Bitcoin;
+  const factory Amount.currency({
+    required String iso4217Code,
+    required BigInt fractionalAmount,
+  }) = Amount_Currency;
+}
+
 class BindingEventListener {
   final RustStreamSink<SdkEvent> stream;
 
@@ -282,7 +295,7 @@ sealed class InputType with _$InputType {
     required LNInvoice invoice,
   }) = InputType_Bolt11;
   const factory InputType.bolt12Offer({
-    required String offer,
+    required LNOffer offer,
   }) = InputType_Bolt12Offer;
   const factory InputType.nodeId({
     required String nodeId,
@@ -404,6 +417,49 @@ class LNInvoice {
           routingHints == other.routingHints &&
           paymentSecret == other.paymentSecret &&
           minFinalCltvExpiryDelta == other.minFinalCltvExpiryDelta;
+}
+
+class LNOffer {
+  final String bolt12;
+  final List<String> chains;
+  final Amount? amount;
+  final String? description;
+  final BigInt? absoluteExpiry;
+  final String? issuer;
+  final String? signingPubkey;
+
+  const LNOffer({
+    required this.bolt12,
+    required this.chains,
+    this.amount,
+    this.description,
+    this.absoluteExpiry,
+    this.issuer,
+    this.signingPubkey,
+  });
+
+  @override
+  int get hashCode =>
+      bolt12.hashCode ^
+      chains.hashCode ^
+      amount.hashCode ^
+      description.hashCode ^
+      absoluteExpiry.hashCode ^
+      issuer.hashCode ^
+      signingPubkey.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LNOffer &&
+          runtimeType == other.runtimeType &&
+          bolt12 == other.bolt12 &&
+          chains == other.chains &&
+          amount == other.amount &&
+          description == other.description &&
+          absoluteExpiry == other.absoluteExpiry &&
+          issuer == other.issuer &&
+          signingPubkey == other.signingPubkey;
 }
 
 class LnUrlAuthRequestData {

--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -463,6 +463,83 @@ abstract class InputType_Bolt11 extends InputType {
 }
 
 /// @nodoc
+abstract class _$$InputType_Bolt12ImplCopyWith<$Res> {
+  factory _$$InputType_Bolt12ImplCopyWith(
+          _$InputType_Bolt12Impl value, $Res Function(_$InputType_Bolt12Impl) then) =
+      __$$InputType_Bolt12ImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String offer});
+}
+
+/// @nodoc
+class __$$InputType_Bolt12ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl<$Res, _$InputType_Bolt12Impl>
+    implements _$$InputType_Bolt12ImplCopyWith<$Res> {
+  __$$InputType_Bolt12ImplCopyWithImpl(
+      _$InputType_Bolt12Impl _value, $Res Function(_$InputType_Bolt12Impl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offer = null,
+  }) {
+    return _then(_$InputType_Bolt12Impl(
+      offer: null == offer
+          ? _value.offer
+          : offer // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InputType_Bolt12Impl extends InputType_Bolt12 {
+  const _$InputType_Bolt12Impl({required this.offer}) : super._();
+
+  @override
+  final String offer;
+
+  @override
+  String toString() {
+    return 'InputType.bolt12(offer: $offer)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InputType_Bolt12Impl &&
+            (identical(other.offer, offer) || other.offer == offer));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, offer);
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InputType_Bolt12ImplCopyWith<_$InputType_Bolt12Impl> get copyWith =>
+      __$$InputType_Bolt12ImplCopyWithImpl<_$InputType_Bolt12Impl>(this, _$identity);
+}
+
+abstract class InputType_Bolt12 extends InputType {
+  const factory InputType_Bolt12({required final String offer}) = _$InputType_Bolt12Impl;
+  const InputType_Bolt12._() : super._();
+
+  String get offer;
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$InputType_Bolt12ImplCopyWith<_$InputType_Bolt12Impl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 abstract class _$$InputType_NodeIdImplCopyWith<$Res> {
   factory _$$InputType_NodeIdImplCopyWith(
           _$InputType_NodeIdImpl value, $Res Function(_$InputType_NodeIdImpl) then) =

--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -463,19 +463,20 @@ abstract class InputType_Bolt11 extends InputType {
 }
 
 /// @nodoc
-abstract class _$$InputType_Bolt12ImplCopyWith<$Res> {
-  factory _$$InputType_Bolt12ImplCopyWith(
-          _$InputType_Bolt12Impl value, $Res Function(_$InputType_Bolt12Impl) then) =
-      __$$InputType_Bolt12ImplCopyWithImpl<$Res>;
+abstract class _$$InputType_Bolt12OfferImplCopyWith<$Res> {
+  factory _$$InputType_Bolt12OfferImplCopyWith(
+          _$InputType_Bolt12OfferImpl value, $Res Function(_$InputType_Bolt12OfferImpl) then) =
+      __$$InputType_Bolt12OfferImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String offer});
 }
 
 /// @nodoc
-class __$$InputType_Bolt12ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl<$Res, _$InputType_Bolt12Impl>
-    implements _$$InputType_Bolt12ImplCopyWith<$Res> {
-  __$$InputType_Bolt12ImplCopyWithImpl(
-      _$InputType_Bolt12Impl _value, $Res Function(_$InputType_Bolt12Impl) _then)
+class __$$InputType_Bolt12OfferImplCopyWithImpl<$Res>
+    extends _$InputTypeCopyWithImpl<$Res, _$InputType_Bolt12OfferImpl>
+    implements _$$InputType_Bolt12OfferImplCopyWith<$Res> {
+  __$$InputType_Bolt12OfferImplCopyWithImpl(
+      _$InputType_Bolt12OfferImpl _value, $Res Function(_$InputType_Bolt12OfferImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of InputType
@@ -485,7 +486,7 @@ class __$$InputType_Bolt12ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl
   $Res call({
     Object? offer = null,
   }) {
-    return _then(_$InputType_Bolt12Impl(
+    return _then(_$InputType_Bolt12OfferImpl(
       offer: null == offer
           ? _value.offer
           : offer // ignore: cast_nullable_to_non_nullable
@@ -496,22 +497,22 @@ class __$$InputType_Bolt12ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl
 
 /// @nodoc
 
-class _$InputType_Bolt12Impl extends InputType_Bolt12 {
-  const _$InputType_Bolt12Impl({required this.offer}) : super._();
+class _$InputType_Bolt12OfferImpl extends InputType_Bolt12Offer {
+  const _$InputType_Bolt12OfferImpl({required this.offer}) : super._();
 
   @override
   final String offer;
 
   @override
   String toString() {
-    return 'InputType.bolt12(offer: $offer)';
+    return 'InputType.bolt12Offer(offer: $offer)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$InputType_Bolt12Impl &&
+            other is _$InputType_Bolt12OfferImpl &&
             (identical(other.offer, offer) || other.offer == offer));
   }
 
@@ -523,20 +524,21 @@ class _$InputType_Bolt12Impl extends InputType_Bolt12 {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$InputType_Bolt12ImplCopyWith<_$InputType_Bolt12Impl> get copyWith =>
-      __$$InputType_Bolt12ImplCopyWithImpl<_$InputType_Bolt12Impl>(this, _$identity);
+  _$$InputType_Bolt12OfferImplCopyWith<_$InputType_Bolt12OfferImpl> get copyWith =>
+      __$$InputType_Bolt12OfferImplCopyWithImpl<_$InputType_Bolt12OfferImpl>(this, _$identity);
 }
 
-abstract class InputType_Bolt12 extends InputType {
-  const factory InputType_Bolt12({required final String offer}) = _$InputType_Bolt12Impl;
-  const InputType_Bolt12._() : super._();
+abstract class InputType_Bolt12Offer extends InputType {
+  const factory InputType_Bolt12Offer({required final String offer}) = _$InputType_Bolt12OfferImpl;
+  const InputType_Bolt12Offer._() : super._();
 
   String get offer;
 
   /// Create a copy of InputType
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InputType_Bolt12ImplCopyWith<_$InputType_Bolt12Impl> get copyWith => throw _privateConstructorUsedError;
+  _$$InputType_Bolt12OfferImplCopyWith<_$InputType_Bolt12OfferImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc

--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -204,6 +204,191 @@ abstract class AesSuccessActionDataResult_ErrorStatus extends AesSuccessActionDa
 }
 
 /// @nodoc
+mixin _$Amount {}
+
+/// @nodoc
+abstract class $AmountCopyWith<$Res> {
+  factory $AmountCopyWith(Amount value, $Res Function(Amount) then) = _$AmountCopyWithImpl<$Res, Amount>;
+}
+
+/// @nodoc
+class _$AmountCopyWithImpl<$Res, $Val extends Amount> implements $AmountCopyWith<$Res> {
+  _$AmountCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$Amount_BitcoinImplCopyWith<$Res> {
+  factory _$$Amount_BitcoinImplCopyWith(
+          _$Amount_BitcoinImpl value, $Res Function(_$Amount_BitcoinImpl) then) =
+      __$$Amount_BitcoinImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({BigInt amountMsat});
+}
+
+/// @nodoc
+class __$$Amount_BitcoinImplCopyWithImpl<$Res> extends _$AmountCopyWithImpl<$Res, _$Amount_BitcoinImpl>
+    implements _$$Amount_BitcoinImplCopyWith<$Res> {
+  __$$Amount_BitcoinImplCopyWithImpl(_$Amount_BitcoinImpl _value, $Res Function(_$Amount_BitcoinImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? amountMsat = null,
+  }) {
+    return _then(_$Amount_BitcoinImpl(
+      amountMsat: null == amountMsat
+          ? _value.amountMsat
+          : amountMsat // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Amount_BitcoinImpl extends Amount_Bitcoin {
+  const _$Amount_BitcoinImpl({required this.amountMsat}) : super._();
+
+  @override
+  final BigInt amountMsat;
+
+  @override
+  String toString() {
+    return 'Amount.bitcoin(amountMsat: $amountMsat)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Amount_BitcoinImpl &&
+            (identical(other.amountMsat, amountMsat) || other.amountMsat == amountMsat));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, amountMsat);
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Amount_BitcoinImplCopyWith<_$Amount_BitcoinImpl> get copyWith =>
+      __$$Amount_BitcoinImplCopyWithImpl<_$Amount_BitcoinImpl>(this, _$identity);
+}
+
+abstract class Amount_Bitcoin extends Amount {
+  const factory Amount_Bitcoin({required final BigInt amountMsat}) = _$Amount_BitcoinImpl;
+  const Amount_Bitcoin._() : super._();
+
+  BigInt get amountMsat;
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$Amount_BitcoinImplCopyWith<_$Amount_BitcoinImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$Amount_CurrencyImplCopyWith<$Res> {
+  factory _$$Amount_CurrencyImplCopyWith(
+          _$Amount_CurrencyImpl value, $Res Function(_$Amount_CurrencyImpl) then) =
+      __$$Amount_CurrencyImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String iso4217Code, BigInt fractionalAmount});
+}
+
+/// @nodoc
+class __$$Amount_CurrencyImplCopyWithImpl<$Res> extends _$AmountCopyWithImpl<$Res, _$Amount_CurrencyImpl>
+    implements _$$Amount_CurrencyImplCopyWith<$Res> {
+  __$$Amount_CurrencyImplCopyWithImpl(
+      _$Amount_CurrencyImpl _value, $Res Function(_$Amount_CurrencyImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? iso4217Code = null,
+    Object? fractionalAmount = null,
+  }) {
+    return _then(_$Amount_CurrencyImpl(
+      iso4217Code: null == iso4217Code
+          ? _value.iso4217Code
+          : iso4217Code // ignore: cast_nullable_to_non_nullable
+              as String,
+      fractionalAmount: null == fractionalAmount
+          ? _value.fractionalAmount
+          : fractionalAmount // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Amount_CurrencyImpl extends Amount_Currency {
+  const _$Amount_CurrencyImpl({required this.iso4217Code, required this.fractionalAmount}) : super._();
+
+  @override
+  final String iso4217Code;
+  @override
+  final BigInt fractionalAmount;
+
+  @override
+  String toString() {
+    return 'Amount.currency(iso4217Code: $iso4217Code, fractionalAmount: $fractionalAmount)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Amount_CurrencyImpl &&
+            (identical(other.iso4217Code, iso4217Code) || other.iso4217Code == iso4217Code) &&
+            (identical(other.fractionalAmount, fractionalAmount) ||
+                other.fractionalAmount == fractionalAmount));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, iso4217Code, fractionalAmount);
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$Amount_CurrencyImplCopyWith<_$Amount_CurrencyImpl> get copyWith =>
+      __$$Amount_CurrencyImplCopyWithImpl<_$Amount_CurrencyImpl>(this, _$identity);
+}
+
+abstract class Amount_Currency extends Amount {
+  const factory Amount_Currency({required final String iso4217Code, required final BigInt fractionalAmount}) =
+      _$Amount_CurrencyImpl;
+  const Amount_Currency._() : super._();
+
+  String get iso4217Code;
+  BigInt get fractionalAmount;
+
+  /// Create a copy of Amount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$Amount_CurrencyImplCopyWith<_$Amount_CurrencyImpl> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$InputType {}
 
 /// @nodoc
@@ -468,7 +653,7 @@ abstract class _$$InputType_Bolt12OfferImplCopyWith<$Res> {
           _$InputType_Bolt12OfferImpl value, $Res Function(_$InputType_Bolt12OfferImpl) then) =
       __$$InputType_Bolt12OfferImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String offer});
+  $Res call({LNOffer offer});
 }
 
 /// @nodoc
@@ -490,7 +675,7 @@ class __$$InputType_Bolt12OfferImplCopyWithImpl<$Res>
       offer: null == offer
           ? _value.offer
           : offer // ignore: cast_nullable_to_non_nullable
-              as String,
+              as LNOffer,
     ));
   }
 }
@@ -501,7 +686,7 @@ class _$InputType_Bolt12OfferImpl extends InputType_Bolt12Offer {
   const _$InputType_Bolt12OfferImpl({required this.offer}) : super._();
 
   @override
-  final String offer;
+  final LNOffer offer;
 
   @override
   String toString() {
@@ -529,10 +714,10 @@ class _$InputType_Bolt12OfferImpl extends InputType_Bolt12Offer {
 }
 
 abstract class InputType_Bolt12Offer extends InputType {
-  const factory InputType_Bolt12Offer({required final String offer}) = _$InputType_Bolt12OfferImpl;
+  const factory InputType_Bolt12Offer({required final LNOffer offer}) = _$InputType_Bolt12OfferImpl;
   const InputType_Bolt12Offer._() : super._();
 
-  String get offer;
+  LNOffer get offer;
 
   /// Create a copy of InputType
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1760,7 +1760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           invoice: dco_decode_box_autoadd_ln_invoice(raw[1]),
         );
       case 3:
-        return InputType_Bolt12(
+        return InputType_Bolt12Offer(
           offer: dco_decode_String(raw[1]),
         );
       case 4:
@@ -3549,7 +3549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return InputType_Bolt11(invoice: var_invoice);
       case 3:
         var var_offer = sse_decode_String(deserializer);
-        return InputType_Bolt12(offer: var_offer);
+        return InputType_Bolt12Offer(offer: var_offer);
       case 4:
         var var_nodeId = sse_decode_String(deserializer);
         return InputType_NodeId(nodeId: var_nodeId);
@@ -5422,7 +5422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case InputType_Bolt11(invoice: final invoice):
         sse_encode_i_32(2, serializer);
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
-      case InputType_Bolt12(offer: final offer):
+      case InputType_Bolt12Offer(offer: final offer):
         sse_encode_i_32(3, serializer);
         sse_encode_String(offer, serializer);
       case InputType_NodeId(nodeId: final nodeId):

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2491,9 +2491,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           description: dco_decode_String(raw[2]),
           preimage: dco_decode_opt_String(raw[3]),
           bolt11: dco_decode_opt_String(raw[4]),
-          paymentHash: dco_decode_opt_String(raw[5]),
-          refundTxId: dco_decode_opt_String(raw[6]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[7]),
+          bolt12Offer: dco_decode_opt_String(raw[5]),
+          paymentHash: dco_decode_opt_String(raw[6]),
+          refundTxId: dco_decode_opt_String(raw[7]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[8]),
         );
       case 1:
         return PaymentDetails_Liquid(
@@ -4465,6 +4466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_description = sse_decode_String(deserializer);
         var var_preimage = sse_decode_opt_String(deserializer);
         var var_bolt11 = sse_decode_opt_String(deserializer);
+        var var_bolt12Offer = sse_decode_opt_String(deserializer);
         var var_paymentHash = sse_decode_opt_String(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
@@ -4473,6 +4475,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             description: var_description,
             preimage: var_preimage,
             bolt11: var_bolt11,
+            bolt12Offer: var_bolt12Offer,
             paymentHash: var_paymentHash,
             refundTxId: var_refundTxId,
             refundTxAmountSat: var_refundTxAmountSat);
@@ -6309,6 +6312,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           description: final description,
           preimage: final preimage,
           bolt11: final bolt11,
+          bolt12Offer: final bolt12Offer,
           paymentHash: final paymentHash,
           refundTxId: final refundTxId,
           refundTxAmountSat: final refundTxAmountSat
@@ -6318,6 +6322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(description, serializer);
         sse_encode_opt_String(preimage, serializer);
         sse_encode_opt_String(bolt11, serializer);
+        sse_encode_opt_String(bolt12Offer, serializer);
         sse_encode_opt_String(paymentHash, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2843,6 +2843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return SendDestination_Bolt12(
           offer: dco_decode_String(raw[1]),
+          receiverAmountSat: dco_decode_u_64(raw[2]),
         );
       default:
         throw Exception("unreachable");
@@ -4668,7 +4669,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return SendDestination_Bolt11(invoice: var_invoice);
       case 2:
         var var_offer = sse_decode_String(deserializer);
-        return SendDestination_Bolt12(offer: var_offer);
+        var var_receiverAmountSat = sse_decode_u_64(deserializer);
+        return SendDestination_Bolt12(offer: var_offer, receiverAmountSat: var_receiverAmountSat);
       default:
         throw UnimplementedError('');
     }
@@ -6357,9 +6359,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case SendDestination_Bolt11(invoice: final invoice):
         sse_encode_i_32(1, serializer);
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
-      case SendDestination_Bolt12(offer: final offer):
+      case SendDestination_Bolt12(offer: final offer, receiverAmountSat: final receiverAmountSat):
         sse_encode_i_32(2, serializer);
         sse_encode_String(offer, serializer);
+        sse_encode_u_64(receiverAmountSat, serializer);
       default:
         throw UnimplementedError('');
     }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1885,7 +1885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  List<LNOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw) {
+  List<LnOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_ln_offer_blinded_path).toList();
   }
@@ -2015,11 +2015,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  LNOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw) {
+  LnOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return LNOfferBlindedPath(
+    return LnOfferBlindedPath(
       blindedHops: dco_decode_list_String(arr[0]),
     );
   }
@@ -3764,11 +3764,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  List<LNOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer) {
+  List<LnOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     var len_ = sse_decode_i_32(deserializer);
-    var ans_ = <LNOfferBlindedPath>[];
+    var ans_ = <LnOfferBlindedPath>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_ln_offer_blinded_path(deserializer));
     }
@@ -3966,10 +3966,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  LNOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer) {
+  LnOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_blindedHops = sse_decode_list_String(deserializer);
-    return LNOfferBlindedPath(blindedHops: var_blindedHops);
+    return LnOfferBlindedPath(blindedHops: var_blindedHops);
   }
 
   @protected
@@ -5735,7 +5735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_list_ln_offer_blinded_path(List<LNOfferBlindedPath> self, SseSerializer serializer) {
+  void sse_encode_list_ln_offer_blinded_path(List<LnOfferBlindedPath> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
@@ -5879,7 +5879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_ln_offer_blinded_path(LNOfferBlindedPath self, SseSerializer serializer) {
+  void sse_encode_ln_offer_blinded_path(LnOfferBlindedPath self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_String(self.blindedHops, serializer);
   }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1885,6 +1885,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<LNOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_ln_offer_blinded_path).toList();
+  }
+
+  @protected
   List<LocaleOverrides> dco_decode_list_locale_overrides(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_locale_overrides).toList();
@@ -1995,7 +2001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LNOffer dco_decode_ln_offer(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return LNOffer(
       offer: dco_decode_String(arr[0]),
       chains: dco_decode_list_String(arr[1]),
@@ -2004,6 +2010,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       absoluteExpiry: dco_decode_opt_box_autoadd_u_64(arr[4]),
       issuer: dco_decode_opt_String(arr[5]),
       signingPubkey: dco_decode_opt_String(arr[6]),
+      paths: dco_decode_list_ln_offer_blinded_path(arr[7]),
+    );
+  }
+
+  @protected
+  LNOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return LNOfferBlindedPath(
+      blindedHops: dco_decode_list_String(arr[0]),
     );
   }
 
@@ -3746,6 +3763,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<LNOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <LNOfferBlindedPath>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_ln_offer_blinded_path(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<LocaleOverrides> sse_decode_list_locale_overrides(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -3923,6 +3952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_absoluteExpiry = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_issuer = sse_decode_opt_String(deserializer);
     var var_signingPubkey = sse_decode_opt_String(deserializer);
+    var var_paths = sse_decode_list_ln_offer_blinded_path(deserializer);
     return LNOffer(
         offer: var_offer,
         chains: var_chains,
@@ -3930,7 +3960,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         description: var_description,
         absoluteExpiry: var_absoluteExpiry,
         issuer: var_issuer,
-        signingPubkey: var_signingPubkey);
+        signingPubkey: var_signingPubkey,
+        paths: var_paths);
+  }
+
+  @protected
+  LNOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_blindedHops = sse_decode_list_String(deserializer);
+    return LNOfferBlindedPath(blindedHops: var_blindedHops);
   }
 
   @protected
@@ -5694,6 +5732,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_ln_offer_blinded_path(List<LNOfferBlindedPath> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_ln_offer_blinded_path(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_locale_overrides(List<LocaleOverrides> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
@@ -5825,6 +5872,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_64(self.absoluteExpiry, serializer);
     sse_encode_opt_String(self.issuer, serializer);
     sse_encode_opt_String(self.signingPubkey, serializer);
+    sse_encode_list_ln_offer_blinded_path(self.paths, serializer);
+  }
+
+  @protected
+  void sse_encode_ln_offer_blinded_path(LNOfferBlindedPath self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_String(self.blindedHops, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1288,6 +1288,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Amount dco_decode_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return Amount_Bitcoin(
+          amountMsat: dco_decode_u_64(raw[1]),
+        );
+      case 1:
+        return Amount_Currency(
+          iso4217Code: dco_decode_String(raw[1]),
+          fractionalAmount: dco_decode_u_64(raw[2]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   BackupRequest dco_decode_backup_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -1343,6 +1361,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AesSuccessActionDataResult dco_decode_box_autoadd_aes_success_action_data_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_aes_success_action_data_result(raw);
+  }
+
+  @protected
+  Amount dco_decode_box_autoadd_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_amount(raw);
   }
 
   @protected
@@ -1421,6 +1445,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LNInvoice dco_decode_box_autoadd_ln_invoice(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_ln_invoice(raw);
+  }
+
+  @protected
+  LNOffer dco_decode_box_autoadd_ln_offer(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_ln_offer(raw);
   }
 
   @protected
@@ -1767,7 +1797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         );
       case 3:
         return InputType_Bolt12Offer(
-          offer: dco_decode_String(raw[1]),
+          offer: dco_decode_box_autoadd_ln_offer(raw[1]),
         );
       case 4:
         return InputType_NodeId(
@@ -1840,6 +1870,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LiquidNetwork dco_decode_liquid_network(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LiquidNetwork.values[raw as int];
+  }
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_String).toList();
   }
 
   @protected
@@ -1952,6 +1988,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       routingHints: dco_decode_list_route_hint(arr[9]),
       paymentSecret: dco_decode_list_prim_u_8_strict(arr[10]),
       minFinalCltvExpiryDelta: dco_decode_u_64(arr[11]),
+    );
+  }
+
+  @protected
+  LNOffer dco_decode_ln_offer(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return LNOffer(
+      bolt12: dco_decode_String(arr[0]),
+      chains: dco_decode_list_String(arr[1]),
+      amount: dco_decode_opt_box_autoadd_amount(arr[2]),
+      description: dco_decode_opt_String(arr[3]),
+      absoluteExpiry: dco_decode_opt_box_autoadd_u_64(arr[4]),
+      issuer: dco_decode_opt_String(arr[5]),
+      signingPubkey: dco_decode_opt_String(arr[6]),
     );
   }
 
@@ -2295,6 +2347,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String? dco_decode_opt_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
+  Amount? dco_decode_opt_box_autoadd_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_amount(raw);
   }
 
   @protected
@@ -3092,6 +3150,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Amount sse_decode_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_amountMsat = sse_decode_u_64(deserializer);
+        return Amount_Bitcoin(amountMsat: var_amountMsat);
+      case 1:
+        var var_iso4217Code = sse_decode_String(deserializer);
+        var var_fractionalAmount = sse_decode_u_64(deserializer);
+        return Amount_Currency(iso4217Code: var_iso4217Code, fractionalAmount: var_fractionalAmount);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   BackupRequest sse_decode_backup_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_backupPath = sse_decode_opt_String(deserializer);
@@ -3145,6 +3221,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_aes_success_action_data_result(deserializer));
+  }
+
+  @protected
+  Amount sse_decode_box_autoadd_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_amount(deserializer));
   }
 
   @protected
@@ -3223,6 +3305,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LNInvoice sse_decode_box_autoadd_ln_invoice(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_ln_invoice(deserializer));
+  }
+
+  @protected
+  LNOffer sse_decode_box_autoadd_ln_offer(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_ln_offer(deserializer));
   }
 
   @protected
@@ -3566,7 +3654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_invoice = sse_decode_box_autoadd_ln_invoice(deserializer);
         return InputType_Bolt11(invoice: var_invoice);
       case 3:
-        var var_offer = sse_decode_String(deserializer);
+        var var_offer = sse_decode_box_autoadd_ln_offer(deserializer);
         return InputType_Bolt12Offer(offer: var_offer);
       case 4:
         var var_nodeId = sse_decode_String(deserializer);
@@ -3631,6 +3719,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return LiquidNetwork.values[inner];
+  }
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <String>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
   }
 
   @protected
@@ -3811,6 +3911,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         routingHints: var_routingHints,
         paymentSecret: var_paymentSecret,
         minFinalCltvExpiryDelta: var_minFinalCltvExpiryDelta);
+  }
+
+  @protected
+  LNOffer sse_decode_ln_offer(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bolt12 = sse_decode_String(deserializer);
+    var var_chains = sse_decode_list_String(deserializer);
+    var var_amount = sse_decode_opt_box_autoadd_amount(deserializer);
+    var var_description = sse_decode_opt_String(deserializer);
+    var var_absoluteExpiry = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_issuer = sse_decode_opt_String(deserializer);
+    var var_signingPubkey = sse_decode_opt_String(deserializer);
+    return LNOffer(
+        bolt12: var_bolt12,
+        chains: var_chains,
+        amount: var_amount,
+        description: var_description,
+        absoluteExpiry: var_absoluteExpiry,
+        issuer: var_issuer,
+        signingPubkey: var_signingPubkey);
   }
 
   @protected
@@ -4113,6 +4233,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  Amount? sse_decode_opt_box_autoadd_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_amount(deserializer));
     } else {
       return null;
     }
@@ -5019,6 +5150,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_amount(Amount self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case Amount_Bitcoin(amountMsat: final amountMsat):
+        sse_encode_i_32(0, serializer);
+        sse_encode_u_64(amountMsat, serializer);
+      case Amount_Currency(iso4217Code: final iso4217Code, fractionalAmount: final fractionalAmount):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(iso4217Code, serializer);
+        sse_encode_u_64(fractionalAmount, serializer);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   void sse_encode_backup_request(BackupRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_opt_String(self.backupPath, serializer);
@@ -5064,6 +5211,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       AesSuccessActionDataResult self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_aes_success_action_data_result(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_amount(Amount self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_amount(self, serializer);
   }
 
   @protected
@@ -5142,6 +5295,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_box_autoadd_ln_invoice(LNInvoice self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_ln_invoice(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_ln_offer(LNOffer self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ln_offer(self, serializer);
   }
 
   @protected
@@ -5459,7 +5618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
       case InputType_Bolt12Offer(offer: final offer):
         sse_encode_i_32(3, serializer);
-        sse_encode_String(offer, serializer);
+        sse_encode_box_autoadd_ln_offer(offer, serializer);
       case InputType_NodeId(nodeId: final nodeId):
         sse_encode_i_32(4, serializer);
         sse_encode_String(nodeId, serializer);
@@ -5514,6 +5673,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_liquid_network(LiquidNetwork self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_String(item, serializer);
+    }
   }
 
   @protected
@@ -5645,6 +5813,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_list_route_hint(self.routingHints, serializer);
     sse_encode_list_prim_u_8_strict(self.paymentSecret, serializer);
     sse_encode_u_64(self.minFinalCltvExpiryDelta, serializer);
+  }
+
+  @protected
+  void sse_encode_ln_offer(LNOffer self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bolt12, serializer);
+    sse_encode_list_String(self.chains, serializer);
+    sse_encode_opt_box_autoadd_amount(self.amount, serializer);
+    sse_encode_opt_String(self.description, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.absoluteExpiry, serializer);
+    sse_encode_opt_String(self.issuer, serializer);
+    sse_encode_opt_String(self.signingPubkey, serializer);
   }
 
   @protected
@@ -5908,6 +6088,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_amount(Amount? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_amount(self, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1997,7 +1997,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final arr = raw as List<dynamic>;
     if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return LNOffer(
-      bolt12: dco_decode_String(arr[0]),
+      offer: dco_decode_String(arr[0]),
       chains: dco_decode_list_String(arr[1]),
       minAmount: dco_decode_opt_box_autoadd_amount(arr[2]),
       description: dco_decode_opt_String(arr[3]),
@@ -3916,7 +3916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LNOffer sse_decode_ln_offer(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_bolt12 = sse_decode_String(deserializer);
+    var var_offer = sse_decode_String(deserializer);
     var var_chains = sse_decode_list_String(deserializer);
     var var_minAmount = sse_decode_opt_box_autoadd_amount(deserializer);
     var var_description = sse_decode_opt_String(deserializer);
@@ -3924,7 +3924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_issuer = sse_decode_opt_String(deserializer);
     var var_signingPubkey = sse_decode_opt_String(deserializer);
     return LNOffer(
-        bolt12: var_bolt12,
+        offer: var_offer,
         chains: var_chains,
         minAmount: var_minAmount,
         description: var_description,
@@ -5818,7 +5818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_ln_offer(LNOffer self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.bolt12, serializer);
+    sse_encode_String(self.offer, serializer);
     sse_encode_list_String(self.chains, serializer);
     sse_encode_opt_box_autoadd_amount(self.minAmount, serializer);
     sse_encode_opt_String(self.description, serializer);

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2912,7 +2912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         );
       case 2:
         return SendDestination_Bolt12(
-          offer: dco_decode_String(raw[1]),
+          offer: dco_decode_box_autoadd_ln_offer(raw[1]),
           receiverAmountSat: dco_decode_u_64(raw[2]),
         );
       default:
@@ -4828,7 +4828,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_invoice = sse_decode_box_autoadd_ln_invoice(deserializer);
         return SendDestination_Bolt11(invoice: var_invoice);
       case 2:
-        var var_offer = sse_decode_String(deserializer);
+        var var_offer = sse_decode_box_autoadd_ln_offer(deserializer);
         var var_receiverAmountSat = sse_decode_u_64(deserializer);
         return SendDestination_Bolt12(offer: var_offer, receiverAmountSat: var_receiverAmountSat);
       default:
@@ -6596,7 +6596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
       case SendDestination_Bolt12(offer: final offer, receiverAmountSat: final receiverAmountSat):
         sse_encode_i_32(2, serializer);
-        sse_encode_String(offer, serializer);
+        sse_encode_box_autoadd_ln_offer(offer, serializer);
         sse_encode_u_64(receiverAmountSat, serializer);
       default:
         throw UnimplementedError('');

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1999,7 +1999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return LNOffer(
       bolt12: dco_decode_String(arr[0]),
       chains: dco_decode_list_String(arr[1]),
-      amount: dco_decode_opt_box_autoadd_amount(arr[2]),
+      minAmount: dco_decode_opt_box_autoadd_amount(arr[2]),
       description: dco_decode_opt_String(arr[3]),
       absoluteExpiry: dco_decode_opt_box_autoadd_u_64(arr[4]),
       issuer: dco_decode_opt_String(arr[5]),
@@ -3918,7 +3918,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_bolt12 = sse_decode_String(deserializer);
     var var_chains = sse_decode_list_String(deserializer);
-    var var_amount = sse_decode_opt_box_autoadd_amount(deserializer);
+    var var_minAmount = sse_decode_opt_box_autoadd_amount(deserializer);
     var var_description = sse_decode_opt_String(deserializer);
     var var_absoluteExpiry = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_issuer = sse_decode_opt_String(deserializer);
@@ -3926,7 +3926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return LNOffer(
         bolt12: var_bolt12,
         chains: var_chains,
-        amount: var_amount,
+        minAmount: var_minAmount,
         description: var_description,
         absoluteExpiry: var_absoluteExpiry,
         issuer: var_issuer,
@@ -5820,7 +5820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.bolt12, serializer);
     sse_encode_list_String(self.chains, serializer);
-    sse_encode_opt_box_autoadd_amount(self.amount, serializer);
+    sse_encode_opt_box_autoadd_amount(self.minAmount, serializer);
     sse_encode_opt_String(self.description, serializer);
     sse_encode_opt_box_autoadd_u_64(self.absoluteExpiry, serializer);
     sse_encode_opt_String(self.issuer, serializer);

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1760,26 +1760,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           invoice: dco_decode_box_autoadd_ln_invoice(raw[1]),
         );
       case 3:
+        return InputType_Bolt12(
+          offer: dco_decode_String(raw[1]),
+        );
+      case 4:
         return InputType_NodeId(
           nodeId: dco_decode_String(raw[1]),
         );
-      case 4:
+      case 5:
         return InputType_Url(
           url: dco_decode_String(raw[1]),
         );
-      case 5:
+      case 6:
         return InputType_LnUrlPay(
           data: dco_decode_box_autoadd_ln_url_pay_request_data(raw[1]),
         );
-      case 6:
+      case 7:
         return InputType_LnUrlWithdraw(
           data: dco_decode_box_autoadd_ln_url_withdraw_request_data(raw[1]),
         );
-      case 7:
+      case 8:
         return InputType_LnUrlAuth(
           data: dco_decode_box_autoadd_ln_url_auth_request_data(raw[1]),
         );
-      case 8:
+      case 9:
         return InputType_LnUrlError(
           data: dco_decode_box_autoadd_ln_url_error_data(raw[1]),
         );
@@ -2836,6 +2840,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return SendDestination_Bolt11(
           invoice: dco_decode_box_autoadd_ln_invoice(raw[1]),
         );
+      case 2:
+        return SendDestination_Bolt12(
+          offer: dco_decode_String(raw[1]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -3539,21 +3547,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_invoice = sse_decode_box_autoadd_ln_invoice(deserializer);
         return InputType_Bolt11(invoice: var_invoice);
       case 3:
+        var var_offer = sse_decode_String(deserializer);
+        return InputType_Bolt12(offer: var_offer);
+      case 4:
         var var_nodeId = sse_decode_String(deserializer);
         return InputType_NodeId(nodeId: var_nodeId);
-      case 4:
+      case 5:
         var var_url = sse_decode_String(deserializer);
         return InputType_Url(url: var_url);
-      case 5:
+      case 6:
         var var_data = sse_decode_box_autoadd_ln_url_pay_request_data(deserializer);
         return InputType_LnUrlPay(data: var_data);
-      case 6:
+      case 7:
         var var_data = sse_decode_box_autoadd_ln_url_withdraw_request_data(deserializer);
         return InputType_LnUrlWithdraw(data: var_data);
-      case 7:
+      case 8:
         var var_data = sse_decode_box_autoadd_ln_url_auth_request_data(deserializer);
         return InputType_LnUrlAuth(data: var_data);
-      case 8:
+      case 9:
         var var_data = sse_decode_box_autoadd_ln_url_error_data(deserializer);
         return InputType_LnUrlError(data: var_data);
       default:
@@ -4655,6 +4666,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 1:
         var var_invoice = sse_decode_box_autoadd_ln_invoice(deserializer);
         return SendDestination_Bolt11(invoice: var_invoice);
+      case 2:
+        var var_offer = sse_decode_String(deserializer);
+        return SendDestination_Bolt12(offer: var_offer);
       default:
         throw UnimplementedError('');
     }
@@ -5406,23 +5420,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case InputType_Bolt11(invoice: final invoice):
         sse_encode_i_32(2, serializer);
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
-      case InputType_NodeId(nodeId: final nodeId):
+      case InputType_Bolt12(offer: final offer):
         sse_encode_i_32(3, serializer);
+        sse_encode_String(offer, serializer);
+      case InputType_NodeId(nodeId: final nodeId):
+        sse_encode_i_32(4, serializer);
         sse_encode_String(nodeId, serializer);
       case InputType_Url(url: final url):
-        sse_encode_i_32(4, serializer);
+        sse_encode_i_32(5, serializer);
         sse_encode_String(url, serializer);
       case InputType_LnUrlPay(data: final data):
-        sse_encode_i_32(5, serializer);
+        sse_encode_i_32(6, serializer);
         sse_encode_box_autoadd_ln_url_pay_request_data(data, serializer);
       case InputType_LnUrlWithdraw(data: final data):
-        sse_encode_i_32(6, serializer);
+        sse_encode_i_32(7, serializer);
         sse_encode_box_autoadd_ln_url_withdraw_request_data(data, serializer);
       case InputType_LnUrlAuth(data: final data):
-        sse_encode_i_32(7, serializer);
+        sse_encode_i_32(8, serializer);
         sse_encode_box_autoadd_ln_url_auth_request_data(data, serializer);
       case InputType_LnUrlError(data: final data):
-        sse_encode_i_32(8, serializer);
+        sse_encode_i_32(9, serializer);
         sse_encode_box_autoadd_ln_url_error_data(data, serializer);
       default:
         throw UnimplementedError('');
@@ -6340,6 +6357,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case SendDestination_Bolt11(invoice: final invoice):
         sse_encode_i_32(1, serializer);
         sse_encode_box_autoadd_ln_invoice(invoice, serializer);
+      case SendDestination_Bolt12(offer: final offer):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(offer, serializer);
       default:
         throw UnimplementedError('');
     }

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2064,39 +2064,45 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Bolt11.invoice = pre_invoice;
       return;
     }
+    if (apiObj is InputType_Bolt12) {
+      var pre_offer = cst_encode_String(apiObj.offer);
+      wireObj.tag = 3;
+      wireObj.kind.Bolt12.offer = pre_offer;
+      return;
+    }
     if (apiObj is InputType_NodeId) {
       var pre_node_id = cst_encode_String(apiObj.nodeId);
-      wireObj.tag = 3;
+      wireObj.tag = 4;
       wireObj.kind.NodeId.node_id = pre_node_id;
       return;
     }
     if (apiObj is InputType_Url) {
       var pre_url = cst_encode_String(apiObj.url);
-      wireObj.tag = 4;
+      wireObj.tag = 5;
       wireObj.kind.Url.url = pre_url;
       return;
     }
     if (apiObj is InputType_LnUrlPay) {
       var pre_data = cst_encode_box_autoadd_ln_url_pay_request_data(apiObj.data);
-      wireObj.tag = 5;
+      wireObj.tag = 6;
       wireObj.kind.LnUrlPay.data = pre_data;
       return;
     }
     if (apiObj is InputType_LnUrlWithdraw) {
       var pre_data = cst_encode_box_autoadd_ln_url_withdraw_request_data(apiObj.data);
-      wireObj.tag = 6;
+      wireObj.tag = 7;
       wireObj.kind.LnUrlWithdraw.data = pre_data;
       return;
     }
     if (apiObj is InputType_LnUrlAuth) {
       var pre_data = cst_encode_box_autoadd_ln_url_auth_request_data(apiObj.data);
-      wireObj.tag = 7;
+      wireObj.tag = 8;
       wireObj.kind.LnUrlAuth.data = pre_data;
       return;
     }
     if (apiObj is InputType_LnUrlError) {
       var pre_data = cst_encode_box_autoadd_ln_url_error_data(apiObj.data);
-      wireObj.tag = 8;
+      wireObj.tag = 9;
       wireObj.kind.LnUrlError.data = pre_data;
       return;
     }
@@ -2897,6 +2903,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_invoice = cst_encode_box_autoadd_ln_invoice(apiObj.invoice);
       wireObj.tag = 1;
       wireObj.kind.Bolt11.invoice = pre_invoice;
+      return;
+    }
+    if (apiObj is SendDestination_Bolt12) {
+      var pre_offer = cst_encode_String(apiObj.offer);
+      wireObj.tag = 2;
+      wireObj.kind.Bolt12.offer = pre_offer;
       return;
     }
   }
@@ -5190,10 +5202,16 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
+final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+}
+
 final class SendDestinationKind extends ffi.Union {
   external wire_cst_SendDestination_LiquidAddress LiquidAddress;
 
   external wire_cst_SendDestination_Bolt11 Bolt11;
+
+  external wire_cst_SendDestination_Bolt12 Bolt12;
 }
 
 final class wire_cst_send_destination extends ffi.Struct {
@@ -5810,6 +5828,10 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
+final class wire_cst_InputType_Bolt12 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+}
+
 final class wire_cst_InputType_NodeId extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> node_id;
 }
@@ -5840,6 +5862,8 @@ final class InputTypeKind extends ffi.Union {
   external wire_cst_InputType_LiquidAddress LiquidAddress;
 
   external wire_cst_InputType_Bolt11 Bolt11;
+
+  external wire_cst_InputType_Bolt12 Bolt12;
 
   external wire_cst_InputType_NodeId NodeId;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -282,7 +282,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<FiatCurrency> dco_decode_list_fiat_currency(dynamic raw);
 
   @protected
-  List<LNOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw);
+  List<LnOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw);
 
   @protected
   List<LocaleOverrides> dco_decode_list_locale_overrides(dynamic raw);
@@ -324,7 +324,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LNOffer dco_decode_ln_offer(dynamic raw);
 
   @protected
-  LNOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw);
+  LnOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw);
 
   @protected
   LnUrlAuthError dco_decode_ln_url_auth_error(dynamic raw);
@@ -829,7 +829,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<FiatCurrency> sse_decode_list_fiat_currency(SseDeserializer deserializer);
 
   @protected
-  List<LNOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer);
+  List<LnOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer);
 
   @protected
   List<LocaleOverrides> sse_decode_list_locale_overrides(SseDeserializer deserializer);
@@ -871,7 +871,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LNOffer sse_decode_ln_offer(SseDeserializer deserializer);
 
   @protected
-  LNOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer);
+  LnOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer);
 
   @protected
   LnUrlAuthError sse_decode_ln_url_auth_error(SseDeserializer deserializer);
@@ -1593,7 +1593,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ffi.Pointer<wire_cst_list_ln_offer_blinded_path> cst_encode_list_ln_offer_blinded_path(
-      List<LNOfferBlindedPath> raw) {
+      List<LnOfferBlindedPath> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ans = wire.cst_new_list_ln_offer_blinded_path(raw.length);
     for (var i = 0; i < raw.length; ++i) {
@@ -2342,7 +2342,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_ln_offer_blinded_path(
-      LNOfferBlindedPath apiObj, wire_cst_ln_offer_blinded_path wireObj) {
+      LnOfferBlindedPath apiObj, wire_cst_ln_offer_blinded_path wireObj) {
     wireObj.blinded_hops = cst_encode_list_String(apiObj.blindedHops);
   }
 
@@ -3488,7 +3488,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_list_fiat_currency(List<FiatCurrency> self, SseSerializer serializer);
 
   @protected
-  void sse_encode_list_ln_offer_blinded_path(List<LNOfferBlindedPath> self, SseSerializer serializer);
+  void sse_encode_list_ln_offer_blinded_path(List<LnOfferBlindedPath> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_locale_overrides(List<LocaleOverrides> self, SseSerializer serializer);
@@ -3530,7 +3530,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_ln_offer(LNOffer self, SseSerializer serializer);
 
   @protected
-  void sse_encode_ln_offer_blinded_path(LNOfferBlindedPath self, SseSerializer serializer);
+  void sse_encode_ln_offer_blinded_path(LnOfferBlindedPath self, SseSerializer serializer);
 
   @protected
   void sse_encode_ln_url_auth_error(LnUrlAuthError self, SseSerializer serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -282,6 +282,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<FiatCurrency> dco_decode_list_fiat_currency(dynamic raw);
 
   @protected
+  List<LNOfferBlindedPath> dco_decode_list_ln_offer_blinded_path(dynamic raw);
+
+  @protected
   List<LocaleOverrides> dco_decode_list_locale_overrides(dynamic raw);
 
   @protected
@@ -319,6 +322,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNOffer dco_decode_ln_offer(dynamic raw);
+
+  @protected
+  LNOfferBlindedPath dco_decode_ln_offer_blinded_path(dynamic raw);
 
   @protected
   LnUrlAuthError dco_decode_ln_url_auth_error(dynamic raw);
@@ -823,6 +829,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<FiatCurrency> sse_decode_list_fiat_currency(SseDeserializer deserializer);
 
   @protected
+  List<LNOfferBlindedPath> sse_decode_list_ln_offer_blinded_path(SseDeserializer deserializer);
+
+  @protected
   List<LocaleOverrides> sse_decode_list_locale_overrides(SseDeserializer deserializer);
 
   @protected
@@ -860,6 +869,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNOffer sse_decode_ln_offer(SseDeserializer deserializer);
+
+  @protected
+  LNOfferBlindedPath sse_decode_ln_offer_blinded_path(SseDeserializer deserializer);
 
   @protected
   LnUrlAuthError sse_decode_ln_url_auth_error(SseDeserializer deserializer);
@@ -1575,6 +1587,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     final ans = wire.cst_new_list_fiat_currency(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       cst_api_fill_to_wire_fiat_currency(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_ln_offer_blinded_path> cst_encode_list_ln_offer_blinded_path(
+      List<LNOfferBlindedPath> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_ln_offer_blinded_path(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_ln_offer_blinded_path(raw[i], ans.ref.ptr[i]);
     }
     return ans;
   }
@@ -2314,6 +2337,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.absolute_expiry = cst_encode_opt_box_autoadd_u_64(apiObj.absoluteExpiry);
     wireObj.issuer = cst_encode_opt_String(apiObj.issuer);
     wireObj.signing_pubkey = cst_encode_opt_String(apiObj.signingPubkey);
+    wireObj.paths = cst_encode_list_ln_offer_blinded_path(apiObj.paths);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_ln_offer_blinded_path(
+      LNOfferBlindedPath apiObj, wire_cst_ln_offer_blinded_path wireObj) {
+    wireObj.blinded_hops = cst_encode_list_String(apiObj.blindedHops);
   }
 
   @protected
@@ -3456,6 +3486,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_list_fiat_currency(List<FiatCurrency> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_list_ln_offer_blinded_path(List<LNOfferBlindedPath> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_locale_overrides(List<LocaleOverrides> self, SseSerializer serializer);
 
   @protected
@@ -3493,6 +3526,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_ln_offer(LNOffer self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ln_offer_blinded_path(LNOfferBlindedPath self, SseSerializer serializer);
 
   @protected
   void sse_encode_ln_url_auth_error(LnUrlAuthError self, SseSerializer serializer);
@@ -5075,6 +5111,20 @@ class RustLibWire implements BaseWire {
   late final _cst_new_list_fiat_currency =
       _cst_new_list_fiat_currencyPtr.asFunction<ffi.Pointer<wire_cst_list_fiat_currency> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_ln_offer_blinded_path> cst_new_list_ln_offer_blinded_path(
+    int len,
+  ) {
+    return _cst_new_list_ln_offer_blinded_path(
+      len,
+    );
+  }
+
+  late final _cst_new_list_ln_offer_blinded_pathPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_ln_offer_blinded_path> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path');
+  late final _cst_new_list_ln_offer_blinded_path = _cst_new_list_ln_offer_blinded_pathPtr
+      .asFunction<ffi.Pointer<wire_cst_list_ln_offer_blinded_path> Function(int)>();
+
   ffi.Pointer<wire_cst_list_locale_overrides> cst_new_list_locale_overrides(
     int len,
   ) {
@@ -5443,6 +5493,17 @@ final class wire_cst_amount extends ffi.Struct {
   external AmountKind kind;
 }
 
+final class wire_cst_ln_offer_blinded_path extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_String> blinded_hops;
+}
+
+final class wire_cst_list_ln_offer_blinded_path extends ffi.Struct {
+  external ffi.Pointer<wire_cst_ln_offer_blinded_path> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_ln_offer extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
 
@@ -5457,6 +5518,8 @@ final class wire_cst_ln_offer extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
+
+  external ffi.Pointer<wire_cst_list_ln_offer_blinded_path> paths;
 }
 
 final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -60,6 +60,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AesSuccessActionDataResult dco_decode_aes_success_action_data_result(dynamic raw);
 
   @protected
+  Amount dco_decode_amount(dynamic raw);
+
+  @protected
   BackupRequest dco_decode_backup_request(dynamic raw);
 
   @protected
@@ -79,6 +82,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   AesSuccessActionDataResult dco_decode_box_autoadd_aes_success_action_data_result(dynamic raw);
+
+  @protected
+  Amount dco_decode_box_autoadd_amount(dynamic raw);
 
   @protected
   BackupRequest dco_decode_box_autoadd_backup_request(dynamic raw);
@@ -118,6 +124,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNInvoice dco_decode_box_autoadd_ln_invoice(dynamic raw);
+
+  @protected
+  LNOffer dco_decode_box_autoadd_ln_offer(dynamic raw);
 
   @protected
   LnUrlAuthRequestData dco_decode_box_autoadd_ln_url_auth_request_data(dynamic raw);
@@ -267,6 +276,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LiquidNetwork dco_decode_liquid_network(dynamic raw);
 
   @protected
+  List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
   List<FiatCurrency> dco_decode_list_fiat_currency(dynamic raw);
 
   @protected
@@ -304,6 +316,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNInvoice dco_decode_ln_invoice(dynamic raw);
+
+  @protected
+  LNOffer dco_decode_ln_offer(dynamic raw);
 
   @protected
   LnUrlAuthError dco_decode_ln_url_auth_error(dynamic raw);
@@ -370,6 +385,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String? dco_decode_opt_String(dynamic raw);
+
+  @protected
+  Amount? dco_decode_opt_box_autoadd_amount(dynamic raw);
 
   @protected
   bool? dco_decode_opt_box_autoadd_bool(dynamic raw);
@@ -581,6 +599,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AesSuccessActionDataResult sse_decode_aes_success_action_data_result(SseDeserializer deserializer);
 
   @protected
+  Amount sse_decode_amount(SseDeserializer deserializer);
+
+  @protected
   BackupRequest sse_decode_backup_request(SseDeserializer deserializer);
 
   @protected
@@ -602,6 +623,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   AesSuccessActionDataResult sse_decode_box_autoadd_aes_success_action_data_result(
       SseDeserializer deserializer);
+
+  @protected
+  Amount sse_decode_box_autoadd_amount(SseDeserializer deserializer);
 
   @protected
   BackupRequest sse_decode_box_autoadd_backup_request(SseDeserializer deserializer);
@@ -641,6 +665,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNInvoice sse_decode_box_autoadd_ln_invoice(SseDeserializer deserializer);
+
+  @protected
+  LNOffer sse_decode_box_autoadd_ln_offer(SseDeserializer deserializer);
 
   @protected
   LnUrlAuthRequestData sse_decode_box_autoadd_ln_url_auth_request_data(SseDeserializer deserializer);
@@ -790,6 +817,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LiquidNetwork sse_decode_liquid_network(SseDeserializer deserializer);
 
   @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
   List<FiatCurrency> sse_decode_list_fiat_currency(SseDeserializer deserializer);
 
   @protected
@@ -827,6 +857,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   LNInvoice sse_decode_ln_invoice(SseDeserializer deserializer);
+
+  @protected
+  LNOffer sse_decode_ln_offer(SseDeserializer deserializer);
 
   @protected
   LnUrlAuthError sse_decode_ln_url_auth_error(SseDeserializer deserializer);
@@ -893,6 +926,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
+  Amount? sse_decode_opt_box_autoadd_amount(SseDeserializer deserializer);
 
   @protected
   bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer);
@@ -1130,6 +1166,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_amount> cst_encode_box_autoadd_amount(Amount raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_amount();
+    cst_api_fill_to_wire_amount(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_backup_request> cst_encode_box_autoadd_backup_request(BackupRequest raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_backup_request();
@@ -1234,6 +1278,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_ln_invoice();
     cst_api_fill_to_wire_ln_invoice(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_ln_offer> cst_encode_box_autoadd_ln_offer(LNOffer raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_ln_offer();
+    cst_api_fill_to_wire_ln_offer(raw, ptr.ref);
     return ptr;
   }
 
@@ -1508,6 +1560,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_String> cst_encode_list_String(List<String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_String(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      ans.ref.ptr[i] = cst_encode_String(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_fiat_currency> cst_encode_list_fiat_currency(List<FiatCurrency> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ans = wire.cst_new_list_fiat_currency(raw.length);
@@ -1609,6 +1671,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_opt_String(String? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_String(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_amount> cst_encode_opt_box_autoadd_amount(Amount? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_amount(raw);
   }
 
   @protected
@@ -1724,6 +1792,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_amount(Amount apiObj, wire_cst_amount wireObj) {
+    if (apiObj is Amount_Bitcoin) {
+      var pre_amount_msat = cst_encode_u_64(apiObj.amountMsat);
+      wireObj.tag = 0;
+      wireObj.kind.Bitcoin.amount_msat = pre_amount_msat;
+      return;
+    }
+    if (apiObj is Amount_Currency) {
+      var pre_iso4217_code = cst_encode_String(apiObj.iso4217Code);
+      var pre_fractional_amount = cst_encode_u_64(apiObj.fractionalAmount);
+      wireObj.tag = 1;
+      wireObj.kind.Currency.iso4217_code = pre_iso4217_code;
+      wireObj.kind.Currency.fractional_amount = pre_fractional_amount;
+      return;
+    }
+  }
+
+  @protected
   void cst_api_fill_to_wire_backup_request(BackupRequest apiObj, wire_cst_backup_request wireObj) {
     wireObj.backup_path = cst_encode_opt_String(apiObj.backupPath);
   }
@@ -1760,6 +1846,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_box_autoadd_aes_success_action_data_result(
       AesSuccessActionDataResult apiObj, ffi.Pointer<wire_cst_aes_success_action_data_result> wireObj) {
     cst_api_fill_to_wire_aes_success_action_data_result(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_amount(Amount apiObj, ffi.Pointer<wire_cst_amount> wireObj) {
+    cst_api_fill_to_wire_amount(apiObj, wireObj.ref);
   }
 
   @protected
@@ -1826,6 +1917,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_box_autoadd_ln_invoice(
       LNInvoice apiObj, ffi.Pointer<wire_cst_ln_invoice> wireObj) {
     cst_api_fill_to_wire_ln_invoice(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_ln_offer(LNOffer apiObj, ffi.Pointer<wire_cst_ln_offer> wireObj) {
+    cst_api_fill_to_wire_ln_offer(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2097,7 +2193,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       return;
     }
     if (apiObj is InputType_Bolt12Offer) {
-      var pre_offer = cst_encode_String(apiObj.offer);
+      var pre_offer = cst_encode_box_autoadd_ln_offer(apiObj.offer);
       wireObj.tag = 3;
       wireObj.kind.Bolt12Offer.offer = pre_offer;
       return;
@@ -2207,6 +2303,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.routing_hints = cst_encode_list_route_hint(apiObj.routingHints);
     wireObj.payment_secret = cst_encode_list_prim_u_8_strict(apiObj.paymentSecret);
     wireObj.min_final_cltv_expiry_delta = cst_encode_u_64(apiObj.minFinalCltvExpiryDelta);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_ln_offer(LNOffer apiObj, wire_cst_ln_offer wireObj) {
+    wireObj.bolt12 = cst_encode_String(apiObj.bolt12);
+    wireObj.chains = cst_encode_list_String(apiObj.chains);
+    wireObj.amount = cst_encode_opt_box_autoadd_amount(apiObj.amount);
+    wireObj.description = cst_encode_opt_String(apiObj.description);
+    wireObj.absolute_expiry = cst_encode_opt_box_autoadd_u_64(apiObj.absoluteExpiry);
+    wireObj.issuer = cst_encode_opt_String(apiObj.issuer);
+    wireObj.signing_pubkey = cst_encode_opt_String(apiObj.signingPubkey);
   }
 
   @protected
@@ -3118,6 +3225,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_aes_success_action_data_result(AesSuccessActionDataResult self, SseSerializer serializer);
 
   @protected
+  void sse_encode_amount(Amount self, SseSerializer serializer);
+
+  @protected
   void sse_encode_backup_request(BackupRequest self, SseSerializer serializer);
 
   @protected
@@ -3139,6 +3249,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_aes_success_action_data_result(
       AesSuccessActionDataResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_amount(Amount self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_backup_request(BackupRequest self, SseSerializer serializer);
@@ -3178,6 +3291,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_ln_invoice(LNInvoice self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_ln_offer(LNOffer self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_ln_url_auth_request_data(LnUrlAuthRequestData self, SseSerializer serializer);
@@ -3334,6 +3450,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_liquid_network(LiquidNetwork self, SseSerializer serializer);
 
   @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_fiat_currency(List<FiatCurrency> self, SseSerializer serializer);
 
   @protected
@@ -3371,6 +3490,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_ln_invoice(LNInvoice self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ln_offer(LNOffer self, SseSerializer serializer);
 
   @protected
   void sse_encode_ln_url_auth_error(LnUrlAuthError self, SseSerializer serializer);
@@ -3438,6 +3560,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_amount(Amount? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer);
@@ -4440,6 +4565,16 @@ class RustLibWire implements BaseWire {
       _cst_new_box_autoadd_aes_success_action_data_resultPtr
           .asFunction<ffi.Pointer<wire_cst_aes_success_action_data_result> Function()>();
 
+  ffi.Pointer<wire_cst_amount> cst_new_box_autoadd_amount() {
+    return _cst_new_box_autoadd_amount();
+  }
+
+  late final _cst_new_box_autoadd_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_amount');
+  late final _cst_new_box_autoadd_amount =
+      _cst_new_box_autoadd_amountPtr.asFunction<ffi.Pointer<wire_cst_amount> Function()>();
+
   ffi.Pointer<wire_cst_backup_request> cst_new_box_autoadd_backup_request() {
     return _cst_new_box_autoadd_backup_request();
   }
@@ -4577,6 +4712,16 @@ class RustLibWire implements BaseWire {
           'frbgen_breez_liquid_cst_new_box_autoadd_ln_invoice');
   late final _cst_new_box_autoadd_ln_invoice =
       _cst_new_box_autoadd_ln_invoicePtr.asFunction<ffi.Pointer<wire_cst_ln_invoice> Function()>();
+
+  ffi.Pointer<wire_cst_ln_offer> cst_new_box_autoadd_ln_offer() {
+    return _cst_new_box_autoadd_ln_offer();
+  }
+
+  late final _cst_new_box_autoadd_ln_offerPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_ln_offer> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_ln_offer');
+  late final _cst_new_box_autoadd_ln_offer =
+      _cst_new_box_autoadd_ln_offerPtr.asFunction<ffi.Pointer<wire_cst_ln_offer> Function()>();
 
   ffi.Pointer<wire_cst_ln_url_auth_request_data> cst_new_box_autoadd_ln_url_auth_request_data() {
     return _cst_new_box_autoadd_ln_url_auth_request_data();
@@ -4901,6 +5046,20 @@ class RustLibWire implements BaseWire {
           'frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data');
   late final _cst_new_box_autoadd_url_success_action_data = _cst_new_box_autoadd_url_success_action_dataPtr
       .asFunction<ffi.Pointer<wire_cst_url_success_action_data> Function()>();
+
+  ffi.Pointer<wire_cst_list_String> cst_new_list_String(
+    int len,
+  ) {
+    return _cst_new_list_String(
+      len,
+    );
+  }
+
+  late final _cst_new_list_StringPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_String> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_String');
+  late final _cst_new_list_String =
+      _cst_new_list_StringPtr.asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
 
   ffi.Pointer<wire_cst_list_fiat_currency> cst_new_list_fiat_currency(
     int len,
@@ -5683,6 +5842,31 @@ final class wire_cst_aes_success_action_data_result extends ffi.Struct {
   external AesSuccessActionDataResultKind kind;
 }
 
+final class wire_cst_Amount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_msat;
+}
+
+final class wire_cst_Amount_Currency extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
+
+  @ffi.Uint64()
+  external int fractional_amount;
+}
+
+final class AmountKind extends ffi.Union {
+  external wire_cst_Amount_Bitcoin Bitcoin;
+
+  external wire_cst_Amount_Currency Currency;
+}
+
+final class wire_cst_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AmountKind kind;
+}
+
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -5694,6 +5878,29 @@ final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> label;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
+}
+
+final class wire_cst_list_String extends ffi.Struct {
+  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_ln_offer extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
+
+  external ffi.Pointer<wire_cst_list_String> chains;
+
+  external ffi.Pointer<wire_cst_amount> amount;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Uint64> absolute_expiry;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
 }
 
 final class wire_cst_ln_url_error_data extends ffi.Struct {
@@ -5882,7 +6089,7 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
 }
 
 final class wire_cst_InputType_Bolt12Offer extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+  external ffi.Pointer<wire_cst_ln_offer> offer;
 }
 
 final class wire_cst_InputType_NodeId extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3045,7 +3045,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       return;
     }
     if (apiObj is SendDestination_Bolt12) {
-      var pre_offer = cst_encode_String(apiObj.offer);
+      var pre_offer = cst_encode_box_autoadd_ln_offer(apiObj.offer);
       var pre_receiver_amount_sat = cst_encode_u_64(apiObj.receiverAmountSat);
       wireObj.tag = 2;
       wireObj.kind.Bolt12.offer = pre_offer;
@@ -5411,8 +5411,56 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
+final class wire_cst_list_String extends ffi.Struct {
+  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_Amount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_msat;
+}
+
+final class wire_cst_Amount_Currency extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
+
+  @ffi.Uint64()
+  external int fractional_amount;
+}
+
+final class AmountKind extends ffi.Union {
+  external wire_cst_Amount_Bitcoin Bitcoin;
+
+  external wire_cst_Amount_Currency Currency;
+}
+
+final class wire_cst_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AmountKind kind;
+}
+
+final class wire_cst_ln_offer extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
+
+  external ffi.Pointer<wire_cst_list_String> chains;
+
+  external ffi.Pointer<wire_cst_amount> amount;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Uint64> absolute_expiry;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
+}
+
 final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+  external ffi.Pointer<wire_cst_ln_offer> offer;
 
   @ffi.Uint64()
   external int receiver_amount_sat;
@@ -5842,31 +5890,6 @@ final class wire_cst_aes_success_action_data_result extends ffi.Struct {
   external AesSuccessActionDataResultKind kind;
 }
 
-final class wire_cst_Amount_Bitcoin extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_msat;
-}
-
-final class wire_cst_Amount_Currency extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
-
-  @ffi.Uint64()
-  external int fractional_amount;
-}
-
-final class AmountKind extends ffi.Union {
-  external wire_cst_Amount_Bitcoin Bitcoin;
-
-  external wire_cst_Amount_Currency Currency;
-}
-
-final class wire_cst_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external AmountKind kind;
-}
-
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -5878,29 +5901,6 @@ final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> label;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
-}
-
-final class wire_cst_list_String extends ffi.Struct {
-  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-final class wire_cst_ln_offer extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
-
-  external ffi.Pointer<wire_cst_list_String> chains;
-
-  external ffi.Pointer<wire_cst_amount> amount;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<ffi.Uint64> absolute_expiry;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
 }
 
 final class wire_cst_ln_url_error_data extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2686,6 +2686,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_description = cst_encode_String(apiObj.description);
       var pre_preimage = cst_encode_opt_String(apiObj.preimage);
       var pre_bolt11 = cst_encode_opt_String(apiObj.bolt11);
+      var pre_bolt12_offer = cst_encode_opt_String(apiObj.bolt12Offer);
       var pre_payment_hash = cst_encode_opt_String(apiObj.paymentHash);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
@@ -2694,6 +2695,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.description = pre_description;
       wireObj.kind.Lightning.preimage = pre_preimage;
       wireObj.kind.Lightning.bolt11 = pre_bolt11;
+      wireObj.kind.Lightning.bolt12_offer = pre_bolt12_offer;
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
       wireObj.kind.Lightning.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Lightning.refund_tx_amount_sat = pre_refund_tx_amount_sat;
@@ -5790,6 +5792,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt11;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2309,7 +2309,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_ln_offer(LNOffer apiObj, wire_cst_ln_offer wireObj) {
     wireObj.bolt12 = cst_encode_String(apiObj.bolt12);
     wireObj.chains = cst_encode_list_String(apiObj.chains);
-    wireObj.amount = cst_encode_opt_box_autoadd_amount(apiObj.amount);
+    wireObj.min_amount = cst_encode_opt_box_autoadd_amount(apiObj.minAmount);
     wireObj.description = cst_encode_opt_String(apiObj.description);
     wireObj.absolute_expiry = cst_encode_opt_box_autoadd_u_64(apiObj.absoluteExpiry);
     wireObj.issuer = cst_encode_opt_String(apiObj.issuer);
@@ -5448,7 +5448,7 @@ final class wire_cst_ln_offer extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_String> chains;
 
-  external ffi.Pointer<wire_cst_amount> amount;
+  external ffi.Pointer<wire_cst_amount> min_amount;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2307,7 +2307,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_ln_offer(LNOffer apiObj, wire_cst_ln_offer wireObj) {
-    wireObj.bolt12 = cst_encode_String(apiObj.bolt12);
+    wireObj.offer = cst_encode_String(apiObj.offer);
     wireObj.chains = cst_encode_list_String(apiObj.chains);
     wireObj.min_amount = cst_encode_opt_box_autoadd_amount(apiObj.minAmount);
     wireObj.description = cst_encode_opt_String(apiObj.description);
@@ -5444,7 +5444,7 @@ final class wire_cst_amount extends ffi.Struct {
 }
 
 final class wire_cst_ln_offer extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
 
   external ffi.Pointer<wire_cst_list_String> chains;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2064,10 +2064,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Bolt11.invoice = pre_invoice;
       return;
     }
-    if (apiObj is InputType_Bolt12) {
+    if (apiObj is InputType_Bolt12Offer) {
       var pre_offer = cst_encode_String(apiObj.offer);
       wireObj.tag = 3;
-      wireObj.kind.Bolt12.offer = pre_offer;
+      wireObj.kind.Bolt12Offer.offer = pre_offer;
       return;
     }
     if (apiObj is InputType_NodeId) {
@@ -5833,7 +5833,7 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
-final class wire_cst_InputType_Bolt12 extends ffi.Struct {
+final class wire_cst_InputType_Bolt12Offer extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
 }
 
@@ -5868,7 +5868,7 @@ final class InputTypeKind extends ffi.Union {
 
   external wire_cst_InputType_Bolt11 Bolt11;
 
-  external wire_cst_InputType_Bolt12 Bolt12;
+  external wire_cst_InputType_Bolt12Offer Bolt12Offer;
 
   external wire_cst_InputType_NodeId NodeId;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2907,8 +2907,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     }
     if (apiObj is SendDestination_Bolt12) {
       var pre_offer = cst_encode_String(apiObj.offer);
+      var pre_receiver_amount_sat = cst_encode_u_64(apiObj.receiverAmountSat);
       wireObj.tag = 2;
       wireObj.kind.Bolt12.offer = pre_offer;
+      wireObj.kind.Bolt12.receiver_amount_sat = pre_receiver_amount_sat;
       return;
     }
   }
@@ -5204,6 +5206,9 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
 
 final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+
+  @ffi.Uint64()
+  external int receiver_amount_sat;
 }
 
 final class SendDestinationKind extends ffi.Union {

--- a/packages/dart/lib/src/lib.dart
+++ b/packages/dart/lib/src/lib.dart
@@ -6,5 +6,5 @@
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Arc < Box < dyn Signer > >>>
-abstract class ArcBoxSigner implements RustOpaqueInterface {}
+// Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LNOfferBlindedPath>>
+abstract class LnOfferBlindedPath implements RustOpaqueInterface {}

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1001,7 +1001,7 @@ class PrepareRefundResponse {
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_send_payment].
 class PrepareSendRequest {
   /// The destination we intend to pay to.
-  /// Supports BIP21 URIs, BOLT11 invoices and Liquid addresses
+  /// Supports BIP21 URIs, BOLT11 invoices, BOLT12 offers and Liquid addresses
   final String destination;
 
   /// Should only be set when paying directly onchain or to a BIP21 URI
@@ -1257,6 +1257,9 @@ sealed class SendDestination with _$SendDestination {
   const factory SendDestination.bolt11({
     required LNInvoice invoice,
   }) = SendDestination_Bolt11;
+  const factory SendDestination.bolt12({
+    required String offer,
+  }) = SendDestination_Bolt12;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::send_payment].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -611,10 +611,11 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// In case of a Send swap, this is the preimage of the paid invoice (proof of payment).
     String? preimage,
 
-    /// Represents the invoice associated with a payment
+    /// Represents the Bolt11 invoice associated with a payment
     /// In the case of a Send payment, this is the invoice paid by the swapper
     /// In the case of a Receive payment, this is the invoice paid by the user
     String? bolt11,
+    String? bolt12Offer,
 
     /// The payment hash of the invoice
     String? paymentHash,

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1259,6 +1259,7 @@ sealed class SendDestination with _$SendDestination {
   }) = SendDestination_Bolt11;
   const factory SendDestination.bolt12({
     required String offer,
+    required BigInt receiverAmountSat,
   }) = SendDestination_Bolt12;
 }
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1258,7 +1258,7 @@ sealed class SendDestination with _$SendDestination {
     required LNInvoice invoice,
   }) = SendDestination_Bolt11;
   const factory SendDestination.bolt12({
-    required String offer,
+    required LNOffer offer,
     required BigInt receiverAmountSat,
   }) = SendDestination_Bolt12;
 }

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -793,6 +793,7 @@ abstract class _$$PaymentDetails_LightningImplCopyWith<$Res> implements $Payment
       String description,
       String? preimage,
       String? bolt11,
+      String? bolt12Offer,
       String? paymentHash,
       String? refundTxId,
       BigInt? refundTxAmountSat});
@@ -815,6 +816,7 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
     Object? description = null,
     Object? preimage = freezed,
     Object? bolt11 = freezed,
+    Object? bolt12Offer = freezed,
     Object? paymentHash = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
@@ -835,6 +837,10 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
       bolt11: freezed == bolt11
           ? _value.bolt11
           : bolt11 // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bolt12Offer: freezed == bolt12Offer
+          ? _value.bolt12Offer
+          : bolt12Offer // ignore: cast_nullable_to_non_nullable
               as String?,
       paymentHash: freezed == paymentHash
           ? _value.paymentHash
@@ -860,6 +866,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
       required this.description,
       this.preimage,
       this.bolt11,
+      this.bolt12Offer,
       this.paymentHash,
       this.refundTxId,
       this.refundTxAmountSat})
@@ -876,11 +883,13 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   @override
   final String? preimage;
 
-  /// Represents the invoice associated with a payment
+  /// Represents the Bolt11 invoice associated with a payment
   /// In the case of a Send payment, this is the invoice paid by the swapper
   /// In the case of a Receive payment, this is the invoice paid by the user
   @override
   final String? bolt11;
+  @override
+  final String? bolt12Offer;
 
   /// The payment hash of the invoice
   @override
@@ -896,7 +905,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   String toString() {
-    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, preimage: $preimage, bolt11: $bolt11, paymentHash: $paymentHash, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, preimage: $preimage, bolt11: $bolt11, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -908,6 +917,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
             (identical(other.description, description) || other.description == description) &&
             (identical(other.preimage, preimage) || other.preimage == preimage) &&
             (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
+            (identical(other.bolt12Offer, bolt12Offer) || other.bolt12Offer == bolt12Offer) &&
             (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
@@ -915,8 +925,8 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, swapId, description, preimage, bolt11, paymentHash, refundTxId, refundTxAmountSat);
+  int get hashCode => Object.hash(runtimeType, swapId, description, preimage, bolt11, bolt12Offer,
+      paymentHash, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -933,6 +943,7 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
       required final String description,
       final String? preimage,
       final String? bolt11,
+      final String? bolt12Offer,
       final String? paymentHash,
       final String? refundTxId,
       final BigInt? refundTxAmountSat}) = _$PaymentDetails_LightningImpl;
@@ -947,10 +958,11 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
   /// In case of a Send swap, this is the preimage of the paid invoice (proof of payment).
   String? get preimage;
 
-  /// Represents the invoice associated with a payment
+  /// Represents the Bolt11 invoice associated with a payment
   /// In the case of a Send payment, this is the invoice paid by the swapper
   /// In the case of a Receive payment, this is the invoice paid by the user
   String? get bolt11;
+  String? get bolt12Offer;
 
   /// The payment hash of the invoice
   String? get paymentHash;

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1924,3 +1924,82 @@ abstract class SendDestination_Bolt11 extends SendDestination {
   _$$SendDestination_Bolt11ImplCopyWith<_$SendDestination_Bolt11Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
+
+/// @nodoc
+abstract class _$$SendDestination_Bolt12ImplCopyWith<$Res> {
+  factory _$$SendDestination_Bolt12ImplCopyWith(
+          _$SendDestination_Bolt12Impl value, $Res Function(_$SendDestination_Bolt12Impl) then) =
+      __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String offer});
+}
+
+/// @nodoc
+class __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>
+    extends _$SendDestinationCopyWithImpl<$Res, _$SendDestination_Bolt12Impl>
+    implements _$$SendDestination_Bolt12ImplCopyWith<$Res> {
+  __$$SendDestination_Bolt12ImplCopyWithImpl(
+      _$SendDestination_Bolt12Impl _value, $Res Function(_$SendDestination_Bolt12Impl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SendDestination
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offer = null,
+  }) {
+    return _then(_$SendDestination_Bolt12Impl(
+      offer: null == offer
+          ? _value.offer
+          : offer // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
+  const _$SendDestination_Bolt12Impl({required this.offer}) : super._();
+
+  @override
+  final String offer;
+
+  @override
+  String toString() {
+    return 'SendDestination.bolt12(offer: $offer)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SendDestination_Bolt12Impl &&
+            (identical(other.offer, offer) || other.offer == offer));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, offer);
+
+  /// Create a copy of SendDestination
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SendDestination_Bolt12ImplCopyWith<_$SendDestination_Bolt12Impl> get copyWith =>
+      __$$SendDestination_Bolt12ImplCopyWithImpl<_$SendDestination_Bolt12Impl>(this, _$identity);
+}
+
+abstract class SendDestination_Bolt12 extends SendDestination {
+  const factory SendDestination_Bolt12({required final String offer}) = _$SendDestination_Bolt12Impl;
+  const SendDestination_Bolt12._() : super._();
+
+  String get offer;
+
+  /// Create a copy of SendDestination
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SendDestination_Bolt12ImplCopyWith<_$SendDestination_Bolt12Impl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1927,7 +1927,7 @@ abstract class _$$SendDestination_Bolt12ImplCopyWith<$Res> {
           _$SendDestination_Bolt12Impl value, $Res Function(_$SendDestination_Bolt12Impl) then) =
       __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String offer, BigInt receiverAmountSat});
+  $Res call({LNOffer offer, BigInt receiverAmountSat});
 }
 
 /// @nodoc
@@ -1950,7 +1950,7 @@ class __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>
       offer: null == offer
           ? _value.offer
           : offer // ignore: cast_nullable_to_non_nullable
-              as String,
+              as LNOffer,
       receiverAmountSat: null == receiverAmountSat
           ? _value.receiverAmountSat
           : receiverAmountSat // ignore: cast_nullable_to_non_nullable
@@ -1965,7 +1965,7 @@ class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
   const _$SendDestination_Bolt12Impl({required this.offer, required this.receiverAmountSat}) : super._();
 
   @override
-  final String offer;
+  final LNOffer offer;
   @override
   final BigInt receiverAmountSat;
 
@@ -1998,10 +1998,10 @@ class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
 
 abstract class SendDestination_Bolt12 extends SendDestination {
   const factory SendDestination_Bolt12(
-      {required final String offer, required final BigInt receiverAmountSat}) = _$SendDestination_Bolt12Impl;
+      {required final LNOffer offer, required final BigInt receiverAmountSat}) = _$SendDestination_Bolt12Impl;
   const SendDestination_Bolt12._() : super._();
 
-  String get offer;
+  LNOffer get offer;
   BigInt get receiverAmountSat;
 
   /// Create a copy of SendDestination

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1931,7 +1931,7 @@ abstract class _$$SendDestination_Bolt12ImplCopyWith<$Res> {
           _$SendDestination_Bolt12Impl value, $Res Function(_$SendDestination_Bolt12Impl) then) =
       __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String offer});
+  $Res call({String offer, BigInt receiverAmountSat});
 }
 
 /// @nodoc
@@ -1948,12 +1948,17 @@ class __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? offer = null,
+    Object? receiverAmountSat = null,
   }) {
     return _then(_$SendDestination_Bolt12Impl(
       offer: null == offer
           ? _value.offer
           : offer // ignore: cast_nullable_to_non_nullable
               as String,
+      receiverAmountSat: null == receiverAmountSat
+          ? _value.receiverAmountSat
+          : receiverAmountSat // ignore: cast_nullable_to_non_nullable
+              as BigInt,
     ));
   }
 }
@@ -1961,14 +1966,16 @@ class __$$SendDestination_Bolt12ImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
-  const _$SendDestination_Bolt12Impl({required this.offer}) : super._();
+  const _$SendDestination_Bolt12Impl({required this.offer, required this.receiverAmountSat}) : super._();
 
   @override
   final String offer;
+  @override
+  final BigInt receiverAmountSat;
 
   @override
   String toString() {
-    return 'SendDestination.bolt12(offer: $offer)';
+    return 'SendDestination.bolt12(offer: $offer, receiverAmountSat: $receiverAmountSat)';
   }
 
   @override
@@ -1976,11 +1983,13 @@ class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SendDestination_Bolt12Impl &&
-            (identical(other.offer, offer) || other.offer == offer));
+            (identical(other.offer, offer) || other.offer == offer) &&
+            (identical(other.receiverAmountSat, receiverAmountSat) ||
+                other.receiverAmountSat == receiverAmountSat));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, offer);
+  int get hashCode => Object.hash(runtimeType, offer, receiverAmountSat);
 
   /// Create a copy of SendDestination
   /// with the given fields replaced by the non-null parameter values.
@@ -1992,10 +2001,12 @@ class _$SendDestination_Bolt12Impl extends SendDestination_Bolt12 {
 }
 
 abstract class SendDestination_Bolt12 extends SendDestination {
-  const factory SendDestination_Bolt12({required final String offer}) = _$SendDestination_Bolt12Impl;
+  const factory SendDestination_Bolt12(
+      {required final String offer, required final BigInt receiverAmountSat}) = _$SendDestination_Bolt12Impl;
   const SendDestination_Bolt12._() : super._();
 
   String get offer;
+  BigInt get receiverAmountSat;
 
   /// Create a copy of SendDestination
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -846,6 +846,17 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_aes_success_action_data_resultPtr
           .asFunction<ffi.Pointer<wire_cst_aes_success_action_data_result> Function()>();
 
+  ffi.Pointer<wire_cst_amount> frbgen_breez_liquid_cst_new_box_autoadd_amount() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_amount();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_amount');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_amount =
+      _frbgen_breez_liquid_cst_new_box_autoadd_amountPtr
+          .asFunction<ffi.Pointer<wire_cst_amount> Function()>();
+
   ffi.Pointer<wire_cst_backup_request> frbgen_breez_liquid_cst_new_box_autoadd_backup_request() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_backup_request();
   }
@@ -997,6 +1008,17 @@ class FlutterBreezLiquidBindings {
   late final _frbgen_breez_liquid_cst_new_box_autoadd_ln_invoice =
       _frbgen_breez_liquid_cst_new_box_autoadd_ln_invoicePtr
           .asFunction<ffi.Pointer<wire_cst_ln_invoice> Function()>();
+
+  ffi.Pointer<wire_cst_ln_offer> frbgen_breez_liquid_cst_new_box_autoadd_ln_offer() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_ln_offer();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_ln_offerPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_ln_offer> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_ln_offer');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_ln_offer =
+      _frbgen_breez_liquid_cst_new_box_autoadd_ln_offerPtr
+          .asFunction<ffi.Pointer<wire_cst_ln_offer> Function()>();
 
   ffi.Pointer<wire_cst_ln_url_auth_request_data>
       frbgen_breez_liquid_cst_new_box_autoadd_ln_url_auth_request_data() {
@@ -1360,6 +1382,20 @@ class FlutterBreezLiquidBindings {
   late final _frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data =
       _frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_dataPtr
           .asFunction<ffi.Pointer<wire_cst_url_success_action_data> Function()>();
+
+  ffi.Pointer<wire_cst_list_String> frbgen_breez_liquid_cst_new_list_String(
+    int len,
+  ) {
+    return _frbgen_breez_liquid_cst_new_list_String(
+      len,
+    );
+  }
+
+  late final _frbgen_breez_liquid_cst_new_list_StringPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_String> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_String');
+  late final _frbgen_breez_liquid_cst_new_list_String = _frbgen_breez_liquid_cst_new_list_StringPtr
+      .asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
 
   ffi.Pointer<wire_cst_list_fiat_currency> frbgen_breez_liquid_cst_new_list_fiat_currency(
     int len,
@@ -4428,6 +4464,31 @@ final class wire_cst_aes_success_action_data_result extends ffi.Struct {
   external AesSuccessActionDataResultKind kind;
 }
 
+final class wire_cst_Amount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_msat;
+}
+
+final class wire_cst_Amount_Currency extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
+
+  @ffi.Uint64()
+  external int fractional_amount;
+}
+
+final class AmountKind extends ffi.Union {
+  external wire_cst_Amount_Bitcoin Bitcoin;
+
+  external wire_cst_Amount_Currency Currency;
+}
+
+final class wire_cst_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AmountKind kind;
+}
+
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -4439,6 +4500,29 @@ final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> label;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
+}
+
+final class wire_cst_list_String extends ffi.Struct {
+  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_ln_offer extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
+
+  external ffi.Pointer<wire_cst_list_String> chains;
+
+  external ffi.Pointer<wire_cst_amount> amount;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Uint64> absolute_expiry;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
 }
 
 final class wire_cst_ln_url_error_data extends ffi.Struct {
@@ -4627,7 +4711,7 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
 }
 
 final class wire_cst_InputType_Bolt12Offer extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+  external ffi.Pointer<wire_cst_ln_offer> offer;
 }
 
 final class wire_cst_InputType_NodeId extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -3986,10 +3986,16 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
+final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+}
+
 final class SendDestinationKind extends ffi.Union {
   external wire_cst_SendDestination_LiquidAddress LiquidAddress;
 
   external wire_cst_SendDestination_Bolt11 Bolt11;
+
+  external wire_cst_SendDestination_Bolt12 Bolt12;
 }
 
 final class wire_cst_send_destination extends ffi.Struct {
@@ -4606,6 +4612,10 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
+final class wire_cst_InputType_Bolt12 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+}
+
 final class wire_cst_InputType_NodeId extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> node_id;
 }
@@ -4636,6 +4646,8 @@ final class InputTypeKind extends ffi.Union {
   external wire_cst_InputType_LiquidAddress LiquidAddress;
 
   external wire_cst_InputType_Bolt11 Bolt11;
+
+  external wire_cst_InputType_Bolt12 Bolt12;
 
   external wire_cst_InputType_NodeId NodeId;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1412,6 +1412,21 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_list_fiat_currencyPtr
           .asFunction<ffi.Pointer<wire_cst_list_fiat_currency> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_ln_offer_blinded_path> frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path(
+    int len,
+  ) {
+    return _frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path(
+      len,
+    );
+  }
+
+  late final _frbgen_breez_liquid_cst_new_list_ln_offer_blinded_pathPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_ln_offer_blinded_path> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path');
+  late final _frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path =
+      _frbgen_breez_liquid_cst_new_list_ln_offer_blinded_pathPtr
+          .asFunction<ffi.Pointer<wire_cst_list_ln_offer_blinded_path> Function(int)>();
+
   ffi.Pointer<wire_cst_list_locale_overrides> frbgen_breez_liquid_cst_new_list_locale_overrides(
     int len,
   ) {
@@ -4033,8 +4048,69 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
-final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
+final class wire_cst_list_String extends ffi.Struct {
+  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_Amount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int amount_msat;
+}
+
+final class wire_cst_Amount_Currency extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
+
+  @ffi.Uint64()
+  external int fractional_amount;
+}
+
+final class AmountKind extends ffi.Union {
+  external wire_cst_Amount_Bitcoin Bitcoin;
+
+  external wire_cst_Amount_Currency Currency;
+}
+
+final class wire_cst_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AmountKind kind;
+}
+
+final class wire_cst_ln_offer_blinded_path extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_String> blinded_hops;
+}
+
+final class wire_cst_list_ln_offer_blinded_path extends ffi.Struct {
+  external ffi.Pointer<wire_cst_ln_offer_blinded_path> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_ln_offer extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+
+  external ffi.Pointer<wire_cst_list_String> chains;
+
+  external ffi.Pointer<wire_cst_amount> min_amount;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<ffi.Uint64> absolute_expiry;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
+
+  external ffi.Pointer<wire_cst_list_ln_offer_blinded_path> paths;
+}
+
+final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_ln_offer> offer;
 
   @ffi.Uint64()
   external int receiver_amount_sat;
@@ -4302,6 +4378,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt11;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
@@ -4464,31 +4542,6 @@ final class wire_cst_aes_success_action_data_result extends ffi.Struct {
   external AesSuccessActionDataResultKind kind;
 }
 
-final class wire_cst_Amount_Bitcoin extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_msat;
-}
-
-final class wire_cst_Amount_Currency extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> iso4217_code;
-
-  @ffi.Uint64()
-  external int fractional_amount;
-}
-
-final class AmountKind extends ffi.Union {
-  external wire_cst_Amount_Bitcoin Bitcoin;
-
-  external wire_cst_Amount_Currency Currency;
-}
-
-final class wire_cst_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external AmountKind kind;
-}
-
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -4500,29 +4553,6 @@ final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> label;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> message;
-}
-
-final class wire_cst_list_String extends ffi.Struct {
-  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-final class wire_cst_ln_offer extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12;
-
-  external ffi.Pointer<wire_cst_list_String> chains;
-
-  external ffi.Pointer<wire_cst_amount> amount;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<ffi.Uint64> absolute_expiry;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> issuer;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> signing_pubkey;
 }
 
 final class wire_cst_ln_url_error_data extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4615,7 +4615,7 @@ final class wire_cst_InputType_Bolt11 extends ffi.Struct {
   external ffi.Pointer<wire_cst_ln_invoice> invoice;
 }
 
-final class wire_cst_InputType_Bolt12 extends ffi.Struct {
+final class wire_cst_InputType_Bolt12Offer extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
 }
 
@@ -4650,7 +4650,7 @@ final class InputTypeKind extends ffi.Union {
 
   external wire_cst_InputType_Bolt11 Bolt11;
 
-  external wire_cst_InputType_Bolt12 Bolt12;
+  external wire_cst_InputType_Bolt12Offer Bolt12Offer;
 
   external wire_cst_InputType_NodeId NodeId;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -3988,6 +3988,9 @@ final class wire_cst_SendDestination_Bolt11 extends ffi.Struct {
 
 final class wire_cst_SendDestination_Bolt12 extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> offer;
+
+  @ffi.Uint64()
+  external int receiver_amount_sat;
 }
 
 final class SendDestinationKind extends ffi.Union {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2427,6 +2427,10 @@ fun asInputType(inputType: ReadableMap): InputType? {
         val invoice = inputType.getMap("invoice")?.let { asLnInvoice(it) }!!
         return InputType.Bolt11(invoice)
     }
+    if (type == "bolt12") {
+        val offer = inputType.getString("offer")!!
+        return InputType.Bolt12(offer)
+    }
     if (type == "nodeId") {
         val nodeId = inputType.getString("nodeId")!!
         return InputType.NodeId(nodeId)
@@ -2468,6 +2472,10 @@ fun readableMapOf(inputType: InputType): ReadableMap? {
         is InputType.Bolt11 -> {
             pushToMap(map, "type", "bolt11")
             pushToMap(map, "invoice", readableMapOf(inputType.invoice))
+        }
+        is InputType.Bolt12 -> {
+            pushToMap(map, "type", "bolt12")
+            pushToMap(map, "offer", inputType.offer)
         }
         is InputType.NodeId -> {
             pushToMap(map, "type", "nodeId")
@@ -2960,6 +2968,11 @@ fun asSendDestination(sendDestination: ReadableMap): SendDestination? {
         val invoice = sendDestination.getMap("invoice")?.let { asLnInvoice(it) }!!
         return SendDestination.Bolt11(invoice)
     }
+    if (type == "bolt12") {
+        val offer = sendDestination.getString("offer")!!
+        val receiverAmountSat = sendDestination.getDouble("receiverAmountSat").toULong()
+        return SendDestination.Bolt12(offer, receiverAmountSat)
+    }
     return null
 }
 
@@ -2973,6 +2986,11 @@ fun readableMapOf(sendDestination: SendDestination): ReadableMap? {
         is SendDestination.Bolt11 -> {
             pushToMap(map, "type", "bolt11")
             pushToMap(map, "invoice", readableMapOf(sendDestination.invoice))
+        }
+        is SendDestination.Bolt12 -> {
+            pushToMap(map, "type", "bolt12")
+            pushToMap(map, "offer", sendDestination.offer)
+            pushToMap(map, "receiverAmountSat", sendDestination.receiverAmountSat)
         }
     }
     return map

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2880,6 +2880,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
         val description = paymentDetails.getString("description")!!
         val preimage = if (hasNonNullKey(paymentDetails, "preimage")) paymentDetails.getString("preimage") else null
         val bolt11 = if (hasNonNullKey(paymentDetails, "bolt11")) paymentDetails.getString("bolt11") else null
+        val bolt12Offer = if (hasNonNullKey(paymentDetails, "bolt12Offer")) paymentDetails.getString("bolt12Offer") else null
         val paymentHash = if (hasNonNullKey(paymentDetails, "paymentHash")) paymentDetails.getString("paymentHash") else null
         val refundTxId = if (hasNonNullKey(paymentDetails, "refundTxId")) paymentDetails.getString("refundTxId") else null
         val refundTxAmountSat =
@@ -2892,7 +2893,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
-        return PaymentDetails.Lightning(swapId, description, preimage, bolt11, paymentHash, refundTxId, refundTxAmountSat)
+        return PaymentDetails.Lightning(swapId, description, preimage, bolt11, bolt12Offer, paymentHash, refundTxId, refundTxAmountSat)
     }
     if (type == "liquid") {
         val destination = paymentDetails.getString("destination")!!
@@ -2927,6 +2928,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "description", paymentDetails.description)
             pushToMap(map, "preimage", paymentDetails.preimage)
             pushToMap(map, "bolt11", paymentDetails.bolt11)
+            pushToMap(map, "bolt12Offer", paymentDetails.bolt12Offer)
             pushToMap(map, "paymentHash", paymentDetails.paymentHash)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2427,9 +2427,9 @@ fun asInputType(inputType: ReadableMap): InputType? {
         val invoice = inputType.getMap("invoice")?.let { asLnInvoice(it) }!!
         return InputType.Bolt11(invoice)
     }
-    if (type == "bolt12") {
+    if (type == "bolt12Offer") {
         val offer = inputType.getString("offer")!!
-        return InputType.Bolt12(offer)
+        return InputType.Bolt12Offer(offer)
     }
     if (type == "nodeId") {
         val nodeId = inputType.getString("nodeId")!!
@@ -2473,8 +2473,8 @@ fun readableMapOf(inputType: InputType): ReadableMap? {
             pushToMap(map, "type", "bolt11")
             pushToMap(map, "invoice", readableMapOf(inputType.invoice))
         }
-        is InputType.Bolt12 -> {
-            pushToMap(map, "type", "bolt12")
+        is InputType.Bolt12Offer -> {
+            pushToMap(map, "type", "bolt12Offer")
             pushToMap(map, "offer", inputType.offer)
         }
         is InputType.NodeId -> {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3054,7 +3054,7 @@ fun asSendDestination(sendDestination: ReadableMap): SendDestination? {
         return SendDestination.Bolt11(invoice)
     }
     if (type == "bolt12") {
-        val offer = sendDestination.getString("offer")!!
+        val offer = sendDestination.getMap("offer")?.let { asLnOffer(it) }!!
         val receiverAmountSat = sendDestination.getDouble("receiverAmountSat").toULong()
         return SendDestination.Bolt12(offer, receiverAmountSat)
     }
@@ -3074,7 +3074,7 @@ fun readableMapOf(sendDestination: SendDestination): ReadableMap? {
         }
         is SendDestination.Bolt12 -> {
             pushToMap(map, "type", "bolt12")
-            pushToMap(map, "offer", sendDestination.offer)
+            pushToMap(map, "offer", readableMapOf(sendDestination.offer))
             pushToMap(map, "receiverAmountSat", sendDestination.receiverAmountSat)
         }
     }

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -579,10 +579,10 @@ fun asLnOffer(lnOffer: ReadableMap): LnOffer? {
     val chains = lnOffer.getArray("chains")?.let { asStringList(it) }!!
     val description = if (hasNonNullKey(lnOffer, "description")) lnOffer.getString("description") else null
     val signingPubkey = if (hasNonNullKey(lnOffer, "signingPubkey")) lnOffer.getString("signingPubkey") else null
-    val amount = if (hasNonNullKey(lnOffer, "amount")) lnOffer.getMap("amount")?.let { asAmount(it) } else null
+    val minAmount = if (hasNonNullKey(lnOffer, "minAmount")) lnOffer.getMap("minAmount")?.let { asAmount(it) } else null
     val absoluteExpiry = if (hasNonNullKey(lnOffer, "absoluteExpiry")) lnOffer.getDouble("absoluteExpiry").toULong() else null
     val issuer = if (hasNonNullKey(lnOffer, "issuer")) lnOffer.getString("issuer") else null
-    return LnOffer(bolt12, chains, description, signingPubkey, amount, absoluteExpiry, issuer)
+    return LnOffer(bolt12, chains, description, signingPubkey, minAmount, absoluteExpiry, issuer)
 }
 
 fun readableMapOf(lnOffer: LnOffer): ReadableMap =
@@ -591,7 +591,7 @@ fun readableMapOf(lnOffer: LnOffer): ReadableMap =
         "chains" to readableArrayOf(lnOffer.chains),
         "description" to lnOffer.description,
         "signingPubkey" to lnOffer.signingPubkey,
-        "amount" to lnOffer.amount?.let { readableMapOf(it) },
+        "minAmount" to lnOffer.minAmount?.let { readableMapOf(it) },
         "absoluteExpiry" to lnOffer.absoluteExpiry,
         "issuer" to lnOffer.issuer,
     )

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -568,26 +568,26 @@ fun asLnOffer(lnOffer: ReadableMap): LnOffer? {
     if (!validateMandatoryFields(
             lnOffer,
             arrayOf(
-                "bolt12",
+                "offer",
                 "chains",
             ),
         )
     ) {
         return null
     }
-    val bolt12 = lnOffer.getString("bolt12")!!
+    val offer = lnOffer.getString("offer")!!
     val chains = lnOffer.getArray("chains")?.let { asStringList(it) }!!
     val description = if (hasNonNullKey(lnOffer, "description")) lnOffer.getString("description") else null
     val signingPubkey = if (hasNonNullKey(lnOffer, "signingPubkey")) lnOffer.getString("signingPubkey") else null
     val minAmount = if (hasNonNullKey(lnOffer, "minAmount")) lnOffer.getMap("minAmount")?.let { asAmount(it) } else null
     val absoluteExpiry = if (hasNonNullKey(lnOffer, "absoluteExpiry")) lnOffer.getDouble("absoluteExpiry").toULong() else null
     val issuer = if (hasNonNullKey(lnOffer, "issuer")) lnOffer.getString("issuer") else null
-    return LnOffer(bolt12, chains, description, signingPubkey, minAmount, absoluteExpiry, issuer)
+    return LnOffer(offer, chains, description, signingPubkey, minAmount, absoluteExpiry, issuer)
 }
 
 fun readableMapOf(lnOffer: LnOffer): ReadableMap =
     readableMapOf(
-        "bolt12" to lnOffer.bolt12,
+        "offer" to lnOffer.offer,
         "chains" to readableArrayOf(lnOffer.chains),
         "description" to lnOffer.description,
         "signingPubkey" to lnOffer.signingPubkey,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -686,9 +686,9 @@ enum BreezSDKLiquidMapper {
             }
             signingPubkey = signingPubkeyTmp
         }
-        var amount: Amount?
-        if let amountTmp = lnOffer["amount"] as? [String: Any?] {
-            amount = try asAmount(amount: amountTmp)
+        var minAmount: Amount?
+        if let minAmountTmp = lnOffer["minAmount"] as? [String: Any?] {
+            minAmount = try asAmount(amount: minAmountTmp)
         }
 
         var absoluteExpiry: UInt64?
@@ -706,7 +706,7 @@ enum BreezSDKLiquidMapper {
             issuer = issuerTmp
         }
 
-        return LnOffer(bolt12: bolt12, chains: chains, description: description, signingPubkey: signingPubkey, amount: amount, absoluteExpiry: absoluteExpiry, issuer: issuer)
+        return LnOffer(bolt12: bolt12, chains: chains, description: description, signingPubkey: signingPubkey, minAmount: minAmount, absoluteExpiry: absoluteExpiry, issuer: issuer)
     }
 
     static func dictionaryOf(lnOffer: LnOffer) -> [String: Any?] {
@@ -715,7 +715,7 @@ enum BreezSDKLiquidMapper {
             "chains": lnOffer.chains,
             "description": lnOffer.description == nil ? nil : lnOffer.description,
             "signingPubkey": lnOffer.signingPubkey == nil ? nil : lnOffer.signingPubkey,
-            "amount": lnOffer.amount == nil ? nil : dictionaryOf(amount: lnOffer.amount!),
+            "minAmount": lnOffer.minAmount == nil ? nil : dictionaryOf(amount: lnOffer.minAmount!),
             "absoluteExpiry": lnOffer.absoluteExpiry == nil ? nil : lnOffer.absoluteExpiry,
             "issuer": lnOffer.issuer == nil ? nil : lnOffer.issuer,
         ]

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -666,8 +666,8 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asLnOffer(lnOffer: [String: Any?]) throws -> LnOffer {
-        guard let bolt12 = lnOffer["bolt12"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt12", typeName: "LnOffer"))
+        guard let offer = lnOffer["offer"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "LnOffer"))
         }
         guard let chains = lnOffer["chains"] as? [String] else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "chains", typeName: "LnOffer"))
@@ -706,12 +706,12 @@ enum BreezSDKLiquidMapper {
             issuer = issuerTmp
         }
 
-        return LnOffer(bolt12: bolt12, chains: chains, description: description, signingPubkey: signingPubkey, minAmount: minAmount, absoluteExpiry: absoluteExpiry, issuer: issuer)
+        return LnOffer(offer: offer, chains: chains, description: description, signingPubkey: signingPubkey, minAmount: minAmount, absoluteExpiry: absoluteExpiry, issuer: issuer)
     }
 
     static func dictionaryOf(lnOffer: LnOffer) -> [String: Any?] {
         return [
-            "bolt12": lnOffer.bolt12,
+            "offer": lnOffer.offer,
             "chains": lnOffer.chains,
             "description": lnOffer.description == nil ? nil : lnOffer.description,
             "signingPubkey": lnOffer.signingPubkey == nil ? nil : lnOffer.signingPubkey,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -3561,13 +3561,15 @@ enum BreezSDKLiquidMapper {
 
             let _bolt11 = paymentDetails["bolt11"] as? String
 
+            let _bolt12Offer = paymentDetails["bolt12Offer"] as? String
+
             let _paymentHash = paymentDetails["paymentHash"] as? String
 
             let _refundTxId = paymentDetails["refundTxId"] as? String
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, preimage: _preimage, bolt11: _bolt11, paymentHash: _paymentHash, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, preimage: _preimage, bolt11: _bolt11, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
         if type == "liquid" {
             guard let _destination = paymentDetails["destination"] as? String else {
@@ -3598,7 +3600,7 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
         switch paymentDetails {
         case let .lightning(
-            swapId, description, preimage, bolt11, paymentHash, refundTxId, refundTxAmountSat
+            swapId, description, preimage, bolt11, bolt12Offer, paymentHash, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "lightning",
@@ -3606,6 +3608,7 @@ enum BreezSDKLiquidMapper {
                 "description": description,
                 "preimage": preimage == nil ? nil : preimage,
                 "bolt11": bolt11 == nil ? nil : bolt11,
+                "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
                 "paymentHash": paymentHash == nil ? nil : paymentHash,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2830,6 +2830,12 @@ enum BreezSDKLiquidMapper {
 
             return InputType.bolt11(invoice: _invoice)
         }
+        if type == "bolt12" {
+            guard let _offer = inputType["offer"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "InputType"))
+            }
+            return InputType.bolt12(offer: _offer)
+        }
         if type == "nodeId" {
             guard let _nodeId = inputType["nodeId"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "InputType"))
@@ -2902,6 +2908,14 @@ enum BreezSDKLiquidMapper {
             return [
                 "type": "bolt11",
                 "invoice": dictionaryOf(lnInvoice: invoice),
+            ]
+
+        case let .bolt12(
+            offer
+        ):
+            return [
+                "type": "bolt12",
+                "offer": offer,
             ]
 
         case let .nodeId(
@@ -3770,6 +3784,15 @@ enum BreezSDKLiquidMapper {
 
             return SendDestination.bolt11(invoice: _invoice)
         }
+        if type == "bolt12" {
+            guard let _offer = sendDestination["offer"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "SendDestination"))
+            }
+            guard let _receiverAmountSat = sendDestination["receiverAmountSat"] as? UInt64 else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "SendDestination"))
+            }
+            return SendDestination.bolt12(offer: _offer, receiverAmountSat: _receiverAmountSat)
+        }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum SendDestination")
     }
@@ -3790,6 +3813,15 @@ enum BreezSDKLiquidMapper {
             return [
                 "type": "bolt11",
                 "invoice": dictionaryOf(lnInvoice: invoice),
+            ]
+
+        case let .bolt12(
+            offer, receiverAmountSat
+        ):
+            return [
+                "type": "bolt12",
+                "offer": offer,
+                "receiverAmountSat": receiverAmountSat,
             ]
         }
     }

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2827,11 +2827,11 @@ enum BreezSDKLiquidMapper {
 
             return InputType.bolt11(invoice: _invoice)
         }
-        if type == "bolt12" {
+        if type == "bolt12Offer" {
             guard let _offer = inputType["offer"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "InputType"))
             }
-            return InputType.bolt12(offer: _offer)
+            return InputType.bolt12Offer(offer: _offer)
         }
         if type == "nodeId" {
             guard let _nodeId = inputType["nodeId"] as? String else {
@@ -2907,11 +2907,11 @@ enum BreezSDKLiquidMapper {
                 "invoice": dictionaryOf(lnInvoice: invoice),
             ]
 
-        case let .bolt12(
+        case let .bolt12Offer(
             offer
         ):
             return [
-                "type": "bolt12",
+                "type": "bolt12Offer",
                 "offer": offer,
             ]
 

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -3916,9 +3916,11 @@ enum BreezSDKLiquidMapper {
             return SendDestination.bolt11(invoice: _invoice)
         }
         if type == "bolt12" {
-            guard let _offer = sendDestination["offer"] as? String else {
+            guard let offerTmp = sendDestination["offer"] as? [String: Any?] else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "SendDestination"))
             }
+            let _offer = try asLnOffer(lnOffer: offerTmp)
+
             guard let _receiverAmountSat = sendDestination["receiverAmountSat"] as? UInt64 else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "SendDestination"))
             }
@@ -3951,7 +3953,7 @@ enum BreezSDKLiquidMapper {
         ):
             return [
                 "type": "bolt12",
-                "offer": offer,
+                "offer": dictionaryOf(lnOffer: offer),
                 "receiverAmountSat": receiverAmountSat,
             ]
         }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -117,7 +117,7 @@ export interface LnInvoice {
 }
 
 export interface LnOffer {
-    bolt12: string
+    offer: string
     chains: string[]
     description?: string
     signingPubkey?: string

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -116,6 +116,16 @@ export interface LnInvoice {
     minFinalCltvExpiryDelta: number
 }
 
+export interface LnOffer {
+    bolt12: string
+    chains: string[]
+    description?: string
+    signingPubkey?: string
+    amount?: Amount
+    absoluteExpiry?: number
+    issuer?: string
+}
+
 export interface LightningPaymentLimitsResponse {
     send: Limits
     receive: Limits
@@ -408,6 +418,20 @@ export type AesSuccessActionDataResult = {
     reason: string
 }
 
+export enum AmountVariant {
+    BITCOIN = "bitcoin",
+    CURRENCY = "currency"
+}
+
+export type Amount = {
+    type: AmountVariant.BITCOIN,
+    amountMsat: number
+} | {
+    type: AmountVariant.CURRENCY,
+    iso4217Code: string
+    fractionalAmount: number
+}
+
 export enum BuyBitcoinProvider {
     MOONPAY = "moonpay"
 }
@@ -445,7 +469,7 @@ export type InputType = {
     invoice: LnInvoice
 } | {
     type: InputTypeVariant.BOLT12_OFFER,
-    offer: string
+    offer: LnOffer
 } | {
     type: InputTypeVariant.NODE_ID,
     nodeId: string

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -121,7 +121,7 @@ export interface LnOffer {
     chains: string[]
     description?: string
     signingPubkey?: string
-    amount?: Amount
+    minAmount?: Amount
     absoluteExpiry?: number
     issuer?: string
 }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -667,7 +667,7 @@ export type SendDestination = {
     invoice: LnInvoice
 } | {
     type: SendDestinationVariant.BOLT12,
-    offer: string
+    offer: LnOffer
     receiverAmountSat: number
 }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -590,6 +590,7 @@ export type PaymentDetails = {
     description: string
     preimage?: string
     bolt11?: string
+    bolt12Offer?: string
     paymentHash?: string
     refundTxId?: string
     refundTxAmountSat?: number

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -425,7 +425,7 @@ export enum InputTypeVariant {
     BITCOIN_ADDRESS = "bitcoinAddress",
     LIQUID_ADDRESS = "liquidAddress",
     BOLT11 = "bolt11",
-    BOLT12 = "bolt12",
+    BOLT12_OFFER = "bolt12Offer",
     NODE_ID = "nodeId",
     URL = "url",
     LN_URL_PAY = "lnUrlPay",
@@ -444,7 +444,7 @@ export type InputType = {
     type: InputTypeVariant.BOLT11,
     invoice: LnInvoice
 } | {
-    type: InputTypeVariant.BOLT12,
+    type: InputTypeVariant.BOLT12_OFFER,
     offer: string
 } | {
     type: InputTypeVariant.NODE_ID,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -119,6 +119,7 @@ export interface LnInvoice {
 export interface LnOffer {
     offer: string
     chains: string[]
+    paths: LnOfferBlindedPath[]
     description?: string
     signingPubkey?: string
     minAmount?: Amount
@@ -153,6 +154,10 @@ export interface ListPaymentsRequest {
     offset?: number
     limit?: number
     details?: ListPaymentDetails
+}
+
+export interface LnOfferBlindedPath {
+    blindedHops: string[]
 }
 
 export interface LnUrlAuthRequestData {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -425,6 +425,7 @@ export enum InputTypeVariant {
     BITCOIN_ADDRESS = "bitcoinAddress",
     LIQUID_ADDRESS = "liquidAddress",
     BOLT11 = "bolt11",
+    BOLT12 = "bolt12",
     NODE_ID = "nodeId",
     URL = "url",
     LN_URL_PAY = "lnUrlPay",
@@ -442,6 +443,9 @@ export type InputType = {
 } | {
     type: InputTypeVariant.BOLT11,
     invoice: LnInvoice
+} | {
+    type: InputTypeVariant.BOLT12,
+    offer: string
 } | {
     type: InputTypeVariant.NODE_ID,
     nodeId: string
@@ -627,7 +631,8 @@ export type SdkEvent = {
 
 export enum SendDestinationVariant {
     LIQUID_ADDRESS = "liquidAddress",
-    BOLT11 = "bolt11"
+    BOLT11 = "bolt11",
+    BOLT12 = "bolt12"
 }
 
 export type SendDestination = {
@@ -636,6 +641,10 @@ export type SendDestination = {
 } | {
     type: SendDestinationVariant.BOLT11,
     invoice: LnInvoice
+} | {
+    type: SendDestinationVariant.BOLT12,
+    offer: string
+    receiverAmountSat: number
 }
 
 export enum SuccessActionVariant {


### PR DESCRIPTION
This PR adds support for paying to a BOLT12 offer.

The flow is as follows:
- user specifies a BOLT12 offer destination when paying
- SDK calls Boltz endpoint that fetches a BOLT12 invoice for given offer
- SDK calls `send_payment_via_swap` with the BOLT12 invoice as argument, instead of the usual BOLT11


Open questions
- [x] Should we also support paying directly to BOLT12 invoices, in addition to BOLT12 offers?
- [x] Expand `PaymentDetails::Lightning` with a new field for `bolt12_invoice`? And / or an optional `bolt12_offer`?
  - Or alternatively rename the existing `bolt11` field to `invoice`, so it means either BOLT11 or BOLT12 invoice?
- [x] Should we fetch the invoice during `prepare`? This may take a long time for slow endpoints (Phoenix), causing the user to wait a few seconds for `prepare` to return.
- [x] Update `sdk_common::input_parser` to parse BOLT12 offers / invoice? Or keep changes local to the Liquid SDK?
  - [ ] Use [BIP-353](https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki#resolution) "DNS Payment Instructions" for BOLT12 resolution? (similar to LN Address)

Open TODOs

- [x] Validate returned invoice (check signature) before trying to pay it
- [x] ~Detect / handle MRH in BOLT12 invoices~
- [x] Handle both BOLT11 and BOLT12 in persister
- [x] When paying to a bolt12 offer, `list_payments` shows payments as `Pending`
- [x] When paying to a bolt12 offer, `list_payments` shows the bolt12 invoice under `bolt11` (should show offer instead)