### PR TITLE
Store & Sync LNURL info

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=e537feb8ed134bc3c7af5196e10a0a189dd36ac7#e537feb8ed134bc3c7af5196e10a0a189dd36ac7"
+source = "git+https://github.com/breez/breez-sdk?rev=f77208acd34d74b571388889e856444908c59a85#f77208acd34d74b571388889e856444908c59a85"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3530,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=e537feb8ed134bc3c7af5196e10a0a189dd36ac7#e537feb8ed134bc3c7af5196e10a0a189dd36ac7"
+source = "git+https://github.com/breez/breez-sdk?rev=f77208acd34d74b571388889e856444908c59a85#f77208acd34d74b571388889e856444908c59a85"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -237,6 +237,18 @@ typedef struct wire_cst_send_destination {
   union SendDestinationKind kind;
 } wire_cst_send_destination;
 
+typedef struct wire_cst_ln_url_pay_request_data {
+  struct wire_cst_list_prim_u_8_strict *callback;
+  uint64_t min_sendable;
+  uint64_t max_sendable;
+  struct wire_cst_list_prim_u_8_strict *metadata_str;
+  uint16_t comment_allowed;
+  struct wire_cst_list_prim_u_8_strict *domain;
+  bool allows_nostr;
+  struct wire_cst_list_prim_u_8_strict *nostr_pubkey;
+  struct wire_cst_list_prim_u_8_strict *ln_address;
+} wire_cst_ln_url_pay_request_data;
+
 typedef struct wire_cst_aes_success_action_data {
   struct wire_cst_list_prim_u_8_strict *description;
   struct wire_cst_list_prim_u_8_strict *ciphertext;
@@ -279,6 +291,8 @@ typedef struct wire_cst_success_action {
 typedef struct wire_cst_prepare_ln_url_pay_response {
   struct wire_cst_send_destination destination;
   uint64_t fees_sat;
+  struct wire_cst_ln_url_pay_request_data data;
+  struct wire_cst_list_prim_u_8_strict *comment;
   struct wire_cst_success_action *success_action;
 } wire_cst_prepare_ln_url_pay_response;
 
@@ -315,18 +329,6 @@ typedef struct wire_cst_prepare_buy_bitcoin_request {
   int32_t provider;
   uint64_t amount_sat;
 } wire_cst_prepare_buy_bitcoin_request;
-
-typedef struct wire_cst_ln_url_pay_request_data {
-  struct wire_cst_list_prim_u_8_strict *callback;
-  uint64_t min_sendable;
-  uint64_t max_sendable;
-  struct wire_cst_list_prim_u_8_strict *metadata_str;
-  uint16_t comment_allowed;
-  struct wire_cst_list_prim_u_8_strict *domain;
-  bool allows_nostr;
-  struct wire_cst_list_prim_u_8_strict *nostr_pubkey;
-  struct wire_cst_list_prim_u_8_strict *ln_address;
-} wire_cst_ln_url_pay_request_data;
 
 typedef struct wire_cst_prepare_ln_url_pay_request {
   struct wire_cst_ln_url_pay_request_data data;
@@ -411,6 +413,62 @@ typedef struct wire_cst_binding_event_listener {
   struct wire_cst_list_prim_u_8_strict *stream;
 } wire_cst_binding_event_listener;
 
+typedef struct wire_cst_aes_success_action_data_decrypted {
+  struct wire_cst_list_prim_u_8_strict *description;
+  struct wire_cst_list_prim_u_8_strict *plaintext;
+} wire_cst_aes_success_action_data_decrypted;
+
+typedef struct wire_cst_AesSuccessActionDataResult_Decrypted {
+  struct wire_cst_aes_success_action_data_decrypted *data;
+} wire_cst_AesSuccessActionDataResult_Decrypted;
+
+typedef struct wire_cst_AesSuccessActionDataResult_ErrorStatus {
+  struct wire_cst_list_prim_u_8_strict *reason;
+} wire_cst_AesSuccessActionDataResult_ErrorStatus;
+
+typedef union AesSuccessActionDataResultKind {
+  struct wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
+  struct wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
+} AesSuccessActionDataResultKind;
+
+typedef struct wire_cst_aes_success_action_data_result {
+  int32_t tag;
+  union AesSuccessActionDataResultKind kind;
+} wire_cst_aes_success_action_data_result;
+
+typedef struct wire_cst_SuccessActionProcessed_Aes {
+  struct wire_cst_aes_success_action_data_result *result;
+} wire_cst_SuccessActionProcessed_Aes;
+
+typedef struct wire_cst_SuccessActionProcessed_Message {
+  struct wire_cst_message_success_action_data *data;
+} wire_cst_SuccessActionProcessed_Message;
+
+typedef struct wire_cst_SuccessActionProcessed_Url {
+  struct wire_cst_url_success_action_data *data;
+} wire_cst_SuccessActionProcessed_Url;
+
+typedef union SuccessActionProcessedKind {
+  struct wire_cst_SuccessActionProcessed_Aes Aes;
+  struct wire_cst_SuccessActionProcessed_Message Message;
+  struct wire_cst_SuccessActionProcessed_Url Url;
+} SuccessActionProcessedKind;
+
+typedef struct wire_cst_success_action_processed {
+  int32_t tag;
+  union SuccessActionProcessedKind kind;
+} wire_cst_success_action_processed;
+
+typedef struct wire_cst_ln_url_info {
+  struct wire_cst_list_prim_u_8_strict *ln_address;
+  struct wire_cst_list_prim_u_8_strict *lnurl_pay_comment;
+  struct wire_cst_list_prim_u_8_strict *lnurl_pay_domain;
+  struct wire_cst_list_prim_u_8_strict *lnurl_pay_metadata;
+  struct wire_cst_success_action_processed *lnurl_pay_success_action;
+  struct wire_cst_success_action *lnurl_pay_unprocessed_success_action;
+  struct wire_cst_list_prim_u_8_strict *lnurl_withdraw_endpoint;
+} wire_cst_ln_url_info;
+
 typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *swap_id;
   struct wire_cst_list_prim_u_8_strict *description;
@@ -418,6 +476,7 @@ typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *bolt11;
   struct wire_cst_list_prim_u_8_strict *bolt12_offer;
   struct wire_cst_list_prim_u_8_strict *payment_hash;
+  struct wire_cst_ln_url_info *lnurl_info;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;
 } wire_cst_PaymentDetails_Lightning;
@@ -526,29 +585,6 @@ typedef struct wire_cst_connect_request {
   struct wire_cst_list_prim_u_8_strict *mnemonic;
 } wire_cst_connect_request;
 
-typedef struct wire_cst_aes_success_action_data_decrypted {
-  struct wire_cst_list_prim_u_8_strict *description;
-  struct wire_cst_list_prim_u_8_strict *plaintext;
-} wire_cst_aes_success_action_data_decrypted;
-
-typedef struct wire_cst_AesSuccessActionDataResult_Decrypted {
-  struct wire_cst_aes_success_action_data_decrypted *data;
-} wire_cst_AesSuccessActionDataResult_Decrypted;
-
-typedef struct wire_cst_AesSuccessActionDataResult_ErrorStatus {
-  struct wire_cst_list_prim_u_8_strict *reason;
-} wire_cst_AesSuccessActionDataResult_ErrorStatus;
-
-typedef union AesSuccessActionDataResultKind {
-  struct wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
-  struct wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
-} AesSuccessActionDataResultKind;
-
-typedef struct wire_cst_aes_success_action_data_result {
-  int32_t tag;
-  union AesSuccessActionDataResultKind kind;
-} wire_cst_aes_success_action_data_result;
-
 typedef struct wire_cst_bitcoin_address_data {
   struct wire_cst_list_prim_u_8_strict *address;
   int32_t network;
@@ -565,29 +601,6 @@ typedef struct wire_cst_ln_url_pay_error_data {
   struct wire_cst_list_prim_u_8_strict *payment_hash;
   struct wire_cst_list_prim_u_8_strict *reason;
 } wire_cst_ln_url_pay_error_data;
-
-typedef struct wire_cst_SuccessActionProcessed_Aes {
-  struct wire_cst_aes_success_action_data_result *result;
-} wire_cst_SuccessActionProcessed_Aes;
-
-typedef struct wire_cst_SuccessActionProcessed_Message {
-  struct wire_cst_message_success_action_data *data;
-} wire_cst_SuccessActionProcessed_Message;
-
-typedef struct wire_cst_SuccessActionProcessed_Url {
-  struct wire_cst_url_success_action_data *data;
-} wire_cst_SuccessActionProcessed_Url;
-
-typedef union SuccessActionProcessedKind {
-  struct wire_cst_SuccessActionProcessed_Aes Aes;
-  struct wire_cst_SuccessActionProcessed_Message Message;
-  struct wire_cst_SuccessActionProcessed_Url Url;
-} SuccessActionProcessedKind;
-
-typedef struct wire_cst_success_action_processed {
-  int32_t tag;
-  union SuccessActionProcessedKind kind;
-} wire_cst_success_action_processed;
 
 typedef struct wire_cst_ln_url_pay_success_data {
   struct wire_cst_payment payment;
@@ -1237,6 +1250,8 @@ struct wire_cst_ln_url_auth_request_data *frbgen_breez_liquid_cst_new_box_autoad
 
 struct wire_cst_ln_url_error_data *frbgen_breez_liquid_cst_new_box_autoadd_ln_url_error_data(void);
 
+struct wire_cst_ln_url_info *frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info(void);
+
 struct wire_cst_ln_url_pay_error_data *frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data(void);
 
 struct wire_cst_ln_url_pay_request *frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_request(void);
@@ -1345,6 +1360,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_offer);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_auth_request_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_error_data);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_request_data);

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -54,7 +54,7 @@ class SwapUpdatedTask : TaskProtocol {
             switch details {
             case let .bitcoin(swapId, _, _, _):
                 return swapId
-            case let .lightning(swapId, _, _, _, _, _, _, _):
+            case let .lightning(swapId, _, _, _, _, _, _, _, _):
                 return swapId
             default:
                 break

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -389,6 +389,8 @@ dictionary PrepareLnUrlPayRequest {
 dictionary PrepareLnUrlPayResponse {
     SendDestination destination;
     u64 fees_sat;
+    LnUrlPayRequestData data;
+    string? comment = null;
     SuccessAction? success_action = null;
 };
 
@@ -538,9 +540,19 @@ interface GetPaymentRequest {
     Lightning(string payment_hash);
 };
 
+dictionary LnUrlInfo {
+    string? ln_address;
+    string? lnurl_pay_comment;
+    string? lnurl_pay_domain;
+    string? lnurl_pay_metadata;
+    SuccessActionProcessed? lnurl_pay_success_action;
+    SuccessAction? lnurl_pay_unprocessed_success_action;
+    string? lnurl_withdraw_endpoint;
+};
+
 [Enum]
 interface PaymentDetails {
-    Lightning(string swap_id, string description, string? preimage, string? bolt11, string? bolt12_offer, string? payment_hash, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Lightning(string swap_id, string description, string? preimage, string? bolt11, string? bolt12_offer, string? payment_hash, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
     Bitcoin(string swap_id, string description, string? refund_tx_id, u64? refund_tx_amount_sat);
 };

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -32,7 +32,7 @@ lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-s
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "e537feb8ed134bc3c7af5196e10a0a189dd36ac7", features = ["liquid"] }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "f77208acd34d74b571388889e856444908c59a85", features = ["liquid"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 strum = "0.25"

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -485,7 +485,7 @@ impl ChainSwapHandler {
                             fees_sat: lockup_tx_fees_sat + swap.claim_fees_sat,
                             payment_type: PaymentType::Send,
                             is_confirmed: false,
-                        }, None)?;
+                        }, None, false)?;
 
                         self.update_swap_info(&ChainSwapUpdate {
                             swap_id: id,
@@ -840,6 +840,7 @@ impl ChainSwapHandler {
                                         is_confirmed: false,
                                     },
                                     None,
+                                    false,
                                 )?;
                                 Some(claim_tx_id.clone())
                             }
@@ -1319,9 +1320,8 @@ impl ChainSwapHandler {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
-
     use anyhow::Result;
+    use std::collections::{HashMap, HashSet};
 
     use crate::{
         model::{

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -485,7 +485,7 @@ impl ChainSwapHandler {
                             fees_sat: lockup_tx_fees_sat + swap.claim_fees_sat,
                             payment_type: PaymentType::Send,
                             is_confirmed: false,
-                        }, None, None)?;
+                        }, None)?;
 
                         self.update_swap_info(&ChainSwapUpdate {
                             swap_id: id,
@@ -839,7 +839,6 @@ impl ChainSwapHandler {
                                         payment_type: PaymentType::Receive,
                                         is_confirmed: false,
                                     },
-                                    None,
                                     None,
                                 )?;
                                 Some(claim_tx_id.clone())

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2989,6 +2989,30 @@ impl SseDecode for crate::bindings::LnUrlErrorData {
     }
 }
 
+impl SseDecode for crate::model::LnUrlInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_lnAddress = <Option<String>>::sse_decode(deserializer);
+        let mut var_lnurlPayComment = <Option<String>>::sse_decode(deserializer);
+        let mut var_lnurlPayDomain = <Option<String>>::sse_decode(deserializer);
+        let mut var_lnurlPayMetadata = <Option<String>>::sse_decode(deserializer);
+        let mut var_lnurlPaySuccessAction =
+            <Option<crate::bindings::SuccessActionProcessed>>::sse_decode(deserializer);
+        let mut var_lnurlPayUnprocessedSuccessAction =
+            <Option<crate::bindings::SuccessAction>>::sse_decode(deserializer);
+        let mut var_lnurlWithdrawEndpoint = <Option<String>>::sse_decode(deserializer);
+        return crate::model::LnUrlInfo {
+            ln_address: var_lnAddress,
+            lnurl_pay_comment: var_lnurlPayComment,
+            lnurl_pay_domain: var_lnurlPayDomain,
+            lnurl_pay_metadata: var_lnurlPayMetadata,
+            lnurl_pay_success_action: var_lnurlPaySuccessAction,
+            lnurl_pay_unprocessed_success_action: var_lnurlPayUnprocessedSuccessAction,
+            lnurl_withdraw_endpoint: var_lnurlWithdrawEndpoint,
+        };
+    }
+}
+
 impl SseDecode for crate::bindings::duplicates::LnUrlPayError {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3400,6 +3424,17 @@ impl SseDecode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
+impl SseDecode for Option<crate::model::LnUrlInfo> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::model::LnUrlInfo>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::model::PayAmount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3586,6 +3621,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_bolt11 = <Option<String>>::sse_decode(deserializer);
                 let mut var_bolt12Offer = <Option<String>>::sse_decode(deserializer);
                 let mut var_paymentHash = <Option<String>>::sse_decode(deserializer);
+                let mut var_lnurlInfo = <Option<crate::model::LnUrlInfo>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Lightning {
@@ -3595,6 +3631,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     bolt11: var_bolt11,
                     bolt12_offer: var_bolt12Offer,
                     payment_hash: var_paymentHash,
+                    lnurl_info: var_lnurlInfo,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
                 };
@@ -3804,11 +3841,15 @@ impl SseDecode for crate::model::PrepareLnUrlPayResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_destination = <crate::model::SendDestination>::sse_decode(deserializer);
         let mut var_feesSat = <u64>::sse_decode(deserializer);
+        let mut var_data = <crate::bindings::LnUrlPayRequestData>::sse_decode(deserializer);
+        let mut var_comment = <Option<String>>::sse_decode(deserializer);
         let mut var_successAction =
             <Option<crate::bindings::SuccessAction>>::sse_decode(deserializer);
         return crate::model::PrepareLnUrlPayResponse {
             destination: var_destination,
             fees_sat: var_feesSat,
+            data: var_data,
+            comment: var_comment,
             success_action: var_successAction,
         };
     }
@@ -5130,6 +5171,29 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::LnUrlErrorDat
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::LnUrlInfo {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.ln_address.into_into_dart().into_dart(),
+            self.lnurl_pay_comment.into_into_dart().into_dart(),
+            self.lnurl_pay_domain.into_into_dart().into_dart(),
+            self.lnurl_pay_metadata.into_into_dart().into_dart(),
+            self.lnurl_pay_success_action.into_into_dart().into_dart(),
+            self.lnurl_pay_unprocessed_success_action
+                .into_into_dart()
+                .into_dart(),
+            self.lnurl_withdraw_endpoint.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::model::LnUrlInfo {}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::LnUrlInfo> for crate::model::LnUrlInfo {
+    fn into_into_dart(self) -> crate::model::LnUrlInfo {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::bindings::duplicates::LnUrlPayError {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -5622,6 +5686,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 bolt11,
                 bolt12_offer,
                 payment_hash,
+                lnurl_info,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => [
@@ -5632,6 +5697,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 bolt11.into_into_dart().into_dart(),
                 bolt12_offer.into_into_dart().into_dart(),
                 payment_hash.into_into_dart().into_dart(),
+                lnurl_info.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
             ]
@@ -5862,6 +5928,8 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareLnUrlPayResponse {
         [
             self.destination.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
+            self.data.into_into_dart().into_dart(),
+            self.comment.into_into_dart().into_dart(),
             self.success_action.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -7163,6 +7231,25 @@ impl SseEncode for crate::bindings::LnUrlErrorData {
     }
 }
 
+impl SseEncode for crate::model::LnUrlInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<String>>::sse_encode(self.ln_address, serializer);
+        <Option<String>>::sse_encode(self.lnurl_pay_comment, serializer);
+        <Option<String>>::sse_encode(self.lnurl_pay_domain, serializer);
+        <Option<String>>::sse_encode(self.lnurl_pay_metadata, serializer);
+        <Option<crate::bindings::SuccessActionProcessed>>::sse_encode(
+            self.lnurl_pay_success_action,
+            serializer,
+        );
+        <Option<crate::bindings::SuccessAction>>::sse_encode(
+            self.lnurl_pay_unprocessed_success_action,
+            serializer,
+        );
+        <Option<String>>::sse_encode(self.lnurl_withdraw_endpoint, serializer);
+    }
+}
+
 impl SseEncode for crate::bindings::duplicates::LnUrlPayError {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7492,6 +7579,16 @@ impl SseEncode for Option<crate::model::ListPaymentDetails> {
     }
 }
 
+impl SseEncode for Option<crate::model::LnUrlInfo> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::model::LnUrlInfo>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::model::PayAmount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7644,6 +7741,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 bolt11,
                 bolt12_offer,
                 payment_hash,
+                lnurl_info,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => {
@@ -7654,6 +7752,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <Option<String>>::sse_encode(bolt11, serializer);
                 <Option<String>>::sse_encode(bolt12_offer, serializer);
                 <Option<String>>::sse_encode(payment_hash, serializer);
+                <Option<crate::model::LnUrlInfo>>::sse_encode(lnurl_info, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
             }
@@ -7855,6 +7954,8 @@ impl SseEncode for crate::model::PrepareLnUrlPayResponse {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::model::SendDestination>::sse_encode(self.destination, serializer);
         <u64>::sse_encode(self.fees_sat, serializer);
+        <crate::bindings::LnUrlPayRequestData>::sse_encode(self.data, serializer);
+        <Option<String>>::sse_encode(self.comment, serializer);
         <Option<crate::bindings::SuccessAction>>::sse_encode(self.success_action, serializer);
     }
 }
@@ -8571,6 +8672,13 @@ mod io {
             CstDecode::<crate::bindings::LnUrlErrorData>::cst_decode(*wrap).into()
         }
     }
+    impl CstDecode<crate::model::LnUrlInfo> for *mut wire_cst_ln_url_info {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::LnUrlInfo {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::model::LnUrlInfo>::cst_decode(*wrap).into()
+        }
+    }
     impl CstDecode<crate::bindings::LnUrlPayErrorData> for *mut wire_cst_ln_url_pay_error_data {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::bindings::LnUrlPayErrorData {
@@ -9280,6 +9388,22 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::model::LnUrlInfo> for wire_cst_ln_url_info {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::LnUrlInfo {
+            crate::model::LnUrlInfo {
+                ln_address: self.ln_address.cst_decode(),
+                lnurl_pay_comment: self.lnurl_pay_comment.cst_decode(),
+                lnurl_pay_domain: self.lnurl_pay_domain.cst_decode(),
+                lnurl_pay_metadata: self.lnurl_pay_metadata.cst_decode(),
+                lnurl_pay_success_action: self.lnurl_pay_success_action.cst_decode(),
+                lnurl_pay_unprocessed_success_action: self
+                    .lnurl_pay_unprocessed_success_action
+                    .cst_decode(),
+                lnurl_withdraw_endpoint: self.lnurl_withdraw_endpoint.cst_decode(),
+            }
+        }
+    }
     impl CstDecode<crate::bindings::duplicates::LnUrlPayError> for wire_cst_ln_url_pay_error {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::bindings::duplicates::LnUrlPayError {
@@ -9629,6 +9753,7 @@ mod io {
                         bolt11: ans.bolt11.cst_decode(),
                         bolt12_offer: ans.bolt12_offer.cst_decode(),
                         payment_hash: ans.payment_hash.cst_decode(),
+                        lnurl_info: ans.lnurl_info.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
                     }
@@ -9769,6 +9894,8 @@ mod io {
             crate::model::PrepareLnUrlPayResponse {
                 destination: self.destination.cst_decode(),
                 fees_sat: self.fees_sat.cst_decode(),
+                data: self.data.cst_decode(),
+                comment: self.comment.cst_decode(),
                 success_action: self.success_action.cst_decode(),
             }
         }
@@ -10585,6 +10712,24 @@ mod io {
             Self::new_with_null_ptr()
         }
     }
+    impl NewWithNullPtr for wire_cst_ln_url_info {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                ln_address: core::ptr::null_mut(),
+                lnurl_pay_comment: core::ptr::null_mut(),
+                lnurl_pay_domain: core::ptr::null_mut(),
+                lnurl_pay_metadata: core::ptr::null_mut(),
+                lnurl_pay_success_action: core::ptr::null_mut(),
+                lnurl_pay_unprocessed_success_action: core::ptr::null_mut(),
+                lnurl_withdraw_endpoint: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_ln_url_info {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
     impl NewWithNullPtr for wire_cst_ln_url_pay_error {
         fn new_with_null_ptr() -> Self {
             Self {
@@ -10921,6 +11066,8 @@ mod io {
             Self {
                 destination: Default::default(),
                 fees_sat: Default::default(),
+                data: Default::default(),
+                comment: core::ptr::null_mut(),
                 success_action: core::ptr::null_mut(),
             }
         }
@@ -11831,6 +11978,14 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info(
+    ) -> *mut wire_cst_ln_url_info {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_ln_url_info::new_with_null_ptr(),
+        )
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data(
     ) -> *mut wire_cst_ln_url_pay_error_data {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
@@ -12708,6 +12863,17 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_ln_url_info {
+        ln_address: *mut wire_cst_list_prim_u_8_strict,
+        lnurl_pay_comment: *mut wire_cst_list_prim_u_8_strict,
+        lnurl_pay_domain: *mut wire_cst_list_prim_u_8_strict,
+        lnurl_pay_metadata: *mut wire_cst_list_prim_u_8_strict,
+        lnurl_pay_success_action: *mut wire_cst_success_action_processed,
+        lnurl_pay_unprocessed_success_action: *mut wire_cst_success_action,
+        lnurl_withdraw_endpoint: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_ln_url_pay_error {
         tag: i32,
         kind: LnUrlPayErrorKind,
@@ -13028,6 +13194,7 @@ mod io {
         bolt11: *mut wire_cst_list_prim_u_8_strict,
         bolt12_offer: *mut wire_cst_list_prim_u_8_strict,
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
+        lnurl_info: *mut wire_cst_ln_url_info,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,
     }
@@ -13143,6 +13310,8 @@ mod io {
     pub struct wire_cst_prepare_ln_url_pay_response {
         destination: wire_cst_send_destination,
         fees_sat: u64,
+        data: wire_cst_ln_url_pay_request_data,
+        comment: *mut wire_cst_list_prim_u_8_strict,
         success_action: *mut wire_cst_success_action,
     }
     #[repr(C)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1240,8 +1240,21 @@ pub struct PaymentSwapData {
     pub status: PaymentState,
 }
 
+/// Represents the payment LNURL info
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct LnUrlInfo {
+    pub ln_address: Option<String>,
+    pub lnurl_pay_comment: Option<String>,
+    pub lnurl_pay_domain: Option<String>,
+    pub lnurl_pay_metadata: Option<String>,
+    pub lnurl_pay_success_action: Option<SuccessActionProcessed>,
+    pub lnurl_pay_unprocessed_success_action: Option<SuccessAction>,
+    pub lnurl_withdraw_endpoint: Option<String>,
+}
+
 /// The specific details of a payment, depending on its type
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum PaymentDetails {
     /// Swapping to or from Lightning
     Lightning {
@@ -1262,6 +1275,9 @@ pub enum PaymentDetails {
 
         /// The payment hash of the invoice
         payment_hash: Option<String>,
+
+        /// The payment LNURL info
+        lnurl_info: Option<LnUrlInfo>,
 
         /// For a Send swap which was refunded, this is the refund tx id
         refund_tx_id: Option<String>,
@@ -1396,6 +1412,7 @@ impl Payment {
                 bolt12_offer: swap.bolt12_offer,
                 payment_hash: swap.payment_hash,
                 description: swap.description,
+                lnurl_info: None,
                 refund_tx_id: swap.refund_tx_id,
                 refund_tx_amount_sat: swap.refund_tx_amount_sat,
             },
@@ -1585,6 +1602,10 @@ pub struct PrepareLnUrlPayResponse {
     pub destination: SendDestination,
     /// The fees in satoshis to send the payment
     pub fees_sat: u64,
+    /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
+    pub data: LnUrlPayRequestData,
+    /// An optional comment for this payment
+    pub comment: Option<String>,
     /// The unprocessed LUD-09 success action. This will be processed and decrypted if
     /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
     pub success_action: Option<SuccessAction>,

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -213,5 +213,6 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
             data BLOB NOT NULL
         ) STRICT;",
         "ALTER TABLE receive_swaps DROP COLUMN mrh_script_pubkey;",
+        "ALTER TABLE payment_details ADD COLUMN lnurl_info_json TEXT;",
     ]
 }

--- a/lib/core/src/persist/model.rs
+++ b/lib/core/src/persist/model.rs
@@ -2,7 +2,8 @@ use super::LnUrlInfo;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PaymentTxDetails {
-    pub(crate) destination: Option<String>,
+    pub(crate) tx_id: String,
+    pub(crate) destination: String,
     pub(crate) description: Option<String>,
     pub(crate) lnurl_info: Option<LnUrlInfo>,
 }

--- a/lib/core/src/persist/model.rs
+++ b/lib/core/src/persist/model.rs
@@ -1,0 +1,8 @@
+use super::LnUrlInfo;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PaymentTxDetails {
+    pub(crate) destination: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) lnurl_info: Option<LnUrlInfo>,
+}

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -356,7 +356,6 @@ impl ReceiveSwapHandler {
                                 is_confirmed: false,
                             },
                             None,
-                            None,
                         )?;
 
                         info!("Successfully broadcast claim tx {claim_tx_id} for Receive Swap {swap_id}");

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -356,6 +356,7 @@ impl ReceiveSwapHandler {
                                 is_confirmed: false,
                             },
                             None,
+                            false,
                         )?;
 
                         info!("Successfully broadcast claim tx {claim_tx_id} for Receive Swap {swap_id}");

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use futures_util::TryFutureExt;
+use model::data::PaymentDetailsSyncData;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{watch, Mutex};
 
@@ -134,6 +135,13 @@ impl SyncService {
                     *last_commit_time,
                 )
             }
+            SyncData::PaymentDetails(payment_details_sync_data) => {
+                self.persister.commit_incoming_payment_details(
+                    payment_details_sync_data.into(),
+                    new_sync_state,
+                    *last_commit_time,
+                )
+            }
         }
     }
 
@@ -169,6 +177,14 @@ impl SyncService {
                     .ok_or(anyhow!("Could not find last derivation index"))?
                     .parse()?,
             ),
+            RecordType::PaymentDetails => {
+                let payment_details_data: PaymentDetailsSyncData = self
+                    .persister
+                    .get_payment_details(data_id)?
+                    .ok_or(anyhow!("Could not find Payment Details {data_id}"))?
+                    .into();
+                SyncData::PaymentDetails(payment_details_data)
+            }
         };
         Ok(data)
     }

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -27,6 +27,7 @@ pub(crate) enum RecordType {
     Send = 1,
     Chain = 2,
     LastDerivationIndex = 3,
+    PaymentDetails = 4,
 }
 
 impl ToSql for RecordType {
@@ -43,6 +44,7 @@ impl FromSql for RecordType {
                 1 => Ok(Self::Send),
                 2 => Ok(Self::Chain),
                 3 => Ok(Self::LastDerivationIndex),
+                4 => Ok(Self::PaymentDetails),
                 _ => Err(FromSqlError::OutOfRange(i)),
             },
             _ => Err(FromSqlError::InvalidType),
@@ -154,6 +156,7 @@ impl Record {
             SyncData::Send(_) => "send-swap",
             SyncData::Receive(_) => "receive-swap",
             SyncData::LastDerivationIndex(_) => "derivation-index",
+            SyncData::PaymentDetails(_) => "payment-details",
         }
         .to_string();
         Self::id(prefix, data.id())
@@ -165,6 +168,7 @@ impl Record {
             RecordType::Send => "send-swap",
             RecordType::Receive => "receive-swap",
             RecordType::LastDerivationIndex => "derivation-index",
+            RecordType::PaymentDetails => "payment-details",
         }
         .to_string();
         Self::id(prefix, data_id)

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1477,6 +1477,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  LnUrlInfo dco_decode_box_autoadd_ln_url_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_ln_url_info(raw);
+  }
+
+  @protected
   LnUrlPayErrorData dco_decode_box_autoadd_ln_url_pay_error_data(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_ln_url_pay_error_data(raw);
@@ -2123,6 +2129,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  LnUrlInfo dco_decode_ln_url_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return LnUrlInfo(
+      lnAddress: dco_decode_opt_String(arr[0]),
+      lnurlPayComment: dco_decode_opt_String(arr[1]),
+      lnurlPayDomain: dco_decode_opt_String(arr[2]),
+      lnurlPayMetadata: dco_decode_opt_String(arr[3]),
+      lnurlPaySuccessAction: dco_decode_opt_box_autoadd_success_action_processed(arr[4]),
+      lnurlPayUnprocessedSuccessAction: dco_decode_opt_box_autoadd_success_action(arr[5]),
+      lnurlWithdrawEndpoint: dco_decode_opt_String(arr[6]),
+    );
+  }
+
+  @protected
   LnUrlPayError dco_decode_ln_url_pay_error(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -2436,6 +2458,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  LnUrlInfo? dco_decode_opt_box_autoadd_ln_url_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_ln_url_info(raw);
+  }
+
+  @protected
   PayAmount? dco_decode_opt_box_autoadd_pay_amount(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_pay_amount(raw);
@@ -2551,8 +2579,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           bolt11: dco_decode_opt_String(raw[4]),
           bolt12Offer: dco_decode_opt_String(raw[5]),
           paymentHash: dco_decode_opt_String(raw[6]),
-          refundTxId: dco_decode_opt_String(raw[7]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[8]),
+          lnurlInfo: dco_decode_opt_box_autoadd_ln_url_info(raw[7]),
+          refundTxId: dco_decode_opt_String(raw[8]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[9]),
         );
       case 1:
         return PaymentDetails_Liquid(
@@ -2701,11 +2730,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareLnUrlPayResponse dco_decode_prepare_ln_url_pay_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return PrepareLnUrlPayResponse(
       destination: dco_decode_send_destination(arr[0]),
       feesSat: dco_decode_u_64(arr[1]),
-      successAction: dco_decode_opt_box_autoadd_success_action(arr[2]),
+      data: dco_decode_ln_url_pay_request_data(arr[2]),
+      comment: dco_decode_opt_String(arr[3]),
+      successAction: dco_decode_opt_box_autoadd_success_action(arr[4]),
     );
   }
 
@@ -3408,6 +3439,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   LnUrlErrorData sse_decode_box_autoadd_ln_url_error_data(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_ln_url_error_data(deserializer));
+  }
+
+  @protected
+  LnUrlInfo sse_decode_box_autoadd_ln_url_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_ln_url_info(deserializer));
   }
 
   @protected
@@ -4135,6 +4172,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  LnUrlInfo sse_decode_ln_url_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_lnAddress = sse_decode_opt_String(deserializer);
+    var var_lnurlPayComment = sse_decode_opt_String(deserializer);
+    var var_lnurlPayDomain = sse_decode_opt_String(deserializer);
+    var var_lnurlPayMetadata = sse_decode_opt_String(deserializer);
+    var var_lnurlPaySuccessAction = sse_decode_opt_box_autoadd_success_action_processed(deserializer);
+    var var_lnurlPayUnprocessedSuccessAction = sse_decode_opt_box_autoadd_success_action(deserializer);
+    var var_lnurlWithdrawEndpoint = sse_decode_opt_String(deserializer);
+    return LnUrlInfo(
+        lnAddress: var_lnAddress,
+        lnurlPayComment: var_lnurlPayComment,
+        lnurlPayDomain: var_lnurlPayDomain,
+        lnurlPayMetadata: var_lnurlPayMetadata,
+        lnurlPaySuccessAction: var_lnurlPaySuccessAction,
+        lnurlPayUnprocessedSuccessAction: var_lnurlPayUnprocessedSuccessAction,
+        lnurlWithdrawEndpoint: var_lnurlWithdrawEndpoint);
+  }
+
+  @protected
   LnUrlPayError sse_decode_ln_url_pay_error(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4442,6 +4499,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  LnUrlInfo? sse_decode_opt_box_autoadd_ln_url_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_ln_url_info(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   PayAmount? sse_decode_opt_box_autoadd_pay_amount(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4612,6 +4680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_bolt11 = sse_decode_opt_String(deserializer);
         var var_bolt12Offer = sse_decode_opt_String(deserializer);
         var var_paymentHash = sse_decode_opt_String(deserializer);
+        var var_lnurlInfo = sse_decode_opt_box_autoadd_ln_url_info(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
         return PaymentDetails_Lightning(
@@ -4621,6 +4690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             bolt11: var_bolt11,
             bolt12Offer: var_bolt12Offer,
             paymentHash: var_paymentHash,
+            lnurlInfo: var_lnurlInfo,
             refundTxId: var_refundTxId,
             refundTxAmountSat: var_refundTxAmountSat);
       case 1:
@@ -4763,9 +4833,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_destination = sse_decode_send_destination(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
+    var var_data = sse_decode_ln_url_pay_request_data(deserializer);
+    var var_comment = sse_decode_opt_String(deserializer);
     var var_successAction = sse_decode_opt_box_autoadd_success_action(deserializer);
     return PrepareLnUrlPayResponse(
-        destination: var_destination, feesSat: var_feesSat, successAction: var_successAction);
+        destination: var_destination,
+        feesSat: var_feesSat,
+        data: var_data,
+        comment: var_comment,
+        successAction: var_successAction);
   }
 
   @protected
@@ -5515,6 +5591,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_ln_url_info(LnUrlInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ln_url_info(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_ln_url_pay_error_data(LnUrlPayErrorData self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_ln_url_pay_error_data(self, serializer);
@@ -6120,6 +6202,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_ln_url_info(LnUrlInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_String(self.lnAddress, serializer);
+    sse_encode_opt_String(self.lnurlPayComment, serializer);
+    sse_encode_opt_String(self.lnurlPayDomain, serializer);
+    sse_encode_opt_String(self.lnurlPayMetadata, serializer);
+    sse_encode_opt_box_autoadd_success_action_processed(self.lnurlPaySuccessAction, serializer);
+    sse_encode_opt_box_autoadd_success_action(self.lnurlPayUnprocessedSuccessAction, serializer);
+    sse_encode_opt_String(self.lnurlWithdrawEndpoint, serializer);
+  }
+
+  @protected
   void sse_encode_ln_url_pay_error(LnUrlPayError self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
@@ -6387,6 +6481,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_ln_url_info(LnUrlInfo? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_ln_url_info(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_pay_amount(PayAmount? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -6533,6 +6637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           bolt11: final bolt11,
           bolt12Offer: final bolt12Offer,
           paymentHash: final paymentHash,
+          lnurlInfo: final lnurlInfo,
           refundTxId: final refundTxId,
           refundTxAmountSat: final refundTxAmountSat
         ):
@@ -6543,6 +6648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_String(bolt11, serializer);
         sse_encode_opt_String(bolt12Offer, serializer);
         sse_encode_opt_String(paymentHash, serializer);
+        sse_encode_opt_box_autoadd_ln_url_info(lnurlInfo, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
       case PaymentDetails_Liquid(destination: final destination, description: final description):
@@ -6674,6 +6780,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_send_destination(self.destination, serializer);
     sse_encode_u_64(self.feesSat, serializer);
+    sse_encode_ln_url_pay_request_data(self.data, serializer);
+    sse_encode_opt_String(self.comment, serializer);
     sse_encode_opt_box_autoadd_success_action(self.successAction, serializer);
   }
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -138,6 +138,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LnUrlErrorData dco_decode_box_autoadd_ln_url_error_data(dynamic raw);
 
   @protected
+  LnUrlInfo dco_decode_box_autoadd_ln_url_info(dynamic raw);
+
+  @protected
   LnUrlPayErrorData dco_decode_box_autoadd_ln_url_pay_error_data(dynamic raw);
 
   @protected
@@ -351,6 +354,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LnUrlErrorData dco_decode_ln_url_error_data(dynamic raw);
 
   @protected
+  LnUrlInfo dco_decode_ln_url_info(dynamic raw);
+
+  @protected
   LnUrlPayError dco_decode_ln_url_pay_error(dynamic raw);
 
   @protected
@@ -418,6 +424,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ListPaymentDetails? dco_decode_opt_box_autoadd_list_payment_details(dynamic raw);
+
+  @protected
+  LnUrlInfo? dco_decode_opt_box_autoadd_ln_url_info(dynamic raw);
 
   @protected
   PayAmount? dco_decode_opt_box_autoadd_pay_amount(dynamic raw);
@@ -706,6 +715,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LnUrlErrorData sse_decode_box_autoadd_ln_url_error_data(SseDeserializer deserializer);
 
   @protected
+  LnUrlInfo sse_decode_box_autoadd_ln_url_info(SseDeserializer deserializer);
+
+  @protected
   LnUrlPayErrorData sse_decode_box_autoadd_ln_url_pay_error_data(SseDeserializer deserializer);
 
   @protected
@@ -919,6 +931,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   LnUrlErrorData sse_decode_ln_url_error_data(SseDeserializer deserializer);
 
   @protected
+  LnUrlInfo sse_decode_ln_url_info(SseDeserializer deserializer);
+
+  @protected
   LnUrlPayError sse_decode_ln_url_pay_error(SseDeserializer deserializer);
 
   @protected
@@ -986,6 +1001,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ListPaymentDetails? sse_decode_opt_box_autoadd_list_payment_details(SseDeserializer deserializer);
+
+  @protected
+  LnUrlInfo? sse_decode_opt_box_autoadd_ln_url_info(SseDeserializer deserializer);
 
   @protected
   PayAmount? sse_decode_opt_box_autoadd_pay_amount(SseDeserializer deserializer);
@@ -1363,6 +1381,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     // Codec=Cst (C-struct based), see doc to use other codecs
     final ptr = wire.cst_new_box_autoadd_ln_url_error_data();
     cst_api_fill_to_wire_ln_url_error_data(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_ln_url_info> cst_encode_box_autoadd_ln_url_info(LnUrlInfo raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_ln_url_info();
+    cst_api_fill_to_wire_ln_url_info(raw, ptr.ref);
     return ptr;
   }
 
@@ -1797,6 +1823,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_ln_url_info> cst_encode_opt_box_autoadd_ln_url_info(LnUrlInfo? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_ln_url_info(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_cst_pay_amount> cst_encode_opt_box_autoadd_pay_amount(PayAmount? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_box_autoadd_pay_amount(raw);
@@ -2045,6 +2077,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_box_autoadd_ln_url_error_data(
       LnUrlErrorData apiObj, ffi.Pointer<wire_cst_ln_url_error_data> wireObj) {
     cst_api_fill_to_wire_ln_url_error_data(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_ln_url_info(
+      LnUrlInfo apiObj, ffi.Pointer<wire_cst_ln_url_info> wireObj) {
+    cst_api_fill_to_wire_ln_url_info(apiObj, wireObj.ref);
   }
 
   @protected
@@ -2498,6 +2536,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_ln_url_info(LnUrlInfo apiObj, wire_cst_ln_url_info wireObj) {
+    wireObj.ln_address = cst_encode_opt_String(apiObj.lnAddress);
+    wireObj.lnurl_pay_comment = cst_encode_opt_String(apiObj.lnurlPayComment);
+    wireObj.lnurl_pay_domain = cst_encode_opt_String(apiObj.lnurlPayDomain);
+    wireObj.lnurl_pay_metadata = cst_encode_opt_String(apiObj.lnurlPayMetadata);
+    wireObj.lnurl_pay_success_action =
+        cst_encode_opt_box_autoadd_success_action_processed(apiObj.lnurlPaySuccessAction);
+    wireObj.lnurl_pay_unprocessed_success_action =
+        cst_encode_opt_box_autoadd_success_action(apiObj.lnurlPayUnprocessedSuccessAction);
+    wireObj.lnurl_withdraw_endpoint = cst_encode_opt_String(apiObj.lnurlWithdrawEndpoint);
+  }
+
+  @protected
   void cst_api_fill_to_wire_ln_url_pay_error(LnUrlPayError apiObj, wire_cst_ln_url_pay_error wireObj) {
     if (apiObj is LnUrlPayError_AlreadyPaid) {
       wireObj.tag = 0;
@@ -2789,6 +2840,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_bolt11 = cst_encode_opt_String(apiObj.bolt11);
       var pre_bolt12_offer = cst_encode_opt_String(apiObj.bolt12Offer);
       var pre_payment_hash = cst_encode_opt_String(apiObj.paymentHash);
+      var pre_lnurl_info = cst_encode_opt_box_autoadd_ln_url_info(apiObj.lnurlInfo);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
       wireObj.tag = 0;
@@ -2798,6 +2850,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.bolt11 = pre_bolt11;
       wireObj.kind.Lightning.bolt12_offer = pre_bolt12_offer;
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
+      wireObj.kind.Lightning.lnurl_info = pre_lnurl_info;
       wireObj.kind.Lightning.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Lightning.refund_tx_amount_sat = pre_refund_tx_amount_sat;
       return;
@@ -2963,6 +3016,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PrepareLnUrlPayResponse apiObj, wire_cst_prepare_ln_url_pay_response wireObj) {
     cst_api_fill_to_wire_send_destination(apiObj.destination, wireObj.destination);
     wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
+    cst_api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
+    wireObj.comment = cst_encode_opt_String(apiObj.comment);
     wireObj.success_action = cst_encode_opt_box_autoadd_success_action(apiObj.successAction);
   }
 
@@ -3441,6 +3496,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_ln_url_error_data(LnUrlErrorData self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_ln_url_info(LnUrlInfo self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_ln_url_pay_error_data(LnUrlPayErrorData self, SseSerializer serializer);
 
   @protected
@@ -3661,6 +3719,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_ln_url_error_data(LnUrlErrorData self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ln_url_info(LnUrlInfo self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ln_url_pay_error(LnUrlPayError self, SseSerializer serializer);
 
   @protected
@@ -3729,6 +3790,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_list_payment_details(ListPaymentDetails? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_ln_url_info(LnUrlInfo? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_pay_amount(PayAmount? self, SseSerializer serializer);
@@ -4924,6 +4988,16 @@ class RustLibWire implements BaseWire {
   late final _cst_new_box_autoadd_ln_url_error_data = _cst_new_box_autoadd_ln_url_error_dataPtr
       .asFunction<ffi.Pointer<wire_cst_ln_url_error_data> Function()>();
 
+  ffi.Pointer<wire_cst_ln_url_info> cst_new_box_autoadd_ln_url_info() {
+    return _cst_new_box_autoadd_ln_url_info();
+  }
+
+  late final _cst_new_box_autoadd_ln_url_infoPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_ln_url_info> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info');
+  late final _cst_new_box_autoadd_ln_url_info =
+      _cst_new_box_autoadd_ln_url_infoPtr.asFunction<ffi.Pointer<wire_cst_ln_url_info> Function()>();
+
   ffi.Pointer<wire_cst_ln_url_pay_error_data> cst_new_box_autoadd_ln_url_pay_error_data() {
     return _cst_new_box_autoadd_ln_url_pay_error_data();
   }
@@ -5726,6 +5800,30 @@ final class wire_cst_send_destination extends ffi.Struct {
   external SendDestinationKind kind;
 }
 
+final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  @ffi.Uint64()
+  external int min_sendable;
+
+  @ffi.Uint64()
+  external int max_sendable;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
+
+  @ffi.Uint16()
+  external int comment_allowed;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
+
+  @ffi.Bool()
+  external bool allows_nostr;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+}
+
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -5780,6 +5878,10 @@ final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
   @ffi.Uint64()
   external int fees_sat;
 
+  external wire_cst_ln_url_pay_request_data data;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
+
   external ffi.Pointer<wire_cst_success_action> success_action;
 }
 
@@ -5833,30 +5935,6 @@ final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
-}
-
-final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  @ffi.Uint64()
-  external int min_sendable;
-
-  @ffi.Uint64()
-  external int max_sendable;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
-
-  @ffi.Uint16()
-  external int comment_allowed;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
-
-  @ffi.Bool()
-  external bool allows_nostr;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
 }
 
 final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
@@ -5970,6 +6048,76 @@ final class wire_cst_binding_event_listener extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> stream;
 }
 
+final class wire_cst_aes_success_action_data_decrypted extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> plaintext;
+}
+
+final class wire_cst_AesSuccessActionDataResult_Decrypted extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data_decrypted> data;
+}
+
+final class wire_cst_AesSuccessActionDataResult_ErrorStatus extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
+}
+
+final class AesSuccessActionDataResultKind extends ffi.Union {
+  external wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
+
+  external wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
+}
+
+final class wire_cst_aes_success_action_data_result extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AesSuccessActionDataResultKind kind;
+}
+
+final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
+}
+
+final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
+  external ffi.Pointer<wire_cst_message_success_action_data> data;
+}
+
+final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {
+  external ffi.Pointer<wire_cst_url_success_action_data> data;
+}
+
+final class SuccessActionProcessedKind extends ffi.Union {
+  external wire_cst_SuccessActionProcessed_Aes Aes;
+
+  external wire_cst_SuccessActionProcessed_Message Message;
+
+  external wire_cst_SuccessActionProcessed_Url Url;
+}
+
+final class wire_cst_success_action_processed extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SuccessActionProcessedKind kind;
+}
+
+final class wire_cst_ln_url_info extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_comment;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_domain;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_metadata;
+
+  external ffi.Pointer<wire_cst_success_action_processed> lnurl_pay_success_action;
+
+  external ffi.Pointer<wire_cst_success_action> lnurl_pay_unprocessed_success_action;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_withdraw_endpoint;
+}
+
 final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 
@@ -5982,6 +6130,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
+
+  external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
@@ -6139,33 +6289,6 @@ final class wire_cst_connect_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> mnemonic;
 }
 
-final class wire_cst_aes_success_action_data_decrypted extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> plaintext;
-}
-
-final class wire_cst_AesSuccessActionDataResult_Decrypted extends ffi.Struct {
-  external ffi.Pointer<wire_cst_aes_success_action_data_decrypted> data;
-}
-
-final class wire_cst_AesSuccessActionDataResult_ErrorStatus extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
-}
-
-final class AesSuccessActionDataResultKind extends ffi.Union {
-  external wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
-
-  external wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
-}
-
-final class wire_cst_aes_success_action_data_result extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external AesSuccessActionDataResultKind kind;
-}
-
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -6187,33 +6310,6 @@ final class wire_cst_ln_url_pay_error_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
-}
-
-final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
-  external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
-}
-
-final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
-  external ffi.Pointer<wire_cst_message_success_action_data> data;
-}
-
-final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {
-  external ffi.Pointer<wire_cst_url_success_action_data> data;
-}
-
-final class SuccessActionProcessedKind extends ffi.Union {
-  external wire_cst_SuccessActionProcessed_Aes Aes;
-
-  external wire_cst_SuccessActionProcessed_Message Message;
-
-  external wire_cst_SuccessActionProcessed_Url Url;
-}
-
-final class wire_cst_success_action_processed extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external SuccessActionProcessedKind kind;
 }
 
 final class wire_cst_ln_url_pay_success_data extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -399,6 +399,50 @@ class ListPaymentsRequest {
           details == other.details;
 }
 
+/// Represents the payment LNURL info
+class LnUrlInfo {
+  final String? lnAddress;
+  final String? lnurlPayComment;
+  final String? lnurlPayDomain;
+  final String? lnurlPayMetadata;
+  final SuccessActionProcessed? lnurlPaySuccessAction;
+  final SuccessAction? lnurlPayUnprocessedSuccessAction;
+  final String? lnurlWithdrawEndpoint;
+
+  const LnUrlInfo({
+    this.lnAddress,
+    this.lnurlPayComment,
+    this.lnurlPayDomain,
+    this.lnurlPayMetadata,
+    this.lnurlPaySuccessAction,
+    this.lnurlPayUnprocessedSuccessAction,
+    this.lnurlWithdrawEndpoint,
+  });
+
+  @override
+  int get hashCode =>
+      lnAddress.hashCode ^
+      lnurlPayComment.hashCode ^
+      lnurlPayDomain.hashCode ^
+      lnurlPayMetadata.hashCode ^
+      lnurlPaySuccessAction.hashCode ^
+      lnurlPayUnprocessedSuccessAction.hashCode ^
+      lnurlWithdrawEndpoint.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LnUrlInfo &&
+          runtimeType == other.runtimeType &&
+          lnAddress == other.lnAddress &&
+          lnurlPayComment == other.lnurlPayComment &&
+          lnurlPayDomain == other.lnurlPayDomain &&
+          lnurlPayMetadata == other.lnurlPayMetadata &&
+          lnurlPaySuccessAction == other.lnurlPaySuccessAction &&
+          lnurlPayUnprocessedSuccessAction == other.lnurlPayUnprocessedSuccessAction &&
+          lnurlWithdrawEndpoint == other.lnurlWithdrawEndpoint;
+}
+
 /// An argument when calling [crate::sdk::LiquidSdk::lnurl_pay].
 class LnUrlPayRequest {
   /// The response from calling [crate::sdk::LiquidSdk::prepare_lnurl_pay]
@@ -651,6 +695,9 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// The payment hash of the invoice
     String? paymentHash,
 
+    /// The payment LNURL info
+    LnUrlInfo? lnurlInfo,
+
     /// For a Send swap which was refunded, this is the refund tx id
     String? refundTxId,
 
@@ -856,6 +903,12 @@ class PrepareLnUrlPayResponse {
   /// The fees in satoshis to send the payment
   final BigInt feesSat;
 
+  /// The [LnUrlPayRequestData] returned by [crate::input_parser::parse]
+  final LnUrlPayRequestData data;
+
+  /// An optional comment for this payment
+  final String? comment;
+
   /// The unprocessed LUD-09 success action. This will be processed and decrypted if
   /// needed after calling [crate::sdk::LiquidSdk::lnurl_pay]
   final SuccessAction? successAction;
@@ -863,11 +916,14 @@ class PrepareLnUrlPayResponse {
   const PrepareLnUrlPayResponse({
     required this.destination,
     required this.feesSat,
+    required this.data,
+    this.comment,
     this.successAction,
   });
 
   @override
-  int get hashCode => destination.hashCode ^ feesSat.hashCode ^ successAction.hashCode;
+  int get hashCode =>
+      destination.hashCode ^ feesSat.hashCode ^ data.hashCode ^ comment.hashCode ^ successAction.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -876,6 +932,8 @@ class PrepareLnUrlPayResponse {
           runtimeType == other.runtimeType &&
           destination == other.destination &&
           feesSat == other.feesSat &&
+          data == other.data &&
+          comment == other.comment &&
           successAction == other.successAction;
 }
 

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -795,6 +795,7 @@ abstract class _$$PaymentDetails_LightningImplCopyWith<$Res> implements $Payment
       String? bolt11,
       String? bolt12Offer,
       String? paymentHash,
+      LnUrlInfo? lnurlInfo,
       String? refundTxId,
       BigInt? refundTxAmountSat});
 }
@@ -818,6 +819,7 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
     Object? bolt11 = freezed,
     Object? bolt12Offer = freezed,
     Object? paymentHash = freezed,
+    Object? lnurlInfo = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
   }) {
@@ -846,6 +848,10 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
           ? _value.paymentHash
           : paymentHash // ignore: cast_nullable_to_non_nullable
               as String?,
+      lnurlInfo: freezed == lnurlInfo
+          ? _value.lnurlInfo
+          : lnurlInfo // ignore: cast_nullable_to_non_nullable
+              as LnUrlInfo?,
       refundTxId: freezed == refundTxId
           ? _value.refundTxId
           : refundTxId // ignore: cast_nullable_to_non_nullable
@@ -868,6 +874,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
       this.bolt11,
       this.bolt12Offer,
       this.paymentHash,
+      this.lnurlInfo,
       this.refundTxId,
       this.refundTxAmountSat})
       : super._();
@@ -895,6 +902,10 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   @override
   final String? paymentHash;
 
+  /// The payment LNURL info
+  @override
+  final LnUrlInfo? lnurlInfo;
+
   /// For a Send swap which was refunded, this is the refund tx id
   @override
   final String? refundTxId;
@@ -905,7 +916,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   String toString() {
-    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, preimage: $preimage, bolt11: $bolt11, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, preimage: $preimage, bolt11: $bolt11, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -919,6 +930,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
             (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
             (identical(other.bolt12Offer, bolt12Offer) || other.bolt12Offer == bolt12Offer) &&
             (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
+            (identical(other.lnurlInfo, lnurlInfo) || other.lnurlInfo == lnurlInfo) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
                 other.refundTxAmountSat == refundTxAmountSat));
@@ -926,7 +938,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   int get hashCode => Object.hash(runtimeType, swapId, description, preimage, bolt11, bolt12Offer,
-      paymentHash, refundTxId, refundTxAmountSat);
+      paymentHash, lnurlInfo, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -945,6 +957,7 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
       final String? bolt11,
       final String? bolt12Offer,
       final String? paymentHash,
+      final LnUrlInfo? lnurlInfo,
       final String? refundTxId,
       final BigInt? refundTxAmountSat}) = _$PaymentDetails_LightningImpl;
   const PaymentDetails_Lightning._() : super._();
@@ -966,6 +979,9 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
 
   /// The payment hash of the invoice
   String? get paymentHash;
+
+  /// The payment LNURL info
+  LnUrlInfo? get lnurlInfo;
 
   /// For a Send swap which was refunded, this is the refund tx id
   String? get refundTxId;

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1060,6 +1060,17 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_error_dataPtr
           .asFunction<ffi.Pointer<wire_cst_ln_url_error_data> Function()>();
 
+  ffi.Pointer<wire_cst_ln_url_info> frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_infoPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_ln_url_info> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_info =
+      _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_infoPtr
+          .asFunction<ffi.Pointer<wire_cst_ln_url_info> Function()>();
+
   ffi.Pointer<wire_cst_ln_url_pay_error_data>
       frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_ln_url_pay_error_data();
@@ -4211,6 +4222,30 @@ final class wire_cst_send_destination extends ffi.Struct {
   external SendDestinationKind kind;
 }
 
+final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
+
+  @ffi.Uint64()
+  external int min_sendable;
+
+  @ffi.Uint64()
+  external int max_sendable;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
+
+  @ffi.Uint16()
+  external int comment_allowed;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
+
+  @ffi.Bool()
+  external bool allows_nostr;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+}
+
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -4265,6 +4300,10 @@ final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
   @ffi.Uint64()
   external int fees_sat;
 
