### PR TITLE
Add preimage to receive payment

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -174,6 +174,7 @@ impl Persister {
                 rs.invoice,
                 rs.payment_hash,
                 rs.description,
+                rs.preimage,
                 rs.payer_amount_sat,
                 rs.receiver_amount_sat,
                 rs.state,
@@ -250,37 +251,38 @@ impl Persister {
         let maybe_receive_swap_invoice: Option<String> = row.get(8)?;
         let maybe_receive_swap_payment_hash: Option<String> = row.get(9)?;
         let maybe_receive_swap_description: Option<String> = row.get(10)?;
-        let maybe_receive_swap_payer_amount_sat: Option<u64> = row.get(11)?;
-        let maybe_receive_swap_receiver_amount_sat: Option<u64> = row.get(12)?;
-        let maybe_receive_swap_receiver_state: Option<PaymentState> = row.get(13)?;
+        let maybe_receive_swap_preimage: Option<String> = row.get(11)?;
+        let maybe_receive_swap_payer_amount_sat: Option<u64> = row.get(12)?;
+        let maybe_receive_swap_receiver_amount_sat: Option<u64> = row.get(13)?;
+        let maybe_receive_swap_receiver_state: Option<PaymentState> = row.get(14)?;
 
-        let maybe_send_swap_id: Option<String> = row.get(14)?;
-        let maybe_send_swap_created_at: Option<u32> = row.get(15)?;
-        let maybe_send_swap_invoice: Option<String> = row.get(16)?;
-        let maybe_send_swap_bolt12_offer: Option<String> = row.get(17)?;
-        let maybe_send_swap_payment_hash: Option<String> = row.get(18)?;
-        let maybe_send_swap_description: Option<String> = row.get(19)?;
-        let maybe_send_swap_preimage: Option<String> = row.get(20)?;
-        let maybe_send_swap_refund_tx_id: Option<String> = row.get(21)?;
-        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(22)?;
-        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(23)?;
-        let maybe_send_swap_state: Option<PaymentState> = row.get(24)?;
+        let maybe_send_swap_id: Option<String> = row.get(15)?;
+        let maybe_send_swap_created_at: Option<u32> = row.get(16)?;
+        let maybe_send_swap_invoice: Option<String> = row.get(17)?;
+        let maybe_send_swap_bolt12_offer: Option<String> = row.get(18)?;
+        let maybe_send_swap_payment_hash: Option<String> = row.get(19)?;
+        let maybe_send_swap_description: Option<String> = row.get(20)?;
+        let maybe_send_swap_preimage: Option<String> = row.get(21)?;
+        let maybe_send_swap_refund_tx_id: Option<String> = row.get(22)?;
+        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(23)?;
+        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(24)?;
+        let maybe_send_swap_state: Option<PaymentState> = row.get(25)?;
 
-        let maybe_chain_swap_id: Option<String> = row.get(25)?;
-        let maybe_chain_swap_created_at: Option<u32> = row.get(26)?;
-        let maybe_chain_swap_direction: Option<Direction> = row.get(27)?;
-        let maybe_chain_swap_preimage: Option<String> = row.get(28)?;
-        let maybe_chain_swap_description: Option<String> = row.get(29)?;
-        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(30)?;
-        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(31)?;
-        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(32)?;
-        let maybe_chain_swap_claim_address: Option<String> = row.get(33)?;
-        let maybe_chain_swap_state: Option<PaymentState> = row.get(34)?;
+        let maybe_chain_swap_id: Option<String> = row.get(26)?;
+        let maybe_chain_swap_created_at: Option<u32> = row.get(27)?;
+        let maybe_chain_swap_direction: Option<Direction> = row.get(28)?;
+        let maybe_chain_swap_preimage: Option<String> = row.get(29)?;
+        let maybe_chain_swap_description: Option<String> = row.get(30)?;
+        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(31)?;
+        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(32)?;
+        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(33)?;
+        let maybe_chain_swap_claim_address: Option<String> = row.get(34)?;
+        let maybe_chain_swap_state: Option<PaymentState> = row.get(35)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(35)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(36)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(36)?;
-        let maybe_payment_details_description: Option<String> = row.get(37)?;
+        let maybe_payment_details_destination: Option<String> = row.get(37)?;
+        let maybe_payment_details_description: Option<String> = row.get(38)?;
 
         let (swap, payment_type) = match maybe_receive_swap_id {
             Some(receive_swap_id) => (
@@ -288,7 +290,7 @@ impl Persister {
                     swap_id: receive_swap_id,
                     swap_type: PaymentSwapType::Receive,
                     created_at: maybe_receive_swap_created_at.unwrap_or(utils::now()),
-                    preimage: None,
+                    preimage: maybe_receive_swap_preimage,
                     bolt11: maybe_receive_swap_invoice.clone(),
                     bolt12_offer: None, // Bolt12 not supported for Receive Swaps
                     payment_hash: maybe_receive_swap_payment_hash,


### PR DESCRIPTION
This PR fixes the receive payment Lightning details to include the preimage.

Fixes #570