### PR TITLE
Fix clippy CI step

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,7 +39,8 @@ fn show_results(result: Result<String>) -> Result<()> {
         })?,
     };
 
-    Ok(println!("{result_str}"))
+    println!("{result_str}");
+    Ok(())
 }
 
 struct CliEventListener {}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,6 +30,9 @@ resolver = "2"
 [workspace.package]
 version = "0.4.0-rc3"
 
+[workspace.lints.clippy]
+empty_line_after_doc_comments = "allow"
+
 [workspace.dependencies]
 anyhow = "1.0"
 log = "0.4.20"

--- a/lib/bindings/Cargo.toml
+++ b/lib/bindings/Cargo.toml
@@ -11,6 +11,9 @@ path = "uniffi-bindgen.rs"
 name = "breez_sdk_liquid_bindings"
 crate-type = ["staticlib", "cdylib", "lib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 breez-sdk-liquid = { path = "../core" }

--- a/lib/bindings/langs/react-native/Cargo.toml
+++ b/lib/bindings/langs/react-native/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 thiserror = "1.0"

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["lib", "cdylib", "staticlib"]
 default = ["frb"]
 frb = ["dep:flutter_rust_bridge"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"


### PR DESCRIPTION
This PR adds a workspace-wide `clippy` lint config.

This allows us to selectively allow `empty_line_after_doc_comments`, which is caused by the the combination of a recent bump in rust version (which now classifies this as a warning) and a uniffi rust file generated  by `uniffi_macros` (which causes this to trigger because of an extra space after some rustdocs).