+  external wire_cst_ln_url_pay_request_data data;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
+
   external ffi.Pointer<wire_cst_success_action> success_action;
 }
 
@@ -4318,30 +4357,6 @@ final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
-}
-
-final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> callback;
-
-  @ffi.Uint64()
-  external int min_sendable;
-
-  @ffi.Uint64()
-  external int max_sendable;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> metadata_str;
-
-  @ffi.Uint16()
-  external int comment_allowed;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> domain;
-
-  @ffi.Bool()
-  external bool allows_nostr;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> nostr_pubkey;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
 }
 
 final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
@@ -4455,6 +4470,76 @@ final class wire_cst_binding_event_listener extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> stream;
 }
 
+final class wire_cst_aes_success_action_data_decrypted extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> plaintext;
+}
+
+final class wire_cst_AesSuccessActionDataResult_Decrypted extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data_decrypted> data;
+}
+
+final class wire_cst_AesSuccessActionDataResult_ErrorStatus extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
+}
+
+final class AesSuccessActionDataResultKind extends ffi.Union {
+  external wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
+
+  external wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
+}
+
+final class wire_cst_aes_success_action_data_result extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external AesSuccessActionDataResultKind kind;
+}
+
+final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
+  external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
+}
+
+final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
+  external ffi.Pointer<wire_cst_message_success_action_data> data;
+}
+
+final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {
+  external ffi.Pointer<wire_cst_url_success_action_data> data;
+}
+
+final class SuccessActionProcessedKind extends ffi.Union {
+  external wire_cst_SuccessActionProcessed_Aes Aes;
+
+  external wire_cst_SuccessActionProcessed_Message Message;
+
+  external wire_cst_SuccessActionProcessed_Url Url;
+}
+
+final class wire_cst_success_action_processed extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external SuccessActionProcessedKind kind;
+}
+
+final class wire_cst_ln_url_info extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_comment;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_domain;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_pay_metadata;
+
+  external ffi.Pointer<wire_cst_success_action_processed> lnurl_pay_success_action;
+
+  external ffi.Pointer<wire_cst_success_action> lnurl_pay_unprocessed_success_action;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lnurl_withdraw_endpoint;
+}
+
 final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 
