### PR TITLE
Liquid/Lightning drain

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -332,8 +332,8 @@ pub(crate) async fn handle_command(
                 }
             };
             let amount = match (amount_sat, drain.unwrap_or(false)) {
-                (Some(amount_sat), _) => Some(PayOnchainAmount::Receiver { amount_sat }),
-                (_, true) => Some(PayOnchainAmount::Drain),
+                (Some(amount_sat), _) => Some(PayAmount::Receiver { amount_sat }),
+                (_, true) => Some(PayAmount::Drain),
                 (_, _) => None,
             };
 
@@ -376,8 +376,8 @@ pub(crate) async fn handle_command(
             fee_rate_sat_per_vbyte,
         } => {
             let amount = match drain.unwrap_or(false) {
-                true => PayOnchainAmount::Drain,
-                false => PayOnchainAmount::Receiver {
+                true => PayAmount::Drain,
+                false => PayAmount::Receiver {
                     amount_sat: receiver_amount_sat.ok_or(anyhow::anyhow!(
                         "Must specify `receiver_amount_sat` if not draining"
                     ))?,

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -310,7 +310,7 @@ typedef struct wire_cst_prepare_refund_request {
 
 typedef struct wire_cst_prepare_send_request {
   struct wire_cst_list_prim_u_8_strict *destination;
-  uint64_t *amount_sat;
+  struct wire_cst_pay_onchain_amount *amount;
 } wire_cst_prepare_send_request;
 
 typedef struct wire_cst_prepare_receive_response {
@@ -1166,6 +1166,8 @@ struct wire_cst_ln_url_withdraw_success_data *frbgen_breez_liquid_cst_new_box_au
 
 struct wire_cst_message_success_action_data *frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_data(void);
 
+struct wire_cst_pay_onchain_amount *frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount(void);
+
 struct wire_cst_pay_onchain_request *frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request(void);
 
 struct wire_cst_payment *frbgen_breez_liquid_cst_new_box_autoadd_payment(void);
@@ -1253,6 +1255,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_withdraw_request_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_withdraw_success_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_data);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_buy_bitcoin_request);

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -279,21 +279,21 @@ typedef struct wire_cst_prepare_ln_url_pay_request {
   bool *validate_success_action_url;
 } wire_cst_prepare_ln_url_pay_request;
 
-typedef struct wire_cst_PayOnchainAmount_Receiver {
+typedef struct wire_cst_PayAmount_Receiver {
   uint64_t amount_sat;
-} wire_cst_PayOnchainAmount_Receiver;
+} wire_cst_PayAmount_Receiver;
 
-typedef union PayOnchainAmountKind {
-  struct wire_cst_PayOnchainAmount_Receiver Receiver;
-} PayOnchainAmountKind;
+typedef union PayAmountKind {
+  struct wire_cst_PayAmount_Receiver Receiver;
+} PayAmountKind;
 
-typedef struct wire_cst_pay_onchain_amount {
+typedef struct wire_cst_pay_amount {
   int32_t tag;
-  union PayOnchainAmountKind kind;
-} wire_cst_pay_onchain_amount;
+  union PayAmountKind kind;
+} wire_cst_pay_amount;
 
 typedef struct wire_cst_prepare_pay_onchain_request {
-  struct wire_cst_pay_onchain_amount amount;
+  struct wire_cst_pay_amount amount;
   uint32_t *fee_rate_sat_per_vbyte;
 } wire_cst_prepare_pay_onchain_request;
 
@@ -310,7 +310,7 @@ typedef struct wire_cst_prepare_refund_request {
 
 typedef struct wire_cst_prepare_send_request {
   struct wire_cst_list_prim_u_8_strict *destination;
-  struct wire_cst_pay_onchain_amount *amount;
+  struct wire_cst_pay_amount *amount;
 } wire_cst_prepare_send_request;
 
 typedef struct wire_cst_prepare_receive_response {
@@ -1166,7 +1166,7 @@ struct wire_cst_ln_url_withdraw_success_data *frbgen_breez_liquid_cst_new_box_au
 
 struct wire_cst_message_success_action_data *frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_data(void);
 
-struct wire_cst_pay_onchain_amount *frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount(void);
+struct wire_cst_pay_amount *frbgen_breez_liquid_cst_new_box_autoadd_pay_amount(void);
 
 struct wire_cst_pay_onchain_request *frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request(void);
 
@@ -1255,7 +1255,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_withdraw_request_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_withdraw_success_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_data);
-    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_buy_bitcoin_request);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -373,7 +373,7 @@ dictionary LnUrlPayRequest {
 
 dictionary PrepareSendRequest {
     string destination;
-    u64? amount_sat = null;
+    PayOnchainAmount? amount = null;
 };
 
 [Enum]

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -373,7 +373,7 @@ dictionary LnUrlPayRequest {
 
 dictionary PrepareSendRequest {
     string destination;
-    PayOnchainAmount? amount = null;
+    PayAmount? amount = null;
 };
 
 [Enum]
@@ -439,13 +439,13 @@ dictionary OnchainPaymentLimitsResponse {
 };
 
 [Enum]
-interface PayOnchainAmount {
+interface PayAmount {
     Receiver(u64 amount_sat);
     Drain();
 };
 
 dictionary PreparePayOnchainRequest {
-    PayOnchainAmount amount;
+    PayAmount amount;
     u32? fee_rate_sat_per_vbyte = null;
 };
 

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -612,30 +612,14 @@ impl ChainSwapHandler {
             lockup_details.amount, lockup_details.lockup_address
         );
 
-        let lockup_tx = match self
+        let lockup_tx = self
             .onchain_wallet
-            .build_tx(
-                self.config
-                    .lowball_fee_rate_msat_per_vbyte()
-                    .map(|v| v as f32),
+            .build_tx_or_drain_tx(
+                self.config.lowball_fee_rate_msat_per_vbyte(),
                 &lockup_details.lockup_address,
                 lockup_details.amount,
             )
-            .await
-        {
-            Err(PaymentError::InsufficientFunds) => {
-                warn!("Cannot build normal lockup tx due to insufficient funds, attempting to build drain tx");
-                self.onchain_wallet
-                    .build_drain_tx(
-                        None,
-                        &lockup_details.lockup_address,
-                        Some(lockup_details.amount),
-                    )
-                    .await
-            }
-            Err(e) => Err(e),
-            Ok(lockup_tx) => Ok(lockup_tx),
-        }?;
+            .await?;
 
         let lockup_tx_id = self
             .liquid_chain_service

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3180,11 +3180,11 @@ impl SseDecode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
-impl SseDecode for Option<crate::model::PayOnchainAmount> {
+impl SseDecode for Option<crate::model::PayAmount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
-            return Some(<crate::model::PayOnchainAmount>::sse_decode(deserializer));
+            return Some(<crate::model::PayAmount>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -3270,19 +3270,19 @@ impl SseDecode for Option<Vec<crate::model::PaymentType>> {
     }
 }
 
-impl SseDecode for crate::model::PayOnchainAmount {
+impl SseDecode for crate::model::PayAmount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut tag_ = <i32>::sse_decode(deserializer);
         match tag_ {
             0 => {
                 let mut var_amountSat = <u64>::sse_decode(deserializer);
-                return crate::model::PayOnchainAmount::Receiver {
+                return crate::model::PayAmount::Receiver {
                     amount_sat: var_amountSat,
                 };
             }
             1 => {
-                return crate::model::PayOnchainAmount::Drain;
+                return crate::model::PayAmount::Drain;
             }
             _ => {
                 unimplemented!("");
@@ -3569,7 +3569,7 @@ impl SseDecode for crate::model::PrepareLnUrlPayResponse {
 impl SseDecode for crate::model::PreparePayOnchainRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_amount = <crate::model::PayOnchainAmount>::sse_decode(deserializer);
+        let mut var_amount = <crate::model::PayAmount>::sse_decode(deserializer);
         let mut var_feeRateSatPerVbyte = <Option<u32>>::sse_decode(deserializer);
         return crate::model::PreparePayOnchainRequest {
             amount: var_amount,
@@ -3650,7 +3650,7 @@ impl SseDecode for crate::model::PrepareSendRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_destination = <String>::sse_decode(deserializer);
-        let mut var_amount = <Option<crate::model::PayOnchainAmount>>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::model::PayAmount>>::sse_decode(deserializer);
         return crate::model::PrepareSendRequest {
             destination: var_destination,
             amount: var_amount,
@@ -5180,27 +5180,22 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::OnchainPaymentLimitsRespons
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::model::PayOnchainAmount {
+impl flutter_rust_bridge::IntoDart for crate::model::PayAmount {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
-            crate::model::PayOnchainAmount::Receiver { amount_sat } => {
+            crate::model::PayAmount::Receiver { amount_sat } => {
                 [0.into_dart(), amount_sat.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::PayOnchainAmount::Drain => [1.into_dart()].into_dart(),
+            crate::model::PayAmount::Drain => [1.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
         }
     }
 }
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::model::PayOnchainAmount
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::model::PayOnchainAmount>
-    for crate::model::PayOnchainAmount
-{
-    fn into_into_dart(self) -> crate::model::PayOnchainAmount {
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::model::PayAmount {}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::PayAmount> for crate::model::PayAmount {
+    fn into_into_dart(self) -> crate::model::PayAmount {
         self
     }
 }
@@ -6990,12 +6985,12 @@ impl SseEncode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
-impl SseEncode for Option<crate::model::PayOnchainAmount> {
+impl SseEncode for Option<crate::model::PayAmount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
-            <crate::model::PayOnchainAmount>::sse_encode(value, serializer);
+            <crate::model::PayAmount>::sse_encode(value, serializer);
         }
     }
 }
@@ -7070,15 +7065,15 @@ impl SseEncode for Option<Vec<crate::model::PaymentType>> {
     }
 }
 
-impl SseEncode for crate::model::PayOnchainAmount {
+impl SseEncode for crate::model::PayAmount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         match self {
-            crate::model::PayOnchainAmount::Receiver { amount_sat } => {
+            crate::model::PayAmount::Receiver { amount_sat } => {
                 <i32>::sse_encode(0, serializer);
                 <u64>::sse_encode(amount_sat, serializer);
             }
-            crate::model::PayOnchainAmount::Drain => {
+            crate::model::PayAmount::Drain => {
                 <i32>::sse_encode(1, serializer);
             }
             _ => {
@@ -7337,7 +7332,7 @@ impl SseEncode for crate::model::PrepareLnUrlPayResponse {
 impl SseEncode for crate::model::PreparePayOnchainRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::model::PayOnchainAmount>::sse_encode(self.amount, serializer);
+        <crate::model::PayAmount>::sse_encode(self.amount, serializer);
         <Option<u32>>::sse_encode(self.fee_rate_sat_per_vbyte, serializer);
     }
 }
@@ -7390,7 +7385,7 @@ impl SseEncode for crate::model::PrepareSendRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.destination, serializer);
-        <Option<crate::model::PayOnchainAmount>>::sse_encode(self.amount, serializer);
+        <Option<crate::model::PayAmount>>::sse_encode(self.amount, serializer);
     }
 }
 
@@ -8057,11 +8052,11 @@ mod io {
             CstDecode::<crate::bindings::MessageSuccessActionData>::cst_decode(*wrap).into()
         }
     }
-    impl CstDecode<crate::model::PayOnchainAmount> for *mut wire_cst_pay_onchain_amount {
+    impl CstDecode<crate::model::PayAmount> for *mut wire_cst_pay_amount {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::model::PayOnchainAmount {
+        fn cst_decode(self) -> crate::model::PayAmount {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
-            CstDecode::<crate::model::PayOnchainAmount>::cst_decode(*wrap).into()
+            CstDecode::<crate::model::PayAmount>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::model::PayOnchainRequest> for *mut wire_cst_pay_onchain_request {
@@ -8912,17 +8907,17 @@ mod io {
             }
         }
     }
-    impl CstDecode<crate::model::PayOnchainAmount> for wire_cst_pay_onchain_amount {
+    impl CstDecode<crate::model::PayAmount> for wire_cst_pay_amount {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::model::PayOnchainAmount {
+        fn cst_decode(self) -> crate::model::PayAmount {
             match self.tag {
                 0 => {
                     let ans = unsafe { self.kind.Receiver };
-                    crate::model::PayOnchainAmount::Receiver {
+                    crate::model::PayAmount::Receiver {
                         amount_sat: ans.amount_sat.cst_decode(),
                     }
                 }
-                1 => crate::model::PayOnchainAmount::Drain,
+                1 => crate::model::PayAmount::Drain,
                 _ => unreachable!(),
             }
         }
@@ -10064,15 +10059,15 @@ mod io {
             Self::new_with_null_ptr()
         }
     }
-    impl NewWithNullPtr for wire_cst_pay_onchain_amount {
+    impl NewWithNullPtr for wire_cst_pay_amount {
         fn new_with_null_ptr() -> Self {
             Self {
                 tag: -1,
-                kind: PayOnchainAmountKind { nil__: () },
+                kind: PayAmountKind { nil__: () },
             }
         }
     }
-    impl Default for wire_cst_pay_onchain_amount {
+    impl Default for wire_cst_pay_amount {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -11137,10 +11132,10 @@ mod io {
     }
 
     #[no_mangle]
-    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount(
-    ) -> *mut wire_cst_pay_onchain_amount {
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_pay_amount(
+    ) -> *mut wire_cst_pay_amount {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_pay_onchain_amount::new_with_null_ptr(),
+            wire_cst_pay_amount::new_with_null_ptr(),
         )
     }
 
@@ -12078,19 +12073,19 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_pay_onchain_amount {
+    pub struct wire_cst_pay_amount {
         tag: i32,
-        kind: PayOnchainAmountKind,
+        kind: PayAmountKind,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub union PayOnchainAmountKind {
-        Receiver: wire_cst_PayOnchainAmount_Receiver,
+    pub union PayAmountKind {
+        Receiver: wire_cst_PayAmount_Receiver,
         nil__: (),
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_PayOnchainAmount_Receiver {
+    pub struct wire_cst_PayAmount_Receiver {
         amount_sat: u64,
     }
     #[repr(C)]
@@ -12253,7 +12248,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_pay_onchain_request {
-        amount: wire_cst_pay_onchain_amount,
+        amount: wire_cst_pay_amount,
         fee_rate_sat_per_vbyte: *mut u32,
     }
     #[repr(C)]
@@ -12294,7 +12289,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_send_request {
         destination: *mut wire_cst_list_prim_u_8_strict,
-        amount: *mut wire_cst_pay_onchain_amount,
+        amount: *mut wire_cst_pay_amount,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3180,6 +3180,17 @@ impl SseDecode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
+impl SseDecode for Option<crate::model::PayOnchainAmount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::model::PayOnchainAmount>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::model::Payment> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3639,10 +3650,10 @@ impl SseDecode for crate::model::PrepareSendRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_destination = <String>::sse_decode(deserializer);
-        let mut var_amountSat = <Option<u64>>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::model::PayOnchainAmount>>::sse_decode(deserializer);
         return crate::model::PrepareSendRequest {
             destination: var_destination,
-            amount_sat: var_amountSat,
+            amount: var_amount,
         };
     }
 }
@@ -5636,7 +5647,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareSendRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.destination.into_into_dart().into_dart(),
-            self.amount_sat.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6979,6 +6990,16 @@ impl SseEncode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
+impl SseEncode for Option<crate::model::PayOnchainAmount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::model::PayOnchainAmount>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::model::Payment> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7369,7 +7390,7 @@ impl SseEncode for crate::model::PrepareSendRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.destination, serializer);
-        <Option<u64>>::sse_encode(self.amount_sat, serializer);
+        <Option<crate::model::PayOnchainAmount>>::sse_encode(self.amount, serializer);
     }
 }
 
@@ -8034,6 +8055,13 @@ mod io {
         fn cst_decode(self) -> crate::bindings::MessageSuccessActionData {
             let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
             CstDecode::<crate::bindings::MessageSuccessActionData>::cst_decode(*wrap).into()
+        }
+    }
+    impl CstDecode<crate::model::PayOnchainAmount> for *mut wire_cst_pay_onchain_amount {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::PayOnchainAmount {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::model::PayOnchainAmount>::cst_decode(*wrap).into()
         }
     }
     impl CstDecode<crate::model::PayOnchainRequest> for *mut wire_cst_pay_onchain_request {
@@ -9142,7 +9170,7 @@ mod io {
         fn cst_decode(self) -> crate::model::PrepareSendRequest {
             crate::model::PrepareSendRequest {
                 destination: self.destination.cst_decode(),
-                amount_sat: self.amount_sat.cst_decode(),
+                amount: self.amount.cst_decode(),
             }
         }
     }
@@ -10249,7 +10277,7 @@ mod io {
         fn new_with_null_ptr() -> Self {
             Self {
                 destination: core::ptr::null_mut(),
-                amount_sat: core::ptr::null_mut(),
+                amount: core::ptr::null_mut(),
             }
         }
     }
@@ -11105,6 +11133,14 @@ mod io {
     ) -> *mut wire_cst_message_success_action_data {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
             wire_cst_message_success_action_data::new_with_null_ptr(),
+        )
+    }
+
+    #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount(
+    ) -> *mut wire_cst_pay_onchain_amount {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_pay_onchain_amount::new_with_null_ptr(),
         )
     }
 
@@ -12258,7 +12294,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_send_request {
         destination: *mut wire_cst_list_prim_u_8_strict,
-        amount_sat: *mut u64,
+        amount: *mut wire_cst_pay_onchain_amount,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -350,7 +350,7 @@ pub struct PrepareSendRequest {
 
     /// Should only be set when paying directly onchain or to a BIP21 URI
     /// where no amount is specified
-    pub amount_sat: Option<u64>,
+    pub amount: Option<PayOnchainAmount>,
 }
 
 /// Specifies the supported destinations which can be payed by the SDK

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -349,7 +349,7 @@ pub struct PrepareSendRequest {
     pub destination: String,
 
     /// Should only be set when paying directly onchain or to a BIP21 URI
-    /// where no amount is specified
+    /// where no amount is specified, or when the caller wishes to drain
     pub amount: Option<PayOnchainAmount>,
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -100,9 +100,9 @@ impl Config {
             .unwrap_or(DEFAULT_ZERO_CONF_MAX_SAT)
     }
 
-    pub(crate) fn lowball_fee_rate_msat_per_vbyte(&self) -> Option<f64> {
+    pub(crate) fn lowball_fee_rate_msat_per_vbyte(&self) -> Option<f32> {
         match self.network {
-            LiquidNetwork::Mainnet => Some(LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0),
+            LiquidNetwork::Mainnet => Some((LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0) as f32),
             LiquidNetwork::Testnet => None,
         }
     }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -350,7 +350,7 @@ pub struct PrepareSendRequest {
 
     /// Should only be set when paying directly onchain or to a BIP21 URI
     /// where no amount is specified, or when the caller wishes to drain
-    pub amount: Option<PayOnchainAmount>,
+    pub amount: Option<PayAmount>,
 }
 
 /// Specifies the supported destinations which can be payed by the SDK
@@ -384,7 +384,7 @@ pub struct SendPaymentResponse {
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub enum PayOnchainAmount {
+pub enum PayAmount {
     /// The amount in satoshi that will be received
     Receiver { amount_sat: u64 },
     /// Indicates that all available funds should be sent
@@ -394,7 +394,7 @@ pub enum PayOnchainAmount {
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].
 #[derive(Debug, Serialize, Clone)]
 pub struct PreparePayOnchainRequest {
-    pub amount: PayOnchainAmount,
+    pub amount: PayAmount,
     /// The optional fee rate of the Bitcoin claim transaction in sat/vB. Defaults to the swapper estimated claim fee.
     pub fee_rate_sat_per_vbyte: Option<u32>,
 }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -662,7 +662,7 @@ impl LiquidSdk {
         }
     }
 
-    /// Estimate the lockup tx fee
+    /// Estimate the lockup tx fee for Send and Chain Send swaps
     async fn estimate_lockup_tx_fee(
         &self,
         user_lockup_amount_sat: u64,

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -190,10 +190,8 @@ impl SendSwapHandler {
 
         let lockup_tx = self
             .onchain_wallet
-            .build_tx(
-                self.config
-                    .lowball_fee_rate_msat_per_vbyte()
-                    .map(|v| v as f32),
+            .build_tx_or_drain_tx(
+                self.config.lowball_fee_rate_msat_per_vbyte(),
                 &create_response.address,
                 create_response.expected_amount,
             )

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -53,6 +53,15 @@ impl OnchainWallet for MockWallet {
         Ok(TEST_LIQUID_TX.clone())
     }
 
+    async fn build_tx_or_drain_tx(
+        &self,
+        _fee_rate_sats_per_kvb: Option<f32>,
+        _recipient_address: &str,
+        _amount_sat: u64,
+    ) -> Result<Transaction, PaymentError> {
+        Ok(TEST_LIQUID_TX.clone())
+    }
+
     async fn next_unused_address(&self) -> Result<Address, PaymentError> {
         Ok(TEST_P2TR_ADDR.clone())
     }

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -232,7 +232,7 @@ impl OnchainWallet for LiquidOnchainWallet {
             Ok(tx) => Ok(tx),
             Err(PaymentError::InsufficientFunds) => {
                 warn!("Cannot build tx due to insufficient funds, attempting to build drain tx");
-                self.build_drain_tx(fee_rate_sats_per_kvb, &recipient_address, Some(amount_sat))
+                self.build_drain_tx(fee_rate_sats_per_kvb, recipient_address, Some(amount_sat))
                     .await
             }
             Err(e) => Err(e),

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1484,6 +1484,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PayOnchainAmount dco_decode_box_autoadd_pay_onchain_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_pay_onchain_amount(raw);
+  }
+
+  @protected
   PayOnchainRequest dco_decode_box_autoadd_pay_onchain_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_pay_onchain_request(raw);
@@ -2306,6 +2312,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PayOnchainAmount? dco_decode_opt_box_autoadd_pay_onchain_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_pay_onchain_amount(raw);
+  }
+
+  @protected
   Payment? dco_decode_opt_box_autoadd_payment(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_payment(raw);
@@ -2636,7 +2648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PrepareSendRequest(
       destination: dco_decode_String(arr[0]),
-      amountSat: dco_decode_opt_box_autoadd_u_64(arr[1]),
+      amount: dco_decode_opt_box_autoadd_pay_onchain_amount(arr[1]),
     );
   }
 
@@ -3262,6 +3274,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MessageSuccessActionData sse_decode_box_autoadd_message_success_action_data(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_message_success_action_data(deserializer));
+  }
+
+  @protected
+  PayOnchainAmount sse_decode_box_autoadd_pay_onchain_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_pay_onchain_amount(deserializer));
   }
 
   @protected
@@ -4122,6 +4140,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PayOnchainAmount? sse_decode_opt_box_autoadd_pay_onchain_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_pay_onchain_amount(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   Payment? sse_decode_opt_box_autoadd_payment(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4474,8 +4503,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendRequest sse_decode_prepare_send_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_destination = sse_decode_String(deserializer);
-    var var_amountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
-    return PrepareSendRequest(destination: var_destination, amountSat: var_amountSat);
+    var var_amount = sse_decode_opt_box_autoadd_pay_onchain_amount(deserializer);
+    return PrepareSendRequest(destination: var_destination, amount: var_amount);
   }
 
   @protected
@@ -5160,6 +5189,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       MessageSuccessActionData self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_message_success_action_data(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_pay_onchain_amount(self, serializer);
   }
 
   @protected
@@ -5888,6 +5923,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_pay_onchain_amount(PayOnchainAmount? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_pay_onchain_amount(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_payment(Payment? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -6195,7 +6240,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_prepare_send_request(PrepareSendRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.destination, serializer);
-    sse_encode_opt_box_autoadd_u_64(self.amountSat, serializer);
+    sse_encode_opt_box_autoadd_pay_onchain_amount(self.amount, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1484,9 +1484,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount dco_decode_box_autoadd_pay_onchain_amount(dynamic raw) {
+  PayAmount dco_decode_box_autoadd_pay_amount(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_pay_onchain_amount(raw);
+    return dco_decode_pay_amount(raw);
   }
 
   @protected
@@ -2312,9 +2312,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount? dco_decode_opt_box_autoadd_pay_onchain_amount(dynamic raw) {
+  PayAmount? dco_decode_opt_box_autoadd_pay_amount(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw == null ? null : dco_decode_box_autoadd_pay_onchain_amount(raw);
+    return raw == null ? null : dco_decode_box_autoadd_pay_amount(raw);
   }
 
   @protected
@@ -2360,15 +2360,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount dco_decode_pay_onchain_amount(dynamic raw) {
+  PayAmount dco_decode_pay_amount(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
       case 0:
-        return PayOnchainAmount_Receiver(
+        return PayAmount_Receiver(
           amountSat: dco_decode_u_64(raw[1]),
         );
       case 1:
-        return PayOnchainAmount_Drain();
+        return PayAmount_Drain();
       default:
         throw Exception("unreachable");
     }
@@ -2577,7 +2577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PreparePayOnchainRequest(
-      amount: dco_decode_pay_onchain_amount(arr[0]),
+      amount: dco_decode_pay_amount(arr[0]),
       feeRateSatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[1]),
     );
   }
@@ -2648,7 +2648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PrepareSendRequest(
       destination: dco_decode_String(arr[0]),
-      amount: dco_decode_opt_box_autoadd_pay_onchain_amount(arr[1]),
+      amount: dco_decode_opt_box_autoadd_pay_amount(arr[1]),
     );
   }
 
@@ -3277,9 +3277,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount sse_decode_box_autoadd_pay_onchain_amount(SseDeserializer deserializer) {
+  PayAmount sse_decode_box_autoadd_pay_amount(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_pay_onchain_amount(deserializer));
+    return (sse_decode_pay_amount(deserializer));
   }
 
   @protected
@@ -4140,11 +4140,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount? sse_decode_opt_box_autoadd_pay_onchain_amount(SseDeserializer deserializer) {
+  PayAmount? sse_decode_opt_box_autoadd_pay_amount(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     if (sse_decode_bool(deserializer)) {
-      return (sse_decode_box_autoadd_pay_onchain_amount(deserializer));
+      return (sse_decode_box_autoadd_pay_amount(deserializer));
     } else {
       return null;
     }
@@ -4228,16 +4228,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  PayOnchainAmount sse_decode_pay_onchain_amount(SseDeserializer deserializer) {
+  PayAmount sse_decode_pay_amount(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     var tag_ = sse_decode_i_32(deserializer);
     switch (tag_) {
       case 0:
         var var_amountSat = sse_decode_u_64(deserializer);
-        return PayOnchainAmount_Receiver(amountSat: var_amountSat);
+        return PayAmount_Receiver(amountSat: var_amountSat);
       case 1:
-        return PayOnchainAmount_Drain();
+        return PayAmount_Drain();
       default:
         throw UnimplementedError('');
     }
@@ -4443,7 +4443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PreparePayOnchainRequest sse_decode_prepare_pay_onchain_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_amount = sse_decode_pay_onchain_amount(deserializer);
+    var var_amount = sse_decode_pay_amount(deserializer);
     var var_feeRateSatPerVbyte = sse_decode_opt_box_autoadd_u_32(deserializer);
     return PreparePayOnchainRequest(amount: var_amount, feeRateSatPerVbyte: var_feeRateSatPerVbyte);
   }
@@ -4503,7 +4503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendRequest sse_decode_prepare_send_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_destination = sse_decode_String(deserializer);
-    var var_amount = sse_decode_opt_box_autoadd_pay_onchain_amount(deserializer);
+    var var_amount = sse_decode_opt_box_autoadd_pay_amount(deserializer);
     return PrepareSendRequest(destination: var_destination, amount: var_amount);
   }
 
@@ -5192,9 +5192,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer) {
+  void sse_encode_box_autoadd_pay_amount(PayAmount self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_pay_onchain_amount(self, serializer);
+    sse_encode_pay_amount(self, serializer);
   }
 
   @protected
@@ -5923,12 +5923,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_opt_box_autoadd_pay_onchain_amount(PayOnchainAmount? self, SseSerializer serializer) {
+  void sse_encode_opt_box_autoadd_pay_amount(PayAmount? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
     sse_encode_bool(self != null, serializer);
     if (self != null) {
-      sse_encode_box_autoadd_pay_onchain_amount(self, serializer);
+      sse_encode_box_autoadd_pay_amount(self, serializer);
     }
   }
 
@@ -6004,13 +6004,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer) {
+  void sse_encode_pay_amount(PayAmount self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
-      case PayOnchainAmount_Receiver(amountSat: final amountSat):
+      case PayAmount_Receiver(amountSat: final amountSat):
         sse_encode_i_32(0, serializer);
         sse_encode_u_64(amountSat, serializer);
-      case PayOnchainAmount_Drain():
+      case PayAmount_Drain():
         sse_encode_i_32(1, serializer);
       default:
         throw UnimplementedError('');
@@ -6193,7 +6193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_prepare_pay_onchain_request(PreparePayOnchainRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_pay_onchain_amount(self.amount, serializer);
+    sse_encode_pay_amount(self.amount, serializer);
     sse_encode_opt_box_autoadd_u_32(self.feeRateSatPerVbyte, serializer);
   }
 
@@ -6240,7 +6240,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_prepare_send_request(PrepareSendRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.destination, serializer);
-    sse_encode_opt_box_autoadd_pay_onchain_amount(self.amount, serializer);
+    sse_encode_opt_box_autoadd_pay_amount(self.amount, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -150,6 +150,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MessageSuccessActionData dco_decode_box_autoadd_message_success_action_data(dynamic raw);
 
   @protected
+  PayOnchainAmount dco_decode_box_autoadd_pay_onchain_amount(dynamic raw);
+
+  @protected
   PayOnchainRequest dco_decode_box_autoadd_pay_onchain_request(dynamic raw);
 
   @protected
@@ -376,6 +379,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ListPaymentDetails? dco_decode_opt_box_autoadd_list_payment_details(dynamic raw);
+
+  @protected
+  PayOnchainAmount? dco_decode_opt_box_autoadd_pay_onchain_amount(dynamic raw);
 
   @protected
   Payment? dco_decode_opt_box_autoadd_payment(dynamic raw);
@@ -667,6 +673,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MessageSuccessActionData sse_decode_box_autoadd_message_success_action_data(SseDeserializer deserializer);
 
   @protected
+  PayOnchainAmount sse_decode_box_autoadd_pay_onchain_amount(SseDeserializer deserializer);
+
+  @protected
   PayOnchainRequest sse_decode_box_autoadd_pay_onchain_request(SseDeserializer deserializer);
 
   @protected
@@ -893,6 +902,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ListPaymentDetails? sse_decode_opt_box_autoadd_list_payment_details(SseDeserializer deserializer);
+
+  @protected
+  PayOnchainAmount? sse_decode_opt_box_autoadd_pay_onchain_amount(SseDeserializer deserializer);
 
   @protected
   Payment? sse_decode_opt_box_autoadd_payment(SseDeserializer deserializer);
@@ -1314,6 +1326,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_pay_onchain_amount> cst_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_pay_onchain_amount();
+    cst_api_fill_to_wire_pay_onchain_amount(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_pay_onchain_request> cst_encode_box_autoadd_pay_onchain_request(
       PayOnchainRequest raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1611,6 +1631,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_pay_onchain_amount> cst_encode_opt_box_autoadd_pay_onchain_amount(
+      PayOnchainAmount? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_pay_onchain_amount(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_cst_payment> cst_encode_opt_box_autoadd_payment(Payment? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_box_autoadd_payment(raw);
@@ -1860,6 +1887,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_box_autoadd_message_success_action_data(
       MessageSuccessActionData apiObj, ffi.Pointer<wire_cst_message_success_action_data> wireObj) {
     cst_api_fill_to_wire_message_success_action_data(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_pay_onchain_amount(
+      PayOnchainAmount apiObj, ffi.Pointer<wire_cst_pay_onchain_amount> wireObj) {
+    cst_api_fill_to_wire_pay_onchain_amount(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2738,7 +2771,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_prepare_send_request(
       PrepareSendRequest apiObj, wire_cst_prepare_send_request wireObj) {
     wireObj.destination = cst_encode_String(apiObj.destination);
-    wireObj.amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.amountSat);
+    wireObj.amount = cst_encode_opt_box_autoadd_pay_onchain_amount(apiObj.amount);
   }
 
   @protected
@@ -3167,6 +3200,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       MessageSuccessActionData self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_pay_onchain_request(PayOnchainRequest self, SseSerializer serializer);
 
   @protected
@@ -3398,6 +3434,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_list_payment_details(ListPaymentDetails? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_pay_onchain_amount(PayOnchainAmount? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_payment(Payment? self, SseSerializer serializer);
@@ -4629,6 +4668,16 @@ class RustLibWire implements BaseWire {
       _cst_new_box_autoadd_message_success_action_dataPtr
           .asFunction<ffi.Pointer<wire_cst_message_success_action_data> Function()>();
 
+  ffi.Pointer<wire_cst_pay_onchain_amount> cst_new_box_autoadd_pay_onchain_amount() {
+    return _cst_new_box_autoadd_pay_onchain_amount();
+  }
+
+  late final _cst_new_box_autoadd_pay_onchain_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount');
+  late final _cst_new_box_autoadd_pay_onchain_amount = _cst_new_box_autoadd_pay_onchain_amountPtr
+      .asFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>();
+
   ffi.Pointer<wire_cst_pay_onchain_request> cst_new_box_autoadd_pay_onchain_request() {
     return _cst_new_box_autoadd_pay_onchain_request();
   }
@@ -5388,7 +5437,7 @@ final class wire_cst_prepare_refund_request extends ffi.Struct {
 final class wire_cst_prepare_send_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
-  external ffi.Pointer<ffi.Uint64> amount_sat;
+  external ffi.Pointer<wire_cst_pay_onchain_amount> amount;
 }
 
 final class wire_cst_prepare_receive_response extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -150,7 +150,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MessageSuccessActionData dco_decode_box_autoadd_message_success_action_data(dynamic raw);
 
   @protected
-  PayOnchainAmount dco_decode_box_autoadd_pay_onchain_amount(dynamic raw);
+  PayAmount dco_decode_box_autoadd_pay_amount(dynamic raw);
 
   @protected
   PayOnchainRequest dco_decode_box_autoadd_pay_onchain_request(dynamic raw);
@@ -381,7 +381,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ListPaymentDetails? dco_decode_opt_box_autoadd_list_payment_details(dynamic raw);
 
   @protected
-  PayOnchainAmount? dco_decode_opt_box_autoadd_pay_onchain_amount(dynamic raw);
+  PayAmount? dco_decode_opt_box_autoadd_pay_amount(dynamic raw);
 
   @protected
   Payment? dco_decode_opt_box_autoadd_payment(dynamic raw);
@@ -405,7 +405,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<PaymentType>? dco_decode_opt_list_payment_type(dynamic raw);
 
   @protected
-  PayOnchainAmount dco_decode_pay_onchain_amount(dynamic raw);
+  PayAmount dco_decode_pay_amount(dynamic raw);
 
   @protected
   PayOnchainRequest dco_decode_pay_onchain_request(dynamic raw);
@@ -673,7 +673,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MessageSuccessActionData sse_decode_box_autoadd_message_success_action_data(SseDeserializer deserializer);
 
   @protected
-  PayOnchainAmount sse_decode_box_autoadd_pay_onchain_amount(SseDeserializer deserializer);
+  PayAmount sse_decode_box_autoadd_pay_amount(SseDeserializer deserializer);
 
   @protected
   PayOnchainRequest sse_decode_box_autoadd_pay_onchain_request(SseDeserializer deserializer);
@@ -904,7 +904,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ListPaymentDetails? sse_decode_opt_box_autoadd_list_payment_details(SseDeserializer deserializer);
 
   @protected
-  PayOnchainAmount? sse_decode_opt_box_autoadd_pay_onchain_amount(SseDeserializer deserializer);
+  PayAmount? sse_decode_opt_box_autoadd_pay_amount(SseDeserializer deserializer);
 
   @protected
   Payment? sse_decode_opt_box_autoadd_payment(SseDeserializer deserializer);
@@ -928,7 +928,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<PaymentType>? sse_decode_opt_list_payment_type(SseDeserializer deserializer);
 
   @protected
-  PayOnchainAmount sse_decode_pay_onchain_amount(SseDeserializer deserializer);
+  PayAmount sse_decode_pay_amount(SseDeserializer deserializer);
 
   @protected
   PayOnchainRequest sse_decode_pay_onchain_request(SseDeserializer deserializer);
@@ -1326,10 +1326,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
-  ffi.Pointer<wire_cst_pay_onchain_amount> cst_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount raw) {
+  ffi.Pointer<wire_cst_pay_amount> cst_encode_box_autoadd_pay_amount(PayAmount raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    final ptr = wire.cst_new_box_autoadd_pay_onchain_amount();
-    cst_api_fill_to_wire_pay_onchain_amount(raw, ptr.ref);
+    final ptr = wire.cst_new_box_autoadd_pay_amount();
+    cst_api_fill_to_wire_pay_amount(raw, ptr.ref);
     return ptr;
   }
 
@@ -1631,10 +1631,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
-  ffi.Pointer<wire_cst_pay_onchain_amount> cst_encode_opt_box_autoadd_pay_onchain_amount(
-      PayOnchainAmount? raw) {
+  ffi.Pointer<wire_cst_pay_amount> cst_encode_opt_box_autoadd_pay_amount(PayAmount? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_pay_onchain_amount(raw);
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_pay_amount(raw);
   }
 
   @protected
@@ -1890,9 +1889,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_box_autoadd_pay_onchain_amount(
-      PayOnchainAmount apiObj, ffi.Pointer<wire_cst_pay_onchain_amount> wireObj) {
-    cst_api_fill_to_wire_pay_onchain_amount(apiObj, wireObj.ref);
+  void cst_api_fill_to_wire_box_autoadd_pay_amount(
+      PayAmount apiObj, ffi.Pointer<wire_cst_pay_amount> wireObj) {
+    cst_api_fill_to_wire_pay_amount(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2505,14 +2504,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
-  void cst_api_fill_to_wire_pay_onchain_amount(PayOnchainAmount apiObj, wire_cst_pay_onchain_amount wireObj) {
-    if (apiObj is PayOnchainAmount_Receiver) {
+  void cst_api_fill_to_wire_pay_amount(PayAmount apiObj, wire_cst_pay_amount wireObj) {
+    if (apiObj is PayAmount_Receiver) {
       var pre_amount_sat = cst_encode_u_64(apiObj.amountSat);
       wireObj.tag = 0;
       wireObj.kind.Receiver.amount_sat = pre_amount_sat;
       return;
     }
-    if (apiObj is PayOnchainAmount_Drain) {
+    if (apiObj is PayAmount_Drain) {
       wireObj.tag = 1;
       return;
     }
@@ -2724,7 +2723,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_prepare_pay_onchain_request(
       PreparePayOnchainRequest apiObj, wire_cst_prepare_pay_onchain_request wireObj) {
-    cst_api_fill_to_wire_pay_onchain_amount(apiObj.amount, wireObj.amount);
+    cst_api_fill_to_wire_pay_amount(apiObj.amount, wireObj.amount);
     wireObj.fee_rate_sat_per_vbyte = cst_encode_opt_box_autoadd_u_32(apiObj.feeRateSatPerVbyte);
   }
 
@@ -2771,7 +2770,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_prepare_send_request(
       PrepareSendRequest apiObj, wire_cst_prepare_send_request wireObj) {
     wireObj.destination = cst_encode_String(apiObj.destination);
-    wireObj.amount = cst_encode_opt_box_autoadd_pay_onchain_amount(apiObj.amount);
+    wireObj.amount = cst_encode_opt_box_autoadd_pay_amount(apiObj.amount);
   }
 
   @protected
@@ -3200,7 +3199,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       MessageSuccessActionData self, SseSerializer serializer);
 
   @protected
-  void sse_encode_box_autoadd_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer);
+  void sse_encode_box_autoadd_pay_amount(PayAmount self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_pay_onchain_request(PayOnchainRequest self, SseSerializer serializer);
@@ -3436,7 +3435,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_opt_box_autoadd_list_payment_details(ListPaymentDetails? self, SseSerializer serializer);
 
   @protected
-  void sse_encode_opt_box_autoadd_pay_onchain_amount(PayOnchainAmount? self, SseSerializer serializer);
+  void sse_encode_opt_box_autoadd_pay_amount(PayAmount? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_payment(Payment? self, SseSerializer serializer);
@@ -3461,7 +3460,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_opt_list_payment_type(List<PaymentType>? self, SseSerializer serializer);
 
   @protected
-  void sse_encode_pay_onchain_amount(PayOnchainAmount self, SseSerializer serializer);
+  void sse_encode_pay_amount(PayAmount self, SseSerializer serializer);
 
   @protected
   void sse_encode_pay_onchain_request(PayOnchainRequest self, SseSerializer serializer);
@@ -4668,15 +4667,15 @@ class RustLibWire implements BaseWire {
       _cst_new_box_autoadd_message_success_action_dataPtr
           .asFunction<ffi.Pointer<wire_cst_message_success_action_data> Function()>();
 
-  ffi.Pointer<wire_cst_pay_onchain_amount> cst_new_box_autoadd_pay_onchain_amount() {
-    return _cst_new_box_autoadd_pay_onchain_amount();
+  ffi.Pointer<wire_cst_pay_amount> cst_new_box_autoadd_pay_amount() {
+    return _cst_new_box_autoadd_pay_amount();
   }
 
-  late final _cst_new_box_autoadd_pay_onchain_amountPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>>(
-          'frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount');
-  late final _cst_new_box_autoadd_pay_onchain_amount = _cst_new_box_autoadd_pay_onchain_amountPtr
-      .asFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>();
+  late final _cst_new_box_autoadd_pay_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_pay_amount');
+  late final _cst_new_box_autoadd_pay_amount =
+      _cst_new_box_autoadd_pay_amountPtr.asFunction<ffi.Pointer<wire_cst_pay_amount> Function()>();
 
   ffi.Pointer<wire_cst_pay_onchain_request> cst_new_box_autoadd_pay_onchain_request() {
     return _cst_new_box_autoadd_pay_onchain_request();
@@ -5396,24 +5395,24 @@ final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
   external ffi.Pointer<ffi.Bool> validate_success_action_url;
 }
 
-final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
+final class wire_cst_PayAmount_Receiver extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 }
 
-final class PayOnchainAmountKind extends ffi.Union {
-  external wire_cst_PayOnchainAmount_Receiver Receiver;
+final class PayAmountKind extends ffi.Union {
+  external wire_cst_PayAmount_Receiver Receiver;
 }
 
-final class wire_cst_pay_onchain_amount extends ffi.Struct {
+final class wire_cst_pay_amount extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external PayOnchainAmountKind kind;
+  external PayAmountKind kind;
 }
 
 final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
-  external wire_cst_pay_onchain_amount amount;
+  external wire_cst_pay_amount amount;
 
   external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
 }
@@ -5437,7 +5436,7 @@ final class wire_cst_prepare_refund_request extends ffi.Struct {
 final class wire_cst_prepare_send_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
-  external ffi.Pointer<wire_cst_pay_onchain_amount> amount;
+  external ffi.Pointer<wire_cst_pay_amount> amount;
 }
 
 final class wire_cst_prepare_receive_response extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1006,15 +1006,15 @@ class PrepareSendRequest {
 
   /// Should only be set when paying directly onchain or to a BIP21 URI
   /// where no amount is specified
-  final BigInt? amountSat;
+  final PayOnchainAmount? amount;
 
   const PrepareSendRequest({
     required this.destination,
-    this.amountSat,
+    this.amount,
   });
 
   @override
-  int get hashCode => destination.hashCode ^ amountSat.hashCode;
+  int get hashCode => destination.hashCode ^ amount.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1022,7 +1022,7 @@ class PrepareSendRequest {
       other is PrepareSendRequest &&
           runtimeType == other.runtimeType &&
           destination == other.destination &&
-          amountSat == other.amountSat;
+          amount == other.amount;
 }
 
 /// Returned when calling [crate::sdk::LiquidSdk::prepare_send_payment].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -476,16 +476,16 @@ class OnchainPaymentLimitsResponse {
 }
 
 @freezed
-sealed class PayOnchainAmount with _$PayOnchainAmount {
-  const PayOnchainAmount._();
+sealed class PayAmount with _$PayAmount {
+  const PayAmount._();
 
   /// The amount in satoshi that will be received
-  const factory PayOnchainAmount.receiver({
+  const factory PayAmount.receiver({
     required BigInt amountSat,
-  }) = PayOnchainAmount_Receiver;
+  }) = PayAmount_Receiver;
 
   /// Indicates that all available funds should be sent
-  const factory PayOnchainAmount.drain() = PayOnchainAmount_Drain;
+  const factory PayAmount.drain() = PayAmount_Drain;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::pay_onchain].
@@ -849,7 +849,7 @@ class PrepareLnUrlPayResponse {
 
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_pay_onchain].
 class PreparePayOnchainRequest {
-  final PayOnchainAmount amount;
+  final PayAmount amount;
 
   /// The optional fee rate of the Bitcoin claim transaction in sat/vB. Defaults to the swapper estimated claim fee.
   final int? feeRateSatPerVbyte;
@@ -1006,7 +1006,7 @@ class PrepareSendRequest {
 
   /// Should only be set when paying directly onchain or to a BIP21 URI
   /// where no amount is specified, or when the caller wishes to drain
-  final PayOnchainAmount? amount;
+  final PayAmount? amount;
 
   const PrepareSendRequest({
     required this.destination,

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1005,7 +1005,7 @@ class PrepareSendRequest {
   final String destination;
 
   /// Should only be set when paying directly onchain or to a BIP21 URI
-  /// where no amount is specified
+  /// where no amount is specified, or when the caller wishes to drain
   final PayOnchainAmount? amount;
 
   const PrepareSendRequest({

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -594,53 +594,52 @@ abstract class LnUrlPayResult_PayError extends LnUrlPayResult {
 }
 
 /// @nodoc
-mixin _$PayOnchainAmount {}
+mixin _$PayAmount {}
 
 /// @nodoc
-abstract class $PayOnchainAmountCopyWith<$Res> {
-  factory $PayOnchainAmountCopyWith(PayOnchainAmount value, $Res Function(PayOnchainAmount) then) =
-      _$PayOnchainAmountCopyWithImpl<$Res, PayOnchainAmount>;
+abstract class $PayAmountCopyWith<$Res> {
+  factory $PayAmountCopyWith(PayAmount value, $Res Function(PayAmount) then) =
+      _$PayAmountCopyWithImpl<$Res, PayAmount>;
 }
 
 /// @nodoc
-class _$PayOnchainAmountCopyWithImpl<$Res, $Val extends PayOnchainAmount>
-    implements $PayOnchainAmountCopyWith<$Res> {
-  _$PayOnchainAmountCopyWithImpl(this._value, this._then);
+class _$PayAmountCopyWithImpl<$Res, $Val extends PayAmount> implements $PayAmountCopyWith<$Res> {
+  _$PayAmountCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PayOnchainAmount
+  /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
-abstract class _$$PayOnchainAmount_ReceiverImplCopyWith<$Res> {
-  factory _$$PayOnchainAmount_ReceiverImplCopyWith(
-          _$PayOnchainAmount_ReceiverImpl value, $Res Function(_$PayOnchainAmount_ReceiverImpl) then) =
-      __$$PayOnchainAmount_ReceiverImplCopyWithImpl<$Res>;
+abstract class _$$PayAmount_ReceiverImplCopyWith<$Res> {
+  factory _$$PayAmount_ReceiverImplCopyWith(
+          _$PayAmount_ReceiverImpl value, $Res Function(_$PayAmount_ReceiverImpl) then) =
+      __$$PayAmount_ReceiverImplCopyWithImpl<$Res>;
   @useResult
   $Res call({BigInt amountSat});
 }
 
 /// @nodoc
-class __$$PayOnchainAmount_ReceiverImplCopyWithImpl<$Res>
-    extends _$PayOnchainAmountCopyWithImpl<$Res, _$PayOnchainAmount_ReceiverImpl>
-    implements _$$PayOnchainAmount_ReceiverImplCopyWith<$Res> {
-  __$$PayOnchainAmount_ReceiverImplCopyWithImpl(
-      _$PayOnchainAmount_ReceiverImpl _value, $Res Function(_$PayOnchainAmount_ReceiverImpl) _then)
+class __$$PayAmount_ReceiverImplCopyWithImpl<$Res>
+    extends _$PayAmountCopyWithImpl<$Res, _$PayAmount_ReceiverImpl>
+    implements _$$PayAmount_ReceiverImplCopyWith<$Res> {
+  __$$PayAmount_ReceiverImplCopyWithImpl(
+      _$PayAmount_ReceiverImpl _value, $Res Function(_$PayAmount_ReceiverImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PayOnchainAmount
+  /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? amountSat = null,
   }) {
-    return _then(_$PayOnchainAmount_ReceiverImpl(
+    return _then(_$PayAmount_ReceiverImpl(
       amountSat: null == amountSat
           ? _value.amountSat
           : amountSat // ignore: cast_nullable_to_non_nullable
@@ -651,93 +650,90 @@ class __$$PayOnchainAmount_ReceiverImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PayOnchainAmount_ReceiverImpl extends PayOnchainAmount_Receiver {
-  const _$PayOnchainAmount_ReceiverImpl({required this.amountSat}) : super._();
+class _$PayAmount_ReceiverImpl extends PayAmount_Receiver {
+  const _$PayAmount_ReceiverImpl({required this.amountSat}) : super._();
 
   @override
   final BigInt amountSat;
 
   @override
   String toString() {
-    return 'PayOnchainAmount.receiver(amountSat: $amountSat)';
+    return 'PayAmount.receiver(amountSat: $amountSat)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PayOnchainAmount_ReceiverImpl &&
+            other is _$PayAmount_ReceiverImpl &&
             (identical(other.amountSat, amountSat) || other.amountSat == amountSat));
   }
 
   @override
   int get hashCode => Object.hash(runtimeType, amountSat);
 
-  /// Create a copy of PayOnchainAmount
+  /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$PayOnchainAmount_ReceiverImplCopyWith<_$PayOnchainAmount_ReceiverImpl> get copyWith =>
-      __$$PayOnchainAmount_ReceiverImplCopyWithImpl<_$PayOnchainAmount_ReceiverImpl>(this, _$identity);
+  _$$PayAmount_ReceiverImplCopyWith<_$PayAmount_ReceiverImpl> get copyWith =>
+      __$$PayAmount_ReceiverImplCopyWithImpl<_$PayAmount_ReceiverImpl>(this, _$identity);
 }
 
-abstract class PayOnchainAmount_Receiver extends PayOnchainAmount {
-  const factory PayOnchainAmount_Receiver({required final BigInt amountSat}) =
-      _$PayOnchainAmount_ReceiverImpl;
-  const PayOnchainAmount_Receiver._() : super._();
+abstract class PayAmount_Receiver extends PayAmount {
+  const factory PayAmount_Receiver({required final BigInt amountSat}) = _$PayAmount_ReceiverImpl;
+  const PayAmount_Receiver._() : super._();
 
   BigInt get amountSat;
 
-  /// Create a copy of PayOnchainAmount
+  /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PayOnchainAmount_ReceiverImplCopyWith<_$PayOnchainAmount_ReceiverImpl> get copyWith =>
+  _$$PayAmount_ReceiverImplCopyWith<_$PayAmount_ReceiverImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PayOnchainAmount_DrainImplCopyWith<$Res> {
-  factory _$$PayOnchainAmount_DrainImplCopyWith(
-          _$PayOnchainAmount_DrainImpl value, $Res Function(_$PayOnchainAmount_DrainImpl) then) =
-      __$$PayOnchainAmount_DrainImplCopyWithImpl<$Res>;
+abstract class _$$PayAmount_DrainImplCopyWith<$Res> {
+  factory _$$PayAmount_DrainImplCopyWith(
+          _$PayAmount_DrainImpl value, $Res Function(_$PayAmount_DrainImpl) then) =
+      __$$PayAmount_DrainImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$PayOnchainAmount_DrainImplCopyWithImpl<$Res>
-    extends _$PayOnchainAmountCopyWithImpl<$Res, _$PayOnchainAmount_DrainImpl>
-    implements _$$PayOnchainAmount_DrainImplCopyWith<$Res> {
-  __$$PayOnchainAmount_DrainImplCopyWithImpl(
-      _$PayOnchainAmount_DrainImpl _value, $Res Function(_$PayOnchainAmount_DrainImpl) _then)
+class __$$PayAmount_DrainImplCopyWithImpl<$Res> extends _$PayAmountCopyWithImpl<$Res, _$PayAmount_DrainImpl>
+    implements _$$PayAmount_DrainImplCopyWith<$Res> {
+  __$$PayAmount_DrainImplCopyWithImpl(
+      _$PayAmount_DrainImpl _value, $Res Function(_$PayAmount_DrainImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PayOnchainAmount
+  /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
 
-class _$PayOnchainAmount_DrainImpl extends PayOnchainAmount_Drain {
-  const _$PayOnchainAmount_DrainImpl() : super._();
+class _$PayAmount_DrainImpl extends PayAmount_Drain {
+  const _$PayAmount_DrainImpl() : super._();
 
   @override
   String toString() {
-    return 'PayOnchainAmount.drain()';
+    return 'PayAmount.drain()';
   }
 
   @override
   bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$PayOnchainAmount_DrainImpl);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$PayAmount_DrainImpl);
   }
 
   @override
   int get hashCode => runtimeType.hashCode;
 }
 
-abstract class PayOnchainAmount_Drain extends PayOnchainAmount {
-  const factory PayOnchainAmount_Drain() = _$PayOnchainAmount_DrainImpl;
-  const PayOnchainAmount_Drain._() : super._();
+abstract class PayAmount_Drain extends PayAmount {
+  const factory PayAmount_Drain() = _$PayAmount_DrainImpl;
+  const PayAmount_Drain._() : super._();
 }
 
 /// @nodoc

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1116,6 +1116,17 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_dataPtr
           .asFunction<ffi.Pointer<wire_cst_message_success_action_data> Function()>();
 
+  ffi.Pointer<wire_cst_pay_onchain_amount> frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount =
+      _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amountPtr
+          .asFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>();
+
   ffi.Pointer<wire_cst_pay_onchain_request> frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request();
   }
@@ -4184,7 +4195,7 @@ final class wire_cst_prepare_refund_request extends ffi.Struct {
 final class wire_cst_prepare_send_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
-  external ffi.Pointer<ffi.Uint64> amount_sat;
+  external ffi.Pointer<wire_cst_pay_onchain_amount> amount;
 }
 
 final class wire_cst_prepare_receive_response extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1116,16 +1116,16 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_message_success_action_dataPtr
           .asFunction<ffi.Pointer<wire_cst_message_success_action_data> Function()>();
 
-  ffi.Pointer<wire_cst_pay_onchain_amount> frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount() {
-    return _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount();
+  ffi.Pointer<wire_cst_pay_amount> frbgen_breez_liquid_cst_new_box_autoadd_pay_amount() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_pay_amount();
   }
 
-  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amountPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>>(
-          'frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount');
-  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amount =
-      _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_amountPtr
-          .asFunction<ffi.Pointer<wire_cst_pay_onchain_amount> Function()>();
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_pay_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_pay_amount');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_pay_amount =
+      _frbgen_breez_liquid_cst_new_box_autoadd_pay_amountPtr
+          .asFunction<ffi.Pointer<wire_cst_pay_amount> Function()>();
 
   ffi.Pointer<wire_cst_pay_onchain_request> frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_pay_onchain_request();
@@ -4154,24 +4154,24 @@ final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
   external ffi.Pointer<ffi.Bool> validate_success_action_url;
 }
 
-final class wire_cst_PayOnchainAmount_Receiver extends ffi.Struct {
+final class wire_cst_PayAmount_Receiver extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 }
 
-final class PayOnchainAmountKind extends ffi.Union {
-  external wire_cst_PayOnchainAmount_Receiver Receiver;
+final class PayAmountKind extends ffi.Union {
+  external wire_cst_PayAmount_Receiver Receiver;
 }
 
-final class wire_cst_pay_onchain_amount extends ffi.Struct {
+final class wire_cst_pay_amount extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external PayOnchainAmountKind kind;
+  external PayAmountKind kind;
 }
 
 final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
-  external wire_cst_pay_onchain_amount amount;
+  external wire_cst_pay_amount amount;
 
   external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
 }
@@ -4195,7 +4195,7 @@ final class wire_cst_prepare_refund_request extends ffi.Struct {
 final class wire_cst_prepare_send_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
-  external ffi.Pointer<wire_cst_pay_onchain_amount> amount;
+  external ffi.Pointer<wire_cst_pay_amount> amount;
 }
 
 final class wire_cst_prepare_receive_response extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1721,14 +1721,23 @@ fun asPrepareSendRequest(prepareSendRequest: ReadableMap): PrepareSendRequest? {
         return null
     }
     val destination = prepareSendRequest.getString("destination")!!
-    val amountSat = if (hasNonNullKey(prepareSendRequest, "amountSat")) prepareSendRequest.getDouble("amountSat").toULong() else null
-    return PrepareSendRequest(destination, amountSat)
+    val amount =
+        if (hasNonNullKey(
+                prepareSendRequest,
+                "amount",
+            )
+        ) {
+            prepareSendRequest.getMap("amount")?.let { asPayOnchainAmount(it) }
+        } else {
+            null
+        }
+    return PrepareSendRequest(destination, amount)
 }
 
 fun readableMapOf(prepareSendRequest: PrepareSendRequest): ReadableMap =
     readableMapOf(
         "destination" to prepareSendRequest.destination,
-        "amountSat" to prepareSendRequest.amountSat,
+        "amount" to prepareSendRequest.amount?.let { readableMapOf(it) },
     )
 
 fun asPrepareSendRequestList(arr: ReadableArray): List<PrepareSendRequest> {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1487,7 +1487,7 @@ fun asPreparePayOnchainRequest(preparePayOnchainRequest: ReadableMap): PreparePa
     ) {
         return null
     }
-    val amount = preparePayOnchainRequest.getMap("amount")?.let { asPayOnchainAmount(it) }!!
+    val amount = preparePayOnchainRequest.getMap("amount")?.let { asPayAmount(it) }!!
     val feeRateSatPerVbyte =
         if (hasNonNullKey(
                 preparePayOnchainRequest,
@@ -1721,16 +1721,7 @@ fun asPrepareSendRequest(prepareSendRequest: ReadableMap): PrepareSendRequest? {
         return null
     }
     val destination = prepareSendRequest.getString("destination")!!
-    val amount =
-        if (hasNonNullKey(
-                prepareSendRequest,
-                "amount",
-            )
-        ) {
-            prepareSendRequest.getMap("amount")?.let { asPayOnchainAmount(it) }
-        } else {
-            null
-        }
+    val amount = if (hasNonNullKey(prepareSendRequest, "amount")) prepareSendRequest.getMap("amount")?.let { asPayAmount(it) } else null
     return PrepareSendRequest(destination, amount)
 }
 
@@ -2717,38 +2708,38 @@ fun asNetworkList(arr: ReadableArray): List<Network> {
     return list
 }
 
-fun asPayOnchainAmount(payOnchainAmount: ReadableMap): PayOnchainAmount? {
-    val type = payOnchainAmount.getString("type")
+fun asPayAmount(payAmount: ReadableMap): PayAmount? {
+    val type = payAmount.getString("type")
 
     if (type == "receiver") {
-        val amountSat = payOnchainAmount.getDouble("amountSat").toULong()
-        return PayOnchainAmount.Receiver(amountSat)
+        val amountSat = payAmount.getDouble("amountSat").toULong()
+        return PayAmount.Receiver(amountSat)
     }
     if (type == "drain") {
-        return PayOnchainAmount.Drain
+        return PayAmount.Drain
     }
     return null
 }
 
-fun readableMapOf(payOnchainAmount: PayOnchainAmount): ReadableMap? {
+fun readableMapOf(payAmount: PayAmount): ReadableMap? {
     val map = Arguments.createMap()
-    when (payOnchainAmount) {
-        is PayOnchainAmount.Receiver -> {
+    when (payAmount) {
+        is PayAmount.Receiver -> {
             pushToMap(map, "type", "receiver")
-            pushToMap(map, "amountSat", payOnchainAmount.amountSat)
+            pushToMap(map, "amountSat", payAmount.amountSat)
         }
-        is PayOnchainAmount.Drain -> {
+        is PayAmount.Drain -> {
             pushToMap(map, "type", "drain")
         }
     }
     return map
 }
 
-fun asPayOnchainAmountList(arr: ReadableArray): List<PayOnchainAmount> {
-    val list = ArrayList<PayOnchainAmount>()
+fun asPayAmountList(arr: ReadableArray): List<PayAmount> {
+    val list = ArrayList<PayAmount>()
     for (value in arr.toList()) {
         when (value) {
-            is ReadableMap -> list.add(asPayOnchainAmount(value)!!)
+            is ReadableMap -> list.add(asPayAmount(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType(value))
         }
     }

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1976,21 +1976,18 @@ enum BreezSDKLiquidMapper {
         guard let destination = prepareSendRequest["destination"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendRequest"))
         }
-        var amountSat: UInt64?
-        if hasNonNilKey(data: prepareSendRequest, key: "amountSat") {
-            guard let amountSatTmp = prepareSendRequest["amountSat"] as? UInt64 else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "amountSat"))
-            }
-            amountSat = amountSatTmp
+        var amount: PayOnchainAmount?
+        if let amountTmp = prepareSendRequest["amount"] as? [String: Any?] {
+            amount = try asPayOnchainAmount(payOnchainAmount: amountTmp)
         }
 
-        return PrepareSendRequest(destination: destination, amountSat: amountSat)
+        return PrepareSendRequest(destination: destination, amount: amount)
     }
 
     static func dictionaryOf(prepareSendRequest: PrepareSendRequest) -> [String: Any?] {
         return [
             "destination": prepareSendRequest.destination,
-            "amountSat": prepareSendRequest.amountSat == nil ? nil : prepareSendRequest.amountSat,
+            "amount": prepareSendRequest.amount == nil ? nil : dictionaryOf(payOnchainAmount: prepareSendRequest.amount!),
         ]
     }
 

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1728,7 +1728,7 @@ enum BreezSDKLiquidMapper {
         guard let amountTmp = preparePayOnchainRequest["amount"] as? [String: Any?] else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PreparePayOnchainRequest"))
         }
-        let amount = try asPayOnchainAmount(payOnchainAmount: amountTmp)
+        let amount = try asPayAmount(payAmount: amountTmp)
 
         var feeRateSatPerVbyte: UInt32?
         if hasNonNilKey(data: preparePayOnchainRequest, key: "feeRateSatPerVbyte") {
@@ -1743,7 +1743,7 @@ enum BreezSDKLiquidMapper {
 
     static func dictionaryOf(preparePayOnchainRequest: PreparePayOnchainRequest) -> [String: Any?] {
         return [
-            "amount": dictionaryOf(payOnchainAmount: preparePayOnchainRequest.amount),
+            "amount": dictionaryOf(payAmount: preparePayOnchainRequest.amount),
             "feeRateSatPerVbyte": preparePayOnchainRequest.feeRateSatPerVbyte == nil ? nil : preparePayOnchainRequest.feeRateSatPerVbyte,
         ]
     }
@@ -1976,9 +1976,9 @@ enum BreezSDKLiquidMapper {
         guard let destination = prepareSendRequest["destination"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendRequest"))
         }
-        var amount: PayOnchainAmount?
+        var amount: PayAmount?
         if let amountTmp = prepareSendRequest["amount"] as? [String: Any?] {
-            amount = try asPayOnchainAmount(payOnchainAmount: amountTmp)
+            amount = try asPayAmount(payAmount: amountTmp)
         }
 
         return PrepareSendRequest(destination: destination, amount: amount)
@@ -1987,7 +1987,7 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(prepareSendRequest: PrepareSendRequest) -> [String: Any?] {
         return [
             "destination": prepareSendRequest.destination,
-            "amount": prepareSendRequest.amount == nil ? nil : dictionaryOf(payOnchainAmount: prepareSendRequest.amount!),
+            "amount": prepareSendRequest.amount == nil ? nil : dictionaryOf(payAmount: prepareSendRequest.amount!),
         ]
     }
 
@@ -3314,23 +3314,23 @@ enum BreezSDKLiquidMapper {
         return list
     }
 
-    static func asPayOnchainAmount(payOnchainAmount: [String: Any?]) throws -> PayOnchainAmount {
-        let type = payOnchainAmount["type"] as! String
+    static func asPayAmount(payAmount: [String: Any?]) throws -> PayAmount {
+        let type = payAmount["type"] as! String
         if type == "receiver" {
-            guard let _amountSat = payOnchainAmount["amountSat"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PayOnchainAmount"))
+            guard let _amountSat = payAmount["amountSat"] as? UInt64 else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PayAmount"))
             }
-            return PayOnchainAmount.receiver(amountSat: _amountSat)
+            return PayAmount.receiver(amountSat: _amountSat)
         }
         if type == "drain" {
-            return PayOnchainAmount.drain
+            return PayAmount.drain
         }
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum PayOnchainAmount")
+        throw SdkError.Generic(message: "Unexpected type \(type) for enum PayAmount")
     }
 
-    static func dictionaryOf(payOnchainAmount: PayOnchainAmount) -> [String: Any?] {
-        switch payOnchainAmount {
+    static func dictionaryOf(payAmount: PayAmount) -> [String: Any?] {
+        switch payAmount {
         case let .receiver(
             amountSat
         ):
@@ -3346,18 +3346,18 @@ enum BreezSDKLiquidMapper {
         }
     }
 
-    static func arrayOf(payOnchainAmountList: [PayOnchainAmount]) -> [Any] {
-        return payOnchainAmountList.map { v -> [String: Any?] in return dictionaryOf(payOnchainAmount: v) }
+    static func arrayOf(payAmountList: [PayAmount]) -> [Any] {
+        return payAmountList.map { v -> [String: Any?] in return dictionaryOf(payAmount: v) }
     }
 
-    static func asPayOnchainAmountList(arr: [Any]) throws -> [PayOnchainAmount] {
-        var list = [PayOnchainAmount]()
+    static func asPayAmountList(arr: [Any]) throws -> [PayAmount] {
+        var list = [PayAmount]()
         for value in arr {
             if let val = value as? [String: Any?] {
-                var payOnchainAmount = try asPayOnchainAmount(payOnchainAmount: val)
-                list.append(payOnchainAmount)
+                var payAmount = try asPayAmount(payAmount: val)
+                list.append(payAmount)
             } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PayOnchainAmount"))
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "PayAmount"))
             }
         }
         return list

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -266,7 +266,7 @@ export interface PrepareLnUrlPayResponse {
 }
 
 export interface PreparePayOnchainRequest {
-    amount: PayOnchainAmount
+    amount: PayAmount
     feeRateSatPerVbyte?: number
 }
 
@@ -301,7 +301,7 @@ export interface PrepareRefundResponse {
 
 export interface PrepareSendRequest {
     destination: string
-    amount?: PayOnchainAmount
+    amount?: PayAmount
 }
 
 export interface PrepareSendResponse {
@@ -533,16 +533,16 @@ export enum Network {
     REGTEST = "regtest"
 }
 
-export enum PayOnchainAmountVariant {
+export enum PayAmountVariant {
     RECEIVER = "receiver",
     DRAIN = "drain"
 }
 
-export type PayOnchainAmount = {
-    type: PayOnchainAmountVariant.RECEIVER,
+export type PayAmount = {
+    type: PayAmountVariant.RECEIVER,
     amountSat: number
 } | {
-    type: PayOnchainAmountVariant.DRAIN
+    type: PayAmountVariant.DRAIN
 }
 
 export enum PaymentDetailsVariant {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -301,7 +301,7 @@ export interface PrepareRefundResponse {
 
 export interface PrepareSendRequest {
     destination: string
-    amountSat?: number
+    amount?: PayOnchainAmount
 }
 
 export interface PrepareSendResponse {


### PR DESCRIPTION
This PR:
- fixes drain tx (drain tx fee estimate) to use the lowball fee
- estimate fees for liquid/mrh/lightning with fallback to drain fees
- attempt to fallback to drain txs for paying to liquid or send swap lockup
- blocks draining while there are pending payments

It's difficult to add a drain option to the PrepareLnUrlPayRequest because at the point when preparing we don't know if the LNURL invoice response will contain an MRH or not for a direct Liquid tx. Because of this we can't calculate an invoice amount to drain for both options. See #559

TODO
- [x] Add drain option to to prepare_send_payment [80830de](https://github.com/breez/breez-sdk-liquid/pull/553/commits/80830dea80bcac0b1521e66c2bf303e728631ad5)

Fixes #543 
Fixes #550 