### PR TITLE
Add precision validation for Moonpay call

### DIFF
--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -137,6 +137,12 @@ impl PaymentError {
         }
     }
 
+    pub(crate) fn invalid_network(err: &str) -> Self {
+        Self::InvalidNetwork {
+            err: err.to_string(),
+        }
+    }
+
     pub(crate) fn receive_error(err: &str) -> Self {
         Self::ReceiveError {
             err: err.to_string(),


### PR DESCRIPTION
The Moonpay API defines BTC amounts as having `precision = 5`, so only 5 decimals are considered. This means sat amounts must be mutiples of `1_000`.

When this is not the case, the Moonpay URL shows an ambiguous error:
> "Invalid queries, check 'errors' property for more info."

which, when checked, shows another ambiguous

> quoteCurrencyAmount must be a decimal number

thrown by the [getbuyquote](https://dev.moonpay.com/reference/getbuyquote) endpoint. Here, `quoteCurrencyAmount` is the sat amount expressed as BTC (e.g. `0.0005`).