### PR TITLE
Adding the ability to send a payment to a BIP353 address that includes a bolt12 offer

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -651,7 +651,9 @@ dependencies = [
  "async-trait",
  "bip39",
  "boltz-client",
+ "bytes",
  "chrono",
+ "domain",
  "electrum-client",
  "env_logger 0.11.5",
  "flutter_rust_bridge",
@@ -1004,6 +1006,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.75",
+]
+
+[[package]]
+name = "domain"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fbe77a63bf2445649b4ec41ba5300d30dc8358fef4503da03bf2313e31bef3"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "octseq",
+ "rand",
+ "smallvec",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -2232,6 +2250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "octseq"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190e3482f38446ee3f3ab50b049a16b072b6111cba008381b816598478ba65d"
+dependencies = [
+ "bytes",
+ "smallvec",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -749,7 +749,9 @@ dependencies = [
  "async-trait",
  "bip39",
  "boltz-client",
+ "bytes",
  "chrono",
+ "domain",
  "electrum-client",
  "env_logger 0.11.5",
  "flutter_rust_bridge",
@@ -1185,6 +1187,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "domain"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fbe77a63bf2445649b4ec41ba5300d30dc8358fef4503da03bf2313e31bef3"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "octseq",
+ "rand 0.8.5",
+ "smallvec",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -2416,6 +2434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "octseq"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190e3482f38446ee3f3ab50b049a16b072b6111cba008381b816598478ba65d"
+dependencies = [
+ "bytes",
+ "smallvec",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -54,6 +54,8 @@ electrum-client = { version = "0.19.0" }
 zbase32 = "0.1.2"
 x509-parser = { version = "0.16.0" }
 tempfile = "3"
+domain = { version = "0.8.0", features = ["resolv"] }
+bytes = "1.0"
 
 [dev-dependencies]
 lazy_static = "1.5.0"


### PR DESCRIPTION
Feature : Payment to BIP353 addresses

I try to implement a BIP353 address resolver to the sdk to add the ability to send payments to BIP353 type addresses that includes a bolt12 offer.

I will be improving it and also adding to feature to the greenlight implementation