### PR TITLE
Pre-check updated fields before committing outgoing sync

### DIFF
--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -102,13 +102,12 @@ impl Persister {
         let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         Self::insert_or_update_chain_swap_inner(&tx, chain_swap)?;
+
         // Trigger a sync if:
         // - updated_fields is None (swap is inserted, not updated)
         // - updated_fields in a non empty list of updated fields
         let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
-        if trigger_sync {
-            self.commit_outgoing(&tx, &chain_swap.id, RecordType::Chain, updated_fields)?;
-        }
+        self.commit_outgoing(&tx, &chain_swap.id, RecordType::Chain, updated_fields)?;
 
         tx.commit()?;
 

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -63,8 +63,6 @@ impl Persister {
             "UPDATE chain_swaps
             SET
                 description = :description,
-                payer_amount_sat = :payer_amount_sat,
-                receiver_amount_sat = :receiver_amount_sat,
                 accept_zero_conf = :accept_zero_conf,
                 server_lockup_tx_id = :server_lockup_tx_id,
                 user_lockup_tx_id = :user_lockup_tx_id,
@@ -78,8 +76,6 @@ impl Persister {
             named_params! {
                 ":id": &chain_swap.id,
                 ":description": &chain_swap.description,
-                ":payer_amount_sat": &chain_swap.payer_amount_sat,
-                ":receiver_amount_sat": &chain_swap.receiver_amount_sat,
                 ":accept_zero_conf": &chain_swap.accept_zero_conf,
                 ":server_lockup_tx_id": &chain_swap.server_lockup_tx_id,
                 ":user_lockup_tx_id": &chain_swap.user_lockup_tx_id,

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -107,13 +107,16 @@ impl Persister {
         // - updated_fields is None (swap is inserted, not updated)
         // - updated_fields in a non empty list of updated fields
         let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
-        self.commit_outgoing(&tx, &chain_swap.id, RecordType::Chain, updated_fields)?;
-
-        tx.commit()?;
-
-        if trigger_sync {
-            self.sync_trigger.try_send(())?;
-        }
+        match trigger_sync {
+            true => {
+                self.commit_outgoing(&tx, &chain_swap.id, RecordType::Chain, updated_fields)?;
+                tx.commit()?;
+                self.sync_trigger.try_send(())?;
+            }
+            false => {
+                tx.commit()?;
+            }
+        };
 
         Ok(())
     }

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -91,13 +91,12 @@ impl Persister {
         let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         Self::insert_or_update_receive_swap_inner(&tx, receive_swap)?;
+
         // Trigger a sync if:
         // - updated_fields is None (swap is inserted, not updated)
         // - updated_fields in a non empty list of updated fields
         let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
-        if trigger_sync {
-            self.commit_outgoing(&tx, &receive_swap.id, RecordType::Receive, updated_fields)?;
-        }
+        self.commit_outgoing(&tx, &receive_swap.id, RecordType::Receive, updated_fields)?;
 
         tx.commit()?;
 

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -8,6 +8,7 @@ use crate::ensure_sdk;
 use crate::error::PaymentError;
 use crate::model::*;
 use crate::persist::{get_where_clause_state_in, Persister};
+use crate::sync::model::data::ReceiveSyncData;
 use crate::sync::model::RecordType;
 
 impl Persister {
@@ -83,13 +84,26 @@ impl Persister {
     }
 
     pub(crate) fn insert_or_update_receive_swap(&self, receive_swap: &ReceiveSwap) -> Result<()> {
+        let maybe_swap = self.fetch_receive_swap_by_id(&receive_swap.id)?;
+        let updated_fields = ReceiveSyncData::updated_fields(maybe_swap, receive_swap);
+
         let mut con = self.get_connection()?;
         let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         Self::insert_or_update_receive_swap_inner(&tx, receive_swap)?;
-        self.commit_outgoing(&tx, &receive_swap.id, RecordType::Receive, None)?;
+        // Trigger a sync if:
+        // - updated_fields is None (swap is inserted, not updated)
+        // - updated_fields in a non empty list of updated fields
+        let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
+        if trigger_sync {
+            self.commit_outgoing(&tx, &receive_swap.id, RecordType::Receive, updated_fields)?;
+        }
+
         tx.commit()?;
-        self.sync_trigger.try_send(())?;
+
+        if trigger_sync {
+            self.sync_trigger.try_send(())?;
+        }
 
         Ok(())
     }

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -83,13 +83,12 @@ impl Persister {
         let tx = con.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
         Self::insert_or_update_send_swap_inner(&tx, send_swap)?;
+
         // Trigger a sync if:
         // - updated_fields is None (swap is inserted, not updated)
         // - updated_fields in a non empty list of updated fields
         let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
-        if trigger_sync {
-            self.commit_outgoing(&tx, &send_swap.id, RecordType::Send, updated_fields)?;
-        }
+        self.commit_outgoing(&tx, &send_swap.id, RecordType::Send, updated_fields)?;
 
         tx.commit()?;
 

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -88,13 +88,16 @@ impl Persister {
         // - updated_fields is None (swap is inserted, not updated)
         // - updated_fields in a non empty list of updated fields
         let trigger_sync = updated_fields.as_ref().map_or(true, |u| !u.is_empty());
-        self.commit_outgoing(&tx, &send_swap.id, RecordType::Send, updated_fields)?;
-
-        tx.commit()?;
-
-        if trigger_sync {
-            self.sync_trigger.try_send(())?;
-        }
+        match trigger_sync {
+            true => {
+                self.commit_outgoing(&tx, &send_swap.id, RecordType::Send, updated_fields)?;
+                tx.commit()?;
+                self.sync_trigger.try_send(())?;
+            }
+            false => {
+                tx.commit()?;
+            }
+        };
 
         Ok(())
     }

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -37,6 +37,28 @@ impl ChainSyncData {
             }
         }
     }
+
+    pub(crate) fn updated_fields(
+        swap: Option<ChainSwap>,
+        update: &ChainSwap,
+    ) -> Option<Vec<String>> {
+        match swap {
+            Some(swap) => {
+                let mut updated_fields = vec![];
+                if update.accept_zero_conf != swap.accept_zero_conf {
+                    updated_fields.push("accept_zero_conf".to_string());
+                }
+                if update.payer_amount_sat != swap.payer_amount_sat {
+                    updated_fields.push("payer_amount_sat".to_string());
+                }
+                if update.receiver_amount_sat != swap.receiver_amount_sat {
+                    updated_fields.push("receiver_amount_sat".to_string());
+                }
+                Some(updated_fields)
+            }
+            None => None,
+        }
+    }
 }
 
 impl From<ChainSwap> for ChainSyncData {
@@ -114,6 +136,20 @@ impl SendSyncData {
             }
         }
     }
+
+    pub(crate) fn updated_fields(swap: Option<SendSwap>, update: &SendSwap) -> Option<Vec<String>> {
+        match swap {
+            Some(swap) => {
+                let mut updated_fields = vec![];
+                if !matches!(update.preimage.clone(), Some(u) if swap.preimage.map_or(false, |s| s == u))
+                {
+                    updated_fields.push("preimage".to_string());
+                }
+                Some(updated_fields)
+            }
+            None => None,
+        }
+    }
 }
 
 impl From<SendSwap> for SendSyncData {
@@ -172,6 +208,21 @@ pub(crate) struct ReceiveSyncData {
     pub(crate) created_at: u32,
     pub(crate) payment_hash: Option<String>,
     pub(crate) description: Option<String>,
+}
+
+impl ReceiveSyncData {
+    pub(crate) fn updated_fields(
+        swap: Option<ReceiveSwap>,
+        _update: &ReceiveSwap,
+    ) -> Option<Vec<String>> {
+        match swap {
+            Some(_swap) => {
+                let updated_fields = vec![];
+                Some(updated_fields)
+            }
+            None => None,
+        }
+    }
 }
 
 impl From<ReceiveSwap> for ReceiveSyncData {

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -141,8 +141,7 @@ impl SendSyncData {
         match swap {
             Some(swap) => {
                 let mut updated_fields = vec![];
-                if !matches!(update.preimage.clone(), Some(u) if swap.preimage.map_or(false, |s| s == u))
-                {
+                if update.preimage.is_some() && update.preimage != swap.preimage {
                     updated_fields.push("preimage".to_string());
                 }
                 Some(updated_fields)

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -30,8 +30,6 @@ impl ChainSyncData {
     pub(crate) fn merge(&mut self, other: &Self, updated_fields: &[String]) {
         for field in updated_fields {
             match field.as_str() {
-                "payer_amount_sat" => self.payer_amount_sat = other.payer_amount_sat,
-                "receiver_amount_sat" => self.receiver_amount_sat = other.receiver_amount_sat,
                 "accept_zero_conf" => self.accept_zero_conf = other.accept_zero_conf,
                 _ => continue,
             }
@@ -47,12 +45,6 @@ impl ChainSyncData {
                 let mut updated_fields = vec![];
                 if update.accept_zero_conf != swap.accept_zero_conf {
                     updated_fields.push("accept_zero_conf".to_string());
-                }
-                if update.payer_amount_sat != swap.payer_amount_sat {
-                    updated_fields.push("payer_amount_sat".to_string());
-                }
-                if update.receiver_amount_sat != swap.receiver_amount_sat {
-                    updated_fields.push("receiver_amount_sat".to_string());
                 }
                 Some(updated_fields)
             }


### PR DESCRIPTION
This PR pre-checks the updated swap against the existing swap, if some fields are updated then commit outgoing sync

(Draft while I can't test with rt-sync)