### PR TITLE
Increase MRH robustness

### DIFF
--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -273,6 +273,7 @@ impl TryFrom<SendSwap> for SendSwapImmutableData {
 #[derive(Clone)]
 pub(crate) struct ReceiveSwapImmutableData {
     pub(crate) swap_id: String,
+    pub(crate) swap_timestamp: u32,
     pub(crate) timeout_block_height: u32,
     pub(crate) claim_script: LBtcScript,
     pub(crate) mrh_script: Option<LBtcScript>,
@@ -294,6 +295,7 @@ impl TryFrom<ReceiveSwap> for ReceiveSwapImmutableData {
         let swap_id = swap.id;
         Ok(ReceiveSwapImmutableData {
             swap_id,
+            swap_timestamp: swap.created_at,
             timeout_block_height: create_response.timeout_block_height,
             claim_script: funding_address.script_pubkey(),
             mrh_script: mrh_address.map(|s| s.script_pubkey()),

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -344,9 +344,11 @@ impl OnchainWallet for LiquidOnchainWallet {
             true,
             true,
         ))?;
+        // Use the cached derivation index with a buffer of 5 to perform the scan
         let index = self
             .persister
             .get_last_derivation_index()?
+            .map(|i| i + 5)
             .unwrap_or_default();
         match lwk_wollet::full_scan_to_index_with_electrum_client(
             &mut wallet,


### PR DESCRIPTION
This PR:
- Filters the incoming txs for an MRH script by swap `created_at` timestamp, so an MRH tx will only be associated with a swap when: 
    - swap has no claim/lockup txs
    - MRH tx height less than swap timeout block height
    - MRH tx block timestamp greater than swap created timestamp
- Adds a 5 index buffer to the wallet full scan incase our cached derivation index is behind

Fixes #607 