### PR TITLE
Zero-amount quote get balance retry

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=238245bd34be15727493d7d0c625c6ae55f2a845#238245bd34be15727493d7d0c625c6ae55f2a845"
+source = "git+https://github.com/breez/breez-sdk?rev=e537feb8ed134bc3c7af5196e10a0a189dd36ac7#e537feb8ed134bc3c7af5196e10a0a189dd36ac7"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/core/src/chain/bitcoin.rs
+++ b/lib/core/src/chain/bitcoin.rs
@@ -55,6 +55,13 @@ pub trait BitcoinChainService: Send + Sync {
     /// Return the confirmed and unconfirmed balances of a list of script hashes
     fn scripts_get_balance(&self, scripts: &[&Script]) -> Result<Vec<GetBalanceRes>>;
 
+    /// Return the confirmed and unconfirmed balances of a script hash
+    async fn script_get_balance_with_retry(
+        &self,
+        script: &Script,
+        retries: u64,
+    ) -> Result<GetBalanceRes>;
+
     /// Verify that a transaction appears in the address script history
     async fn verify_tx(
         &self,
@@ -211,6 +218,39 @@ impl BitcoinChainService for HybridBitcoinChainService {
 
     fn scripts_get_balance(&self, scripts: &[&Script]) -> Result<Vec<GetBalanceRes>> {
         Ok(self.client.batch_script_get_balance(scripts)?)
+    }
+
+    async fn script_get_balance_with_retry(
+        &self,
+        script: &Script,
+        retries: u64,
+    ) -> Result<GetBalanceRes> {
+        let script_hash = sha256::Hash::hash(script.as_bytes()).to_hex();
+        info!("Fetching script balance for {}", script_hash);
+        let mut script_balance = GetBalanceRes {
+            confirmed: 0,
+            unconfirmed: 0,
+        };
+
+        let mut retry = 0;
+        while retry <= retries {
+            script_balance = self.script_get_balance(script)?;
+            match script_balance {
+                GetBalanceRes {
+                    confirmed: 0,
+                    unconfirmed: 0,
+                } => {
+                    retry += 1;
+                    info!(
+                        "Got zero balance for script {}, retrying in {} seconds...",
+                        script_hash, retry
+                    );
+                    tokio::time::sleep(Duration::from_secs(retry)).await;
+                }
+                _ => break,
+            }
+        }
+        Ok(script_balance)
     }
 
     async fn verify_tx(

--- a/lib/core/src/chain/bitcoin.rs
+++ b/lib/core/src/chain/bitcoin.rs
@@ -1,4 +1,3 @@
-use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
@@ -173,7 +172,7 @@ impl BitcoinChainService for HybridBitcoinChainService {
                         "Script history for {} got zero transactions, retrying in {} seconds...",
                         script_hash, retry
                     );
-                    thread::sleep(Duration::from_secs(retry));
+                    tokio::time::sleep(Duration::from_secs(retry)).await;
                 }
                 false => break,
             }

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, thread, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -192,7 +192,7 @@ impl LiquidChainService for HybridLiquidChainService {
                     retry += 1;
                     info!("Script history for {script_hash} is empty, retrying in 1 second... ({retry} of {retries})");
                     // Waiting 1s between retries, so we detect the new tx as soon as possible
-                    thread::sleep(Duration::from_secs(1));
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                 }
                 false => break,
             }
@@ -290,7 +290,7 @@ async fn get_with_retry(url: &str, retries: usize) -> Result<Response> {
             }
             let secs = 1 << attempt;
 
-            thread::sleep(Duration::from_secs(secs));
+            tokio::time::sleep(Duration::from_secs(secs)).await;
         }
     }
 }

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -513,7 +513,8 @@ impl ChainSwapHandler {
             .bitcoin_chain_service
             .lock()
             .await
-            .script_get_balance(script_pubkey.as_script())?;
+            .script_get_balance_with_retry(script_pubkey.as_script(), 10)
+            .await?;
         debug!("Found lockup balance {script_balance:?}");
         let user_lockup_amount_sat = match script_balance.confirmed > 0 {
             true => script_balance.confirmed,

--- a/lib/core/src/test_utils/chain.rs
+++ b/lib/core/src/test_utils/chain.rs
@@ -193,6 +193,14 @@ impl BitcoinChainService for MockBitcoinChainService {
         unimplemented!()
     }
 
+    async fn script_get_balance_with_retry(
+        &self,
+        _script: &boltz_client::bitcoin::Script,
+        _retries: u64,
+    ) -> Result<electrum_client::GetBalanceRes> {
+        unimplemented!()
+    }
+
     async fn verify_tx(
         &self,
         _address: &boltz_client::Address,


### PR DESCRIPTION
This PR improves the robustness of handling the quote validation by retrying to get the script balance in case the electrum server has not seen the tx yet.
- Adds retries to getting the user lockup script balance when validating the zero-amount chain swap server lockup quote
- Uses non-blocking sleep when retying

Fixes #601 