### PR TITLE
Add destination pubkey and bolt12 invoice to payment details

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=e0f2548b4ba917e69c532eb9ff900b64ed9a3da3#e0f2548b4ba917e69c532eb9ff900b64ed9a3da3"
+source = "git+https://github.com/breez/breez-sdk?rev=f3256140944e52eb10e80608be804a0e43084c35#f3256140944e52eb10e80608be804a0e43084c35"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=e0f2548b4ba917e69c532eb9ff900b64ed9a3da3#e0f2548b4ba917e69c532eb9ff900b64ed9a3da3"
+source = "git+https://github.com/breez/breez-sdk?rev=f3256140944e52eb10e80608be804a0e43084c35#f3256140944e52eb10e80608be804a0e43084c35"
 dependencies = [
  "aes 0.8.4",
  "anyhow",

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -491,9 +491,10 @@ typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *description;
   uint32_t liquid_expiration_blockheight;
   struct wire_cst_list_prim_u_8_strict *preimage;
-  struct wire_cst_list_prim_u_8_strict *bolt11;
+  struct wire_cst_list_prim_u_8_strict *invoice;
   struct wire_cst_list_prim_u_8_strict *bolt12_offer;
   struct wire_cst_list_prim_u_8_strict *payment_hash;
+  struct wire_cst_list_prim_u_8_strict *destination_pubkey;
   struct wire_cst_ln_url_info *lnurl_info;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -61,7 +61,7 @@ class SwapUpdatedTask : TaskProtocol {
             switch details {
             case let .bitcoin(swapId, _, _, _, _, _):
                 return swapId
-            case let .lightning(swapId, _, _, _, _, _, _, _, _, _):
+            case let .lightning(swapId, _, _, _, _, _, _, _, _, _, _):
                 return swapId
             default:
                 break

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -579,7 +579,7 @@ dictionary LnUrlInfo {
 
 [Enum]
 interface PaymentDetails {
-    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? bolt11, string? bolt12_offer, string? payment_hash, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
     Bitcoin(string swap_id, string description, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
 };

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -28,7 +28,7 @@ lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-full-s
 #lwk_wollet = "0.7.0"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "e0f2548b4ba917e69c532eb9ff900b64ed9a3da3", features = [
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "f3256140944e52eb10e80608be804a0e43084c35", features = [
     "liquid",
 ] }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3769,9 +3769,10 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_description = <String>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <u32>::sse_decode(deserializer);
                 let mut var_preimage = <Option<String>>::sse_decode(deserializer);
-                let mut var_bolt11 = <Option<String>>::sse_decode(deserializer);
+                let mut var_invoice = <Option<String>>::sse_decode(deserializer);
                 let mut var_bolt12Offer = <Option<String>>::sse_decode(deserializer);
                 let mut var_paymentHash = <Option<String>>::sse_decode(deserializer);
+                let mut var_destinationPubkey = <Option<String>>::sse_decode(deserializer);
                 let mut var_lnurlInfo = <Option<crate::model::LnUrlInfo>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
@@ -3780,9 +3781,10 @@ impl SseDecode for crate::model::PaymentDetails {
                     description: var_description,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
                     preimage: var_preimage,
-                    bolt11: var_bolt11,
+                    invoice: var_invoice,
                     bolt12_offer: var_bolt12Offer,
                     payment_hash: var_paymentHash,
+                    destination_pubkey: var_destinationPubkey,
                     lnurl_info: var_lnurlInfo,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
@@ -5944,9 +5946,10 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 description,
                 liquid_expiration_blockheight,
                 preimage,
-                bolt11,
+                invoice,
                 bolt12_offer,
                 payment_hash,
+                destination_pubkey,
                 lnurl_info,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -5956,9 +5959,10 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 description.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
                 preimage.into_into_dart().into_dart(),
-                bolt11.into_into_dart().into_dart(),
+                invoice.into_into_dart().into_dart(),
                 bolt12_offer.into_into_dart().into_dart(),
                 payment_hash.into_into_dart().into_dart(),
+                destination_pubkey.into_into_dart().into_dart(),
                 lnurl_info.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
@@ -8060,9 +8064,10 @@ impl SseEncode for crate::model::PaymentDetails {
                 description,
                 liquid_expiration_blockheight,
                 preimage,
-                bolt11,
+                invoice,
                 bolt12_offer,
                 payment_hash,
+                destination_pubkey,
                 lnurl_info,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -8072,9 +8077,10 @@ impl SseEncode for crate::model::PaymentDetails {
                 <String>::sse_encode(description, serializer);
                 <u32>::sse_encode(liquid_expiration_blockheight, serializer);
                 <Option<String>>::sse_encode(preimage, serializer);
-                <Option<String>>::sse_encode(bolt11, serializer);
+                <Option<String>>::sse_encode(invoice, serializer);
                 <Option<String>>::sse_encode(bolt12_offer, serializer);
                 <Option<String>>::sse_encode(payment_hash, serializer);
+                <Option<String>>::sse_encode(destination_pubkey, serializer);
                 <Option<crate::model::LnUrlInfo>>::sse_encode(lnurl_info, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
@@ -10160,9 +10166,10 @@ mod io {
                             .liquid_expiration_blockheight
                             .cst_decode(),
                         preimage: ans.preimage.cst_decode(),
-                        bolt11: ans.bolt11.cst_decode(),
+                        invoice: ans.invoice.cst_decode(),
                         bolt12_offer: ans.bolt12_offer.cst_decode(),
                         payment_hash: ans.payment_hash.cst_decode(),
+                        destination_pubkey: ans.destination_pubkey.cst_decode(),
                         lnurl_info: ans.lnurl_info.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
@@ -13752,9 +13759,10 @@ mod io {
         description: *mut wire_cst_list_prim_u_8_strict,
         liquid_expiration_blockheight: u32,
         preimage: *mut wire_cst_list_prim_u_8_strict,
-        bolt11: *mut wire_cst_list_prim_u_8_strict,
+        invoice: *mut wire_cst_list_prim_u_8_strict,
         bolt12_offer: *mut wire_cst_list_prim_u_8_strict,
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
+        destination_pubkey: *mut wire_cst_list_prim_u_8_strict,
         lnurl_info: *mut wire_cst_ln_url_info,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -910,6 +910,7 @@ pub(crate) struct SendSwap {
     /// The bolt12 offer, if this swap sends to a Bolt12 offer
     pub(crate) bolt12_offer: Option<String>,
     pub(crate) payment_hash: Option<String>,
+    pub(crate) destination_pubkey: Option<String>,
     pub(crate) description: Option<String>,
     pub(crate) preimage: Option<String>,
     pub(crate) payer_amount_sat: u64,
@@ -999,6 +1000,7 @@ pub(crate) struct ReceiveSwap {
     pub(crate) claim_private_key: String,
     pub(crate) invoice: String,
     pub(crate) payment_hash: Option<String>,
+    pub(crate) destination_pubkey: Option<String>,
     pub(crate) description: Option<String>,
     /// The amount of the invoice
     pub(crate) payer_amount_sat: u64,
@@ -1316,9 +1318,10 @@ pub struct PaymentSwapData {
     pub expiration_blockheight: u32,
 
     pub preimage: Option<String>,
-    pub bolt11: Option<String>,
+    pub invoice: Option<String>,
     pub bolt12_offer: Option<String>,
     pub payment_hash: Option<String>,
+    pub destination_pubkey: Option<String>,
     pub description: String,
 
     /// Amount sent by the swap payer
@@ -1371,15 +1374,18 @@ pub enum PaymentDetails {
         /// The preimage of the paid invoice (proof of payment).
         preimage: Option<String>,
 
-        /// Represents the Bolt11 invoice associated with a payment
+        /// Represents the Bolt11/Bolt12 invoice associated with a payment
         /// In the case of a Send payment, this is the invoice paid by the swapper
         /// In the case of a Receive payment, this is the invoice paid by the user
-        bolt11: Option<String>,
+        invoice: Option<String>,
 
         bolt12_offer: Option<String>,
 
         /// The payment hash of the invoice
         payment_hash: Option<String>,
+
+        /// The invoice destination/payee pubkey
+        destination_pubkey: Option<String>,
 
         /// The payment LNURL info
         lnurl_info: Option<LnUrlInfo>,
@@ -1518,7 +1524,7 @@ impl Payment {
         };
 
         Payment {
-            destination: swap.bolt11.clone(),
+            destination: swap.invoice.clone(),
             tx_id: None,
             unblinding_data: None,
             timestamp: swap.created_at,
@@ -1545,15 +1551,15 @@ impl Payment {
             destination: match &swap {
                 Some(PaymentSwapData {
                     swap_type: PaymentSwapType::Receive,
-                    bolt11,
+                    invoice,
                     ..
-                }) => bolt11.clone(),
+                }) => invoice.clone(),
                 Some(PaymentSwapData {
                     swap_type: PaymentSwapType::Send,
-                    bolt11,
+                    invoice,
                     bolt12_offer,
                     ..
-                }) => bolt11.clone().or(bolt12_offer.clone()),
+                }) => bolt12_offer.clone().or(invoice.clone()),
                 Some(PaymentSwapData {
                     swap_type: PaymentSwapType::Chain,
                     claim_address,
@@ -1867,6 +1873,23 @@ macro_rules! get_invoice_description {
         {
             Bolt11InvoiceDescription::Direct(msg) => Some(msg.to_string()),
             Bolt11InvoiceDescription::Hash(_) => None,
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! get_invoice_destination_pubkey {
+    ($invoice:expr, $is_bolt12:expr) => {
+        if $is_bolt12 {
+            utils::parse_bolt12_invoice($invoice)
+                .ok()
+                .map(|i| i.signing_pubkey().to_hex())
+        } else {
+            $invoice
+                .trim()
+                .parse::<Bolt11Invoice>()
+                .ok()
+                .map(|i| sdk_common::prelude::invoice_pubkey(&i))
         }
     };
 }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1878,23 +1878,6 @@ macro_rules! get_invoice_description {
 }
 
 #[macro_export]
-macro_rules! get_invoice_destination_pubkey {
-    ($invoice:expr, $is_bolt12:expr) => {
-        if $is_bolt12 {
-            utils::parse_bolt12_invoice($invoice)
-                .ok()
-                .map(|i| i.signing_pubkey().to_hex())
-        } else {
-            $invoice
-                .trim()
-                .parse::<Bolt11Invoice>()
-                .ok()
-                .map(|i| sdk_common::prelude::invoice_pubkey(&i))
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! get_updated_fields {
     ($($var:ident),* $(,)?) => {{
         let mut options = Vec::new();

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -221,5 +221,9 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE receive_swaps ADD COLUMN timeout_block_height INTEGER NOT NULL DEFAULT 0;
         ALTER TABLE send_swaps ADD COLUMN timeout_block_height INTEGER NOT NULL DEFAULT 0;
         ",
+        "
+        ALTER TABLE receive_swaps ADD COLUMN destination_pubkey TEXT;
+        ALTER TABLE send_swaps ADD COLUMN destination_pubkey TEXT;
+        ",
     ]
 }

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -13,9 +13,9 @@ use std::ops::Not;
 use std::{fs::create_dir_all, path::PathBuf, str::FromStr};
 
 use crate::lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
+use crate::model::*;
 use crate::sync::model::RecordType;
 use crate::{get_invoice_description, utils};
-use crate::{get_invoice_destination_pubkey, model::*};
 use anyhow::{anyhow, Result};
 use boltz_client::boltz::{ChainPair, ReversePair, SubmarinePair};
 use lwk_wollet::WalletTx;
@@ -675,7 +675,7 @@ impl Persister {
                 payment_hash,
                 destination_pubkey: destination_pubkey.or_else(|| {
                     invoice.and_then(|invoice| {
-                        get_invoice_destination_pubkey!(&invoice, bolt12_offer.is_some())
+                        utils::get_invoice_destination_pubkey(&invoice, bolt12_offer.is_some()).ok()
                     })
                 }),
                 lnurl_info: maybe_payment_details_lnurl_info,

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -13,9 +13,9 @@ use std::ops::Not;
 use std::{fs::create_dir_all, path::PathBuf, str::FromStr};
 
 use crate::lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription};
-use crate::model::*;
 use crate::sync::model::RecordType;
 use crate::{get_invoice_description, utils};
+use crate::{get_invoice_destination_pubkey, model::*};
 use anyhow::{anyhow, Result};
 use boltz_client::boltz::{ChainPair, ReversePair, SubmarinePair};
 use lwk_wollet::WalletTx;
@@ -372,6 +372,7 @@ impl Persister {
                 rs.timeout_block_height,
                 rs.invoice,
                 rs.payment_hash,
+                rs.destination_pubkey,
                 rs.description,
                 rs.preimage,
                 rs.payer_amount_sat,
@@ -384,6 +385,7 @@ impl Persister {
                 ss.invoice,
                 ss.bolt12_offer,
                 ss.payment_hash,
+                ss.destination_pubkey,
                 ss.description,
                 ss.preimage,
                 ss.refund_tx_id,
@@ -466,53 +468,55 @@ impl Persister {
         let maybe_receive_swap_timeout_block_height: Option<u32> = row.get(9)?;
         let maybe_receive_swap_invoice: Option<String> = row.get(10)?;
         let maybe_receive_swap_payment_hash: Option<String> = row.get(11)?;
-        let maybe_receive_swap_description: Option<String> = row.get(12)?;
-        let maybe_receive_swap_preimage: Option<String> = row.get(13)?;
-        let maybe_receive_swap_payer_amount_sat: Option<u64> = row.get(14)?;
-        let maybe_receive_swap_receiver_amount_sat: Option<u64> = row.get(15)?;
-        let maybe_receive_swap_receiver_state: Option<PaymentState> = row.get(16)?;
-        let maybe_receive_swap_pair_fees_json: Option<String> = row.get(17)?;
+        let maybe_receive_swap_destination_pubkey: Option<String> = row.get(12)?;
+        let maybe_receive_swap_description: Option<String> = row.get(13)?;
+        let maybe_receive_swap_preimage: Option<String> = row.get(14)?;
+        let maybe_receive_swap_payer_amount_sat: Option<u64> = row.get(15)?;
+        let maybe_receive_swap_receiver_amount_sat: Option<u64> = row.get(16)?;
+        let maybe_receive_swap_receiver_state: Option<PaymentState> = row.get(17)?;
+        let maybe_receive_swap_pair_fees_json: Option<String> = row.get(18)?;
         let maybe_receive_swap_pair_fees: Option<ReversePair> =
             maybe_receive_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
 
-        let maybe_send_swap_id: Option<String> = row.get(18)?;
-        let maybe_send_swap_created_at: Option<u32> = row.get(19)?;
-        let maybe_send_swap_timeout_block_height: Option<u32> = row.get(20)?;
-        let maybe_send_swap_invoice: Option<String> = row.get(21)?;
-        let maybe_send_swap_bolt12_offer: Option<String> = row.get(22)?;
-        let maybe_send_swap_payment_hash: Option<String> = row.get(23)?;
-        let maybe_send_swap_description: Option<String> = row.get(24)?;
-        let maybe_send_swap_preimage: Option<String> = row.get(25)?;
-        let maybe_send_swap_refund_tx_id: Option<String> = row.get(26)?;
-        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(27)?;
-        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(28)?;
-        let maybe_send_swap_state: Option<PaymentState> = row.get(29)?;
-        let maybe_send_swap_pair_fees_json: Option<String> = row.get(30)?;
+        let maybe_send_swap_id: Option<String> = row.get(19)?;
+        let maybe_send_swap_created_at: Option<u32> = row.get(20)?;
+        let maybe_send_swap_timeout_block_height: Option<u32> = row.get(21)?;
+        let maybe_send_swap_invoice: Option<String> = row.get(22)?;
+        let maybe_send_swap_bolt12_offer: Option<String> = row.get(23)?;
+        let maybe_send_swap_payment_hash: Option<String> = row.get(24)?;
+        let maybe_send_swap_destination_pubkey: Option<String> = row.get(25)?;
+        let maybe_send_swap_description: Option<String> = row.get(26)?;
+        let maybe_send_swap_preimage: Option<String> = row.get(27)?;
+        let maybe_send_swap_refund_tx_id: Option<String> = row.get(28)?;
+        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(29)?;
+        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(30)?;
+        let maybe_send_swap_state: Option<PaymentState> = row.get(31)?;
+        let maybe_send_swap_pair_fees_json: Option<String> = row.get(32)?;
         let maybe_send_swap_pair_fees: Option<SubmarinePair> =
             maybe_send_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
 
-        let maybe_chain_swap_id: Option<String> = row.get(31)?;
-        let maybe_chain_swap_created_at: Option<u32> = row.get(32)?;
-        let maybe_chain_swap_timeout_block_height: Option<u32> = row.get(33)?;
-        let maybe_chain_swap_direction: Option<Direction> = row.get(34)?;
-        let maybe_chain_swap_preimage: Option<String> = row.get(35)?;
-        let maybe_chain_swap_description: Option<String> = row.get(36)?;
-        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(37)?;
-        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(38)?;
-        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(39)?;
-        let maybe_chain_swap_claim_address: Option<String> = row.get(40)?;
-        let maybe_chain_swap_state: Option<PaymentState> = row.get(41)?;
-        let maybe_chain_swap_pair_fees_json: Option<String> = row.get(42)?;
+        let maybe_chain_swap_id: Option<String> = row.get(33)?;
+        let maybe_chain_swap_created_at: Option<u32> = row.get(34)?;
+        let maybe_chain_swap_timeout_block_height: Option<u32> = row.get(35)?;
+        let maybe_chain_swap_direction: Option<Direction> = row.get(36)?;
+        let maybe_chain_swap_preimage: Option<String> = row.get(37)?;
+        let maybe_chain_swap_description: Option<String> = row.get(38)?;
+        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(39)?;
+        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(40)?;
+        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(41)?;
+        let maybe_chain_swap_claim_address: Option<String> = row.get(42)?;
+        let maybe_chain_swap_state: Option<PaymentState> = row.get(43)?;
+        let maybe_chain_swap_pair_fees_json: Option<String> = row.get(44)?;
         let maybe_chain_swap_pair_fees: Option<ChainPair> =
             maybe_chain_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
-        let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(43)?;
-        let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(44)?;
+        let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(45)?;
+        let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(46)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(45)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(47)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(46)?;
-        let maybe_payment_details_description: Option<String> = row.get(47)?;
-        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(48)?;
+        let maybe_payment_details_destination: Option<String> = row.get(48)?;
+        let maybe_payment_details_description: Option<String> = row.get(49)?;
+        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(50)?;
         let maybe_payment_details_lnurl_info: Option<LnUrlInfo> =
             maybe_payment_details_lnurl_info_json.and_then(|info| serde_json::from_str(&info).ok());
 
@@ -528,9 +532,10 @@ impl Persister {
                         expiration_blockheight: maybe_receive_swap_timeout_block_height
                             .unwrap_or(0),
                         preimage: maybe_receive_swap_preimage,
-                        bolt11: maybe_receive_swap_invoice.clone(),
+                        invoice: maybe_receive_swap_invoice.clone(),
                         bolt12_offer: None, // Bolt12 not supported for Receive Swaps
                         payment_hash: maybe_receive_swap_payment_hash,
+                        destination_pubkey: maybe_receive_swap_destination_pubkey,
                         description: maybe_receive_swap_description.unwrap_or_else(|| {
                             maybe_receive_swap_invoice
                                 .and_then(|bolt11| get_invoice_description!(bolt11))
@@ -560,12 +565,10 @@ impl Persister {
                             expiration_blockheight: maybe_send_swap_timeout_block_height
                                 .unwrap_or(0),
                             preimage: maybe_send_swap_preimage,
-                            bolt11: match maybe_send_swap_bolt12_offer.is_some() {
-                                true => None, // We don't expose the Bolt12 invoice
-                                false => maybe_send_swap_invoice,
-                            },
+                            invoice: maybe_send_swap_invoice,
                             bolt12_offer: maybe_send_swap_bolt12_offer,
                             payment_hash: maybe_send_swap_payment_hash,
+                            destination_pubkey: maybe_send_swap_destination_pubkey,
                             description: maybe_send_swap_description
                                 .unwrap_or("Lightning payment".to_string()),
                             payer_amount_sat: maybe_send_swap_payer_amount_sat.unwrap_or(0),
@@ -611,9 +614,10 @@ impl Persister {
                                 expiration_blockheight: maybe_chain_swap_timeout_block_height
                                     .unwrap_or(0),
                                 preimage: maybe_chain_swap_preimage,
-                                bolt11: None,
+                                invoice: None,
                                 bolt12_offer: None, // Bolt12 not supported for Chain Swaps
                                 payment_hash: None,
+                                destination_pubkey: None,
                                 description: maybe_chain_swap_description
                                     .unwrap_or("Bitcoin transfer".to_string()),
                                 payer_amount_sat,
@@ -640,9 +644,10 @@ impl Persister {
                 PaymentSwapData {
                     swap_type: PaymentSwapType::Receive,
                     swap_id,
-                    bolt11,
+                    invoice,
                     bolt12_offer,
                     payment_hash,
+                    destination_pubkey,
                     refund_tx_id,
                     preimage,
                     refund_tx_amount_sat,
@@ -652,9 +657,10 @@ impl Persister {
                 | PaymentSwapData {
                     swap_type: PaymentSwapType::Send,
                     swap_id,
-                    bolt11,
+                    invoice,
                     bolt12_offer,
                     payment_hash,
+                    destination_pubkey,
                     preimage,
                     refund_tx_id,
                     refund_tx_amount_sat,
@@ -664,9 +670,14 @@ impl Persister {
             ) => PaymentDetails::Lightning {
                 swap_id,
                 preimage,
-                bolt11,
-                bolt12_offer,
+                invoice: invoice.clone(),
+                bolt12_offer: bolt12_offer.clone(),
                 payment_hash,
+                destination_pubkey: destination_pubkey.or_else(|| {
+                    invoice.and_then(|invoice| {
+                        get_invoice_destination_pubkey!(&invoice, bolt12_offer.is_some())
+                    })
+                }),
                 lnurl_info: maybe_payment_details_lnurl_info,
                 refund_tx_id,
                 refund_tx_amount_sat,

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -28,6 +28,7 @@ impl Persister {
                 invoice,
                 timeout_block_height,
                 payment_hash,
+                destination_pubkey,
                 payer_amount_sat,
                 receiver_amount_sat,
                 created_at,
@@ -36,7 +37,7 @@ impl Persister {
                 state,
                 pair_fees_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT DO NOTHING
             ",
             (
@@ -48,6 +49,7 @@ impl Persister {
                 &receive_swap.invoice,
                 &receive_swap.timeout_block_height,
                 &receive_swap.payment_hash,
+                &receive_swap.destination_pubkey,
                 &receive_swap.payer_amount_sat,
                 &receive_swap.receiver_amount_sat,
                 &receive_swap.created_at,
@@ -128,6 +130,7 @@ impl Persister {
                 rs.claim_private_key,
                 rs.invoice,
                 rs.payment_hash,
+                rs.destination_pubkey,
                 rs.timeout_block_height,
                 rs.description,
                 rs.payer_amount_sat,
@@ -174,18 +177,19 @@ impl Persister {
             claim_private_key: row.get(3)?,
             invoice: row.get(4)?,
             payment_hash: row.get(5)?,
-            timeout_block_height: row.get(6)?,
-            description: row.get(7)?,
-            payer_amount_sat: row.get(8)?,
-            receiver_amount_sat: row.get(9)?,
-            claim_fees_sat: row.get(10)?,
-            claim_tx_id: row.get(11)?,
-            lockup_tx_id: row.get(12)?,
-            mrh_address: row.get(13)?,
-            mrh_tx_id: row.get(14)?,
-            created_at: row.get(15)?,
-            state: row.get(16)?,
-            pair_fees_json: row.get(17)?,
+            destination_pubkey: row.get(6)?,
+            timeout_block_height: row.get(7)?,
+            description: row.get(8)?,
+            payer_amount_sat: row.get(9)?,
+            receiver_amount_sat: row.get(10)?,
+            claim_fees_sat: row.get(11)?,
+            claim_tx_id: row.get(12)?,
+            lockup_tx_id: row.get(13)?,
+            mrh_address: row.get(14)?,
+            mrh_tx_id: row.get(15)?,
+            created_at: row.get(16)?,
+            state: row.get(17)?,
+            pair_fees_json: row.get(18)?,
         })
     }
 

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -25,6 +25,7 @@ impl Persister {
                 invoice,
                 bolt12_offer,
                 payment_hash,
+                destination_pubkey,
                 timeout_block_height,
                 payer_amount_sat,
                 receiver_amount_sat,
@@ -34,7 +35,7 @@ impl Persister {
                 state,
                 pair_fees_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT DO NOTHING
             ",
             (
@@ -43,6 +44,7 @@ impl Persister {
                 &send_swap.invoice,
                 &send_swap.bolt12_offer,
                 &send_swap.payment_hash,
+                &send_swap.destination_pubkey,
                 &send_swap.timeout_block_height,
                 &send_swap.payer_amount_sat,
                 &send_swap.receiver_amount_sat,
@@ -140,6 +142,7 @@ impl Persister {
                 invoice,
                 bolt12_offer,
                 payment_hash,
+                destination_pubkey,
                 timeout_block_height,
                 description,
                 preimage,
@@ -181,18 +184,19 @@ impl Persister {
             invoice: row.get(1)?,
             bolt12_offer: row.get(2)?,
             payment_hash: row.get(3)?,
-            timeout_block_height: row.get(4)?,
-            description: row.get(5)?,
-            preimage: row.get(6)?,
-            payer_amount_sat: row.get(7)?,
-            receiver_amount_sat: row.get(8)?,
-            create_response_json: row.get(9)?,
-            refund_private_key: row.get(10)?,
-            lockup_tx_id: row.get(11)?,
-            refund_tx_id: row.get(12)?,
-            created_at: row.get(13)?,
-            state: row.get(14)?,
-            pair_fees_json: row.get(15)?,
+            destination_pubkey: row.get(4)?,
+            timeout_block_height: row.get(5)?,
+            description: row.get(6)?,
+            preimage: row.get(7)?,
+            payer_amount_sat: row.get(8)?,
+            receiver_amount_sat: row.get(9)?,
+            create_response_json: row.get(10)?,
+            refund_private_key: row.get(11)?,
+            lockup_tx_id: row.get(12)?,
+            refund_tx_id: row.get(13)?,
+            created_at: row.get(14)?,
+            state: row.get(15)?,
+            pair_fees_json: row.get(16)?,
         })
     }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1361,6 +1361,8 @@ impl LiquidSdk {
                 let swap_id = &create_response.id;
                 let create_response_json =
                     SendSwap::from_boltz_struct_to_json(&create_response, swap_id)?;
+                let destination_pubkey =
+                    get_invoice_destination_pubkey!(invoice, bolt12_offer.is_some());
 
                 let payer_amount_sat = fees_sat + receiver_amount_sat;
                 let swap = SendSwap {
@@ -1368,6 +1370,7 @@ impl LiquidSdk {
                     invoice: invoice.to_string(),
                     bolt12_offer,
                     payment_hash: Some(payment_hash.to_string()),
+                    destination_pubkey,
                     timeout_block_height: create_response.timeout_block_height,
                     description,
                     preimage: None,
@@ -1978,6 +1981,7 @@ impl LiquidSdk {
                     "Invoice does not contain an amount",
                 ))?
                 / 1000;
+        let destination_pubkey = invoice_pubkey(&invoice);
 
         // Double check that the generated invoice includes our data
         // https://docs.boltz.exchange/v/api/dont-trust-verify#lightning-invoice-verification
@@ -2004,6 +2008,7 @@ impl LiquidSdk {
                 claim_private_key: keypair.display_secret().to_string(),
                 invoice: invoice.to_string(),
                 payment_hash: Some(preimage_hash),
+                destination_pubkey: Some(destination_pubkey),
                 timeout_block_height: create_response.timeout_block_height,
                 description: invoice_description,
                 payer_amount_sat,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1362,7 +1362,7 @@ impl LiquidSdk {
                 let create_response_json =
                     SendSwap::from_boltz_struct_to_json(&create_response, swap_id)?;
                 let destination_pubkey =
-                    get_invoice_destination_pubkey!(invoice, bolt12_offer.is_some());
+                    utils::get_invoice_destination_pubkey(invoice, bolt12_offer.is_some())?;
 
                 let payer_amount_sat = fees_sat + receiver_amount_sat;
                 let swap = SendSwap {
@@ -1370,7 +1370,7 @@ impl LiquidSdk {
                     invoice: invoice.to_string(),
                     bolt12_offer,
                     payment_hash: Some(payment_hash.to_string()),
-                    destination_pubkey,
+                    destination_pubkey: Some(destination_pubkey),
                     timeout_block_height: create_response.timeout_block_height,
                     description,
                     preimage: None,

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -130,6 +130,7 @@ pub(crate) struct SendSyncData {
     pub(crate) bolt12_offer: Option<String>,
     pub(crate) payment_hash: Option<String>,
     pub(crate) description: Option<String>,
+    pub(crate) destination_pubkey: Option<String>,
 }
 
 impl SendSyncData {
@@ -172,6 +173,7 @@ impl From<SendSwap> for SendSyncData {
             preimage: value.preimage,
             description: value.description,
             bolt12_offer: value.bolt12_offer,
+            destination_pubkey: value.destination_pubkey,
         }
     }
 }
@@ -182,6 +184,7 @@ impl From<SendSyncData> for SendSwap {
             id: val.swap_id,
             invoice: val.invoice,
             payment_hash: val.payment_hash,
+            destination_pubkey: val.destination_pubkey,
             description: val.description,
             preimage: val.preimage,
             payer_amount_sat: val.payer_amount_sat,
@@ -216,6 +219,7 @@ pub(crate) struct ReceiveSyncData {
     pub(crate) created_at: u32,
     pub(crate) payment_hash: Option<String>,
     pub(crate) description: Option<String>,
+    pub(crate) destination_pubkey: Option<String>,
 }
 
 impl ReceiveSyncData {
@@ -250,6 +254,7 @@ impl From<ReceiveSwap> for ReceiveSyncData {
             timeout_block_height: value.timeout_block_height,
             created_at: value.created_at,
             description: value.description,
+            destination_pubkey: value.destination_pubkey,
         }
     }
 }
@@ -264,6 +269,7 @@ impl From<ReceiveSyncData> for ReceiveSwap {
             claim_private_key: val.claim_private_key,
             invoice: val.invoice,
             payment_hash: val.payment_hash,
+            destination_pubkey: val.destination_pubkey,
             description: val.description,
             payer_amount_sat: val.payer_amount_sat,
             receiver_amount_sat: val.receiver_amount_sat,

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod sync;
 
 const MESSAGE_PREFIX: &[u8; 13] = b"realtimesync:";
 lazy_static! {
-    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.1.0").unwrap();
+    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.2.0").unwrap();
 }
 
 #[derive(Copy, Clone)]

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -8,6 +8,7 @@ use sdk_common::{
     },
     lightning::ln::PaymentSecret,
     lightning_invoice::{Currency, InvoiceBuilder},
+    prelude::invoice_pubkey,
 };
 
 use crate::{
@@ -35,12 +36,14 @@ pub(crate) fn new_send_swap(payment_state: Option<PaymentState>) -> SendSwap {
         .min_final_cltv_expiry_delta(144)
         .build_signed(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
         .expect("Expected valid invoice");
+    let destination_pubkey = invoice_pubkey(&invoice);
 
     SendSwap {
         id: generate_random_string(4),
         invoice: invoice.to_string(),
         bolt12_offer: None,
         payment_hash: Some(payment_hash.to_string()),
+        destination_pubkey: Some(destination_pubkey),
         timeout_block_height: 1459611,
         description: Some("Send to BTC lightning".to_string()),
         preimage: None,
@@ -112,6 +115,7 @@ pub(crate) fn new_receive_swap(payment_state: Option<PaymentState>) -> ReceiveSw
         claim_private_key: "179dc5137d2c211fb84e2159252832658afb6d03e095fb5cf324a2b782d2a5ca".to_string(),
         invoice: "lntb10u1pngqdj3pp5ujsq2txha9nnjwm3sql0t3g8hy67d6qvrr0ykygtycej44jvdljqdpz2djkuepqw3hjqnpdgf2yxgrpv3j8yetnwvcqz95xqyp2xqrzjqf4rczme3t5y9s94fkx7xcgwhj6zy9t56rwqhez9gl8s52k0scz8gzzxeyqq28qqqqqqqqqqqqqqq9gq2ysp5fmynazrpmuz05vp8r5dxpu9cupkaus7hcd258saklp3v79azt6qs9qxpqysgq5sxknac9fwe69q5vzffgayjddskzhjeyu6h8vx45m4svchsy2e3rv6yc3puht7pjzvhwfl7ljamkzfy2dsa75fxd5j82ug0ty0y4xhgq82gc9k".to_string(),
         payment_hash: Some("e4a0052cd7e967393b71803ef5c507b935e6e80c18de4b110b26332ad64c6fe4".to_string()),
+        destination_pubkey: Some("03f060953bef5b777dc77e44afa3859d022fc1a77c55138deb232ad7255e869c00".to_string()),
         payer_amount_sat: 1000,
         receiver_amount_sat: 587,
         pair_fees_json: r#"{

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -128,6 +128,7 @@ pub(crate) fn new_receive_sync_data() -> ReceiveSyncData {
         preimage: "".to_string(),
         payment_hash: None,
         description: None,
+        destination_pubkey: None,
     }
 }
 
@@ -146,6 +147,7 @@ pub(crate) fn new_send_sync_data(preimage: Option<String>) -> SendSyncData {
         payment_hash: None,
         description: None,
         bolt12_offer: None,
+        destination_pubkey: None,
     }
 }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2691,12 +2691,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           description: dco_decode_String(raw[2]),
           liquidExpirationBlockheight: dco_decode_u_32(raw[3]),
           preimage: dco_decode_opt_String(raw[4]),
-          bolt11: dco_decode_opt_String(raw[5]),
+          invoice: dco_decode_opt_String(raw[5]),
           bolt12Offer: dco_decode_opt_String(raw[6]),
           paymentHash: dco_decode_opt_String(raw[7]),
-          lnurlInfo: dco_decode_opt_box_autoadd_ln_url_info(raw[8]),
-          refundTxId: dco_decode_opt_String(raw[9]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[10]),
+          destinationPubkey: dco_decode_opt_String(raw[8]),
+          lnurlInfo: dco_decode_opt_box_autoadd_ln_url_info(raw[9]),
+          refundTxId: dco_decode_opt_String(raw[10]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[11]),
         );
       case 1:
         return PaymentDetails_Liquid(
@@ -4864,9 +4865,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_description = sse_decode_String(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_u_32(deserializer);
         var var_preimage = sse_decode_opt_String(deserializer);
-        var var_bolt11 = sse_decode_opt_String(deserializer);
+        var var_invoice = sse_decode_opt_String(deserializer);
         var var_bolt12Offer = sse_decode_opt_String(deserializer);
         var var_paymentHash = sse_decode_opt_String(deserializer);
+        var var_destinationPubkey = sse_decode_opt_String(deserializer);
         var var_lnurlInfo = sse_decode_opt_box_autoadd_ln_url_info(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
@@ -4875,9 +4877,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             description: var_description,
             liquidExpirationBlockheight: var_liquidExpirationBlockheight,
             preimage: var_preimage,
-            bolt11: var_bolt11,
+            invoice: var_invoice,
             bolt12Offer: var_bolt12Offer,
             paymentHash: var_paymentHash,
+            destinationPubkey: var_destinationPubkey,
             lnurlInfo: var_lnurlInfo,
             refundTxId: var_refundTxId,
             refundTxAmountSat: var_refundTxAmountSat);
@@ -6867,9 +6870,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           description: final description,
           liquidExpirationBlockheight: final liquidExpirationBlockheight,
           preimage: final preimage,
-          bolt11: final bolt11,
+          invoice: final invoice,
           bolt12Offer: final bolt12Offer,
           paymentHash: final paymentHash,
+          destinationPubkey: final destinationPubkey,
           lnurlInfo: final lnurlInfo,
           refundTxId: final refundTxId,
           refundTxAmountSat: final refundTxAmountSat
@@ -6879,9 +6883,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(description, serializer);
         sse_encode_u_32(liquidExpirationBlockheight, serializer);
         sse_encode_opt_String(preimage, serializer);
-        sse_encode_opt_String(bolt11, serializer);
+        sse_encode_opt_String(invoice, serializer);
         sse_encode_opt_String(bolt12Offer, serializer);
         sse_encode_opt_String(paymentHash, serializer);
+        sse_encode_opt_String(destinationPubkey, serializer);
         sse_encode_opt_box_autoadd_ln_url_info(lnurlInfo, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2945,9 +2945,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_description = cst_encode_String(apiObj.description);
       var pre_liquid_expiration_blockheight = cst_encode_u_32(apiObj.liquidExpirationBlockheight);
       var pre_preimage = cst_encode_opt_String(apiObj.preimage);
-      var pre_bolt11 = cst_encode_opt_String(apiObj.bolt11);
+      var pre_invoice = cst_encode_opt_String(apiObj.invoice);
       var pre_bolt12_offer = cst_encode_opt_String(apiObj.bolt12Offer);
       var pre_payment_hash = cst_encode_opt_String(apiObj.paymentHash);
+      var pre_destination_pubkey = cst_encode_opt_String(apiObj.destinationPubkey);
       var pre_lnurl_info = cst_encode_opt_box_autoadd_ln_url_info(apiObj.lnurlInfo);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
@@ -2956,9 +2957,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.description = pre_description;
       wireObj.kind.Lightning.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
       wireObj.kind.Lightning.preimage = pre_preimage;
-      wireObj.kind.Lightning.bolt11 = pre_bolt11;
+      wireObj.kind.Lightning.invoice = pre_invoice;
       wireObj.kind.Lightning.bolt12_offer = pre_bolt12_offer;
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
+      wireObj.kind.Lightning.destination_pubkey = pre_destination_pubkey;
       wireObj.kind.Lightning.lnurl_info = pre_lnurl_info;
       wireObj.kind.Lightning.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Lightning.refund_tx_amount_sat = pre_refund_tx_amount_sat;
@@ -6371,11 +6373,13 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt11;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> invoice;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_pubkey;
 
   external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -785,14 +785,17 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// The preimage of the paid invoice (proof of payment).
     String? preimage,
 
-    /// Represents the Bolt11 invoice associated with a payment
+    /// Represents the Bolt11/Bolt12 invoice associated with a payment
     /// In the case of a Send payment, this is the invoice paid by the swapper
     /// In the case of a Receive payment, this is the invoice paid by the user
-    String? bolt11,
+    String? invoice,
     String? bolt12Offer,
 
     /// The payment hash of the invoice
     String? paymentHash,
+
+    /// The invoice destination/payee pubkey
+    String? destinationPubkey,
 
     /// The payment LNURL info
     LnUrlInfo? lnurlInfo,

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -793,9 +793,10 @@ abstract class _$$PaymentDetails_LightningImplCopyWith<$Res> implements $Payment
       String description,
       int liquidExpirationBlockheight,
       String? preimage,
-      String? bolt11,
+      String? invoice,
       String? bolt12Offer,
       String? paymentHash,
+      String? destinationPubkey,
       LnUrlInfo? lnurlInfo,
       String? refundTxId,
       BigInt? refundTxAmountSat});
@@ -818,9 +819,10 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
     Object? description = null,
     Object? liquidExpirationBlockheight = null,
     Object? preimage = freezed,
-    Object? bolt11 = freezed,
+    Object? invoice = freezed,
     Object? bolt12Offer = freezed,
     Object? paymentHash = freezed,
+    Object? destinationPubkey = freezed,
     Object? lnurlInfo = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
@@ -842,9 +844,9 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
           ? _value.preimage
           : preimage // ignore: cast_nullable_to_non_nullable
               as String?,
-      bolt11: freezed == bolt11
-          ? _value.bolt11
-          : bolt11 // ignore: cast_nullable_to_non_nullable
+      invoice: freezed == invoice
+          ? _value.invoice
+          : invoice // ignore: cast_nullable_to_non_nullable
               as String?,
       bolt12Offer: freezed == bolt12Offer
           ? _value.bolt12Offer
@@ -853,6 +855,10 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
       paymentHash: freezed == paymentHash
           ? _value.paymentHash
           : paymentHash // ignore: cast_nullable_to_non_nullable
+              as String?,
+      destinationPubkey: freezed == destinationPubkey
+          ? _value.destinationPubkey
+          : destinationPubkey // ignore: cast_nullable_to_non_nullable
               as String?,
       lnurlInfo: freezed == lnurlInfo
           ? _value.lnurlInfo
@@ -878,9 +884,10 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
       required this.description,
       required this.liquidExpirationBlockheight,
       this.preimage,
-      this.bolt11,
+      this.invoice,
       this.bolt12Offer,
       this.paymentHash,
+      this.destinationPubkey,
       this.lnurlInfo,
       this.refundTxId,
       this.refundTxAmountSat})
@@ -901,17 +908,21 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   @override
   final String? preimage;
 
-  /// Represents the Bolt11 invoice associated with a payment
+  /// Represents the Bolt11/Bolt12 invoice associated with a payment
   /// In the case of a Send payment, this is the invoice paid by the swapper
   /// In the case of a Receive payment, this is the invoice paid by the user
   @override
-  final String? bolt11;
+  final String? invoice;
   @override
   final String? bolt12Offer;
 
   /// The payment hash of the invoice
   @override
   final String? paymentHash;
+
+  /// The invoice destination/payee pubkey
+  @override
+  final String? destinationPubkey;
 
   /// The payment LNURL info
   @override
@@ -927,7 +938,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   String toString() {
-    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, preimage: $preimage, bolt11: $bolt11, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, preimage: $preimage, invoice: $invoice, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, destinationPubkey: $destinationPubkey, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -940,9 +951,11 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
             (identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) ||
                 other.liquidExpirationBlockheight == liquidExpirationBlockheight) &&
             (identical(other.preimage, preimage) || other.preimage == preimage) &&
-            (identical(other.bolt11, bolt11) || other.bolt11 == bolt11) &&
+            (identical(other.invoice, invoice) || other.invoice == invoice) &&
             (identical(other.bolt12Offer, bolt12Offer) || other.bolt12Offer == bolt12Offer) &&
             (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
+            (identical(other.destinationPubkey, destinationPubkey) ||
+                other.destinationPubkey == destinationPubkey) &&
             (identical(other.lnurlInfo, lnurlInfo) || other.lnurlInfo == lnurlInfo) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
@@ -951,7 +964,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight, preimage,
-      bolt11, bolt12Offer, paymentHash, lnurlInfo, refundTxId, refundTxAmountSat);
+      invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -968,9 +981,10 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
       required final String description,
       required final int liquidExpirationBlockheight,
       final String? preimage,
-      final String? bolt11,
+      final String? invoice,
       final String? bolt12Offer,
       final String? paymentHash,
+      final String? destinationPubkey,
       final LnUrlInfo? lnurlInfo,
       final String? refundTxId,
       final BigInt? refundTxAmountSat}) = _$PaymentDetails_LightningImpl;
@@ -988,14 +1002,17 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
   /// The preimage of the paid invoice (proof of payment).
   String? get preimage;
 
-  /// Represents the Bolt11 invoice associated with a payment
+  /// Represents the Bolt11/Bolt12 invoice associated with a payment
   /// In the case of a Send payment, this is the invoice paid by the swapper
   /// In the case of a Receive payment, this is the invoice paid by the user
-  String? get bolt11;
+  String? get invoice;
   String? get bolt12Offer;
 
   /// The payment hash of the invoice
   String? get paymentHash;
+
+  /// The invoice destination/payee pubkey
+  String? get destinationPubkey;
 
   /// The payment LNURL info
   LnUrlInfo? get lnurlInfo;

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4703,11 +4703,13 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt11;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> invoice;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_pubkey;
 
   external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3240,9 +3240,19 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
         val description = paymentDetails.getString("description")!!
         val liquidExpirationBlockheight = paymentDetails.getInt("liquidExpirationBlockheight").toUInt()
         val preimage = if (hasNonNullKey(paymentDetails, "preimage")) paymentDetails.getString("preimage") else null
-        val bolt11 = if (hasNonNullKey(paymentDetails, "bolt11")) paymentDetails.getString("bolt11") else null
+        val invoice = if (hasNonNullKey(paymentDetails, "invoice")) paymentDetails.getString("invoice") else null
         val bolt12Offer = if (hasNonNullKey(paymentDetails, "bolt12Offer")) paymentDetails.getString("bolt12Offer") else null
         val paymentHash = if (hasNonNullKey(paymentDetails, "paymentHash")) paymentDetails.getString("paymentHash") else null
+        val destinationPubkey =
+            if (hasNonNullKey(
+                    paymentDetails,
+                    "destinationPubkey",
+                )
+            ) {
+                paymentDetails.getString("destinationPubkey")
+            } else {
+                null
+            }
         val lnurlInfo =
             if (hasNonNullKey(
                     paymentDetails,
@@ -3269,9 +3279,10 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             description,
             liquidExpirationBlockheight,
             preimage,
-            bolt11,
+            invoice,
             bolt12Offer,
             paymentHash,
+            destinationPubkey,
             lnurlInfo,
             refundTxId,
             refundTxAmountSat,
@@ -3337,9 +3348,10 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "description", paymentDetails.description)
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
             pushToMap(map, "preimage", paymentDetails.preimage)
-            pushToMap(map, "bolt11", paymentDetails.bolt11)
+            pushToMap(map, "invoice", paymentDetails.invoice)
             pushToMap(map, "bolt12Offer", paymentDetails.bolt12Offer)
             pushToMap(map, "paymentHash", paymentDetails.paymentHash)
+            pushToMap(map, "destinationPubkey", paymentDetails.destinationPubkey)
             pushToMap(map, "lnurlInfo", paymentDetails.lnurlInfo?.let { readableMapOf(it) })
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -3949,11 +3949,13 @@ enum BreezSDKLiquidMapper {
             }
             let _preimage = paymentDetails["preimage"] as? String
 
-            let _bolt11 = paymentDetails["bolt11"] as? String
+            let _invoice = paymentDetails["invoice"] as? String
 
             let _bolt12Offer = paymentDetails["bolt12Offer"] as? String
 
             let _paymentHash = paymentDetails["paymentHash"] as? String
+
+            let _destinationPubkey = paymentDetails["destinationPubkey"] as? String
 
             var _lnurlInfo: LnUrlInfo?
             if let lnurlInfoTmp = paymentDetails["lnurlInfo"] as? [String: Any?] {
@@ -3964,7 +3966,7 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, bolt11: _bolt11, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
         if type == "liquid" {
             guard let _destination = paymentDetails["destination"] as? String else {
@@ -3999,7 +4001,7 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
         switch paymentDetails {
         case let .lightning(
-            swapId, description, liquidExpirationBlockheight, preimage, bolt11, bolt12Offer, paymentHash, lnurlInfo, refundTxId, refundTxAmountSat
+            swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "lightning",
@@ -4007,9 +4009,10 @@ enum BreezSDKLiquidMapper {
                 "description": description,
                 "liquidExpirationBlockheight": liquidExpirationBlockheight,
                 "preimage": preimage == nil ? nil : preimage,
-                "bolt11": bolt11 == nil ? nil : bolt11,
+                "invoice": invoice == nil ? nil : invoice,
                 "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
                 "paymentHash": paymentHash == nil ? nil : paymentHash,
+                "destinationPubkey": destinationPubkey == nil ? nil : destinationPubkey,
                 "lnurlInfo": lnurlInfo == nil ? nil : dictionaryOf(lnUrlInfo: lnurlInfo!),
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -644,9 +644,10 @@ export type PaymentDetails = {
     description: string
     liquidExpirationBlockheight: number
     preimage?: string
-    bolt11?: string
+    invoice?: string
     bolt12Offer?: string
     paymentHash?: string
+    destinationPubkey?: string
     lnurlInfo?: LnUrlInfo
     refundTxId?: string
     refundTxAmountSat?: number


### PR DESCRIPTION
This PR:
- adds the invoice's destination pubkey (bolt11: payee pubkey, bolt12: signing pubkey) to the payment details as `destination_pubkey`
- renames the payment detail's `bolt11` to `invoice` to expose both bolt11 and bolt12 invoices

Depends on https://github.com/breez/breez-sdk-greenlight/pull/1156

Fixes #646
Fixes #648 
