### PR TITLE
fix liquid panding timestamp

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -268,7 +268,7 @@ impl Persister {
                 ptx.tx_id NOT IN (SELECT refund_tx_id FROM chain_swaps WHERE refund_tx_id NOT NULL)
             AND {}
             ORDER BY                             -- Order by swap creation time or tx timestamp (in case of direct tx)
-                COALESCE(rs.created_at, ss.created_at, cs.created_at, ptx.timestamp) DESC
+                COALESCE(rs.created_at, ss.created_at, cs.created_at, ptx.timestamp, strftime('%s', 'now')) DESC
             LIMIT {}
             OFFSET {}
             ",


### PR DESCRIPTION
Before this PR pending liquid transactions that were synced were shown at the bottom of the list payments.
This is because their timestamp was null as there was no swap and the transactions was in the mempool.
Now it fallbacks to the current timestamp for pending transaction.

fixed https://github.com/breez/breez-sdk-liquid/issues/611