### PR TITLE
Set IPHONEOS_DEPLOYMENT_TARGET in CI

### DIFF
--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -47,6 +47,9 @@ jobs:
         rustup toolchain install stable --profile minimal
         rustup target add ${{ matrix.target }}
 
+    - name: Set IPHONEOS_DEPLOYMENT_TARGET 
+      run: echo "IPHONEOS_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:


### PR DESCRIPTION
This PR adds the IPHONEOS_DEPLOYMENT_TARGET env in the CI to prevent the following error in the `aarch64-apple-ios` build:
```
          ld: warning: object file (/Users/runner/work/breez-sdk-liquid/breez-sdk-liquid/lib/target/aarch64-apple-ios/release/deps/liboslog-2986680f3acc6ccb.rlib[4](db3b6bfb95261072-wrapper.o)) was built for newer 'iOS' version (18.1) than being linked (10.0)
          ld: warning: object file (/Users/runner/work/breez-sdk-liquid/breez-sdk-liquid/lib/target/aarch64-apple-ios/release/deps/libdart_sys_fork-f573a0ab53d8c10b.rlib[4](248f927bf32daba4-dart_api_dl.o)) was built for newer 'iOS' version (18.1) than being linked (10.0)
          Undefined symbols for architecture arm64:
            "___chkstk_darwin", referenced from:
                _BN_mod_exp_mont_consttime in libopenssl_sys-f99c0e84555f3e11.rlib[220](libcrypto-lib-bn_exp.o)
                _ossl_curve448_base_double_scalarmul_non_secret in libopenssl_sys-f99c0e84555f3e11.rlib[363](libcrypto-lib-curve448.o)
                _ERR_print_errors_cb in libopenssl_sys-f99c0e84555f3e11.rlib[439](libcrypto-lib-err_prn.o)
                _rustsecp256k1zkp_v0_8_0_rangeproof_verify_impl in libsecp256k1_zkp_sys-667bf511af936cad.rlib[5](fce6141bfa9bf74c-secp256k1.o)
                _rustsecp256k1zkp_v0_8_0_rangeproof_sign in libsecp256k1_zkp_sys-667bf511af936cad.rlib[5](fce6141bfa9bf74c-secp256k1.o)
                _rustsecp256k1zkp_v0_8_0_surjectionproof_generate in libsecp256k1_zkp_sys-667bf511af936cad.rlib[5](fce6141bfa9bf74c-secp256k1.o)
                _rustsecp256k1zkp_v0_8_0_surjectionproof_verify in libsecp256k1_zkp_sys-667bf511af936cad.rlib[5](fce6141bfa9bf74c-secp256k1.o)
                ...
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Successful run: https://github.com/breez/breez-sdk-liquid/actions/runs/12121904313