### PR TITLE
Check MRH has already been paid

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -115,13 +115,17 @@ impl Persister {
         )?;
 
         if let Some(destination) = destination {
+            // Only store the destination if there is no payment_details entry else
+            // the destination is overwritten by the tx script_pubkey
             con.execute(
-                "INSERT OR REPLACE INTO payment_details (
+                "INSERT INTO payment_details (
                     tx_id,
                     destination,
                     description 
                 )
-                VALUES (?, ?, ?)
+                VALUES (?1, ?2, ?3)
+                ON CONFLICT (tx_id)
+                DO UPDATE SET description = COALESCE(?3, description) 
             ",
                 (ptx.tx_id, destination, description),
             )?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1021,7 +1021,7 @@ impl LiquidSdk {
                     PaymentError::InsufficientFunds
                 );
 
-                self.pay_liquid(liquid_address_data.clone(), amount_sat, *fees_sat)
+                self.pay_liquid(liquid_address_data.clone(), amount_sat, *fees_sat, true)
                     .await
             }
             SendDestination::Bolt11 { invoice } => {
@@ -1075,6 +1075,7 @@ impl LiquidSdk {
                     },
                     amount_sat,
                     fees_sat,
+                    false,
                 )
                 .await
             }
@@ -1128,7 +1129,22 @@ impl LiquidSdk {
         address_data: LiquidAddressData,
         receiver_amount_sat: u64,
         fees_sat: u64,
+        skip_already_paid_check: bool,
     ) -> Result<SendPaymentResponse, PaymentError> {
+        let destination = address_data
+            .to_uri()
+            .unwrap_or(address_data.address.clone());
+        let payments = self.persister.get_payments(&ListPaymentsRequest {
+            details: Some(ListPaymentDetails::Liquid {
+                destination: destination.clone(),
+            }),
+            ..Default::default()
+        })?;
+        ensure_sdk!(
+            skip_already_paid_check || payments.is_empty(),
+            PaymentError::AlreadyPaid
+        );
+
         let tx = self
             .onchain_wallet
             .build_tx_or_drain_tx(
@@ -1160,7 +1176,6 @@ impl LiquidSdk {
             is_confirmed: false,
         };
 
-        let destination = address_data.to_uri().unwrap_or(address_data.address);
         let description = address_data.message;
 
         self.persister.insert_or_update_payment(


### PR DESCRIPTION
This PR changes when sending a payment using the MRH of a BOLT11 invoice that we first check that we've not already paid to the same MRH previously.

Fixes #592 