### PR TITLE
Remove mandatory API key checks

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,11 +80,8 @@ async fn main() -> Result<()> {
     let mut config = LiquidSdk::default_config(network, breez_api_key)?;
     config.working_dir = data_dir_str;
     config.cache_dir = args.cache_dir;
-    if let Some(sync_service_url) = std::env::var_os("SYNC_SERVICE_URL") {
-        config.sync_service_url = sync_service_url
-            .into_string()
-            .expect("Expected valid sync service url");
-    }
+    config.sync_service_url = std::env::var_os("SYNC_SERVICE_URL")
+        .map(|var| var.into_string().expect("Expected valid sync service url"));
     let sdk = LiquidSdk::connect(ConnectRequest {
         mnemonic: mnemonic.to_string(),
         config,

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -332,7 +332,7 @@ dictionary Config {
     LiquidNetwork network;
     u64 payment_timeout_sec;
     u32 zero_conf_min_fee_rate_msat;
-    string sync_service_url;
+    string? sync_service_url;
     string? breez_api_key;
     string? cache_dir;
     u64? zero_conf_max_amount_sat;

--- a/lib/bindings/tests/bindings/csharp/Program.cs
+++ b/lib/bindings/tests/bindings/csharp/Program.cs
@@ -4,7 +4,7 @@ using Breez.Sdk.Liquid;
 try
 {
     var mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-    var config = BreezSdkLiquidMethods.DefaultConfig(LiquidNetwork.Testnet, null);
+    var config = BreezSdkLiquidMethods.DefaultConfig(LiquidNetwork.Testnet, null) with { syncServiceUrl = null };
 
     var connectReq = new ConnectRequest(config, mnemonic);
     BindingLiquidSdk sdk = BreezSdkLiquidMethods.Connect(connectReq);

--- a/lib/bindings/tests/bindings/golang/test_breez_sdk_liquid.go
+++ b/lib/bindings/tests/bindings/golang/test_breez_sdk_liquid.go
@@ -9,6 +9,7 @@ import (
 func main() {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 	config, err := breez_sdk_liquid.DefaultConfig(breez_sdk_liquid.LiquidNetworkTestnet, nil)
+	config.SyncServiceUrl = nil
 
 	if err != nil {
 		log.Fatalf("Config creation failed: %#v", err)

--- a/lib/bindings/tests/bindings/test_breez_liquid_sdk.cs
+++ b/lib/bindings/tests/bindings/test_breez_liquid_sdk.cs
@@ -4,7 +4,7 @@ using breez_sdk_liquid.breez_sdk_liquid;
 try
 {
     var mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-    var config = BreezSdkLiquidMethods.DefaultConfig(LiquidNetwork.Testnet, null);
+    var config = BreezSdkLiquidMethods.DefaultConfig(LiquidNetwork.Testnet, null) with { syncServiceUrl = null };
 
     var connectReq = new ConnectRequest(config, mnemonic);
     BindingLiquidSdk sdk = BreezSdkLiquidMethods.Connect(connectReq);

--- a/lib/bindings/tests/bindings/test_breez_sdk_liquid.kts
+++ b/lib/bindings/tests/bindings/test_breez_sdk_liquid.kts
@@ -8,6 +8,7 @@ class SDKListener: breez_sdk_liquid.EventListener {
 try {
     var mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     var config = breez_sdk_liquid.defaultConfig(breez_sdk_liquid.LiquidNetwork.TESTNET, null)
+    config.syncServiceUrl = null
     var connectRequest = breez_sdk_liquid.ConnectRequest(config, mnemonic)
     var sdk = breez_sdk_liquid.connect(connectRequest)
 

--- a/lib/bindings/tests/bindings/test_breez_sdk_liquid.py
+++ b/lib/bindings/tests/bindings/test_breez_sdk_liquid.py
@@ -9,6 +9,7 @@ class SDKListener(breez_sdk_liquid.EventListener):
 def test():
     mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     config = breez_sdk_liquid.default_config(breez_sdk_liquid.LiquidNetwork.TESTNET, None)
+    config.sync_service_url = None
     connect_request = breez_sdk_liquid.ConnectRequest(config=config, mnemonic=mnemonic)
     sdk = breez_sdk_liquid.connect(connect_request)
 

--- a/lib/bindings/tests/bindings/test_breez_sdk_liquid.swift
+++ b/lib/bindings/tests/bindings/test_breez_sdk_liquid.swift
@@ -7,7 +7,8 @@ class SDKListener: EventListener {
 }
 
 let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-let config = try breez_sdk_liquid.defaultConfig(network: .testnet, breezApiKey: nil);
+var config = try breez_sdk_liquid.defaultConfig(network: .testnet, breezApiKey: nil);
+config.syncServiceUrl = nil
 let connectRequest = breez_sdk_liquid.ConnectRequest(config: config, mnemonic: mnemonic);
 let sdk = try breez_sdk_liquid.connect(req: connectRequest);
 

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2496,7 +2496,7 @@ impl SseDecode for crate::model::Config {
         let mut var_network = <crate::model::LiquidNetwork>::sse_decode(deserializer);
         let mut var_paymentTimeoutSec = <u64>::sse_decode(deserializer);
         let mut var_zeroConfMinFeeRateMsat = <u32>::sse_decode(deserializer);
-        let mut var_syncServiceUrl = <String>::sse_decode(deserializer);
+        let mut var_syncServiceUrl = <Option<String>>::sse_decode(deserializer);
         let mut var_zeroConfMaxAmountSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_breezApiKey = <Option<String>>::sse_decode(deserializer);
         let mut var_externalInputParsers =
@@ -7082,7 +7082,7 @@ impl SseEncode for crate::model::Config {
         <crate::model::LiquidNetwork>::sse_encode(self.network, serializer);
         <u64>::sse_encode(self.payment_timeout_sec, serializer);
         <u32>::sse_encode(self.zero_conf_min_fee_rate_msat, serializer);
-        <String>::sse_encode(self.sync_service_url, serializer);
+        <Option<String>>::sse_encode(self.sync_service_url, serializer);
         <Option<u64>>::sse_encode(self.zero_conf_max_amount_sat, serializer);
         <Option<String>>::sse_encode(self.breez_api_key, serializer);
         <Option<Vec<crate::bindings::ExternalInputParser>>>::sse_encode(

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -50,7 +50,7 @@ pub struct Config {
     /// Zero-conf minimum accepted fee-rate in millisatoshis per vbyte
     pub zero_conf_min_fee_rate_msat: u32,
     /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
-    /// Setting this field to `None` will disable the serivce
+    /// Setting this field to `None` will disable the service
     pub sync_service_url: Option<String>,
     /// Maximum amount in satoshi to accept zero-conf payments with
     /// Defaults to [DEFAULT_ZERO_CONF_MAX_SAT]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -29,7 +29,7 @@ use crate::utils;
 // Uses f64 for the maximum precision when converting between units
 pub const LIQUID_FEE_RATE_SAT_PER_VBYTE: f64 = 0.1;
 pub const LIQUID_FEE_RATE_MSAT_PER_VBYTE: f32 = (LIQUID_FEE_RATE_SAT_PER_VBYTE * 1000.0) as f32;
-const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
+pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 
 /// Configuration for the Liquid SDK
 #[derive(Clone, Debug, Serialize)]
@@ -49,8 +49,9 @@ pub struct Config {
     pub payment_timeout_sec: u64,
     /// Zero-conf minimum accepted fee-rate in millisatoshis per vbyte
     pub zero_conf_min_fee_rate_msat: u32,
-    /// The url of the real-time sync service
-    pub sync_service_url: String,
+    /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
+    /// Setting this field to `None` will disable the serivce
+    pub sync_service_url: Option<String>,
     /// Maximum amount in satoshi to accept zero-conf payments with
     /// Defaults to [DEFAULT_ZERO_CONF_MAX_SAT]
     pub zero_conf_max_amount_sat: Option<u64>,
@@ -74,7 +75,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn mainnet(breez_api_key: String) -> Self {
+    pub fn mainnet(breez_api_key: Option<String>) -> Self {
         Config {
             liquid_electrum_url: "elements-mainnet.breez.technology:50002".to_string(),
             bitcoin_electrum_url: "bitcoin-mainnet.blockstream.info:50002".to_string(),
@@ -84,9 +85,9 @@ impl Config {
             network: LiquidNetwork::Mainnet,
             payment_timeout_sec: 15,
             zero_conf_min_fee_rate_msat: DEFAULT_ZERO_CONF_MIN_FEE_RATE,
-            sync_service_url: BREEZ_SYNC_SERVICE_URL.to_string(),
+            sync_service_url: Some(BREEZ_SYNC_SERVICE_URL.to_string()),
             zero_conf_max_amount_sat: None,
-            breez_api_key: Some(breez_api_key),
+            breez_api_key,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
             onchain_fee_rate_leeway_sat_per_vbyte: None,
@@ -103,7 +104,7 @@ impl Config {
             network: LiquidNetwork::Testnet,
             payment_timeout_sec: 15,
             zero_conf_min_fee_rate_msat: DEFAULT_ZERO_CONF_MIN_FEE_RATE,
-            sync_service_url: BREEZ_SYNC_SERVICE_URL.to_string(),
+            sync_service_url: Some(BREEZ_SYNC_SERVICE_URL.to_string()),
             zero_conf_max_amount_sat: None,
             breez_api_key,
             external_input_parsers: None,

--- a/lib/core/src/persist/cache.rs
+++ b/lib/core/src/persist/cache.rs
@@ -159,7 +159,7 @@ impl Persister {
         let tx = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
         self.set_last_derivation_index_inner(&tx, index)?;
         tx.commit()?;
-        self.sync_trigger.try_send(())?;
+        self.trigger_sync()?;
         Ok(())
     }
 
@@ -183,8 +183,7 @@ impl Persister {
             None => None,
         };
         tx.commit()?;
-        self.sync_trigger.try_send(())?;
-
+        self.trigger_sync()?;
         Ok(res)
     }
 }

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -117,7 +117,7 @@ impl Persister {
             true => {
                 self.commit_outgoing(&tx, &chain_swap.id, RecordType::Chain, updated_fields)?;
                 tx.commit()?;
-                self.sync_trigger.try_send(())?;
+                self.trigger_sync()?;
             }
             false => {
                 tx.commit()?;
@@ -305,11 +305,9 @@ impl Persister {
             Some(vec!["accept_zero_conf".to_string()]),
         )?;
         tx.commit()?;
-        self.sync_trigger
-            .try_send(())
-            .map_err(|err| PaymentError::Generic {
-                err: format!("Could not trigger manual sync: {err:?}"),
-            })?;
+        self.trigger_sync().map_err(|err| PaymentError::Generic {
+            err: format!("Could not trigger manual sync: {err:?}"),
+        })?;
 
         Ok(())
     }
@@ -367,11 +365,9 @@ impl Persister {
             Some(vec!["accepted_receiver_amount_sat".to_string()]),
         )?;
         tx.commit()?;
-        self.sync_trigger
-            .try_send(())
-            .map_err(|err| PaymentError::Generic {
-                err: format!("Could not trigger manual sync: {err:?}"),
-            })?;
+        self.trigger_sync().map_err(|err| PaymentError::Generic {
+            err: format!("Could not trigger manual sync: {err:?}"),
+        })?;
 
         Ok(())
     }

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -117,7 +117,7 @@ impl Persister {
             true => {
                 self.commit_outgoing(&tx, &receive_swap.id, RecordType::Receive, updated_fields)?;
                 tx.commit()?;
-                self.sync_trigger.try_send(())?;
+                self.trigger_sync()?;
             }
             false => {
                 tx.commit()?;

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -102,7 +102,7 @@ impl Persister {
             true => {
                 self.commit_outgoing(&tx, &send_swap.id, RecordType::Send, updated_fields)?;
                 tx.commit()?;
-                self.sync_trigger.try_send(())?;
+                self.trigger_sync()?;
             }
             false => {
                 tx.commit()?;
@@ -298,11 +298,10 @@ impl Persister {
         let updated_fields = get_updated_fields!(preimage);
         self.commit_outgoing(&tx, swap_id, RecordType::Send, updated_fields)?;
         tx.commit()?;
-        self.sync_trigger
-            .try_send(())
-            .map_err(|err| PaymentError::Generic {
-                err: format!("Could not trigger manual sync: {err:?}"),
-            })?;
+
+        self.trigger_sync().map_err(|err| PaymentError::Generic {
+            err: format!("Could not trigger manual sync: {err:?}"),
+        })?;
 
         Ok(())
     }

--- a/lib/core/src/persist/sync.rs
+++ b/lib/core/src/persist/sync.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use anyhow::Result;
 use rusqlite::{

--- a/lib/core/src/sync/client.rs
+++ b/lib/core/src/sync/client.rs
@@ -113,9 +113,9 @@ pub struct ApiKeyInterceptor {
 
 impl Interceptor for ApiKeyInterceptor {
     fn call(&mut self, mut req: Request<()>) -> Result<Request<()>, Status> {
-        if self.api_key_metadata.clone().is_some() {
+        if let Some(api_key_metadata) = &self.api_key_metadata {
             req.metadata_mut()
-                .insert("authorization", self.api_key_metadata.clone().unwrap());
+                .insert("authorization", api_key_metadata.clone());
         }
         Ok(req)
     }

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -147,7 +147,6 @@ pub(crate) fn new_receive_swap(payment_state: Option<PaymentState>) -> ReceiveSw
 
 macro_rules! create_persister {
     ($name:ident) => {
-        let (sync_trigger_tx, _sync_trigger_rx) = tokio::sync::mpsc::channel::<()>(100);
         let temp_dir = tempdir::TempDir::new("liquid-sdk")?;
         let $name = std::sync::Arc::new(crate::persist::Persister::new(
             temp_dir
@@ -155,7 +154,7 @@ macro_rules! create_persister {
                 .to_str()
                 .ok_or(anyhow::anyhow!("Could not create temporary directory"))?,
             crate::model::LiquidNetwork::Testnet,
-            sync_trigger_tx,
+            None,
         )?);
         $name.init()?;
     };

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -106,7 +106,7 @@ pub(crate) fn new_liquid_sdk_with_chain_services(
 
     let (_incoming_tx, _outgoing_records, sync_service) =
         new_sync_service(persister.clone(), recoverer.clone(), signer.clone())?;
-    let sync_service = Arc::new(sync_service);
+    let sync_service = Some(Arc::new(sync_service));
 
     Ok(LiquidSdk {
         config,

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -94,7 +94,6 @@ pub(crate) fn new_sync_service(
     Arc<Mutex<HashMap<String, Record>>>,
     SyncService,
 )> {
-    let (_, sync_trigger_rx) = mpsc::channel::<()>(30);
     let (incoming_tx, incoming_rx) = mpsc::channel::<Record>(10);
     let outgoing_records = Arc::new(Mutex::new(HashMap::new()));
     let client = Box::new(MockSyncerClient::new(incoming_rx, outgoing_records.clone()));
@@ -104,7 +103,6 @@ pub(crate) fn new_sync_service(
         recoverer,
         signer.clone(),
         client,
-        sync_trigger_rx,
     );
 
     Ok((incoming_tx, outgoing_records, sync_service))

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1800,7 +1800,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       network: dco_decode_liquid_network(arr[5]),
       paymentTimeoutSec: dco_decode_u_64(arr[6]),
       zeroConfMinFeeRateMsat: dco_decode_u_32(arr[7]),
-      syncServiceUrl: dco_decode_String(arr[8]),
+      syncServiceUrl: dco_decode_opt_String(arr[8]),
       zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[9]),
       breezApiKey: dco_decode_opt_String(arr[10]),
       externalInputParsers: dco_decode_opt_list_external_input_parser(arr[11]),
@@ -3830,7 +3830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_network = sse_decode_liquid_network(deserializer);
     var var_paymentTimeoutSec = sse_decode_u_64(deserializer);
     var var_zeroConfMinFeeRateMsat = sse_decode_u_32(deserializer);
-    var var_syncServiceUrl = sse_decode_String(deserializer);
+    var var_syncServiceUrl = sse_decode_opt_String(deserializer);
     var var_zeroConfMaxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_breezApiKey = sse_decode_opt_String(deserializer);
     var var_externalInputParsers = sse_decode_opt_list_external_input_parser(deserializer);
@@ -6056,7 +6056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_liquid_network(self.network, serializer);
     sse_encode_u_64(self.paymentTimeoutSec, serializer);
     sse_encode_u_32(self.zeroConfMinFeeRateMsat, serializer);
-    sse_encode_String(self.syncServiceUrl, serializer);
+    sse_encode_opt_String(self.syncServiceUrl, serializer);
     sse_encode_opt_box_autoadd_u_64(self.zeroConfMaxAmountSat, serializer);
     sse_encode_opt_String(self.breezApiKey, serializer);
     sse_encode_opt_list_external_input_parser(self.externalInputParsers, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2366,7 +2366,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.network = cst_encode_liquid_network(apiObj.network);
     wireObj.payment_timeout_sec = cst_encode_u_64(apiObj.paymentTimeoutSec);
     wireObj.zero_conf_min_fee_rate_msat = cst_encode_u_32(apiObj.zeroConfMinFeeRateMsat);
-    wireObj.sync_service_url = cst_encode_String(apiObj.syncServiceUrl);
+    wireObj.sync_service_url = cst_encode_opt_String(apiObj.syncServiceUrl);
     wireObj.zero_conf_max_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.zeroConfMaxAmountSat);
     wireObj.breez_api_key = cst_encode_opt_String(apiObj.breezApiKey);
     wireObj.external_input_parsers = cst_encode_opt_list_external_input_parser(apiObj.externalInputParsers);

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -175,7 +175,7 @@ class Config {
   final int zeroConfMinFeeRateMsat;
 
   /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
-  /// Setting this field to `None` will disable the serivce
+  /// Setting this field to `None` will disable the service
   final String? syncServiceUrl;
 
   /// Maximum amount in satoshi to accept zero-conf payments with

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -174,8 +174,9 @@ class Config {
   /// Zero-conf minimum accepted fee-rate in millisatoshis per vbyte
   final int zeroConfMinFeeRateMsat;
 
-  /// The url of the real-time sync service
-  final String syncServiceUrl;
+  /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
+  /// Setting this field to `None` will disable the serivce
+  final String? syncServiceUrl;
 
   /// Maximum amount in satoshi to accept zero-conf payments with
   /// Defaults to [DEFAULT_ZERO_CONF_MAX_SAT]
@@ -211,7 +212,7 @@ class Config {
     required this.network,
     required this.paymentTimeoutSec,
     required this.zeroConfMinFeeRateMsat,
-    required this.syncServiceUrl,
+    this.syncServiceUrl,
     this.zeroConfMaxAmountSat,
     this.breezApiKey,
     this.externalInputParsers,

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -311,7 +311,6 @@ fun asConfig(config: ReadableMap): Config? {
                 "network",
                 "paymentTimeoutSec",
                 "zeroConfMinFeeRateMsat",
-                "syncServiceUrl",
                 "useDefaultExternalInputParsers",
             ),
         )
@@ -325,7 +324,7 @@ fun asConfig(config: ReadableMap): Config? {
     val network = config.getString("network")?.let { asLiquidNetwork(it) }!!
     val paymentTimeoutSec = config.getDouble("paymentTimeoutSec").toULong()
     val zeroConfMinFeeRateMsat = config.getInt("zeroConfMinFeeRateMsat").toUInt()
-    val syncServiceUrl = config.getString("syncServiceUrl")!!
+    val syncServiceUrl = if (hasNonNullKey(config, "syncServiceUrl")) config.getString("syncServiceUrl") else null
     val breezApiKey = if (hasNonNullKey(config, "breezApiKey")) config.getString("breezApiKey") else null
     val cacheDir = if (hasNonNullKey(config, "cacheDir")) config.getString("cacheDir") else null
     val zeroConfMaxAmountSat =

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -374,8 +374,12 @@ enum BreezSDKLiquidMapper {
         guard let zeroConfMinFeeRateMsat = config["zeroConfMinFeeRateMsat"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "zeroConfMinFeeRateMsat", typeName: "Config"))
         }
-        guard let syncServiceUrl = config["syncServiceUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "syncServiceUrl", typeName: "Config"))
+        var syncServiceUrl: String?
+        if hasNonNilKey(data: config, key: "syncServiceUrl") {
+            guard let syncServiceUrlTmp = config["syncServiceUrl"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "syncServiceUrl"))
+            }
+            syncServiceUrl = syncServiceUrlTmp
         }
         var breezApiKey: String?
         if hasNonNilKey(data: config, key: "breezApiKey") {
@@ -426,7 +430,7 @@ enum BreezSDKLiquidMapper {
             "network": valueOf(liquidNetwork: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,
             "zeroConfMinFeeRateMsat": config.zeroConfMinFeeRateMsat,
-            "syncServiceUrl": config.syncServiceUrl,
+            "syncServiceUrl": config.syncServiceUrl == nil ? nil : config.syncServiceUrl,
             "breezApiKey": config.breezApiKey == nil ? nil : config.breezApiKey,
             "cacheDir": config.cacheDir == nil ? nil : config.cacheDir,
             "zeroConfMaxAmountSat": config.zeroConfMaxAmountSat == nil ? nil : config.zeroConfMaxAmountSat,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -74,7 +74,7 @@ export interface Config {
     network: LiquidNetwork
     paymentTimeoutSec: number
     zeroConfMinFeeRateMsat: number
-    syncServiceUrl: string
+    syncServiceUrl?: string
     breezApiKey?: string
     cacheDir?: string
     zeroConfMaxAmountSat?: number


### PR DESCRIPTION
Closes #661.
Built on top of #637.

This PR:
- Makes the real-time sync service optional (depending on the presence of `sync_service_url`) as follows:
   - Set and equal to `BREEZ_SYNC_SERVICE_URL`: Check for API key
   - Set and different from `BREEZ_SYNC_SERVICE_URL`: Use without API key
   - Not set: Disable the sync service
- Conditionally calls rt-sync commit methods to avoid cluttering of the db when the sync service is not active
- Skips the initial `validate_api_key` call unless it is set in the config

This should complete all the requirements for #554, except for the swapper proxy changes & fiat api.