### PR TITLE
Multi-asset send/receive

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -200,44 +200,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 dependencies = [
  "backtrace",
 ]
@@ -305,7 +304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -352,7 +351,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -364,7 +363,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -376,14 +375,14 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.6"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -392,24 +391,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.6"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -437,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -454,7 +453,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -479,7 +478,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -490,7 +489,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.2",
+ "sync_wrapper 1.0.1",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -522,13 +521,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -554,7 +553,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin_hashes 0.14.0",
 ]
 
@@ -619,7 +618,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "toml",
  "uniffi 0.23.0",
@@ -640,11 +639,11 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.11.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -664,28 +663,22 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.0",
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
- "hex-conservative 0.2.1",
+ "hex-conservative",
  "hex_lit",
  "secp256k1 0.29.1",
  "serde",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -714,7 +707,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-internals",
  "serde",
 ]
 
@@ -726,22 +719,12 @@ checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
-]
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.1",
+ "hex-conservative",
  "serde",
 ]
 
@@ -764,7 +747,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "serde",
  "serde_json",
 ]
@@ -777,9 +760,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -822,7 +805,7 @@ version = "0.2.0"
 source = "git+https://github.com/danielgranhao/boltz-rust?rev=e3e87186604c818c667b1293149423af5757dfbe#e3e87186604c818c667b1293149423af5757dfbe"
 dependencies = [
  "bip39",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "electrum-client",
  "elements",
  "env_logger 0.7.1",
@@ -849,7 +832,7 @@ dependencies = [
  "derivative",
  "ecies",
  "electrum-client",
- "env_logger 0.11.6",
+ "env_logger 0.11.5",
  "flutter_rust_bridge",
  "futures-util",
  "glob",
@@ -875,7 +858,7 @@ dependencies = [
  "strum_macros",
  "tempdir",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -897,7 +880,7 @@ dependencies = [
  "glob",
  "log",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "uniffi 0.25.3",
  "uniffi_bindgen 0.25.3",
@@ -918,9 +901,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -930,9 +913,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "camino"
@@ -945,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -963,7 +946,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -977,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -989,12 +972,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1022,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1074,23 +1051,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.24",
+ "clap_derive 4.5.13",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
+ "clap_lex 0.7.2",
  "strsim 0.11.1",
 ]
 
@@ -1109,14 +1086,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1130,15 +1107,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -1177,9 +1154,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1201,9 +1178,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1247,7 +1224,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1319,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "delegate-attr"
@@ -1331,7 +1308,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1396,7 +1373,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1428,11 +1405,11 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0bd443023f9f5c4b7153053721939accc7113cbdf810a024434eed454b3db1"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.21",
+ "rustls 0.23.12",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1446,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ab681914c4d96235d4c30d6a758f4aeb4eace26837f4995ca84bf7ea3189ea"
 dependencies = [
  "bech32 0.11.0",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1458,7 +1435,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571fa105690f83c7833df2109eb2e14ca0e62d633d2624ffcb166ff18a3da870"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "elements",
  "miniscript",
  "serde",
@@ -1466,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1482,14 +1459,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -1520,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1539,12 +1516,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1561,9 +1538,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1588,9 +1565,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1637,7 +1614,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1680,7 +1657,7 @@ dependencies = [
  "md-5",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1730,9 +1707,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1745,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1755,15 +1732,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1772,38 +1749,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1851,15 +1828,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
@@ -1884,7 +1861,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1893,17 +1870,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.1",
+ "http 1.1.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1930,12 +1907,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -1981,12 +1952,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
-
-[[package]]
-name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
@@ -2018,7 +1983,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "ring 0.16.20",
- "thiserror 1.0.69",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2041,7 +2006,7 @@ dependencies = [
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2066,11 +2031,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2097,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2124,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2135,16 +2100,16 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2169,9 +2134,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2193,15 +2158,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.6",
+ "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2214,20 +2179,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.1.0",
+ "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.21",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.5",
 ]
 
 [[package]]
@@ -2236,7 +2201,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2248,7 +2213,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.2",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2262,7 +2227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2277,9 +2242,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2297,7 +2262,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "thiserror 1.0.69",
+ "thiserror",
  "unic-langid",
 ]
 
@@ -2317,7 +2282,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rust-embed",
- "thiserror 1.0.69",
+ "thiserror",
  "unic-langid",
  "walkdir",
 ]
@@ -2339,7 +2304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.96",
+ "syn 2.0.87",
  "unic-langid",
 ]
 
@@ -2353,14 +2318,14 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2494,7 +2459,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2508,6 +2473,16 @@ name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2565,12 +2540,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2631,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2651,27 +2626,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2695,9 +2660,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libsecp256k1"
@@ -2771,7 +2736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "lightning-invoice 0.32.0",
  "lightning-types",
 ]
@@ -2797,7 +2762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "lightning-types",
 ]
 
@@ -2808,8 +2773,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.5",
- "hex-conservative 0.2.1",
+ "bitcoin 0.32.4",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -2820,9 +2785,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
@@ -2842,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru-cache"
@@ -2867,7 +2832,7 @@ dependencies = [
  "getrandom",
  "qr_code",
  "rand 0.8.5",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2876,7 +2841,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f88c9817902800ee931cc42ef91df10df1e98fdb14848c07996463b4c711f80"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
  "rand 0.8.5",
  "tempfile",
  "testcontainers",
@@ -2895,13 +2860,13 @@ dependencies = [
  "lwk_common",
  "lwk_containers",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.7",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "wasm-timer",
 ]
 
@@ -2916,7 +2881,7 @@ dependencies = [
  "elements-miniscript",
  "lwk_common",
  "lwk_jade",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2939,10 +2904,10 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "regex-lite",
- "reqwest 0.12.12",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
  "url",
 ]
 
@@ -3003,14 +2968,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd3c9608217b0d6fa9c9c8ddd875b85ab72bd4311cfc8db35e1b5a08fc11f4d"
 dependencies = [
  "bech32 0.11.0",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.4",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
 ]
@@ -3028,10 +2993,11 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -3042,12 +3008,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
@@ -3122,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -3162,11 +3122,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3183,7 +3143,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3194,18 +3154,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.3.2+3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -3274,7 +3234,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3314,34 +3274,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.5.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -3351,9 +3311,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plain"
@@ -3417,12 +3377,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3451,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3486,10 +3446,10 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -3507,16 +3467,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools",
  "log",
- "multimap 0.10.0",
+ "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.29",
+ "prettyplease 0.2.25",
  "prost 0.13.4",
  "prost-types 0.13.4",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -3527,7 +3487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3540,10 +3500,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3587,49 +3547,45 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
- "rustls 0.23.21",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.12",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "getrandom",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 2.1.0",
- "rustls 0.23.21",
- "rustls-pki-types",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.12",
  "slab",
- "thiserror 2.0.11",
+ "thiserror",
  "tinyvec",
  "tracing",
- "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
- "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -3639,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -3724,11 +3680,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3789,7 +3745,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3814,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3824,11 +3780,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.6",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.4.1",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -3839,23 +3795,22 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.21",
- "rustls-pemfile 2.2.0",
+ "rustls 0.23.12",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.26.1",
- "tower 0.5.2",
+ "tokio-rustls 0.26.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.5",
  "windows-registry",
 ]
 
@@ -3905,7 +3860,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.6.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3943,7 +3898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.96",
+ "syn 2.0.87",
  "walkdir",
 ]
 
@@ -3971,9 +3926,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -3995,15 +3950,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4020,15 +3975,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -4056,27 +4023,35 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.2.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "web-time",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -4085,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -4115,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -4145,7 +4120,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4196,7 +4171,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tonic 0.8.3",
  "tonic-build 0.8.4",
@@ -4314,18 +4289,18 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -4351,20 +4326,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -4466,9 +4441,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4526,7 +4501,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4548,9 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4565,9 +4540,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
 ]
@@ -4580,7 +4555,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4589,7 +4564,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4616,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4661,42 +4636,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4710,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -4731,9 +4686,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4751,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4766,9 +4721,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4794,13 +4749,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4826,19 +4781,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.21",
+ "rustls 0.23.12",
+ "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4862,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4898,7 +4854,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
@@ -4929,26 +4885,26 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.6",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.4.1",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.4",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile 2.1.3",
  "socket2",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.5",
 ]
 
 [[package]]
@@ -4970,12 +4926,12 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
- "prettyplease 0.2.29",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5007,8 +4963,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -5027,9 +4982,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5038,20 +4993,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -5081,13 +5036,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http 1.1.0",
  "httparse",
  "log",
  "native-tls",
  "rand 0.8.5",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror",
  "url",
  "utf-8",
 ]
@@ -5128,21 +5083,24 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.18"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -5175,7 +5133,7 @@ checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
 dependencies = [
  "anyhow",
  "camino",
- "clap 4.5.27",
+ "clap 4.5.17",
  "uniffi_bindgen 0.25.3",
  "uniffi_build 0.25.3",
  "uniffi_core 0.25.3",
@@ -5216,7 +5174,7 @@ dependencies = [
  "askama 0.12.1",
  "camino",
  "cargo_metadata",
- "clap 4.5.27",
+ "clap 4.5.17",
  "fs-err",
  "glob",
  "goblin",
@@ -5238,7 +5196,7 @@ dependencies = [
  "anyhow",
  "askama 0.12.1",
  "camino",
- "clap 4.5.27",
+ "clap 4.5.17",
  "heck 0.4.1",
  "include_dir",
  "paste",
@@ -5286,7 +5244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5353,7 +5311,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.96",
+ "syn 2.0.87",
  "toml",
  "uniffi_build 0.25.3",
  "uniffi_meta 0.25.3",
@@ -5456,31 +5414,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "flate2",
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.21",
- "rustls-pki-types",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -5516,9 +5474,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -5562,48 +5520,47 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5611,25 +5568,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-timer"
@@ -5648,19 +5602,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5693,9 +5637,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5992,7 +5936,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
 ]
 
@@ -6016,7 +5960,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -6044,7 +5988,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6064,7 +6008,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -6085,7 +6029,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6107,5 +6051,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.87",
 ]

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayInvoice.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayInvoice.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import breez_sdk_liquid.BindingLiquidSdk
 import breez_sdk_liquid.PaymentMethod
 import breez_sdk_liquid.PrepareReceiveRequest
+import breez_sdk_liquid.ReceiveAmount
 import breez_sdk_liquid.ReceivePaymentRequest
 import breez_sdk_liquid_notification.Constants.DEFAULT_LNURL_PAY_INVOICE_NOTIFICATION_TITLE
 import breez_sdk_liquid_notification.Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
@@ -62,7 +63,7 @@ class LnurlPayInvoiceJob(
                 DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT
             )
             val prepareReceivePaymentRes = liquidSDK.prepareReceivePayment(
-                PrepareReceiveRequest(PaymentMethod.LIGHTNING, amountSat)
+                PrepareReceiveRequest(PaymentMethod.LIGHTNING, ReceiveAmount.Bitcoin(amountSat))
             )
             val receivePaymentResponse = liquidSDK.receivePayment(
                 ReceivePaymentRequest(

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -102,6 +102,7 @@ typedef struct wire_cst_list_payment_state {
 } wire_cst_list_payment_state;
 
 typedef struct wire_cst_ListPaymentDetails_Liquid {
+  struct wire_cst_list_prim_u_8_strict *asset_id;
   struct wire_cst_list_prim_u_8_strict *destination;
 } wire_cst_ListPaymentDetails_Liquid;
 
@@ -353,12 +354,18 @@ typedef struct wire_cst_prepare_ln_url_pay_request {
   bool *validate_success_action_url;
 } wire_cst_prepare_ln_url_pay_request;
 
-typedef struct wire_cst_PayAmount_Receiver {
-  uint64_t amount_sat;
-} wire_cst_PayAmount_Receiver;
+typedef struct wire_cst_PayAmount_Bitcoin {
+  uint64_t receiver_amount_sat;
+} wire_cst_PayAmount_Bitcoin;
+
+typedef struct wire_cst_PayAmount_Asset {
+  struct wire_cst_list_prim_u_8_strict *asset_id;
+  uint64_t receiver_amount;
+} wire_cst_PayAmount_Asset;
 
 typedef union PayAmountKind {
-  struct wire_cst_PayAmount_Receiver Receiver;
+  struct wire_cst_PayAmount_Bitcoin Bitcoin;
+  struct wire_cst_PayAmount_Asset Asset;
 } PayAmountKind;
 
 typedef struct wire_cst_pay_amount {
@@ -371,9 +378,28 @@ typedef struct wire_cst_prepare_pay_onchain_request {
   uint32_t *fee_rate_sat_per_vbyte;
 } wire_cst_prepare_pay_onchain_request;
 
+typedef struct wire_cst_ReceiveAmount_Bitcoin {
+  uint64_t payer_amount_sat;
+} wire_cst_ReceiveAmount_Bitcoin;
+
+typedef struct wire_cst_ReceiveAmount_Asset {
+  struct wire_cst_list_prim_u_8_strict *asset_id;
+  uint64_t *payer_amount;
+} wire_cst_ReceiveAmount_Asset;
+
+typedef union ReceiveAmountKind {
+  struct wire_cst_ReceiveAmount_Bitcoin Bitcoin;
+  struct wire_cst_ReceiveAmount_Asset Asset;
+} ReceiveAmountKind;
+
+typedef struct wire_cst_receive_amount {
+  int32_t tag;
+  union ReceiveAmountKind kind;
+} wire_cst_receive_amount;
+
 typedef struct wire_cst_prepare_receive_request {
-  uint64_t *payer_amount_sat;
   int32_t payment_method;
+  struct wire_cst_receive_amount *amount;
 } wire_cst_prepare_receive_request;
 
 typedef struct wire_cst_prepare_refund_request {
@@ -389,7 +415,7 @@ typedef struct wire_cst_prepare_send_request {
 
 typedef struct wire_cst_prepare_receive_response {
   int32_t payment_method;
-  uint64_t *payer_amount_sat;
+  struct wire_cst_receive_amount *amount;
   uint64_t fees_sat;
   uint64_t *min_payer_amount_sat;
   uint64_t *max_payer_amount_sat;
@@ -502,6 +528,7 @@ typedef struct wire_cst_PaymentDetails_Lightning {
 typedef struct wire_cst_PaymentDetails_Liquid {
   struct wire_cst_list_prim_u_8_strict *destination;
   struct wire_cst_list_prim_u_8_strict *description;
+  struct wire_cst_list_prim_u_8_strict *asset_id;
 } wire_cst_PaymentDetails_Liquid;
 
 typedef struct wire_cst_PaymentDetails_Bitcoin {
@@ -652,6 +679,16 @@ typedef struct wire_cst_symbol {
   uint32_t *position;
 } wire_cst_symbol;
 
+typedef struct wire_cst_asset_balance {
+  struct wire_cst_list_prim_u_8_strict *asset_id;
+  uint64_t balance;
+} wire_cst_asset_balance;
+
+typedef struct wire_cst_list_asset_balance {
+  struct wire_cst_asset_balance *ptr;
+  int32_t len;
+} wire_cst_list_asset_balance;
+
 typedef struct wire_cst_localized_name {
   struct wire_cst_list_prim_u_8_strict *locale;
   struct wire_cst_list_prim_u_8_strict *name;
@@ -735,6 +772,7 @@ typedef struct wire_cst_wallet_info {
   uint64_t pending_receive_sat;
   struct wire_cst_list_prim_u_8_strict *fingerprint;
   struct wire_cst_list_prim_u_8_strict *pubkey;
+  struct wire_cst_list_asset_balance *asset_balances;
 } wire_cst_wallet_info;
 
 typedef struct wire_cst_get_info_response {
@@ -1343,6 +1381,8 @@ struct wire_cst_prepare_refund_request *frbgen_breez_liquid_cst_new_box_autoadd_
 
 struct wire_cst_prepare_send_request *frbgen_breez_liquid_cst_new_box_autoadd_prepare_send_request(void);
 
+struct wire_cst_receive_amount *frbgen_breez_liquid_cst_new_box_autoadd_receive_amount(void);
+
 struct wire_cst_receive_payment_request *frbgen_breez_liquid_cst_new_box_autoadd_receive_payment_request(void);
 
 struct wire_cst_refund_request *frbgen_breez_liquid_cst_new_box_autoadd_refund_request(void);
@@ -1368,6 +1408,8 @@ uint64_t *frbgen_breez_liquid_cst_new_box_autoadd_u_64(uint64_t value);
 struct wire_cst_url_success_action_data *frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data(void);
 
 struct wire_cst_list_String *frbgen_breez_liquid_cst_new_list_String(int32_t len);
+
+struct wire_cst_list_asset_balance *frbgen_breez_liquid_cst_new_list_asset_balance(int32_t len);
 
 struct wire_cst_list_external_input_parser *frbgen_breez_liquid_cst_new_list_external_input_parser(int32_t len);
 
@@ -1437,6 +1479,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_receive_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_refund_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_prepare_send_request);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_receive_amount);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_receive_payment_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_refund_request);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_restore_request);
@@ -1450,6 +1493,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_u_64);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_box_autoadd_url_success_action_data);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_String);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_asset_balance);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_external_input_parser);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_fiat_currency);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path);

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift
@@ -45,7 +45,8 @@ class LnurlPayInvoiceTask : LnurlPayTask {
             }
             let plainTextMetadata = ResourceHelper.shared.getString(key: Constants.LNURL_PAY_METADATA_PLAIN_TEXT, fallback: Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT)
             let metadata = "[[\"text/plain\",\"\(plainTextMetadata)\"]]"
