### PR TITLE
Fix Swift URL init compatibility

### DIFF
--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/SDKNotificationService.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/SDKNotificationService.swift
@@ -28,7 +28,13 @@ open class SDKNotificationService: UNNotificationServiceExtension {
         }
 
         if connectRequest.config.cacheDir == nil {
-            connectRequest.config.cacheDir = URL(filePath: connectRequest.config.workingDir).appendingPathComponent("pluginCache").path
+            var workingDir: URL
+            if #available(iOS 16, *) {
+                workingDir = URL(filePath: connectRequest.config.workingDir)
+            } else {
+                workingDir = URL(fileURLWithPath: connectRequest.config.workingDir)
+            }
+            connectRequest.config.cacheDir = workingDir.appendingPathComponent("pluginCache").path
         }
         
         if let currentTask = self.getTaskFromNotification() {


### PR DESCRIPTION
Fixes an issue from PR #567 where there is a compatibility issue initialising the workingDir URL in the Swift Notification Plugin.