### PR TITLE
Use lockup or claim address for Bitcoin address query

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -507,7 +507,12 @@ fn filter_to_where_clause(req: &ListPaymentsRequest) -> (String, Vec<Box<dyn ToS
     if let Some(details) = &req.details {
         match details {
             ListPaymentDetails::Bitcoin { address } => {
-                where_clause.push("cs.claim_address = ?".to_string());
+                // Use the lockup address if it's incoming, else use the claim address
+                where_clause.push(
+                    "(cs.direction = 0 AND cs.lockup_address = ? OR cs.direction = 1 AND cs.claim_address = ?)"
+                        .to_string(),
+                );
+                where_params.push(Box::new(address));
                 where_params.push(Box::new(address));
             }
             ListPaymentDetails::Liquid { destination } => {


### PR DESCRIPTION
This PR updates the list payments details query by Bitcoin address to check the lockup address for incoming and claim address for outgoing chain swaps.