-            let prepareReceivePaymentRes = try liquidSDK.prepareReceivePayment(req: PrepareReceiveRequest(paymentMethod: PaymentMethod.lightning, payerAmountSat: amountSat))
+            let amount = ReceiveAmount.bitcoin(payerAmountSat: amountSat)
+            let prepareReceivePaymentRes = try liquidSDK.prepareReceivePayment(req: PrepareReceiveRequest(paymentMethod: PaymentMethod.lightning, amount: amount))
             let receivePaymentRes = try liquidSDK.receivePayment(req: ReceivePaymentRequest(prepareResponse: prepareReceivePaymentRes, description: metadata, useDescriptionHash: true))
             self.replyServer(encodable: LnurlInvoiceResponse(pr: receivePaymentRes.destination, routes: []), replyURL: request!.reply_url)
         } catch let e {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -355,6 +355,11 @@ dictionary ConnectWithSignerRequest {
   Config config;  
 };
 
+dictionary AssetBalance {
+    string asset_id;
+    u64 balance;
+};
+
 dictionary BlockchainInfo {
     u32 liquid_tip;
     u32 bitcoin_tip;
@@ -366,6 +371,7 @@ dictionary WalletInfo {
     u64 pending_receive_sat;
     string fingerprint;
     string pubkey;
+    sequence<AssetBalance> asset_balances;
 };
 
 dictionary GetInfoResponse {
@@ -441,15 +447,21 @@ enum PaymentMethod {
     "LiquidAddress",
 };
 
+[Enum]
+interface ReceiveAmount {
+    Bitcoin(u64 payer_amount_sat);
+    Asset(string asset_id, u64? payer_amount);
+};
+
 dictionary PrepareReceiveRequest {
     PaymentMethod payment_method;
-    u64? payer_amount_sat = null;
+    ReceiveAmount? amount = null;
 };
 
 dictionary PrepareReceiveResponse {
     PaymentMethod payment_method;
     u64 fees_sat;
-    u64? payer_amount_sat;
+    ReceiveAmount? amount;
     u64? min_payer_amount_sat;
     u64? max_payer_amount_sat;
     f64? swapper_feerate;
@@ -483,7 +495,8 @@ dictionary OnchainPaymentLimitsResponse {
 
 [Enum]
 interface PayAmount {
-    Receiver(u64 amount_sat);
+    Bitcoin(u64 receiver_amount_sat);
+    Asset(string asset_id, u64 receiver_amount);
     Drain();
 };
 
@@ -544,8 +557,8 @@ dictionary ListPaymentsRequest {
 
 [Enum]
 interface ListPaymentDetails {
-    Liquid(string destination);
-    Bitcoin(string address);
+    Liquid(string? asset_id, string? destination);
+    Bitcoin(string? address);
 };
 
 [Enum]
@@ -581,7 +594,7 @@ dictionary LnUrlInfo {
 [Enum]
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
-    Liquid(string destination, string description);
+    Liquid(string asset_id, string destination, string description);
     Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -538,9 +538,9 @@ impl ChainSwapHandler {
                         self.persister.insert_or_update_payment(PaymentTxData {
                             tx_id: lockup_tx_id.clone(),
                             timestamp: Some(utils::now()),
-                            amount_sat: swap.receiver_amount_sat,
-                            // This should be: boltz fee + lockup fee + claim fee
-                            fees_sat: lockup_tx_fees_sat + swap.claim_fees_sat,
+                            asset_id: self.config.lbtc_asset_id().to_string(),
+                            amount: create_response.lockup_details.amount,
+                            fees_sat: lockup_tx_fees_sat,
                             payment_type: PaymentType::Send,
                             is_confirmed: false,
                             unblinding_data: None,
@@ -753,6 +753,7 @@ impl ChainSwapHandler {
             .build_tx_or_drain_tx(
                 Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
                 &lockup_details.lockup_address,
+                &self.config.lbtc_asset_id().to_string(),
                 lockup_details.amount,
             )
             .await?;
@@ -877,7 +878,8 @@ impl ChainSwapHandler {
                                     PaymentTxData {
                                         tx_id: claim_tx_id.clone(),
                                         timestamp: Some(utils::now()),
-                                        amount_sat: swap.receiver_amount_sat,
+                                        asset_id: self.config.lbtc_asset_id().to_string(),
+                                        amount: swap.receiver_amount_sat,
                                         fees_sat: 0,
                                         payment_type: PaymentType::Receive,
                                         is_confirmed: false,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2379,6 +2379,18 @@ impl SseDecode for crate::bindings::Amount {
     }
 }
 
+impl SseDecode for crate::model::AssetBalance {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_assetId = <String>::sse_decode(deserializer);
+        let mut var_balance = <u64>::sse_decode(deserializer);
+        return crate::model::AssetBalance {
+            asset_id: var_assetId,
+            balance: var_balance,
+        };
+    }
+}
+
 impl SseDecode for crate::model::BackupRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2794,6 +2806,18 @@ impl SseDecode for Vec<String> {
     }
 }
 
+impl SseDecode for Vec<crate::model::AssetBalance> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::model::AssetBalance>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::bindings::ExternalInputParser> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2876,13 +2900,15 @@ impl SseDecode for crate::model::ListPaymentDetails {
         let mut tag_ = <i32>::sse_decode(deserializer);
         match tag_ {
             0 => {
-                let mut var_destination = <String>::sse_decode(deserializer);
+                let mut var_assetId = <Option<String>>::sse_decode(deserializer);
+                let mut var_destination = <Option<String>>::sse_decode(deserializer);
                 return crate::model::ListPaymentDetails::Liquid {
+                    asset_id: var_assetId,
                     destination: var_destination,
                 };
             }
             1 => {
-                let mut var_address = <String>::sse_decode(deserializer);
+                let mut var_address = <Option<String>>::sse_decode(deserializer);
                 return crate::model::ListPaymentDetails::Bitcoin {
                     address: var_address,
                 };
@@ -3607,6 +3633,17 @@ impl SseDecode for Option<crate::model::Payment> {
     }
 }
 
+impl SseDecode for Option<crate::model::ReceiveAmount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::model::ReceiveAmount>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::bindings::SuccessAction> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3705,12 +3742,20 @@ impl SseDecode for crate::model::PayAmount {
         let mut tag_ = <i32>::sse_decode(deserializer);
         match tag_ {
             0 => {
-                let mut var_amountSat = <u64>::sse_decode(deserializer);
-                return crate::model::PayAmount::Receiver {
-                    amount_sat: var_amountSat,
+                let mut var_receiverAmountSat = <u64>::sse_decode(deserializer);
+                return crate::model::PayAmount::Bitcoin {
+                    receiver_amount_sat: var_receiverAmountSat,
                 };
             }
             1 => {
+                let mut var_assetId = <String>::sse_decode(deserializer);
+                let mut var_receiverAmount = <u64>::sse_decode(deserializer);
+                return crate::model::PayAmount::Asset {
+                    asset_id: var_assetId,
+                    receiver_amount: var_receiverAmount,
+                };
+            }
+            2 => {
                 return crate::model::PayAmount::Drain;
             }
             _ => {
@@ -3795,9 +3840,11 @@ impl SseDecode for crate::model::PaymentDetails {
             1 => {
                 let mut var_destination = <String>::sse_decode(deserializer);
                 let mut var_description = <String>::sse_decode(deserializer);
+                let mut var_assetId = <String>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Liquid {
                     destination: var_destination,
                     description: var_description,
+                    asset_id: var_assetId,
                 };
             }
             2 => {
@@ -4047,11 +4094,11 @@ impl SseDecode for crate::model::PreparePayOnchainResponse {
 impl SseDecode for crate::model::PrepareReceiveRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_payerAmountSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_paymentMethod = <crate::model::PaymentMethod>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::model::ReceiveAmount>>::sse_decode(deserializer);
         return crate::model::PrepareReceiveRequest {
-            payer_amount_sat: var_payerAmountSat,
             payment_method: var_paymentMethod,
+            amount: var_amount,
         };
     }
 }
@@ -4060,14 +4107,14 @@ impl SseDecode for crate::model::PrepareReceiveResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_paymentMethod = <crate::model::PaymentMethod>::sse_decode(deserializer);
-        let mut var_payerAmountSat = <Option<u64>>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::model::ReceiveAmount>>::sse_decode(deserializer);
         let mut var_feesSat = <u64>::sse_decode(deserializer);
         let mut var_minPayerAmountSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_maxPayerAmountSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_swapperFeerate = <Option<f64>>::sse_decode(deserializer);
         return crate::model::PrepareReceiveResponse {
             payment_method: var_paymentMethod,
-            payer_amount_sat: var_payerAmountSat,
+            amount: var_amount,
             fees_sat: var_feesSat,
             min_payer_amount_sat: var_minPayerAmountSat,
             max_payer_amount_sat: var_maxPayerAmountSat,
@@ -4137,6 +4184,32 @@ impl SseDecode for crate::bindings::Rate {
             coin: var_coin,
             value: var_value,
         };
+    }
+}
+
+impl SseDecode for crate::model::ReceiveAmount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_payerAmountSat = <u64>::sse_decode(deserializer);
+                return crate::model::ReceiveAmount::Bitcoin {
+                    payer_amount_sat: var_payerAmountSat,
+                };
+            }
+            1 => {
+                let mut var_assetId = <String>::sse_decode(deserializer);
+                let mut var_payerAmount = <Option<u64>>::sse_decode(deserializer);
+                return crate::model::ReceiveAmount::Asset {
+                    asset_id: var_assetId,
+                    payer_amount: var_payerAmount,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -4557,12 +4630,14 @@ impl SseDecode for crate::model::WalletInfo {
         let mut var_pendingReceiveSat = <u64>::sse_decode(deserializer);
         let mut var_fingerprint = <String>::sse_decode(deserializer);
         let mut var_pubkey = <String>::sse_decode(deserializer);
+        let mut var_assetBalances = <Vec<crate::model::AssetBalance>>::sse_decode(deserializer);
         return crate::model::WalletInfo {
             balance_sat: var_balanceSat,
             pending_send_sat: var_pendingSendSat,
             pending_receive_sat: var_pendingReceiveSat,
             fingerprint: var_fingerprint,
             pubkey: var_pubkey,
+            asset_balances: var_assetBalances,
         };
     }
 }
@@ -4727,6 +4802,22 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::Amount>>
 {
     fn into_into_dart(self) -> FrbWrapper<crate::bindings::Amount> {
         self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::AssetBalance {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.asset_id.into_into_dart().into_dart(),
+            self.balance.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::model::AssetBalance {}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::AssetBalance> for crate::model::AssetBalance {
+    fn into_into_dart(self) -> crate::model::AssetBalance {
+        self
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -5221,9 +5312,15 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::LiquidNetwork>
 impl flutter_rust_bridge::IntoDart for crate::model::ListPaymentDetails {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
-            crate::model::ListPaymentDetails::Liquid { destination } => {
-                [0.into_dart(), destination.into_into_dart().into_dart()].into_dart()
-            }
+            crate::model::ListPaymentDetails::Liquid {
+                asset_id,
+                destination,
+            } => [
+                0.into_dart(),
+                asset_id.into_into_dart().into_dart(),
+                destination.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
             crate::model::ListPaymentDetails::Bitcoin { address } => {
                 [1.into_dart(), address.into_into_dart().into_dart()].into_dart()
             }
@@ -5889,10 +5986,23 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::OnchainPaymentLimitsRespons
 impl flutter_rust_bridge::IntoDart for crate::model::PayAmount {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
-            crate::model::PayAmount::Receiver { amount_sat } => {
-                [0.into_dart(), amount_sat.into_into_dart().into_dart()].into_dart()
-            }
-            crate::model::PayAmount::Drain => [1.into_dart()].into_dart(),
+            crate::model::PayAmount::Bitcoin {
+                receiver_amount_sat,
+            } => [
+                0.into_dart(),
+                receiver_amount_sat.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::model::PayAmount::Asset {
+                asset_id,
+                receiver_amount,
+            } => [
+                1.into_dart(),
+                asset_id.into_into_dart().into_dart(),
+                receiver_amount.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::model::PayAmount::Drain => [2.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -5984,10 +6094,12 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             crate::model::PaymentDetails::Liquid {
                 destination,
                 description,
+                asset_id,
             } => [
                 1.into_dart(),
                 destination.into_into_dart().into_dart(),
                 description.into_into_dart().into_dart(),
+                asset_id.into_into_dart().into_dart(),
             ]
             .into_dart(),
             crate::model::PaymentDetails::Bitcoin {
@@ -6279,8 +6391,8 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::PreparePayOnchainResponse>
 impl flutter_rust_bridge::IntoDart for crate::model::PrepareReceiveRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.payer_amount_sat.into_into_dart().into_dart(),
             self.payment_method.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6301,7 +6413,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareReceiveResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.payment_method.into_into_dart().into_dart(),
-            self.payer_amount_sat.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
             self.min_payer_amount_sat.into_into_dart().into_dart(),
             self.max_payer_amount_sat.into_into_dart().into_dart(),
@@ -6426,6 +6538,36 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::Rate>>
 {
     fn into_into_dart(self) -> FrbWrapper<crate::bindings::Rate> {
         self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::ReceiveAmount {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::model::ReceiveAmount::Bitcoin { payer_amount_sat } => {
+                [0.into_dart(), payer_amount_sat.into_into_dart().into_dart()].into_dart()
+            }
+            crate::model::ReceiveAmount::Asset {
+                asset_id,
+                payer_amount,
+            } => [
+                1.into_dart(),
+                asset_id.into_into_dart().into_dart(),
+                payer_amount.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::model::ReceiveAmount {}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::ReceiveAmount>
+    for crate::model::ReceiveAmount
+{
+    fn into_into_dart(self) -> crate::model::ReceiveAmount {
+        self
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -6881,6 +7023,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::WalletInfo {
             self.pending_receive_sat.into_into_dart().into_dart(),
             self.fingerprint.into_into_dart().into_dart(),
             self.pubkey.into_into_dart().into_dart(),
+            self.asset_balances.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -7005,6 +7148,14 @@ impl SseEncode for crate::bindings::Amount {
                 unimplemented!("");
             }
         }
+    }
+}
+
+impl SseEncode for crate::model::AssetBalance {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.asset_id, serializer);
+        <u64>::sse_encode(self.balance, serializer);
     }
 }
 
@@ -7315,6 +7466,16 @@ impl SseEncode for Vec<String> {
     }
 }
 
+impl SseEncode for Vec<crate::model::AssetBalance> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::model::AssetBalance>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::bindings::ExternalInputParser> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7379,13 +7540,17 @@ impl SseEncode for crate::model::ListPaymentDetails {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         match self {
-            crate::model::ListPaymentDetails::Liquid { destination } => {
+            crate::model::ListPaymentDetails::Liquid {
+                asset_id,
+                destination,
+            } => {
                 <i32>::sse_encode(0, serializer);
-                <String>::sse_encode(destination, serializer);
+                <Option<String>>::sse_encode(asset_id, serializer);
+                <Option<String>>::sse_encode(destination, serializer);
             }
             crate::model::ListPaymentDetails::Bitcoin { address } => {
                 <i32>::sse_encode(1, serializer);
-                <String>::sse_encode(address, serializer);
+                <Option<String>>::sse_encode(address, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -7953,6 +8118,16 @@ impl SseEncode for Option<crate::model::Payment> {
     }
 }
 
+impl SseEncode for Option<crate::model::ReceiveAmount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::model::ReceiveAmount>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::bindings::SuccessAction> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8037,12 +8212,22 @@ impl SseEncode for crate::model::PayAmount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         match self {
-            crate::model::PayAmount::Receiver { amount_sat } => {
+            crate::model::PayAmount::Bitcoin {
+                receiver_amount_sat,
+            } => {
                 <i32>::sse_encode(0, serializer);
-                <u64>::sse_encode(amount_sat, serializer);
+                <u64>::sse_encode(receiver_amount_sat, serializer);
+            }
+            crate::model::PayAmount::Asset {
+                asset_id,
+                receiver_amount,
+            } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(asset_id, serializer);
+                <u64>::sse_encode(receiver_amount, serializer);
             }
             crate::model::PayAmount::Drain => {
-                <i32>::sse_encode(1, serializer);
+                <i32>::sse_encode(2, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -8108,10 +8293,12 @@ impl SseEncode for crate::model::PaymentDetails {
             crate::model::PaymentDetails::Liquid {
                 destination,
                 description,
+                asset_id,
             } => {
                 <i32>::sse_encode(1, serializer);
                 <String>::sse_encode(destination, serializer);
                 <String>::sse_encode(description, serializer);
+                <String>::sse_encode(asset_id, serializer);
             }
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
@@ -8336,8 +8523,8 @@ impl SseEncode for crate::model::PreparePayOnchainResponse {
 impl SseEncode for crate::model::PrepareReceiveRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <Option<u64>>::sse_encode(self.payer_amount_sat, serializer);
         <crate::model::PaymentMethod>::sse_encode(self.payment_method, serializer);
+        <Option<crate::model::ReceiveAmount>>::sse_encode(self.amount, serializer);
     }
 }
 
@@ -8345,7 +8532,7 @@ impl SseEncode for crate::model::PrepareReceiveResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::model::PaymentMethod>::sse_encode(self.payment_method, serializer);
-        <Option<u64>>::sse_encode(self.payer_amount_sat, serializer);
+        <Option<crate::model::ReceiveAmount>>::sse_encode(self.amount, serializer);
         <u64>::sse_encode(self.fees_sat, serializer);
         <Option<u64>>::sse_encode(self.min_payer_amount_sat, serializer);
         <Option<u64>>::sse_encode(self.max_payer_amount_sat, serializer);
@@ -8392,6 +8579,29 @@ impl SseEncode for crate::bindings::Rate {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.coin, serializer);
         <f64>::sse_encode(self.value, serializer);
+    }
+}
+
+impl SseEncode for crate::model::ReceiveAmount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::model::ReceiveAmount::Bitcoin { payer_amount_sat } => {
+                <i32>::sse_encode(0, serializer);
+                <u64>::sse_encode(payer_amount_sat, serializer);
+            }
+            crate::model::ReceiveAmount::Asset {
+                asset_id,
+                payer_amount,
+            } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(asset_id, serializer);
+                <Option<u64>>::sse_encode(payer_amount, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -8717,6 +8927,7 @@ impl SseEncode for crate::model::WalletInfo {
         <u64>::sse_encode(self.pending_receive_sat, serializer);
         <String>::sse_encode(self.fingerprint, serializer);
         <String>::sse_encode(self.pubkey, serializer);
+        <Vec<crate::model::AssetBalance>>::sse_encode(self.asset_balances, serializer);
     }
 }
 
@@ -8879,6 +9090,15 @@ mod io {
                     }
                 }
                 _ => unreachable!(),
+            }
+        }
+    }
+    impl CstDecode<crate::model::AssetBalance> for wire_cst_asset_balance {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::AssetBalance {
+            crate::model::AssetBalance {
+                asset_id: self.asset_id.cst_decode(),
+                balance: self.balance.cst_decode(),
             }
         }
     }
@@ -9222,6 +9442,13 @@ mod io {
             CstDecode::<crate::model::PrepareSendRequest>::cst_decode(*wrap).into()
         }
     }
+    impl CstDecode<crate::model::ReceiveAmount> for *mut wire_cst_receive_amount {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::ReceiveAmount {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::model::ReceiveAmount>::cst_decode(*wrap).into()
+        }
+    }
     impl CstDecode<crate::model::ReceivePaymentRequest> for *mut wire_cst_receive_payment_request {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::ReceivePaymentRequest {
@@ -9556,6 +9783,16 @@ mod io {
             vec.into_iter().map(CstDecode::cst_decode).collect()
         }
     }
+    impl CstDecode<Vec<crate::model::AssetBalance>> for *mut wire_cst_list_asset_balance {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::model::AssetBalance> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
     impl CstDecode<Vec<crate::bindings::ExternalInputParser>>
         for *mut wire_cst_list_external_input_parser
     {
@@ -9627,6 +9864,7 @@ mod io {
                 0 => {
                     let ans = unsafe { self.kind.Liquid };
                     crate::model::ListPaymentDetails::Liquid {
+                        asset_id: ans.asset_id.cst_decode(),
                         destination: ans.destination.cst_decode(),
                     }
                 }
@@ -10145,12 +10383,19 @@ mod io {
         fn cst_decode(self) -> crate::model::PayAmount {
             match self.tag {
                 0 => {
-                    let ans = unsafe { self.kind.Receiver };
-                    crate::model::PayAmount::Receiver {
-                        amount_sat: ans.amount_sat.cst_decode(),
+                    let ans = unsafe { self.kind.Bitcoin };
+                    crate::model::PayAmount::Bitcoin {
+                        receiver_amount_sat: ans.receiver_amount_sat.cst_decode(),
                     }
                 }
-                1 => crate::model::PayAmount::Drain,
+                1 => {
+                    let ans = unsafe { self.kind.Asset };
+                    crate::model::PayAmount::Asset {
+                        asset_id: ans.asset_id.cst_decode(),
+                        receiver_amount: ans.receiver_amount.cst_decode(),
+                    }
+                }
+                2 => crate::model::PayAmount::Drain,
                 _ => unreachable!(),
             }
         }
@@ -10208,6 +10453,7 @@ mod io {
                     crate::model::PaymentDetails::Liquid {
                         destination: ans.destination.cst_decode(),
                         description: ans.description.cst_decode(),
+                        asset_id: ans.asset_id.cst_decode(),
                     }
                 }
                 2 => {
@@ -10375,8 +10621,8 @@ mod io {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::PrepareReceiveRequest {
             crate::model::PrepareReceiveRequest {
-                payer_amount_sat: self.payer_amount_sat.cst_decode(),
                 payment_method: self.payment_method.cst_decode(),
+                amount: self.amount.cst_decode(),
             }
         }
     }
@@ -10385,7 +10631,7 @@ mod io {
         fn cst_decode(self) -> crate::model::PrepareReceiveResponse {
             crate::model::PrepareReceiveResponse {
                 payment_method: self.payment_method.cst_decode(),
-                payer_amount_sat: self.payer_amount_sat.cst_decode(),
+                amount: self.amount.cst_decode(),
                 fees_sat: self.fees_sat.cst_decode(),
                 min_payer_amount_sat: self.min_payer_amount_sat.cst_decode(),
                 max_payer_amount_sat: self.max_payer_amount_sat.cst_decode(),
@@ -10437,6 +10683,27 @@ mod io {
             crate::bindings::Rate {
                 coin: self.coin.cst_decode(),
                 value: self.value.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::model::ReceiveAmount> for wire_cst_receive_amount {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::ReceiveAmount {
+            match self.tag {
+                0 => {
+                    let ans = unsafe { self.kind.Bitcoin };
+                    crate::model::ReceiveAmount::Bitcoin {
+                        payer_amount_sat: ans.payer_amount_sat.cst_decode(),
+                    }
+                }
+                1 => {
+                    let ans = unsafe { self.kind.Asset };
+                    crate::model::ReceiveAmount::Asset {
+                        asset_id: ans.asset_id.cst_decode(),
+                        payer_amount: ans.payer_amount.cst_decode(),
+                    }
+                }
+                _ => unreachable!(),
             }
         }
     }
@@ -10749,6 +11016,7 @@ mod io {
                 pending_receive_sat: self.pending_receive_sat.cst_decode(),
                 fingerprint: self.fingerprint.cst_decode(),
                 pubkey: self.pubkey.cst_decode(),
+                asset_balances: self.asset_balances.cst_decode(),
             }
         }
     }
@@ -10813,6 +11081,19 @@ mod io {
         }
     }
     impl Default for wire_cst_amount {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_asset_balance {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                asset_id: core::ptr::null_mut(),
+                balance: Default::default(),
+            }
+        }
+    }
+    impl Default for wire_cst_asset_balance {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -11637,8 +11918,8 @@ mod io {
     impl NewWithNullPtr for wire_cst_prepare_receive_request {
         fn new_with_null_ptr() -> Self {
             Self {
-                payer_amount_sat: core::ptr::null_mut(),
                 payment_method: Default::default(),
+                amount: core::ptr::null_mut(),
             }
         }
     }
@@ -11651,7 +11932,7 @@ mod io {
         fn new_with_null_ptr() -> Self {
             Self {
                 payment_method: Default::default(),
-                payer_amount_sat: core::ptr::null_mut(),
+                amount: core::ptr::null_mut(),
                 fees_sat: Default::default(),
                 min_payer_amount_sat: core::ptr::null_mut(),
                 max_payer_amount_sat: core::ptr::null_mut(),
@@ -11727,6 +12008,19 @@ mod io {
         }
     }
     impl Default for wire_cst_rate {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_receive_amount {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: ReceiveAmountKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_receive_amount {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -12006,6 +12300,7 @@ mod io {
                 pending_receive_sat: Default::default(),
                 fingerprint: core::ptr::null_mut(),
                 pubkey: core::ptr::null_mut(),
+                asset_balances: core::ptr::null_mut(),
             }
         }
     }
@@ -12700,6 +12995,14 @@ mod io {
     }
 
     #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_receive_amount(
+    ) -> *mut wire_cst_receive_amount {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_receive_amount::new_with_null_ptr(),
+        )
+    }
+
+    #[no_mangle]
     pub extern "C" fn frbgen_breez_liquid_cst_new_box_autoadd_receive_payment_request(
     ) -> *mut wire_cst_receive_payment_request {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
@@ -12791,6 +13094,20 @@ mod io {
         let wrap = wire_cst_list_String {
             ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
                 <*mut wire_cst_list_prim_u_8_strict>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[no_mangle]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_list_asset_balance(
+        len: i32,
+    ) -> *mut wire_cst_list_asset_balance {
+        let wrap = wire_cst_list_asset_balance {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_asset_balance>::new_with_null_ptr(),
                 len,
             ),
             len,
@@ -13036,6 +13353,12 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_asset_balance {
+        asset_id: *mut wire_cst_list_prim_u_8_strict,
+        balance: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_backup_request {
         backup_path: *mut wire_cst_list_prim_u_8_strict,
     }
@@ -13263,6 +13586,12 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_list_asset_balance {
+        ptr: *mut wire_cst_asset_balance,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_list_external_input_parser {
         ptr: *mut wire_cst_external_input_parser,
         len: i32,
@@ -13313,6 +13642,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_ListPaymentDetails_Liquid {
+        asset_id: *mut wire_cst_list_prim_u_8_strict,
         destination: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
@@ -13749,13 +14079,20 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub union PayAmountKind {
-        Receiver: wire_cst_PayAmount_Receiver,
+        Bitcoin: wire_cst_PayAmount_Bitcoin,
+        Asset: wire_cst_PayAmount_Asset,
         nil__: (),
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_PayAmount_Receiver {
-        amount_sat: u64,
+    pub struct wire_cst_PayAmount_Bitcoin {
+        receiver_amount_sat: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_PayAmount_Asset {
+        asset_id: *mut wire_cst_list_prim_u_8_strict,
+        receiver_amount: u64,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -13811,6 +14148,7 @@ mod io {
     pub struct wire_cst_PaymentDetails_Liquid {
         destination: *mut wire_cst_list_prim_u_8_strict,
         description: *mut wire_cst_list_prim_u_8_strict,
+        asset_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -13941,14 +14279,14 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_receive_request {
-        payer_amount_sat: *mut u64,
         payment_method: i32,
+        amount: *mut wire_cst_receive_amount,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_receive_response {
         payment_method: i32,
-        payer_amount_sat: *mut u64,
+        amount: *mut wire_cst_receive_amount,
         fees_sat: u64,
         min_payer_amount_sat: *mut u64,
         max_payer_amount_sat: *mut u64,
@@ -13985,6 +14323,30 @@ mod io {
     pub struct wire_cst_rate {
         coin: *mut wire_cst_list_prim_u_8_strict,
         value: f64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_receive_amount {
+        tag: i32,
+        kind: ReceiveAmountKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union ReceiveAmountKind {
+        Bitcoin: wire_cst_ReceiveAmount_Bitcoin,
+        Asset: wire_cst_ReceiveAmount_Asset,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_ReceiveAmount_Bitcoin {
+        payer_amount_sat: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_ReceiveAmount_Asset {
+        asset_id: *mut wire_cst_list_prim_u_8_strict,
+        payer_amount: *mut u64,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -14261,6 +14623,7 @@ mod io {
         pending_receive_sat: u64,
         fingerprint: *mut wire_cst_list_prim_u_8_strict,
         pubkey: *mut wire_cst_list_prim_u_8_strict,
+        asset_balances: *mut wire_cst_list_asset_balance,
     }
 }
 #[cfg(not(target_family = "wasm"))]

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -1,4 +1,9 @@
-pub(crate) fn current_migrations() -> Vec<&'static str> {
+pub(crate) fn current_migrations(is_mainnet: bool) -> Vec<&'static str> {
+    let alter_payment_tx_data_add_asset_id = if is_mainnet {
+        "ALTER TABLE payment_tx_data ADD COLUMN asset_id TEXT NOT NULL DEFAULT '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d';"
+    } else {
+        "ALTER TABLE payment_tx_data ADD COLUMN asset_id TEXT NOT NULL DEFAULT '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49';"
+    };
     vec![
         "CREATE TABLE IF NOT EXISTS receive_swaps (
             id TEXT NOT NULL PRIMARY KEY,
@@ -249,5 +254,10 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE send_swaps ADD COLUMN destination_pubkey TEXT;
         ",
         "ALTER TABLE chain_swaps ADD COLUMN auto_accepted_fees INTEGER NOT NULL DEFAULT 0;",
+        alter_payment_tx_data_add_asset_id,
+        "
+        ALTER TABLE payment_tx_data RENAME COLUMN amount_sat TO amount;
+        UPDATE payment_tx_data SET amount = amount - fees_sat WHERE payment_type = 1;
+        ",
     ]
 }

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -333,7 +333,8 @@ impl ReceiveSwapHandler {
                             PaymentTxData {
                                 tx_id: claim_tx_id.clone(),
                                 timestamp: Some(utils::now()),
-                                amount_sat: swap.receiver_amount_sat,
+                                asset_id: self.config.lbtc_asset_id(),
+                                amount: swap.receiver_amount_sat,
                                 fees_sat: 0,
                                 payment_type: PaymentType::Receive,
                                 is_confirmed: false,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1923,13 +1923,18 @@ impl LiquidSdk {
                 debug!("Preparing Chain Receive Swap with: payer_amount_sat {payer_amount_sat:?}, fees_sat {fees_sat}");
             }
             PaymentMethod::LiquidAddress => {
-                let payer_amount_sat = match req.amount {
-                    Some(ReceiveAmount::Asset { payer_amount, .. }) => payer_amount,
-                    Some(ReceiveAmount::Bitcoin { payer_amount_sat }) => Some(payer_amount_sat),
-                    None => None,
+                let (asset_id, amount_sat) = match req.amount.clone() {
+                    Some(ReceiveAmount::Asset {
+                        payer_amount,
+                        asset_id,
+                    }) => (asset_id, payer_amount),
+                    Some(ReceiveAmount::Bitcoin { payer_amount_sat }) => {
+                        (self.config.lbtc_asset_id(), Some(payer_amount_sat))
+                    }
+                    None => (self.config.lbtc_asset_id(), None),
                 };
                 fees_sat = 0;
-                debug!("Preparing Liquid Receive with: amount_sat {payer_amount_sat:?}, fees_sat {fees_sat}");
+                debug!("Preparing Liquid Receive with: asset_id {asset_id}, amount_sat {amount_sat:?}, fees_sat {fees_sat}");
             }
         };
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1901,7 +1901,7 @@ impl LiquidSdk {
                 let payer_amount_sat = match req.amount {
                     Some(ReceiveAmount::Asset { .. }) => {
                         return Err(PaymentError::generic(
-                            "Cannot receive an asset the payment method is Bitcoin",
+                            "Cannot receive an asset when the payment method is Bitcoin",
                         ));
                     }
                     Some(ReceiveAmount::Bitcoin { payer_amount_sat }) => Some(payer_amount_sat),
@@ -2007,7 +2007,7 @@ impl LiquidSdk {
                 let amount_sat = match amount.clone() {
                     Some(ReceiveAmount::Asset { .. }) => {
                         return Err(PaymentError::generic(
-                            "Cannot receive an asset the payment method is Bitcoin",
+                            "Cannot receive an asset when the payment method is Bitcoin",
                         ));
                     }
                     Some(ReceiveAmount::Bitcoin { payer_amount_sat }) => Some(payer_amount_sat),

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -197,6 +197,7 @@ impl SendSwapHandler {
             .build_tx_or_drain_tx(
                 Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
                 &create_response.address,
+                &self.config.lbtc_asset_id(),
                 create_response.expected_amount,
             )
             .await?;
@@ -225,7 +226,8 @@ impl SendSwapHandler {
             PaymentTxData {
                 tx_id: lockup_tx_id.clone(),
                 timestamp: Some(utils::now()),
-                amount_sat: swap.payer_amount_sat,
+                asset_id: self.config.lbtc_asset_id(),
+                amount: create_response.expected_amount,
                 fees_sat: lockup_tx_fees_sat,
                 payment_type: PaymentType::Send,
                 is_confirmed: false,

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -12,7 +12,7 @@ use sdk_common::{
 };
 
 use crate::{
-    model::{PaymentState, PaymentTxData, PaymentType, ReceiveSwap, SendSwap},
+    model::{LiquidNetwork, PaymentState, PaymentTxData, PaymentType, ReceiveSwap, SendSwap},
     test_utils::generate_random_string,
     utils,
 };
@@ -161,11 +161,15 @@ macro_rules! create_persister {
 }
 pub(crate) use create_persister;
 
-pub(crate) fn new_payment_tx_data(payment_type: PaymentType) -> PaymentTxData {
+pub(crate) fn new_payment_tx_data(
+    network: LiquidNetwork,
+    payment_type: PaymentType,
+) -> PaymentTxData {
     PaymentTxData {
         tx_id: generate_random_string(4),
         timestamp: None,
-        amount_sat: 0,
+        asset_id: utils::lbtc_asset_id(network).to_string(),
+        amount: 0,
         fees_sat: 0,
         payment_type,
         is_confirmed: false,

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -55,6 +55,7 @@ impl OnchainWallet for MockWallet {
         &self,
         _fee_rate: Option<f32>,
         _recipient_address: &str,
+        _asset_id: &str,
         _amount_sat: u64,
     ) -> Result<Transaction, PaymentError> {
         Ok(TEST_LIQUID_TX.clone())
@@ -73,6 +74,7 @@ impl OnchainWallet for MockWallet {
         &self,
         _fee_rate_sats_per_kvb: Option<f32>,
         _recipient_address: &str,
+        _asset_id: &str,
         _amount_sat: u64,
     ) -> Result<Transaction, PaymentError> {
         Ok(TEST_LIQUID_TX.clone())

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1379,6 +1379,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AssetBalance dco_decode_asset_balance(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return AssetBalance(
+      assetId: dco_decode_String(arr[0]),
+      balance: dco_decode_u_64(arr[1]),
+    );
+  }
+
+  @protected
   BackupRequest dco_decode_backup_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -1673,6 +1684,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendRequest dco_decode_box_autoadd_prepare_send_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_prepare_send_request(raw);
+  }
+
+  @protected
+  ReceiveAmount dco_decode_box_autoadd_receive_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_receive_amount(raw);
   }
 
   @protected
@@ -2024,6 +2041,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<AssetBalance> dco_decode_list_asset_balance(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_asset_balance).toList();
+  }
+
+  @protected
   List<ExternalInputParser> dco_decode_list_external_input_parser(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_external_input_parser).toList();
@@ -2065,11 +2088,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     switch (raw[0]) {
       case 0:
         return ListPaymentDetails_Liquid(
-          destination: dco_decode_String(raw[1]),
+          assetId: dco_decode_opt_String(raw[1]),
+          destination: dco_decode_opt_String(raw[2]),
         );
       case 1:
         return ListPaymentDetails_Bitcoin(
-          address: dco_decode_String(raw[1]),
+          address: dco_decode_opt_String(raw[1]),
         );
       default:
         throw Exception("unreachable");
@@ -2590,6 +2614,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ReceiveAmount? dco_decode_opt_box_autoadd_receive_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_receive_amount(raw);
+  }
+
+  @protected
   SuccessAction? dco_decode_opt_box_autoadd_success_action(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_success_action(raw);
@@ -2642,10 +2672,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
       case 0:
-        return PayAmount_Receiver(
-          amountSat: dco_decode_u_64(raw[1]),
+        return PayAmount_Bitcoin(
+          receiverAmountSat: dco_decode_u_64(raw[1]),
         );
       case 1:
+        return PayAmount_Asset(
+          assetId: dco_decode_String(raw[1]),
+          receiverAmount: dco_decode_u_64(raw[2]),
+        );
+      case 2:
         return PayAmount_Drain();
       default:
         throw Exception("unreachable");
@@ -2704,6 +2739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return PaymentDetails_Liquid(
           destination: dco_decode_String(raw[1]),
           description: dco_decode_String(raw[2]),
+          assetId: dco_decode_String(raw[3]),
         );
       case 2:
         return PaymentDetails_Bitcoin(
@@ -2889,8 +2925,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PrepareReceiveRequest(
-      payerAmountSat: dco_decode_opt_box_autoadd_u_64(arr[0]),
-      paymentMethod: dco_decode_payment_method(arr[1]),
+      paymentMethod: dco_decode_payment_method(arr[0]),
+      amount: dco_decode_opt_box_autoadd_receive_amount(arr[1]),
     );
   }
 
@@ -2901,7 +2937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return PrepareReceiveResponse(
       paymentMethod: dco_decode_payment_method(arr[0]),
-      payerAmountSat: dco_decode_opt_box_autoadd_u_64(arr[1]),
+      amount: dco_decode_opt_box_autoadd_receive_amount(arr[1]),
       feesSat: dco_decode_u_64(arr[2]),
       minPayerAmountSat: dco_decode_opt_box_autoadd_u_64(arr[3]),
       maxPayerAmountSat: dco_decode_opt_box_autoadd_u_64(arr[4]),
@@ -2964,6 +3000,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       coin: dco_decode_String(arr[0]),
       value: dco_decode_f_64(arr[1]),
     );
+  }
+
+  @protected
+  ReceiveAmount dco_decode_receive_amount(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return ReceiveAmount_Bitcoin(
+          payerAmountSat: dco_decode_u_64(raw[1]),
+        );
+      case 1:
+        return ReceiveAmount_Asset(
+          assetId: dco_decode_String(raw[1]),
+          payerAmount: dco_decode_opt_box_autoadd_u_64(raw[2]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
   }
 
   @protected
@@ -3306,13 +3360,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletInfo dco_decode_wallet_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return WalletInfo(
       balanceSat: dco_decode_u_64(arr[0]),
       pendingSendSat: dco_decode_u_64(arr[1]),
       pendingReceiveSat: dco_decode_u_64(arr[2]),
       fingerprint: dco_decode_String(arr[3]),
       pubkey: dco_decode_String(arr[4]),
+      assetBalances: dco_decode_list_asset_balance(arr[5]),
     );
   }
 
@@ -3426,6 +3481,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       default:
         throw UnimplementedError('');
     }
+  }
+
+  @protected
+  AssetBalance sse_decode_asset_balance(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_assetId = sse_decode_String(deserializer);
+    var var_balance = sse_decode_u_64(deserializer);
+    return AssetBalance(assetId: var_assetId, balance: var_balance);
   }
 
   @protected
@@ -3720,6 +3783,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendRequest sse_decode_box_autoadd_prepare_send_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_prepare_send_request(deserializer));
+  }
+
+  @protected
+  ReceiveAmount sse_decode_box_autoadd_receive_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_receive_amount(deserializer));
   }
 
   @protected
@@ -4064,6 +4133,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<AssetBalance> sse_decode_list_asset_balance(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <AssetBalance>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_asset_balance(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<ExternalInputParser> sse_decode_list_external_input_parser(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4142,10 +4223,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var tag_ = sse_decode_i_32(deserializer);
     switch (tag_) {
       case 0:
-        var var_destination = sse_decode_String(deserializer);
-        return ListPaymentDetails_Liquid(destination: var_destination);
+        var var_assetId = sse_decode_opt_String(deserializer);
+        var var_destination = sse_decode_opt_String(deserializer);
+        return ListPaymentDetails_Liquid(assetId: var_assetId, destination: var_destination);
       case 1:
-        var var_address = sse_decode_String(deserializer);
+        var var_address = sse_decode_opt_String(deserializer);
         return ListPaymentDetails_Bitcoin(address: var_address);
       default:
         throw UnimplementedError('');
@@ -4726,6 +4808,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ReceiveAmount? sse_decode_opt_box_autoadd_receive_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_receive_amount(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   SuccessAction? sse_decode_opt_box_autoadd_success_action(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -4820,9 +4913,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var tag_ = sse_decode_i_32(deserializer);
     switch (tag_) {
       case 0:
-        var var_amountSat = sse_decode_u_64(deserializer);
-        return PayAmount_Receiver(amountSat: var_amountSat);
+        var var_receiverAmountSat = sse_decode_u_64(deserializer);
+        return PayAmount_Bitcoin(receiverAmountSat: var_receiverAmountSat);
       case 1:
+        var var_assetId = sse_decode_String(deserializer);
+        var var_receiverAmount = sse_decode_u_64(deserializer);
+        return PayAmount_Asset(assetId: var_assetId, receiverAmount: var_receiverAmount);
+      case 2:
         return PayAmount_Drain();
       default:
         throw UnimplementedError('');
@@ -4896,7 +4993,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 1:
         var var_destination = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
-        return PaymentDetails_Liquid(destination: var_destination, description: var_description);
+        var var_assetId = sse_decode_String(deserializer);
+        return PaymentDetails_Liquid(
+            destination: var_destination, description: var_description, assetId: var_assetId);
       case 2:
         var var_swapId = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
@@ -5073,23 +5172,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PrepareReceiveRequest sse_decode_prepare_receive_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_payerAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_paymentMethod = sse_decode_payment_method(deserializer);
-    return PrepareReceiveRequest(payerAmountSat: var_payerAmountSat, paymentMethod: var_paymentMethod);
+    var var_amount = sse_decode_opt_box_autoadd_receive_amount(deserializer);
+    return PrepareReceiveRequest(paymentMethod: var_paymentMethod, amount: var_amount);
   }
 
   @protected
   PrepareReceiveResponse sse_decode_prepare_receive_response(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_paymentMethod = sse_decode_payment_method(deserializer);
-    var var_payerAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_amount = sse_decode_opt_box_autoadd_receive_amount(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
     var var_minPayerAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_maxPayerAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_swapperFeerate = sse_decode_opt_box_autoadd_f_64(deserializer);
     return PrepareReceiveResponse(
         paymentMethod: var_paymentMethod,
-        payerAmountSat: var_payerAmountSat,
+        amount: var_amount,
         feesSat: var_feesSat,
         minPayerAmountSat: var_minPayerAmountSat,
         maxPayerAmountSat: var_maxPayerAmountSat,
@@ -5140,6 +5239,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_coin = sse_decode_String(deserializer);
     var var_value = sse_decode_f_64(deserializer);
     return Rate(coin: var_coin, value: var_value);
+  }
+
+  @protected
+  ReceiveAmount sse_decode_receive_amount(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_payerAmountSat = sse_decode_u_64(deserializer);
+        return ReceiveAmount_Bitcoin(payerAmountSat: var_payerAmountSat);
+      case 1:
+        var var_assetId = sse_decode_String(deserializer);
+        var var_payerAmount = sse_decode_opt_box_autoadd_u_64(deserializer);
+        return ReceiveAmount_Asset(assetId: var_assetId, payerAmount: var_payerAmount);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -5454,12 +5571,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_pendingReceiveSat = sse_decode_u_64(deserializer);
     var var_fingerprint = sse_decode_String(deserializer);
     var var_pubkey = sse_decode_String(deserializer);
+    var var_assetBalances = sse_decode_list_asset_balance(deserializer);
     return WalletInfo(
         balanceSat: var_balanceSat,
         pendingSendSat: var_pendingSendSat,
         pendingReceiveSat: var_pendingReceiveSat,
         fingerprint: var_fingerprint,
-        pubkey: var_pubkey);
+        pubkey: var_pubkey,
+        assetBalances: var_assetBalances);
   }
 
   @protected
@@ -5669,6 +5788,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(iso4217Code, serializer);
         sse_encode_u_64(fractionalAmount, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_asset_balance(AssetBalance self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.assetId, serializer);
+    sse_encode_u_64(self.balance, serializer);
   }
 
   @protected
@@ -5963,6 +6089,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_receive_amount(ReceiveAmount self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_receive_amount(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_receive_payment_request(ReceivePaymentRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_receive_payment_request(self, serializer);
@@ -6247,6 +6379,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_asset_balance(List<AssetBalance> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_asset_balance(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_external_input_parser(List<ExternalInputParser> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
@@ -6304,12 +6445,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_list_payment_details(ListPaymentDetails self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
-      case ListPaymentDetails_Liquid(destination: final destination):
+      case ListPaymentDetails_Liquid(assetId: final assetId, destination: final destination):
         sse_encode_i_32(0, serializer);
-        sse_encode_String(destination, serializer);
+        sse_encode_opt_String(assetId, serializer);
+        sse_encode_opt_String(destination, serializer);
       case ListPaymentDetails_Bitcoin(address: final address):
         sse_encode_i_32(1, serializer);
-        sse_encode_String(address, serializer);
+        sse_encode_opt_String(address, serializer);
     }
   }
 
@@ -6768,6 +6910,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_receive_amount(ReceiveAmount? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_receive_amount(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_success_action(SuccessAction? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -6852,11 +7004,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_pay_amount(PayAmount self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
-      case PayAmount_Receiver(amountSat: final amountSat):
+      case PayAmount_Bitcoin(receiverAmountSat: final receiverAmountSat):
         sse_encode_i_32(0, serializer);
-        sse_encode_u_64(amountSat, serializer);
-      case PayAmount_Drain():
+        sse_encode_u_64(receiverAmountSat, serializer);
+      case PayAmount_Asset(assetId: final assetId, receiverAmount: final receiverAmount):
         sse_encode_i_32(1, serializer);
+        sse_encode_String(assetId, serializer);
+        sse_encode_u_64(receiverAmount, serializer);
+      case PayAmount_Drain():
+        sse_encode_i_32(2, serializer);
     }
   }
 
@@ -6911,10 +7067,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_box_autoadd_ln_url_info(lnurlInfo, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
-      case PaymentDetails_Liquid(destination: final destination, description: final description):
+      case PaymentDetails_Liquid(
+          destination: final destination,
+          description: final description,
+          assetId: final assetId
+        ):
         sse_encode_i_32(1, serializer);
         sse_encode_String(destination, serializer);
         sse_encode_String(description, serializer);
+        sse_encode_String(assetId, serializer);
       case PaymentDetails_Bitcoin(
           swapId: final swapId,
           description: final description,
@@ -7065,15 +7226,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_prepare_receive_request(PrepareReceiveRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_opt_box_autoadd_u_64(self.payerAmountSat, serializer);
     sse_encode_payment_method(self.paymentMethod, serializer);
+    sse_encode_opt_box_autoadd_receive_amount(self.amount, serializer);
   }
 
   @protected
   void sse_encode_prepare_receive_response(PrepareReceiveResponse self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_payment_method(self.paymentMethod, serializer);
-    sse_encode_opt_box_autoadd_u_64(self.payerAmountSat, serializer);
+    sse_encode_opt_box_autoadd_receive_amount(self.amount, serializer);
     sse_encode_u_64(self.feesSat, serializer);
     sse_encode_opt_box_autoadd_u_64(self.minPayerAmountSat, serializer);
     sse_encode_opt_box_autoadd_u_64(self.maxPayerAmountSat, serializer);
@@ -7115,6 +7276,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.coin, serializer);
     sse_encode_f_64(self.value, serializer);
+  }
+
+  @protected
+  void sse_encode_receive_amount(ReceiveAmount self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case ReceiveAmount_Bitcoin(payerAmountSat: final payerAmountSat):
+        sse_encode_i_32(0, serializer);
+        sse_encode_u_64(payerAmountSat, serializer);
+      case ReceiveAmount_Asset(assetId: final assetId, payerAmount: final payerAmount):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(assetId, serializer);
+        sse_encode_opt_box_autoadd_u_64(payerAmount, serializer);
+    }
   }
 
   @protected
@@ -7371,6 +7546,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.pendingReceiveSat, serializer);
     sse_encode_String(self.fingerprint, serializer);
     sse_encode_String(self.pubkey, serializer);
+    sse_encode_list_asset_balance(self.assetBalances, serializer);
   }
 }
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -66,6 +66,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Amount dco_decode_amount(dynamic raw);
 
   @protected
+  AssetBalance dco_decode_asset_balance(dynamic raw);
+
+  @protected
   BackupRequest dco_decode_backup_request(dynamic raw);
 
   @protected
@@ -204,6 +207,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PrepareSendRequest dco_decode_box_autoadd_prepare_send_request(dynamic raw);
 
   @protected
+  ReceiveAmount dco_decode_box_autoadd_receive_amount(dynamic raw);
+
+  @protected
   ReceivePaymentRequest dco_decode_box_autoadd_receive_payment_request(dynamic raw);
 
   @protected
@@ -304,6 +310,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<AssetBalance> dco_decode_list_asset_balance(dynamic raw);
 
   @protected
   List<ExternalInputParser> dco_decode_list_external_input_parser(dynamic raw);
@@ -453,6 +462,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Payment? dco_decode_opt_box_autoadd_payment(dynamic raw);
 
   @protected
+  ReceiveAmount? dco_decode_opt_box_autoadd_receive_amount(dynamic raw);
+
+  @protected
   SuccessAction? dco_decode_opt_box_autoadd_success_action(dynamic raw);
 
   @protected
@@ -538,6 +550,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Rate dco_decode_rate(dynamic raw);
+
+  @protected
+  ReceiveAmount dco_decode_receive_amount(dynamic raw);
 
   @protected
   ReceivePaymentRequest dco_decode_receive_payment_request(dynamic raw);
@@ -661,6 +676,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Amount sse_decode_amount(SseDeserializer deserializer);
+
+  @protected
+  AssetBalance sse_decode_asset_balance(SseDeserializer deserializer);
 
   @protected
   BackupRequest sse_decode_backup_request(SseDeserializer deserializer);
@@ -805,6 +823,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PrepareSendRequest sse_decode_box_autoadd_prepare_send_request(SseDeserializer deserializer);
 
   @protected
+  ReceiveAmount sse_decode_box_autoadd_receive_amount(SseDeserializer deserializer);
+
+  @protected
   ReceivePaymentRequest sse_decode_box_autoadd_receive_payment_request(SseDeserializer deserializer);
 
   @protected
@@ -907,6 +928,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<AssetBalance> sse_decode_list_asset_balance(SseDeserializer deserializer);
 
   @protected
   List<ExternalInputParser> sse_decode_list_external_input_parser(SseDeserializer deserializer);
@@ -1056,6 +1080,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Payment? sse_decode_opt_box_autoadd_payment(SseDeserializer deserializer);
 
   @protected
+  ReceiveAmount? sse_decode_opt_box_autoadd_receive_amount(SseDeserializer deserializer);
+
+  @protected
   SuccessAction? sse_decode_opt_box_autoadd_success_action(SseDeserializer deserializer);
 
   @protected
@@ -1141,6 +1168,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Rate sse_decode_rate(SseDeserializer deserializer);
+
+  @protected
+  ReceiveAmount sse_decode_receive_amount(SseDeserializer deserializer);
 
   @protected
   ReceivePaymentRequest sse_decode_receive_payment_request(SseDeserializer deserializer);
@@ -1608,6 +1638,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_receive_amount> cst_encode_box_autoadd_receive_amount(ReceiveAmount raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_receive_amount();
+    cst_api_fill_to_wire_receive_amount(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_receive_payment_request> cst_encode_box_autoadd_receive_payment_request(
       ReceivePaymentRequest raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -1716,6 +1754,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     final ans = wire.cst_new_list_String(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       ans.ref.ptr[i] = cst_encode_String(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_asset_balance> cst_encode_list_asset_balance(List<AssetBalance> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_asset_balance(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_asset_balance(raw[i], ans.ref.ptr[i]);
     }
     return ans;
   }
@@ -1906,6 +1954,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_receive_amount> cst_encode_opt_box_autoadd_receive_amount(ReceiveAmount? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_receive_amount(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_cst_success_action> cst_encode_opt_box_autoadd_success_action(SuccessAction? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? ffi.nullptr : cst_encode_box_autoadd_success_action(raw);
@@ -2021,6 +2075,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Currency.fractional_amount = pre_fractional_amount;
       return;
     }
+  }
+
+  @protected
+  void cst_api_fill_to_wire_asset_balance(AssetBalance apiObj, wire_cst_asset_balance wireObj) {
+    wireObj.asset_id = cst_encode_String(apiObj.assetId);
+    wireObj.balance = cst_encode_u_64(apiObj.balance);
   }
 
   @protected
@@ -2278,6 +2338,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_receive_amount(
+      ReceiveAmount apiObj, ffi.Pointer<wire_cst_receive_amount> wireObj) {
+    cst_api_fill_to_wire_receive_amount(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_receive_payment_request(
       ReceivePaymentRequest apiObj, ffi.Pointer<wire_cst_receive_payment_request> wireObj) {
     cst_api_fill_to_wire_receive_payment_request(apiObj, wireObj.ref);
@@ -2531,13 +2597,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_list_payment_details(
       ListPaymentDetails apiObj, wire_cst_list_payment_details wireObj) {
     if (apiObj is ListPaymentDetails_Liquid) {
-      var pre_destination = cst_encode_String(apiObj.destination);
+      var pre_asset_id = cst_encode_opt_String(apiObj.assetId);
+      var pre_destination = cst_encode_opt_String(apiObj.destination);
       wireObj.tag = 0;
+      wireObj.kind.Liquid.asset_id = pre_asset_id;
       wireObj.kind.Liquid.destination = pre_destination;
       return;
     }
     if (apiObj is ListPaymentDetails_Bitcoin) {
-      var pre_address = cst_encode_String(apiObj.address);
+      var pre_address = cst_encode_opt_String(apiObj.address);
       wireObj.tag = 1;
       wireObj.kind.Bitcoin.address = pre_address;
       return;
@@ -2906,14 +2974,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_pay_amount(PayAmount apiObj, wire_cst_pay_amount wireObj) {
-    if (apiObj is PayAmount_Receiver) {
-      var pre_amount_sat = cst_encode_u_64(apiObj.amountSat);
+    if (apiObj is PayAmount_Bitcoin) {
+      var pre_receiver_amount_sat = cst_encode_u_64(apiObj.receiverAmountSat);
       wireObj.tag = 0;
-      wireObj.kind.Receiver.amount_sat = pre_amount_sat;
+      wireObj.kind.Bitcoin.receiver_amount_sat = pre_receiver_amount_sat;
+      return;
+    }
+    if (apiObj is PayAmount_Asset) {
+      var pre_asset_id = cst_encode_String(apiObj.assetId);
+      var pre_receiver_amount = cst_encode_u_64(apiObj.receiverAmount);
+      wireObj.tag = 1;
+      wireObj.kind.Asset.asset_id = pre_asset_id;
+      wireObj.kind.Asset.receiver_amount = pre_receiver_amount;
       return;
     }
     if (apiObj is PayAmount_Drain) {
-      wireObj.tag = 1;
+      wireObj.tag = 2;
       return;
     }
   }
@@ -2970,9 +3046,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is PaymentDetails_Liquid) {
       var pre_destination = cst_encode_String(apiObj.destination);
       var pre_description = cst_encode_String(apiObj.description);
+      var pre_asset_id = cst_encode_String(apiObj.assetId);
       wireObj.tag = 1;
       wireObj.kind.Liquid.destination = pre_destination;
       wireObj.kind.Liquid.description = pre_description;
+      wireObj.kind.Liquid.asset_id = pre_asset_id;
       return;
     }
     if (apiObj is PaymentDetails_Bitcoin) {
@@ -3159,15 +3237,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_prepare_receive_request(
       PrepareReceiveRequest apiObj, wire_cst_prepare_receive_request wireObj) {
-    wireObj.payer_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.payerAmountSat);
     wireObj.payment_method = cst_encode_payment_method(apiObj.paymentMethod);
+    wireObj.amount = cst_encode_opt_box_autoadd_receive_amount(apiObj.amount);
   }
 
   @protected
   void cst_api_fill_to_wire_prepare_receive_response(
       PrepareReceiveResponse apiObj, wire_cst_prepare_receive_response wireObj) {
     wireObj.payment_method = cst_encode_payment_method(apiObj.paymentMethod);
-    wireObj.payer_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.payerAmountSat);
+    wireObj.amount = cst_encode_opt_box_autoadd_receive_amount(apiObj.amount);
     wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
     wireObj.min_payer_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.minPayerAmountSat);
     wireObj.max_payer_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.maxPayerAmountSat);
@@ -3208,6 +3286,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_api_fill_to_wire_rate(Rate apiObj, wire_cst_rate wireObj) {
     wireObj.coin = cst_encode_String(apiObj.coin);
     wireObj.value = cst_encode_f_64(apiObj.value);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_receive_amount(ReceiveAmount apiObj, wire_cst_receive_amount wireObj) {
+    if (apiObj is ReceiveAmount_Bitcoin) {
+      var pre_payer_amount_sat = cst_encode_u_64(apiObj.payerAmountSat);
+      wireObj.tag = 0;
+      wireObj.kind.Bitcoin.payer_amount_sat = pre_payer_amount_sat;
+      return;
+    }
+    if (apiObj is ReceiveAmount_Asset) {
+      var pre_asset_id = cst_encode_String(apiObj.assetId);
+      var pre_payer_amount = cst_encode_opt_box_autoadd_u_64(apiObj.payerAmount);
+      wireObj.tag = 1;
+      wireObj.kind.Asset.asset_id = pre_asset_id;
+      wireObj.kind.Asset.payer_amount = pre_payer_amount;
+      return;
+    }
   }
 
   @protected
@@ -3470,6 +3566,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.pending_receive_sat = cst_encode_u_64(apiObj.pendingReceiveSat);
     wireObj.fingerprint = cst_encode_String(apiObj.fingerprint);
     wireObj.pubkey = cst_encode_String(apiObj.pubkey);
+    wireObj.asset_balances = cst_encode_list_asset_balance(apiObj.assetBalances);
   }
 
   @protected
@@ -3563,6 +3660,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_amount(Amount self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_asset_balance(AssetBalance self, SseSerializer serializer);
 
   @protected
   void sse_encode_backup_request(BackupRequest self, SseSerializer serializer);
@@ -3713,6 +3813,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_prepare_send_request(PrepareSendRequest self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_receive_amount(ReceiveAmount self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_receive_payment_request(ReceivePaymentRequest self, SseSerializer serializer);
 
   @protected
@@ -3816,6 +3919,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_asset_balance(List<AssetBalance> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_external_input_parser(List<ExternalInputParser> self, SseSerializer serializer);
@@ -3966,6 +4072,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_opt_box_autoadd_payment(Payment? self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_receive_amount(ReceiveAmount? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_box_autoadd_success_action(SuccessAction? self, SseSerializer serializer);
 
   @protected
@@ -4052,6 +4161,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_rate(Rate self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_receive_amount(ReceiveAmount self, SseSerializer serializer);
 
   @protected
   void sse_encode_receive_payment_request(ReceivePaymentRequest self, SseSerializer serializer);
@@ -5408,6 +5520,16 @@ class RustLibWire implements BaseWire {
   late final _cst_new_box_autoadd_prepare_send_request = _cst_new_box_autoadd_prepare_send_requestPtr
       .asFunction<ffi.Pointer<wire_cst_prepare_send_request> Function()>();
 
+  ffi.Pointer<wire_cst_receive_amount> cst_new_box_autoadd_receive_amount() {
+    return _cst_new_box_autoadd_receive_amount();
+  }
+
+  late final _cst_new_box_autoadd_receive_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_receive_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_receive_amount');
+  late final _cst_new_box_autoadd_receive_amount =
+      _cst_new_box_autoadd_receive_amountPtr.asFunction<ffi.Pointer<wire_cst_receive_amount> Function()>();
+
   ffi.Pointer<wire_cst_receive_payment_request> cst_new_box_autoadd_receive_payment_request() {
     return _cst_new_box_autoadd_receive_payment_request();
   }
@@ -5549,6 +5671,20 @@ class RustLibWire implements BaseWire {
           'frbgen_breez_liquid_cst_new_list_String');
   late final _cst_new_list_String =
       _cst_new_list_StringPtr.asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_asset_balance> cst_new_list_asset_balance(
+    int len,
+  ) {
+    return _cst_new_list_asset_balance(
+      len,
+    );
+  }
+
+  late final _cst_new_list_asset_balancePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_asset_balance> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_asset_balance');
+  late final _cst_new_list_asset_balance =
+      _cst_new_list_asset_balancePtr.asFunction<ffi.Pointer<wire_cst_list_asset_balance> Function(int)>();
 
   ffi.Pointer<wire_cst_list_external_input_parser> cst_new_list_external_input_parser(
     int len,
@@ -5836,6 +5972,8 @@ final class wire_cst_list_payment_state extends ffi.Struct {
 }
 
 final class wire_cst_ListPaymentDetails_Liquid extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 }
 
@@ -6205,13 +6343,22 @@ final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
   external ffi.Pointer<ffi.Bool> validate_success_action_url;
 }
 
-final class wire_cst_PayAmount_Receiver extends ffi.Struct {
+final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
   @ffi.Uint64()
-  external int amount_sat;
+  external int receiver_amount_sat;
+}
+
+final class wire_cst_PayAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Uint64()
+  external int receiver_amount;
 }
 
 final class PayAmountKind extends ffi.Union {
-  external wire_cst_PayAmount_Receiver Receiver;
+  external wire_cst_PayAmount_Bitcoin Bitcoin;
+
+  external wire_cst_PayAmount_Asset Asset;
 }
 
 final class wire_cst_pay_amount extends ffi.Struct {
@@ -6227,11 +6374,35 @@ final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
 }
 
-final class wire_cst_prepare_receive_request extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+final class wire_cst_ReceiveAmount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int payer_amount_sat;
+}
 
+final class wire_cst_ReceiveAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  external ffi.Pointer<ffi.Uint64> payer_amount;
+}
+
+final class ReceiveAmountKind extends ffi.Union {
+  external wire_cst_ReceiveAmount_Bitcoin Bitcoin;
+
+  external wire_cst_ReceiveAmount_Asset Asset;
+}
+
+final class wire_cst_receive_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external ReceiveAmountKind kind;
+}
+
+final class wire_cst_prepare_receive_request extends ffi.Struct {
   @ffi.Int32()
   external int payment_method;
+
+  external ffi.Pointer<wire_cst_receive_amount> amount;
 }
 
 final class wire_cst_prepare_refund_request extends ffi.Struct {
@@ -6253,7 +6424,7 @@ final class wire_cst_prepare_receive_response extends ffi.Struct {
   @ffi.Int32()
   external int payment_method;
 
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+  external ffi.Pointer<wire_cst_receive_amount> amount;
 
   @ffi.Uint64()
   external int fees_sat;
@@ -6404,6 +6575,8 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
 }
 
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
@@ -6620,6 +6793,20 @@ final class wire_cst_symbol extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> position;
 }
 
+final class wire_cst_asset_balance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Uint64()
+  external int balance;
+}
+
+final class wire_cst_list_asset_balance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_asset_balance> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_localized_name extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> locale;
 
@@ -6744,6 +6931,8 @@ final class wire_cst_wallet_info extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> fingerprint;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> pubkey;
+
+  external ffi.Pointer<wire_cst_list_asset_balance> asset_balances;
 }
 
 final class wire_cst_get_info_response extends ffi.Struct {

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -170,7 +170,7 @@ abstract class _$$ListPaymentDetails_LiquidImplCopyWith<$Res> {
           _$ListPaymentDetails_LiquidImpl value, $Res Function(_$ListPaymentDetails_LiquidImpl) then) =
       __$$ListPaymentDetails_LiquidImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String destination});
+  $Res call({String? assetId, String? destination});
 }
 
 /// @nodoc
@@ -186,13 +186,18 @@ class __$$ListPaymentDetails_LiquidImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? destination = null,
+    Object? assetId = freezed,
+    Object? destination = freezed,
   }) {
     return _then(_$ListPaymentDetails_LiquidImpl(
-      destination: null == destination
+      assetId: freezed == assetId
+          ? _value.assetId
+          : assetId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      destination: freezed == destination
           ? _value.destination
           : destination // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -200,14 +205,19 @@ class __$$ListPaymentDetails_LiquidImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ListPaymentDetails_LiquidImpl extends ListPaymentDetails_Liquid {
-  const _$ListPaymentDetails_LiquidImpl({required this.destination}) : super._();
+  const _$ListPaymentDetails_LiquidImpl({this.assetId, this.destination}) : super._();
 
+  /// Optional asset id
   @override
-  final String destination;
+  final String? assetId;
+
+  /// Optional BIP21 URI or address
+  @override
+  final String? destination;
 
   @override
   String toString() {
-    return 'ListPaymentDetails.liquid(destination: $destination)';
+    return 'ListPaymentDetails.liquid(assetId: $assetId, destination: $destination)';
   }
 
   @override
@@ -215,11 +225,12 @@ class _$ListPaymentDetails_LiquidImpl extends ListPaymentDetails_Liquid {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ListPaymentDetails_LiquidImpl &&
+            (identical(other.assetId, assetId) || other.assetId == assetId) &&
             (identical(other.destination, destination) || other.destination == destination));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, destination);
+  int get hashCode => Object.hash(runtimeType, assetId, destination);
 
   /// Create a copy of ListPaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -231,11 +242,15 @@ class _$ListPaymentDetails_LiquidImpl extends ListPaymentDetails_Liquid {
 }
 
 abstract class ListPaymentDetails_Liquid extends ListPaymentDetails {
-  const factory ListPaymentDetails_Liquid({required final String destination}) =
+  const factory ListPaymentDetails_Liquid({final String? assetId, final String? destination}) =
       _$ListPaymentDetails_LiquidImpl;
   const ListPaymentDetails_Liquid._() : super._();
 
-  String get destination;
+  /// Optional asset id
+  String? get assetId;
+
+  /// Optional BIP21 URI or address
+  String? get destination;
 
   /// Create a copy of ListPaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -250,7 +265,7 @@ abstract class _$$ListPaymentDetails_BitcoinImplCopyWith<$Res> {
           _$ListPaymentDetails_BitcoinImpl value, $Res Function(_$ListPaymentDetails_BitcoinImpl) then) =
       __$$ListPaymentDetails_BitcoinImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String address});
+  $Res call({String? address});
 }
 
 /// @nodoc
@@ -266,13 +281,13 @@ class __$$ListPaymentDetails_BitcoinImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? address = null,
+    Object? address = freezed,
   }) {
     return _then(_$ListPaymentDetails_BitcoinImpl(
-      address: null == address
+      address: freezed == address
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -280,10 +295,11 @@ class __$$ListPaymentDetails_BitcoinImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ListPaymentDetails_BitcoinImpl extends ListPaymentDetails_Bitcoin {
-  const _$ListPaymentDetails_BitcoinImpl({required this.address}) : super._();
+  const _$ListPaymentDetails_BitcoinImpl({this.address}) : super._();
 
+  /// Optional address
   @override
-  final String address;
+  final String? address;
 
   @override
   String toString() {
@@ -311,11 +327,11 @@ class _$ListPaymentDetails_BitcoinImpl extends ListPaymentDetails_Bitcoin {
 }
 
 abstract class ListPaymentDetails_Bitcoin extends ListPaymentDetails {
-  const factory ListPaymentDetails_Bitcoin({required final String address}) =
-      _$ListPaymentDetails_BitcoinImpl;
+  const factory ListPaymentDetails_Bitcoin({final String? address}) = _$ListPaymentDetails_BitcoinImpl;
   const ListPaymentDetails_Bitcoin._() : super._();
 
-  String get address;
+  /// Optional address
+  String? get address;
 
   /// Create a copy of ListPaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -616,20 +632,20 @@ class _$PayAmountCopyWithImpl<$Res, $Val extends PayAmount> implements $PayAmoun
 }
 
 /// @nodoc
-abstract class _$$PayAmount_ReceiverImplCopyWith<$Res> {
-  factory _$$PayAmount_ReceiverImplCopyWith(
-          _$PayAmount_ReceiverImpl value, $Res Function(_$PayAmount_ReceiverImpl) then) =
-      __$$PayAmount_ReceiverImplCopyWithImpl<$Res>;
+abstract class _$$PayAmount_BitcoinImplCopyWith<$Res> {
+  factory _$$PayAmount_BitcoinImplCopyWith(
+          _$PayAmount_BitcoinImpl value, $Res Function(_$PayAmount_BitcoinImpl) then) =
+      __$$PayAmount_BitcoinImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({BigInt amountSat});
+  $Res call({BigInt receiverAmountSat});
 }
 
 /// @nodoc
-class __$$PayAmount_ReceiverImplCopyWithImpl<$Res>
-    extends _$PayAmountCopyWithImpl<$Res, _$PayAmount_ReceiverImpl>
-    implements _$$PayAmount_ReceiverImplCopyWith<$Res> {
-  __$$PayAmount_ReceiverImplCopyWithImpl(
-      _$PayAmount_ReceiverImpl _value, $Res Function(_$PayAmount_ReceiverImpl) _then)
+class __$$PayAmount_BitcoinImplCopyWithImpl<$Res>
+    extends _$PayAmountCopyWithImpl<$Res, _$PayAmount_BitcoinImpl>
+    implements _$$PayAmount_BitcoinImplCopyWith<$Res> {
+  __$$PayAmount_BitcoinImplCopyWithImpl(
+      _$PayAmount_BitcoinImpl _value, $Res Function(_$PayAmount_BitcoinImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of PayAmount
@@ -637,12 +653,12 @@ class __$$PayAmount_ReceiverImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? amountSat = null,
+    Object? receiverAmountSat = null,
   }) {
-    return _then(_$PayAmount_ReceiverImpl(
-      amountSat: null == amountSat
-          ? _value.amountSat
-          : amountSat // ignore: cast_nullable_to_non_nullable
+    return _then(_$PayAmount_BitcoinImpl(
+      receiverAmountSat: null == receiverAmountSat
+          ? _value.receiverAmountSat
+          : receiverAmountSat // ignore: cast_nullable_to_non_nullable
               as BigInt,
     ));
   }
@@ -650,48 +666,136 @@ class __$$PayAmount_ReceiverImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PayAmount_ReceiverImpl extends PayAmount_Receiver {
-  const _$PayAmount_ReceiverImpl({required this.amountSat}) : super._();
+class _$PayAmount_BitcoinImpl extends PayAmount_Bitcoin {
+  const _$PayAmount_BitcoinImpl({required this.receiverAmountSat}) : super._();
 
   @override
-  final BigInt amountSat;
+  final BigInt receiverAmountSat;
 
   @override
   String toString() {
-    return 'PayAmount.receiver(amountSat: $amountSat)';
+    return 'PayAmount.bitcoin(receiverAmountSat: $receiverAmountSat)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PayAmount_ReceiverImpl &&
-            (identical(other.amountSat, amountSat) || other.amountSat == amountSat));
+            other is _$PayAmount_BitcoinImpl &&
+            (identical(other.receiverAmountSat, receiverAmountSat) ||
+                other.receiverAmountSat == receiverAmountSat));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, amountSat);
+  int get hashCode => Object.hash(runtimeType, receiverAmountSat);
 
   /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$PayAmount_ReceiverImplCopyWith<_$PayAmount_ReceiverImpl> get copyWith =>
-      __$$PayAmount_ReceiverImplCopyWithImpl<_$PayAmount_ReceiverImpl>(this, _$identity);
+  _$$PayAmount_BitcoinImplCopyWith<_$PayAmount_BitcoinImpl> get copyWith =>
+      __$$PayAmount_BitcoinImplCopyWithImpl<_$PayAmount_BitcoinImpl>(this, _$identity);
 }
 
-abstract class PayAmount_Receiver extends PayAmount {
-  const factory PayAmount_Receiver({required final BigInt amountSat}) = _$PayAmount_ReceiverImpl;
-  const PayAmount_Receiver._() : super._();
+abstract class PayAmount_Bitcoin extends PayAmount {
+  const factory PayAmount_Bitcoin({required final BigInt receiverAmountSat}) = _$PayAmount_BitcoinImpl;
+  const PayAmount_Bitcoin._() : super._();
 
-  BigInt get amountSat;
+  BigInt get receiverAmountSat;
 
   /// Create a copy of PayAmount
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PayAmount_ReceiverImplCopyWith<_$PayAmount_ReceiverImpl> get copyWith =>
+  _$$PayAmount_BitcoinImplCopyWith<_$PayAmount_BitcoinImpl> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PayAmount_AssetImplCopyWith<$Res> {
+  factory _$$PayAmount_AssetImplCopyWith(
+          _$PayAmount_AssetImpl value, $Res Function(_$PayAmount_AssetImpl) then) =
+      __$$PayAmount_AssetImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String assetId, BigInt receiverAmount});
+}
+
+/// @nodoc
+class __$$PayAmount_AssetImplCopyWithImpl<$Res> extends _$PayAmountCopyWithImpl<$Res, _$PayAmount_AssetImpl>
+    implements _$$PayAmount_AssetImplCopyWith<$Res> {
+  __$$PayAmount_AssetImplCopyWithImpl(
+      _$PayAmount_AssetImpl _value, $Res Function(_$PayAmount_AssetImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PayAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? assetId = null,
+    Object? receiverAmount = null,
+  }) {
+    return _then(_$PayAmount_AssetImpl(
+      assetId: null == assetId
+          ? _value.assetId
+          : assetId // ignore: cast_nullable_to_non_nullable
+              as String,
+      receiverAmount: null == receiverAmount
+          ? _value.receiverAmount
+          : receiverAmount // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PayAmount_AssetImpl extends PayAmount_Asset {
+  const _$PayAmount_AssetImpl({required this.assetId, required this.receiverAmount}) : super._();
+
+  @override
+  final String assetId;
+  @override
+  final BigInt receiverAmount;
+
+  @override
+  String toString() {
+    return 'PayAmount.asset(assetId: $assetId, receiverAmount: $receiverAmount)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PayAmount_AssetImpl &&
+            (identical(other.assetId, assetId) || other.assetId == assetId) &&
+            (identical(other.receiverAmount, receiverAmount) || other.receiverAmount == receiverAmount));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, assetId, receiverAmount);
+
+  /// Create a copy of PayAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PayAmount_AssetImplCopyWith<_$PayAmount_AssetImpl> get copyWith =>
+      __$$PayAmount_AssetImplCopyWithImpl<_$PayAmount_AssetImpl>(this, _$identity);
+}
+
+abstract class PayAmount_Asset extends PayAmount {
+  const factory PayAmount_Asset({required final String assetId, required final BigInt receiverAmount}) =
+      _$PayAmount_AssetImpl;
+  const PayAmount_Asset._() : super._();
+
+  String get assetId;
+  BigInt get receiverAmount;
+
+  /// Create a copy of PayAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PayAmount_AssetImplCopyWith<_$PayAmount_AssetImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1038,7 +1142,7 @@ abstract class _$$PaymentDetails_LiquidImplCopyWith<$Res> implements $PaymentDet
       __$$PaymentDetails_LiquidImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String destination, String description});
+  $Res call({String destination, String description, String assetId});
 }
 
 /// @nodoc
@@ -1056,6 +1160,7 @@ class __$$PaymentDetails_LiquidImplCopyWithImpl<$Res>
   $Res call({
     Object? destination = null,
     Object? description = null,
+    Object? assetId = null,
   }) {
     return _then(_$PaymentDetails_LiquidImpl(
       destination: null == destination
@@ -1066,6 +1171,10 @@ class __$$PaymentDetails_LiquidImplCopyWithImpl<$Res>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String,
+      assetId: null == assetId
+          ? _value.assetId
+          : assetId // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -1073,7 +1182,9 @@ class __$$PaymentDetails_LiquidImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$PaymentDetails_LiquidImpl extends PaymentDetails_Liquid {
-  const _$PaymentDetails_LiquidImpl({required this.destination, required this.description}) : super._();
+  const _$PaymentDetails_LiquidImpl(
+      {required this.destination, required this.description, required this.assetId})
+      : super._();
 
   /// Represents either a Liquid BIP21 URI or pure address
   @override
@@ -1083,9 +1194,13 @@ class _$PaymentDetails_LiquidImpl extends PaymentDetails_Liquid {
   @override
   final String description;
 
+  /// The asset id
+  @override
+  final String assetId;
+
   @override
   String toString() {
-    return 'PaymentDetails.liquid(destination: $destination, description: $description)';
+    return 'PaymentDetails.liquid(destination: $destination, description: $description, assetId: $assetId)';
   }
 
   @override
@@ -1094,11 +1209,12 @@ class _$PaymentDetails_LiquidImpl extends PaymentDetails_Liquid {
         (other.runtimeType == runtimeType &&
             other is _$PaymentDetails_LiquidImpl &&
             (identical(other.destination, destination) || other.destination == destination) &&
-            (identical(other.description, description) || other.description == description));
+            (identical(other.description, description) || other.description == description) &&
+            (identical(other.assetId, assetId) || other.assetId == assetId));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, destination, description);
+  int get hashCode => Object.hash(runtimeType, destination, description, assetId);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1111,7 +1227,9 @@ class _$PaymentDetails_LiquidImpl extends PaymentDetails_Liquid {
 
 abstract class PaymentDetails_Liquid extends PaymentDetails {
   const factory PaymentDetails_Liquid(
-      {required final String destination, required final String description}) = _$PaymentDetails_LiquidImpl;
+      {required final String destination,
+      required final String description,
+      required final String assetId}) = _$PaymentDetails_LiquidImpl;
   const PaymentDetails_Liquid._() : super._();
 
   /// Represents either a Liquid BIP21 URI or pure address
@@ -1120,6 +1238,9 @@ abstract class PaymentDetails_Liquid extends PaymentDetails {
   /// Represents the BIP21 `message` field
   @override
   String get description;
+
+  /// The asset id
+  String get assetId;
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1321,6 +1442,196 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentDetails_BitcoinImplCopyWith<_$PaymentDetails_BitcoinImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReceiveAmount {}
+
+/// @nodoc
+abstract class $ReceiveAmountCopyWith<$Res> {
+  factory $ReceiveAmountCopyWith(ReceiveAmount value, $Res Function(ReceiveAmount) then) =
+      _$ReceiveAmountCopyWithImpl<$Res, ReceiveAmount>;
+}
+
+/// @nodoc
+class _$ReceiveAmountCopyWithImpl<$Res, $Val extends ReceiveAmount> implements $ReceiveAmountCopyWith<$Res> {
+  _$ReceiveAmountCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$ReceiveAmount_BitcoinImplCopyWith<$Res> {
+  factory _$$ReceiveAmount_BitcoinImplCopyWith(
+          _$ReceiveAmount_BitcoinImpl value, $Res Function(_$ReceiveAmount_BitcoinImpl) then) =
+      __$$ReceiveAmount_BitcoinImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({BigInt payerAmountSat});
+}
+
+/// @nodoc
+class __$$ReceiveAmount_BitcoinImplCopyWithImpl<$Res>
+    extends _$ReceiveAmountCopyWithImpl<$Res, _$ReceiveAmount_BitcoinImpl>
+    implements _$$ReceiveAmount_BitcoinImplCopyWith<$Res> {
+  __$$ReceiveAmount_BitcoinImplCopyWithImpl(
+      _$ReceiveAmount_BitcoinImpl _value, $Res Function(_$ReceiveAmount_BitcoinImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? payerAmountSat = null,
+  }) {
+    return _then(_$ReceiveAmount_BitcoinImpl(
+      payerAmountSat: null == payerAmountSat
+          ? _value.payerAmountSat
+          : payerAmountSat // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceiveAmount_BitcoinImpl extends ReceiveAmount_Bitcoin {
+  const _$ReceiveAmount_BitcoinImpl({required this.payerAmountSat}) : super._();
+
+  @override
+  final BigInt payerAmountSat;
+
+  @override
+  String toString() {
+    return 'ReceiveAmount.bitcoin(payerAmountSat: $payerAmountSat)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceiveAmount_BitcoinImpl &&
+            (identical(other.payerAmountSat, payerAmountSat) || other.payerAmountSat == payerAmountSat));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, payerAmountSat);
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceiveAmount_BitcoinImplCopyWith<_$ReceiveAmount_BitcoinImpl> get copyWith =>
+      __$$ReceiveAmount_BitcoinImplCopyWithImpl<_$ReceiveAmount_BitcoinImpl>(this, _$identity);
+}
+
+abstract class ReceiveAmount_Bitcoin extends ReceiveAmount {
+  const factory ReceiveAmount_Bitcoin({required final BigInt payerAmountSat}) = _$ReceiveAmount_BitcoinImpl;
+  const ReceiveAmount_Bitcoin._() : super._();
+
+  BigInt get payerAmountSat;
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReceiveAmount_BitcoinImplCopyWith<_$ReceiveAmount_BitcoinImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ReceiveAmount_AssetImplCopyWith<$Res> {
+  factory _$$ReceiveAmount_AssetImplCopyWith(
+          _$ReceiveAmount_AssetImpl value, $Res Function(_$ReceiveAmount_AssetImpl) then) =
+      __$$ReceiveAmount_AssetImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String assetId, BigInt? payerAmount});
+}
+
+/// @nodoc
+class __$$ReceiveAmount_AssetImplCopyWithImpl<$Res>
+    extends _$ReceiveAmountCopyWithImpl<$Res, _$ReceiveAmount_AssetImpl>
+    implements _$$ReceiveAmount_AssetImplCopyWith<$Res> {
+  __$$ReceiveAmount_AssetImplCopyWithImpl(
+      _$ReceiveAmount_AssetImpl _value, $Res Function(_$ReceiveAmount_AssetImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? assetId = null,
+    Object? payerAmount = freezed,
+  }) {
+    return _then(_$ReceiveAmount_AssetImpl(
+      assetId: null == assetId
+          ? _value.assetId
+          : assetId // ignore: cast_nullable_to_non_nullable
+              as String,
+      payerAmount: freezed == payerAmount
+          ? _value.payerAmount
+          : payerAmount // ignore: cast_nullable_to_non_nullable
+              as BigInt?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceiveAmount_AssetImpl extends ReceiveAmount_Asset {
+  const _$ReceiveAmount_AssetImpl({required this.assetId, this.payerAmount}) : super._();
+
+  @override
+  final String assetId;
+  @override
+  final BigInt? payerAmount;
+
+  @override
+  String toString() {
+    return 'ReceiveAmount.asset(assetId: $assetId, payerAmount: $payerAmount)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceiveAmount_AssetImpl &&
+            (identical(other.assetId, assetId) || other.assetId == assetId) &&
+            (identical(other.payerAmount, payerAmount) || other.payerAmount == payerAmount));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, assetId, payerAmount);
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceiveAmount_AssetImplCopyWith<_$ReceiveAmount_AssetImpl> get copyWith =>
+      __$$ReceiveAmount_AssetImplCopyWithImpl<_$ReceiveAmount_AssetImpl>(this, _$identity);
+}
+
+abstract class ReceiveAmount_Asset extends ReceiveAmount {
+  const factory ReceiveAmount_Asset({required final String assetId, final BigInt? payerAmount}) =
+      _$ReceiveAmount_AssetImpl;
+  const ReceiveAmount_Asset._() : super._();
+
+  String get assetId;
+  BigInt? get payerAmount;
+
+  /// Create a copy of ReceiveAmount
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReceiveAmount_AssetImplCopyWith<_$ReceiveAmount_AssetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1338,6 +1338,17 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_cst_new_box_autoadd_prepare_send_requestPtr
           .asFunction<ffi.Pointer<wire_cst_prepare_send_request> Function()>();
 
+  ffi.Pointer<wire_cst_receive_amount> frbgen_breez_liquid_cst_new_box_autoadd_receive_amount() {
+    return _frbgen_breez_liquid_cst_new_box_autoadd_receive_amount();
+  }
+
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_receive_amountPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_receive_amount> Function()>>(
+          'frbgen_breez_liquid_cst_new_box_autoadd_receive_amount');
+  late final _frbgen_breez_liquid_cst_new_box_autoadd_receive_amount =
+      _frbgen_breez_liquid_cst_new_box_autoadd_receive_amountPtr
+          .asFunction<ffi.Pointer<wire_cst_receive_amount> Function()>();
+
   ffi.Pointer<wire_cst_receive_payment_request>
       frbgen_breez_liquid_cst_new_box_autoadd_receive_payment_request() {
     return _frbgen_breez_liquid_cst_new_box_autoadd_receive_payment_request();
@@ -1492,6 +1503,21 @@ class FlutterBreezLiquidBindings {
           'frbgen_breez_liquid_cst_new_list_String');
   late final _frbgen_breez_liquid_cst_new_list_String = _frbgen_breez_liquid_cst_new_list_StringPtr
       .asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_asset_balance> frbgen_breez_liquid_cst_new_list_asset_balance(
+    int len,
+  ) {
+    return _frbgen_breez_liquid_cst_new_list_asset_balance(
+      len,
+    );
+  }
+
+  late final _frbgen_breez_liquid_cst_new_list_asset_balancePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_asset_balance> Function(ffi.Int32)>>(
+          'frbgen_breez_liquid_cst_new_list_asset_balance');
+  late final _frbgen_breez_liquid_cst_new_list_asset_balance =
+      _frbgen_breez_liquid_cst_new_list_asset_balancePtr
+          .asFunction<ffi.Pointer<wire_cst_list_asset_balance> Function(int)>();
 
   ffi.Pointer<wire_cst_list_external_input_parser> frbgen_breez_liquid_cst_new_list_external_input_parser(
     int len,
@@ -4156,6 +4182,8 @@ final class wire_cst_list_payment_state extends ffi.Struct {
 }
 
 final class wire_cst_ListPaymentDetails_Liquid extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 }
 
@@ -4525,13 +4553,22 @@ final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
   external ffi.Pointer<ffi.Bool> validate_success_action_url;
 }
 
-final class wire_cst_PayAmount_Receiver extends ffi.Struct {
+final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
   @ffi.Uint64()
-  external int amount_sat;
+  external int receiver_amount_sat;
+}
+
+final class wire_cst_PayAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Uint64()
+  external int receiver_amount;
 }
 
 final class PayAmountKind extends ffi.Union {
-  external wire_cst_PayAmount_Receiver Receiver;
+  external wire_cst_PayAmount_Bitcoin Bitcoin;
+
+  external wire_cst_PayAmount_Asset Asset;
 }
 
 final class wire_cst_pay_amount extends ffi.Struct {
@@ -4547,11 +4584,35 @@ final class wire_cst_prepare_pay_onchain_request extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> fee_rate_sat_per_vbyte;
 }
 
-final class wire_cst_prepare_receive_request extends ffi.Struct {
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+final class wire_cst_ReceiveAmount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int payer_amount_sat;
+}
 
+final class wire_cst_ReceiveAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  external ffi.Pointer<ffi.Uint64> payer_amount;
+}
+
+final class ReceiveAmountKind extends ffi.Union {
+  external wire_cst_ReceiveAmount_Bitcoin Bitcoin;
+
+  external wire_cst_ReceiveAmount_Asset Asset;
+}
+
+final class wire_cst_receive_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external ReceiveAmountKind kind;
+}
+
+final class wire_cst_prepare_receive_request extends ffi.Struct {
   @ffi.Int32()
   external int payment_method;
+
+  external ffi.Pointer<wire_cst_receive_amount> amount;
 }
 
 final class wire_cst_prepare_refund_request extends ffi.Struct {
@@ -4573,7 +4634,7 @@ final class wire_cst_prepare_receive_response extends ffi.Struct {
   @ffi.Int32()
   external int payment_method;
 
-  external ffi.Pointer<ffi.Uint64> payer_amount_sat;
+  external ffi.Pointer<wire_cst_receive_amount> amount;
 
   @ffi.Uint64()
   external int fees_sat;
@@ -4724,6 +4785,8 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
 }
 
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
@@ -4940,6 +5003,20 @@ final class wire_cst_symbol extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> position;
 }
 
+final class wire_cst_asset_balance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Uint64()
+  external int balance;
+}
+
+final class wire_cst_list_asset_balance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_asset_balance> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_localized_name extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> locale;
 
@@ -5064,6 +5141,8 @@ final class wire_cst_wallet_info extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> fingerprint;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> pubkey;
+
+  external ffi.Pointer<wire_cst_list_asset_balance> asset_balances;
 }
 
 final class wire_cst_get_info_response extends ffi.Struct {

--- a/packages/react-native/example/App.js
+++ b/packages/react-native/example/App.js
@@ -18,6 +18,7 @@ import {
     removeEventListener,
     prepareReceivePayment,
     prepareSendPayment,
+    ReceiveAmountVariant,
     receivePayment,
     sendPayment,
     PaymentMethod
@@ -84,8 +85,8 @@ const App = () => {
                 addLine("addEventListener", listenerId)
 
                 /* Receive lightning payment */
-
-                let prepareReceiveRes = await prepareReceivePayment({ payerAmountSat: 1000, paymentMethod: PaymentMethod.LIGHTNING })
+                let amount = { type: ReceiveAmountVariant.BITCOIN, payerAmountSat: 1000 }
+                let prepareReceiveRes = await prepareReceivePayment({ amount, paymentMethod: PaymentMethod.LIGHTNING })
                 addLine("prepareReceivePayment", JSON.stringify(prepareReceiveRes))
                 // Get the fees required for this payment
                 addLine("Payment fees", `${prepareReceiveRes.feesSat}`)

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -34,6 +34,11 @@ export interface AesSuccessActionDataDecrypted {
     plaintext: string
 }
 
+export interface AssetBalance {
+    assetId: string
+    balance: number
+}
+
 export interface BackupRequest {
     backupPath?: string
 }
@@ -337,13 +342,13 @@ export interface PreparePayOnchainResponse {
 
 export interface PrepareReceiveRequest {
     paymentMethod: PaymentMethod
-    payerAmountSat?: number
+    amount?: ReceiveAmount
 }
 
 export interface PrepareReceiveResponse {
     paymentMethod: PaymentMethod
     feesSat: number
-    payerAmountSat?: number
+    amount?: ReceiveAmount
     minPayerAmountSat?: number
     maxPayerAmountSat?: number
     swapperFeerate?: number
@@ -464,6 +469,7 @@ export interface WalletInfo {
     pendingReceiveSat: number
     fingerprint: string
     pubkey: string
+    assetBalances: AssetBalance[]
 }
 
 export enum AesSuccessActionDataResultVariant {
@@ -563,10 +569,11 @@ export enum ListPaymentDetailsVariant {
 
 export type ListPaymentDetails = {
     type: ListPaymentDetailsVariant.LIQUID,
-    destination: string
+    assetId?: string
+    destination?: string
 } | {
     type: ListPaymentDetailsVariant.BITCOIN,
-    address: string
+    address?: string
 }
 
 export enum LnUrlCallbackStatusVariant {
@@ -623,13 +630,18 @@ export enum Network {
 }
 
 export enum PayAmountVariant {
-    RECEIVER = "receiver",
+    BITCOIN = "bitcoin",
+    ASSET = "asset",
     DRAIN = "drain"
 }
 
 export type PayAmount = {
-    type: PayAmountVariant.RECEIVER,
-    amountSat: number
+    type: PayAmountVariant.BITCOIN,
+    receiverAmountSat: number
+} | {
+    type: PayAmountVariant.ASSET,
+    assetId: string
+    receiverAmount: number
 } | {
     type: PayAmountVariant.DRAIN
 }
@@ -655,6 +667,7 @@ export type PaymentDetails = {
     refundTxAmountSat?: number
 } | {
     type: PaymentDetailsVariant.LIQUID,
+    assetId: string
     destination: string
     description: string
 } | {
@@ -688,6 +701,20 @@ export enum PaymentState {
 export enum PaymentType {
     RECEIVE = "receive",
     SEND = "send"
+}
+
+export enum ReceiveAmountVariant {
+    BITCOIN = "bitcoin",
+    ASSET = "asset"
+}
+
+export type ReceiveAmount = {
+    type: ReceiveAmountVariant.BITCOIN,
+    payerAmountSat: number
+} | {
+    type: ReceiveAmountVariant.ASSET,
+    assetId: string
+    payerAmount?: number
 }
 
 export enum SdkEventVariant {


### PR DESCRIPTION
This PR:
- [x] adds support to send/receive non Liquid Bitcoin assets
- [x] adds asset balances to the get_info response
- [x] lists and filters non Liquid Bitcoin payments 

**Testing Notes:**
- It's important that the addition of assets handling does not impact swaps
- No other additional testing as Misty doesn't support assets, although there are addition testing notes in https://github.com/breez/misty-breez/pull/323