@@ -4467,6 +4552,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
+
+  external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
@@ -4624,33 +4711,6 @@ final class wire_cst_connect_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> mnemonic;
 }
 
-final class wire_cst_aes_success_action_data_decrypted extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> plaintext;
-}
-
-final class wire_cst_AesSuccessActionDataResult_Decrypted extends ffi.Struct {
-  external ffi.Pointer<wire_cst_aes_success_action_data_decrypted> data;
-}
-
-final class wire_cst_AesSuccessActionDataResult_ErrorStatus extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
-}
-
-final class AesSuccessActionDataResultKind extends ffi.Union {
-  external wire_cst_AesSuccessActionDataResult_Decrypted Decrypted;
-
-  external wire_cst_AesSuccessActionDataResult_ErrorStatus ErrorStatus;
-}
-
-final class wire_cst_aes_success_action_data_result extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external AesSuccessActionDataResultKind kind;
-}
-
 final class wire_cst_bitcoin_address_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> address;
 
@@ -4672,33 +4732,6 @@ final class wire_cst_ln_url_pay_error_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> reason;
-}
-
-final class wire_cst_SuccessActionProcessed_Aes extends ffi.Struct {
-  external ffi.Pointer<wire_cst_aes_success_action_data_result> result;
-}
-
-final class wire_cst_SuccessActionProcessed_Message extends ffi.Struct {
-  external ffi.Pointer<wire_cst_message_success_action_data> data;
-}
-
-final class wire_cst_SuccessActionProcessed_Url extends ffi.Struct {
-  external ffi.Pointer<wire_cst_url_success_action_data> data;
-}
-
-final class SuccessActionProcessedKind extends ffi.Union {
-  external wire_cst_SuccessActionProcessed_Aes Aes;
-
-  external wire_cst_SuccessActionProcessed_Message Message;
-
-  external wire_cst_SuccessActionProcessed_Url Url;
-}
-
-final class wire_cst_success_action_processed extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external SuccessActionProcessedKind kind;
 }
 
 final class wire_cst_ln_url_pay_success_data extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -941,6 +941,81 @@ fun asLnUrlErrorDataList(arr: ReadableArray): List<LnUrlErrorData> {
     return list
 }
 
