### PR TITLE
Fix actual payer amount recovery

### DIFF
--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -210,8 +210,10 @@ impl Recoverer {
                             log::warn!("Could not apply recovered data for incoming Chain swap {swap_id}: recovery data not found");
                             continue;
                         };
-                        chain_swap.actual_payer_amount_sat =
-                            Some(recovered_data.btc_user_lockup_amount_sat);
+                        if recovered_data.btc_user_lockup_amount_sat > 0 {
+                            chain_swap.actual_payer_amount_sat =
+                                Some(recovered_data.btc_user_lockup_amount_sat);
+                        }
                         let is_expired =
                             bitcoin_tip.height as u32 >= chain_swap.timeout_block_height;
                         let min_lockup_amount_sat = chain_swap.payer_amount_sat;


### PR DESCRIPTION
We should only set the actual payer amount if there is some user lockup amount. Without this fix, incoming chain swaps show the amount zero until the recovery process runs.
