### PR TITLE
Update list payments to include chain swaps with only user lockup

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1374,7 +1374,11 @@ pub struct Payment {
     pub details: PaymentDetails,
 }
 impl Payment {
-    pub(crate) fn from_pending_swap(swap: PaymentSwapData, payment_type: PaymentType) -> Payment {
+    pub(crate) fn from_pending_swap(
+        swap: PaymentSwapData,
+        payment_type: PaymentType,
+        payment_details: PaymentDetails,
+    ) -> Payment {
         let amount_sat = match payment_type {
             PaymentType::Receive => swap.receiver_amount_sat,
             PaymentType::Send => swap.payer_amount_sat,
@@ -1389,16 +1393,7 @@ impl Payment {
             swapper_fees_sat: Some(swap.swapper_fees_sat),
             payment_type,
             status: swap.status,
-            details: PaymentDetails::Lightning {
-                swap_id: swap.swap_id,
-                preimage: swap.preimage,
-                bolt11: swap.bolt11,
-                bolt12_offer: swap.bolt12_offer,
-                payment_hash: swap.payment_hash,
-                description: swap.description,
-                refund_tx_id: swap.refund_tx_id,
-                refund_tx_amount_sat: swap.refund_tx_amount_sat,
-            },
+            details: payment_details,
         }
     }
 

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -550,7 +550,11 @@ impl Persister {
         Ok(self
             .get_connection()?
             .query_row(
-                &self.select_payment_query(Some("ptx.tx_id = ?1"), None, None),
+                &self.select_payment_query(
+                    Some("(ptx.tx_id = ?1 OR COALESCE(rs.id, ss.id, cs.id) = ?1)"),
+                    None,
+                    None,
+                ),
                 params![id],
                 |row| self.sql_row_to_payment(row),
             )


### PR DESCRIPTION
This PR allows a payment event to be emitted without a tx_id and updates the payments query to:
- do a FULL JOIN with the chain_swaps table (include chain swaps without claim txs) filtering out where the swap state is Created or TimedOut
- filter out receive_swaps where the swap state is Created, Failed or TimedOut

Fixes https://github.com/breez/misty-breez/issues/276

```
{
    "destination": null,
    "tx_id": null,
    "timestamp": 1734626434,
    "amount_sat": 47796,
    "fees_sat": 2204,
    "swapper_fees_sat": 50,
    "payment_type": "Receive",
    "status": "Pending",
    "details": {
         "Bitcoin": {
             "swap_id": "tYJ9vuAa828n",
             "description": "Bitcoin transfer",
             "refund_tx_id": null,
             "refund_tx_amount_sat": null
         }
    }
}
```