### PR TITLE
Use configured lazy connect channel in sync service

### DIFF
--- a/lib/core/src/sync/client.rs
+++ b/lib/core/src/sync/client.rs
@@ -67,7 +67,7 @@ impl BreezSyncerClient {
         &self,
     ) -> Result<ProtoSyncerClient<InterceptedService<Channel, ApiKeyInterceptor>>, Error> {
         let Some(channel) = self.grpc_channel.lock().await.clone() else {
-            return Err(anyhow!("Cannot run `set_record`: client not connected"));
+            return Err(anyhow!("Cannot get sync client: not connected"));
         };
         let api_key_metadata = self.api_key_metadata()?;
         Ok(ProtoSyncerClient::with_interceptor(


### PR DESCRIPTION
Before this PR after some time the sync requests started to receive transport errors. It seems that the default keep alive settings are not working well for this service and we have to configure the underline grpc channel properly.
Also the way we inject the API key has changed a bit to a more centralised point to keep the API calls cleaner.