+fun asLnUrlInfo(lnUrlInfo: ReadableMap): LnUrlInfo? {
+    if (!validateMandatoryFields(
+            lnUrlInfo,
+            arrayOf(),
+        )
+    ) {
+        return null
+    }
+    val lnAddress = if (hasNonNullKey(lnUrlInfo, "lnAddress")) lnUrlInfo.getString("lnAddress") else null
+    val lnurlPayComment = if (hasNonNullKey(lnUrlInfo, "lnurlPayComment")) lnUrlInfo.getString("lnurlPayComment") else null
+    val lnurlPayDomain = if (hasNonNullKey(lnUrlInfo, "lnurlPayDomain")) lnUrlInfo.getString("lnurlPayDomain") else null
+    val lnurlPayMetadata = if (hasNonNullKey(lnUrlInfo, "lnurlPayMetadata")) lnUrlInfo.getString("lnurlPayMetadata") else null
+    val lnurlPaySuccessAction =
+        if (hasNonNullKey(lnUrlInfo, "lnurlPaySuccessAction")) {
+            lnUrlInfo.getMap("lnurlPaySuccessAction")?.let {
+                asSuccessActionProcessed(it)
+            }
+        } else {
+            null
+        }
+    val lnurlPayUnprocessedSuccessAction =
+        if (hasNonNullKey(
+                lnUrlInfo,
+                "lnurlPayUnprocessedSuccessAction",
+            )
+        ) {
+            lnUrlInfo.getMap("lnurlPayUnprocessedSuccessAction")?.let {
+                asSuccessAction(it)
+            }
+        } else {
+            null
+        }
+    val lnurlWithdrawEndpoint =
+        if (hasNonNullKey(
+                lnUrlInfo,
+                "lnurlWithdrawEndpoint",
+            )
+        ) {
+            lnUrlInfo.getString("lnurlWithdrawEndpoint")
+        } else {
+            null
+        }
+    return LnUrlInfo(
+        lnAddress,
+        lnurlPayComment,
+        lnurlPayDomain,
+        lnurlPayMetadata,
+        lnurlPaySuccessAction,
+        lnurlPayUnprocessedSuccessAction,
+        lnurlWithdrawEndpoint,
+    )
+}
+
+fun readableMapOf(lnUrlInfo: LnUrlInfo): ReadableMap =
+    readableMapOf(
+        "lnAddress" to lnUrlInfo.lnAddress,
+        "lnurlPayComment" to lnUrlInfo.lnurlPayComment,
+        "lnurlPayDomain" to lnUrlInfo.lnurlPayDomain,
+        "lnurlPayMetadata" to lnUrlInfo.lnurlPayMetadata,
+        "lnurlPaySuccessAction" to lnUrlInfo.lnurlPaySuccessAction?.let { readableMapOf(it) },
+        "lnurlPayUnprocessedSuccessAction" to lnUrlInfo.lnurlPayUnprocessedSuccessAction?.let { readableMapOf(it) },
+        "lnurlWithdrawEndpoint" to lnUrlInfo.lnurlWithdrawEndpoint,
+    )
+
+fun asLnUrlInfoList(arr: ReadableArray): List<LnUrlInfo> {
+    val list = ArrayList<LnUrlInfo>()
+    for (value in arr.toList()) {
+        when (value) {
+            is ReadableMap -> list.add(asLnUrlInfo(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType(value))
+        }
+    }
+    return list
+}
+
 fun asLnUrlPayErrorData(lnUrlPayErrorData: ReadableMap): LnUrlPayErrorData? {
     if (!validateMandatoryFields(
             lnUrlPayErrorData,
@@ -1581,6 +1656,7 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
             arrayOf(
                 "destination",
                 "feesSat",
+                "data",
             ),
         )
     ) {
@@ -1588,6 +1664,8 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
     }
     val destination = prepareLnUrlPayResponse.getMap("destination")?.let { asSendDestination(it) }!!
     val feesSat = prepareLnUrlPayResponse.getDouble("feesSat").toULong()
+    val data = prepareLnUrlPayResponse.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
+    val comment = if (hasNonNullKey(prepareLnUrlPayResponse, "comment")) prepareLnUrlPayResponse.getString("comment") else null
     val successAction =
         if (hasNonNullKey(prepareLnUrlPayResponse, "successAction")) {
             prepareLnUrlPayResponse.getMap("successAction")?.let {
@@ -1596,13 +1674,15 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
         } else {
             null
         }
-    return PrepareLnUrlPayResponse(destination, feesSat, successAction)
+    return PrepareLnUrlPayResponse(destination, feesSat, data, comment, successAction)
 }
 
 fun readableMapOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse): ReadableMap =
     readableMapOf(
         "destination" to readableMapOf(prepareLnUrlPayResponse.destination),
         "feesSat" to prepareLnUrlPayResponse.feesSat,
+        "data" to readableMapOf(prepareLnUrlPayResponse.data),
+        "comment" to prepareLnUrlPayResponse.comment,
         "successAction" to prepareLnUrlPayResponse.successAction?.let { readableMapOf(it) },
     )
 
@@ -2979,6 +3059,16 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
         val bolt11 = if (hasNonNullKey(paymentDetails, "bolt11")) paymentDetails.getString("bolt11") else null
         val bolt12Offer = if (hasNonNullKey(paymentDetails, "bolt12Offer")) paymentDetails.getString("bolt12Offer") else null
         val paymentHash = if (hasNonNullKey(paymentDetails, "paymentHash")) paymentDetails.getString("paymentHash") else null
+        val lnurlInfo =
+            if (hasNonNullKey(
+                    paymentDetails,
+                    "lnurlInfo",
+                )
+            ) {
+                paymentDetails.getMap("lnurlInfo")?.let { asLnUrlInfo(it) }
+            } else {
+                null
+            }
         val refundTxId = if (hasNonNullKey(paymentDetails, "refundTxId")) paymentDetails.getString("refundTxId") else null
         val refundTxAmountSat =
             if (hasNonNullKey(
@@ -2990,7 +3080,17 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
-        return PaymentDetails.Lightning(swapId, description, preimage, bolt11, bolt12Offer, paymentHash, refundTxId, refundTxAmountSat)
+        return PaymentDetails.Lightning(
+            swapId,
+            description,
+            preimage,
+            bolt11,
+            bolt12Offer,
+            paymentHash,
+            lnurlInfo,
+            refundTxId,
+            refundTxAmountSat,
+        )
     }
     if (type == "liquid") {
         val destination = paymentDetails.getString("destination")!!
@@ -3027,6 +3127,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "bolt11", paymentDetails.bolt11)
             pushToMap(map, "bolt12Offer", paymentDetails.bolt12Offer)
             pushToMap(map, "paymentHash", paymentDetails.paymentHash)
+            pushToMap(map, "lnurlInfo", paymentDetails.lnurlInfo?.let { readableMapOf(it) })
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)
         }

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1131,6 +1131,85 @@ enum BreezSDKLiquidMapper {
         return lnUrlErrorDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlErrorData: v) }
     }
 
