### PR TITLE
Fix chronological order of `list_payments`

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1319,10 +1319,10 @@ impl Payment {
                     _ => None,
                 },
             },
-            timestamp: match swap {
-                Some(ref swap) => swap.created_at,
-                None => tx.timestamp.unwrap_or(utils::now()),
-            },
+            timestamp: tx
+                .timestamp
+                .or(swap.as_ref().map(|s| s.created_at))
+                .unwrap_or(utils::now()),
             amount_sat: tx.amount_sat,
             fees_sat: match swap.as_ref() {
                 Some(s) => s.payer_amount_sat - s.receiver_amount_sat,

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -219,8 +219,8 @@ impl Persister {
             AND                                  -- Filter out refund txs from Chain Swaps
                 ptx.tx_id NOT IN (SELECT refund_tx_id FROM chain_swaps WHERE refund_tx_id NOT NULL)
             AND {}
-            ORDER BY                             -- Order by tx timestamp or swap creation time
-                COALESCE(ptx.timestamp, rs.created_at, ss.created_at, cs.created_at) DESC
+            ORDER BY                             -- Order by swap creation time or tx timestamp (in case of direct tx)
+                COALESCE(rs.created_at, ss.created_at, cs.created_at, ptx.timestamp) DESC
             LIMIT {}
             OFFSET {}
             ",


### PR DESCRIPTION
This PR:
- Fixes chronological payment ordering, first ordering by swap creation timestamp then tx timestamp
- Fixes use of tx timestamp in payment 

Fixes #540 