### PR TITLE
Real-time Sync: update payer/receiver amounts

### DIFF
--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -27,6 +27,8 @@ impl ChainSyncData {
     pub(crate) fn merge(&mut self, other: &Self, updated_fields: &[String]) {
         for field in updated_fields {
             match field.as_str() {
+                "payer_amount_sat" => self.payer_amount_sat = other.payer_amount_sat,
+                "receiver_amount_sat" => self.receiver_amount_sat = other.receiver_amount_sat,
                 "accept_zero_conf" => self.accept_zero_conf = other.accept_zero_conf,
                 _ => continue,
             }


### PR DESCRIPTION
This PR pushes the `payer_amount_sat` & `receiver_amount_sat` to the rt-sync for updating non-local instances.