+    static func asLnUrlInfo(lnUrlInfo: [String: Any?]) throws -> LnUrlInfo {
+        var lnAddress: String?
+        if hasNonNilKey(data: lnUrlInfo, key: "lnAddress") {
+            guard let lnAddressTmp = lnUrlInfo["lnAddress"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnAddress"))
+            }
+            lnAddress = lnAddressTmp
+        }
+        var lnurlPayComment: String?
+        if hasNonNilKey(data: lnUrlInfo, key: "lnurlPayComment") {
+            guard let lnurlPayCommentTmp = lnUrlInfo["lnurlPayComment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlPayComment"))
+            }
+            lnurlPayComment = lnurlPayCommentTmp
+        }
+        var lnurlPayDomain: String?
+        if hasNonNilKey(data: lnUrlInfo, key: "lnurlPayDomain") {
+            guard let lnurlPayDomainTmp = lnUrlInfo["lnurlPayDomain"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlPayDomain"))
+            }
+            lnurlPayDomain = lnurlPayDomainTmp
+        }
+        var lnurlPayMetadata: String?
+        if hasNonNilKey(data: lnUrlInfo, key: "lnurlPayMetadata") {
+            guard let lnurlPayMetadataTmp = lnUrlInfo["lnurlPayMetadata"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlPayMetadata"))
+            }
+            lnurlPayMetadata = lnurlPayMetadataTmp
+        }
+        var lnurlPaySuccessAction: SuccessActionProcessed?
+        if let lnurlPaySuccessActionTmp = lnUrlInfo["lnurlPaySuccessAction"] as? [String: Any?] {
+            lnurlPaySuccessAction = try asSuccessActionProcessed(successActionProcessed: lnurlPaySuccessActionTmp)
+        }
+
+        var lnurlPayUnprocessedSuccessAction: SuccessAction?
+        if let lnurlPayUnprocessedSuccessActionTmp = lnUrlInfo["lnurlPayUnprocessedSuccessAction"] as? [String: Any?] {
+            lnurlPayUnprocessedSuccessAction = try asSuccessAction(successAction: lnurlPayUnprocessedSuccessActionTmp)
+        }
+
+        var lnurlWithdrawEndpoint: String?
+        if hasNonNilKey(data: lnUrlInfo, key: "lnurlWithdrawEndpoint") {
+            guard let lnurlWithdrawEndpointTmp = lnUrlInfo["lnurlWithdrawEndpoint"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lnurlWithdrawEndpoint"))
+            }
+            lnurlWithdrawEndpoint = lnurlWithdrawEndpointTmp
+        }
+
+        return LnUrlInfo(lnAddress: lnAddress, lnurlPayComment: lnurlPayComment, lnurlPayDomain: lnurlPayDomain, lnurlPayMetadata: lnurlPayMetadata, lnurlPaySuccessAction: lnurlPaySuccessAction, lnurlPayUnprocessedSuccessAction: lnurlPayUnprocessedSuccessAction, lnurlWithdrawEndpoint: lnurlWithdrawEndpoint)
+    }
+
+    static func dictionaryOf(lnUrlInfo: LnUrlInfo) -> [String: Any?] {
+        return [
+            "lnAddress": lnUrlInfo.lnAddress == nil ? nil : lnUrlInfo.lnAddress,
+            "lnurlPayComment": lnUrlInfo.lnurlPayComment == nil ? nil : lnUrlInfo.lnurlPayComment,
+            "lnurlPayDomain": lnUrlInfo.lnurlPayDomain == nil ? nil : lnUrlInfo.lnurlPayDomain,
+            "lnurlPayMetadata": lnUrlInfo.lnurlPayMetadata == nil ? nil : lnUrlInfo.lnurlPayMetadata,
+            "lnurlPaySuccessAction": lnUrlInfo.lnurlPaySuccessAction == nil ? nil : dictionaryOf(successActionProcessed: lnUrlInfo.lnurlPaySuccessAction!),
+            "lnurlPayUnprocessedSuccessAction": lnUrlInfo.lnurlPayUnprocessedSuccessAction == nil ? nil : dictionaryOf(successAction: lnUrlInfo.lnurlPayUnprocessedSuccessAction!),
+            "lnurlWithdrawEndpoint": lnUrlInfo.lnurlWithdrawEndpoint == nil ? nil : lnUrlInfo.lnurlWithdrawEndpoint,
+        ]
+    }
+
+    static func asLnUrlInfoList(arr: [Any]) throws -> [LnUrlInfo] {
+        var list = [LnUrlInfo]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var lnUrlInfo = try asLnUrlInfo(lnUrlInfo: val)
+                list.append(lnUrlInfo)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlInfo"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(lnUrlInfoList: [LnUrlInfo]) -> [Any] {
+        return lnUrlInfoList.map { v -> [String: Any?] in return dictionaryOf(lnUrlInfo: v) }
+    }
+
     static func asLnUrlPayErrorData(lnUrlPayErrorData: [String: Any?]) throws -> LnUrlPayErrorData {
         guard let paymentHash = lnUrlPayErrorData["paymentHash"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPayErrorData"))
@@ -1871,18 +1950,32 @@ enum BreezSDKLiquidMapper {
         guard let feesSat = prepareLnUrlPayResponse["feesSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareLnUrlPayResponse"))
         }
+        guard let dataTmp = prepareLnUrlPayResponse["data"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayResponse"))
+        }
+        let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
+
+        var comment: String?
+        if hasNonNilKey(data: prepareLnUrlPayResponse, key: "comment") {
+            guard let commentTmp = prepareLnUrlPayResponse["comment"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "comment"))
+            }
+            comment = commentTmp
+        }
         var successAction: SuccessAction?
         if let successActionTmp = prepareLnUrlPayResponse["successAction"] as? [String: Any?] {
             successAction = try asSuccessAction(successAction: successActionTmp)
         }
 
