### PR TITLE
Store unblinding data for the tx

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -507,6 +507,7 @@ typedef struct wire_cst_payment_details {
 typedef struct wire_cst_payment {
   struct wire_cst_list_prim_u_8_strict *destination;
   struct wire_cst_list_prim_u_8_strict *tx_id;
+  struct wire_cst_list_prim_u_8_strict *unblinding_data;
   uint32_t timestamp;
   uint64_t amount_sat;
   uint64_t fees_sat;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -568,6 +568,7 @@ dictionary Payment {
     u64? swapper_fees_sat = null;
     string? destination = null;
     string? tx_id = null;
+    string? unblinding_data = null;
 };
 
 enum PaymentType {

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -485,6 +485,7 @@ impl ChainSwapHandler {
                             fees_sat: lockup_tx_fees_sat + swap.claim_fees_sat,
                             payment_type: PaymentType::Send,
                             is_confirmed: false,
+                            unblinding_data: None,
                         }, None, false)?;
 
                         self.update_swap_info(&ChainSwapUpdate {
@@ -817,6 +818,7 @@ impl ChainSwapHandler {
                                         fees_sat: 0,
                                         payment_type: PaymentType::Receive,
                                         is_confirmed: false,
+                                        unblinding_data: None,
                                     },
                                     None,
                                     false,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3590,6 +3590,7 @@ impl SseDecode for crate::model::Payment {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_destination = <Option<String>>::sse_decode(deserializer);
         let mut var_txId = <Option<String>>::sse_decode(deserializer);
+        let mut var_unblindingData = <Option<String>>::sse_decode(deserializer);
         let mut var_timestamp = <u32>::sse_decode(deserializer);
         let mut var_amountSat = <u64>::sse_decode(deserializer);
         let mut var_feesSat = <u64>::sse_decode(deserializer);
@@ -3600,6 +3601,7 @@ impl SseDecode for crate::model::Payment {
         return crate::model::Payment {
             destination: var_destination,
             tx_id: var_txId,
+            unblinding_data: var_unblindingData,
             timestamp: var_timestamp,
             amount_sat: var_amountSat,
             fees_sat: var_feesSat,
@@ -5663,6 +5665,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::Payment {
         [
             self.destination.into_into_dart().into_dart(),
             self.tx_id.into_into_dart().into_dart(),
+            self.unblinding_data.into_into_dart().into_dart(),
             self.timestamp.into_into_dart().into_dart(),
             self.amount_sat.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
@@ -7726,6 +7729,7 @@ impl SseEncode for crate::model::Payment {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Option<String>>::sse_encode(self.destination, serializer);
         <Option<String>>::sse_encode(self.tx_id, serializer);
+        <Option<String>>::sse_encode(self.unblinding_data, serializer);
         <u32>::sse_encode(self.timestamp, serializer);
         <u64>::sse_encode(self.amount_sat, serializer);
         <u64>::sse_encode(self.fees_sat, serializer);
@@ -9739,6 +9743,7 @@ mod io {
             crate::model::Payment {
                 destination: self.destination.cst_decode(),
                 tx_id: self.tx_id.cst_decode(),
+                unblinding_data: self.unblinding_data.cst_decode(),
                 timestamp: self.timestamp.cst_decode(),
                 amount_sat: self.amount_sat.cst_decode(),
                 fees_sat: self.fees_sat.cst_decode(),
@@ -10988,6 +10993,7 @@ mod io {
             Self {
                 destination: core::ptr::null_mut(),
                 tx_id: core::ptr::null_mut(),
+                unblinding_data: core::ptr::null_mut(),
                 timestamp: Default::default(),
                 amount_sat: Default::default(),
                 fees_sat: Default::default(),
@@ -13174,6 +13180,7 @@ mod io {
     pub struct wire_cst_payment {
         destination: *mut wire_cst_list_prim_u_8_strict,
         tx_id: *mut wire_cst_list_prim_u_8_strict,
+        unblinding_data: *mut wire_cst_list_prim_u_8_strict,
         timestamp: u32,
         amount_sat: u64,
         fees_sat: u64,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1220,6 +1220,10 @@ pub struct PaymentTxData {
 
     /// Onchain tx status
     pub is_confirmed: bool,
+
+    /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
+    /// See: https://docs.liquid.net/docs/unblinding-transactions
+    pub unblinding_data: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1369,6 +1373,10 @@ pub struct Payment {
 
     pub tx_id: Option<String>,
 
+    /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
+    /// See: https://docs.liquid.net/docs/unblinding-transactions
+    pub unblinding_data: Option<String>,
+
     /// Composite timestamp that can be used for sorting or displaying the payment.
     ///
     /// If this payment has an associated swap, it is the swap creation time. Otherwise, the point
@@ -1428,6 +1436,7 @@ impl Payment {
         Payment {
             destination: swap.bolt11.clone(),
             tx_id: None,
+            unblinding_data: None,
             timestamp: swap.created_at,
             amount_sat,
             fees_sat: swap.payer_amount_sat - swap.receiver_amount_sat,
@@ -1445,6 +1454,7 @@ impl Payment {
     ) -> Payment {
         Payment {
             tx_id: Some(tx.tx_id),
+            unblinding_data: tx.unblinding_data,
             // When the swap is present and of type send and receive, we retrieve the destination from the invoice.
             // If it's a chain swap instead, we use the `claim_address` field from the swap data (either pure Bitcoin or Liquid address).
             // Otherwise, we specify the Liquid address (BIP21 or pure), set in `payment_details.address`.

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -214,5 +214,6 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ) STRICT;",
         "ALTER TABLE receive_swaps DROP COLUMN mrh_script_pubkey;",
         "ALTER TABLE payment_details ADD COLUMN lnurl_info_json TEXT;",
+        "ALTER TABLE payment_tx_data ADD COLUMN unblinding_data TEXT;",
     ]
 }

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -337,6 +337,7 @@ impl ReceiveSwapHandler {
                                 fees_sat: 0,
                                 payment_type: PaymentType::Receive,
                                 is_confirmed: false,
+                                unblinding_data: None,
                             },
                             None,
                             false,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1228,6 +1228,7 @@ impl LiquidSdk {
             fees_sat,
             payment_type: PaymentType::Send,
             is_confirmed: false,
+            unblinding_data: None,
         };
 
         let description = address_data.message;

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -235,6 +235,7 @@ impl SendSwapHandler {
                 fees_sat: lockup_tx_fees_sat,
                 payment_type: PaymentType::Send,
                 is_confirmed: false,
+                unblinding_data: None,
             },
             None,
             false,

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -162,5 +162,6 @@ pub(crate) fn new_payment_tx_data(payment_type: PaymentType) -> PaymentTxData {
         fees_sat: 0,
         payment_type,
         is_confirmed: false,
+        unblinding_data: None,
     }
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2554,17 +2554,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Payment dco_decode_payment(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9) throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return Payment(
       destination: dco_decode_opt_String(arr[0]),
       txId: dco_decode_opt_String(arr[1]),
-      timestamp: dco_decode_u_32(arr[2]),
-      amountSat: dco_decode_u_64(arr[3]),
-      feesSat: dco_decode_u_64(arr[4]),
-      swapperFeesSat: dco_decode_opt_box_autoadd_u_64(arr[5]),
-      paymentType: dco_decode_payment_type(arr[6]),
-      status: dco_decode_payment_state(arr[7]),
-      details: dco_decode_payment_details(arr[8]),
+      unblindingData: dco_decode_opt_String(arr[2]),
+      timestamp: dco_decode_u_32(arr[3]),
+      amountSat: dco_decode_u_64(arr[4]),
+      feesSat: dco_decode_u_64(arr[5]),
+      swapperFeesSat: dco_decode_opt_box_autoadd_u_64(arr[6]),
+      paymentType: dco_decode_payment_type(arr[7]),
+      status: dco_decode_payment_state(arr[8]),
+      details: dco_decode_payment_details(arr[9]),
     );
   }
 
@@ -4651,6 +4652,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_destination = sse_decode_opt_String(deserializer);
     var var_txId = sse_decode_opt_String(deserializer);
+    var var_unblindingData = sse_decode_opt_String(deserializer);
     var var_timestamp = sse_decode_u_32(deserializer);
     var var_amountSat = sse_decode_u_64(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
@@ -4661,6 +4663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return Payment(
         destination: var_destination,
         txId: var_txId,
+        unblindingData: var_unblindingData,
         timestamp: var_timestamp,
         amountSat: var_amountSat,
         feesSat: var_feesSat,
@@ -6621,6 +6624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_opt_String(self.destination, serializer);
     sse_encode_opt_String(self.txId, serializer);
+    sse_encode_opt_String(self.unblindingData, serializer);
     sse_encode_u_32(self.timestamp, serializer);
     sse_encode_u_64(self.amountSat, serializer);
     sse_encode_u_64(self.feesSat, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2823,6 +2823,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_payment(Payment apiObj, wire_cst_payment wireObj) {
     wireObj.destination = cst_encode_opt_String(apiObj.destination);
     wireObj.tx_id = cst_encode_opt_String(apiObj.txId);
+    wireObj.unblinding_data = cst_encode_opt_String(apiObj.unblindingData);
     wireObj.timestamp = cst_encode_u_32(apiObj.timestamp);
     wireObj.amount_sat = cst_encode_u_64(apiObj.amountSat);
     wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
@@ -6174,6 +6175,8 @@ final class wire_cst_payment extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> tx_id;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> unblinding_data;
 
   @ffi.Uint32()
   external int timestamp;

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -595,6 +595,10 @@ class Payment {
   final String? destination;
   final String? txId;
 
+  /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
+  /// See: https://docs.liquid.net/docs/unblinding-transactions
+  final String? unblindingData;
+
   /// Composite timestamp that can be used for sorting or displaying the payment.
   ///
   /// If this payment has an associated swap, it is the swap creation time. Otherwise, the point
@@ -643,6 +647,7 @@ class Payment {
   const Payment({
     this.destination,
     this.txId,
+    this.unblindingData,
     required this.timestamp,
     required this.amountSat,
     required this.feesSat,
@@ -656,6 +661,7 @@ class Payment {
   int get hashCode =>
       destination.hashCode ^
       txId.hashCode ^
+      unblindingData.hashCode ^
       timestamp.hashCode ^
       amountSat.hashCode ^
       feesSat.hashCode ^
@@ -671,6 +677,7 @@ class Payment {
           runtimeType == other.runtimeType &&
           destination == other.destination &&
           txId == other.txId &&
+          unblindingData == other.unblindingData &&
           timestamp == other.timestamp &&
           amountSat == other.amountSat &&
           feesSat == other.feesSat &&

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4596,6 +4596,8 @@ final class wire_cst_payment extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> tx_id;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> unblinding_data;
+
   @ffi.Uint32()
   external int timestamp;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1512,7 +1512,8 @@ fun asPayment(payment: ReadableMap): Payment? {
     val swapperFeesSat = if (hasNonNullKey(payment, "swapperFeesSat")) payment.getDouble("swapperFeesSat").toULong() else null
     val destination = if (hasNonNullKey(payment, "destination")) payment.getString("destination") else null
     val txId = if (hasNonNullKey(payment, "txId")) payment.getString("txId") else null
-    return Payment(timestamp, amountSat, feesSat, paymentType, status, details, swapperFeesSat, destination, txId)
+    val unblindingData = if (hasNonNullKey(payment, "unblindingData")) payment.getString("unblindingData") else null
+    return Payment(timestamp, amountSat, feesSat, paymentType, status, details, swapperFeesSat, destination, txId, unblindingData)
 }
 
 fun readableMapOf(payment: Payment): ReadableMap =
@@ -1526,6 +1527,7 @@ fun readableMapOf(payment: Payment): ReadableMap =
         "swapperFeesSat" to payment.swapperFeesSat,
         "destination" to payment.destination,
         "txId" to payment.txId,
+        "unblindingData" to payment.unblindingData,
     )
 
 fun asPaymentList(arr: ReadableArray): List<Payment> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1779,8 +1779,15 @@ enum BreezSDKLiquidMapper {
             }
             txId = txIdTmp
         }
+        var unblindingData: String?
+        if hasNonNilKey(data: payment, key: "unblindingData") {
+            guard let unblindingDataTmp = payment["unblindingData"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "unblindingData"))
+            }
+            unblindingData = unblindingDataTmp
+        }
 
-        return Payment(timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, destination: destination, txId: txId)
+        return Payment(timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, destination: destination, txId: txId, unblindingData: unblindingData)
     }
 
     static func dictionaryOf(payment: Payment) -> [String: Any?] {
@@ -1794,6 +1801,7 @@ enum BreezSDKLiquidMapper {
             "swapperFeesSat": payment.swapperFeesSat == nil ? nil : payment.swapperFeesSat,
             "destination": payment.destination == nil ? nil : payment.destination,
             "txId": payment.txId == nil ? nil : payment.txId,
+            "unblindingData": payment.unblindingData == nil ? nil : payment.unblindingData,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -276,6 +276,7 @@ export interface Payment {
     swapperFeesSat?: number
     destination?: string
     txId?: string
+    unblindingData?: string
 }
 
 export interface PrepareBuyBitcoinRequest {


### PR DESCRIPTION
This PR stores the unblinding data which can be used in the `blinded` param when unblinding the transaction in any Liquid explorer. See: https://docs.liquid.net/docs/unblinding-transactions