-        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, successAction: successAction)
+        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, data: data, comment: comment, successAction: successAction)
     }
 
     static func dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
         return [
             "destination": dictionaryOf(sendDestination: prepareLnUrlPayResponse.destination),
             "feesSat": prepareLnUrlPayResponse.feesSat,
+            "data": dictionaryOf(lnUrlPayRequestData: prepareLnUrlPayResponse.data),
+            "comment": prepareLnUrlPayResponse.comment == nil ? nil : prepareLnUrlPayResponse.comment,
             "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),
         ]
     }
@@ -3659,11 +3752,16 @@ enum BreezSDKLiquidMapper {
 
             let _paymentHash = paymentDetails["paymentHash"] as? String
 
+            var _lnurlInfo: LnUrlInfo?
+            if let lnurlInfoTmp = paymentDetails["lnurlInfo"] as? [String: Any?] {
+                _lnurlInfo = try asLnUrlInfo(lnUrlInfo: lnurlInfoTmp)
+            }
+
             let _refundTxId = paymentDetails["refundTxId"] as? String
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, preimage: _preimage, bolt11: _bolt11, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, preimage: _preimage, bolt11: _bolt11, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
         if type == "liquid" {
             guard let _destination = paymentDetails["destination"] as? String else {
@@ -3694,7 +3792,7 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
         switch paymentDetails {
         case let .lightning(
-            swapId, description, preimage, bolt11, bolt12Offer, paymentHash, refundTxId, refundTxAmountSat
+            swapId, description, preimage, bolt11, bolt12Offer, paymentHash, lnurlInfo, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "lightning",
@@ -3704,6 +3802,7 @@ enum BreezSDKLiquidMapper {
                 "bolt11": bolt11 == nil ? nil : bolt11,
                 "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
                 "paymentHash": paymentHash == nil ? nil : paymentHash,
+                "lnurlInfo": lnurlInfo == nil ? nil : dictionaryOf(lnUrlInfo: lnurlInfo!),
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
             ]

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -181,6 +181,16 @@ export interface LnUrlErrorData {
     reason: string
 }
 
+export interface LnUrlInfo {
+    lnAddress?: string
+    lnurlPayComment?: string
+    lnurlPayDomain?: string
+    lnurlPayMetadata?: string
+    lnurlPaySuccessAction?: SuccessActionProcessed
+    lnurlPayUnprocessedSuccessAction?: SuccessAction
+    lnurlWithdrawEndpoint?: string
+}
+
 export interface LnUrlPayErrorData {
     paymentHash: string
     reason: string
@@ -288,6 +298,8 @@ export interface PrepareLnUrlPayRequest {
 export interface PrepareLnUrlPayResponse {
     destination: SendDestination
     feesSat: number
+    data: LnUrlPayRequestData
+    comment?: string
     successAction?: SuccessAction
 }
 
@@ -606,6 +618,7 @@ export type PaymentDetails = {
     bolt11?: string
     bolt12Offer?: string
     paymentHash?: string
+    lnurlInfo?: LnUrlInfo
     refundTxId?: string
     refundTxAmountSat?: number
 } | {


### PR DESCRIPTION
This PR:
- [x] Stores the LNURL-pay/withdraw info in the payment details table
- [x] Decrypts the AES success action data once the preimage is received
- [x] Syncs the payment details table for Liquid and LNURL data

Needs PR https://github.com/breez/breez-sdk-greenlight/pull/1148

Fixes #318 