### PR TITLE
Implement optimistic locking for read-update-write swap operations

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -670,6 +670,27 @@ impl Swap {
             | Swap::Receive(ReceiveSwap { id, .. }) => id.clone(),
         }
     }
+
+    pub(crate) fn version(&self) -> u64 {
+        match self {
+            Swap::Chain(ChainSwap { version, .. })
+            | Swap::Send(SendSwap { version, .. })
+            | Swap::Receive(ReceiveSwap { version, .. }) => *version,
+        }
+    }
+    pub(crate) fn set_version(&mut self, version: u64) {
+        match self {
+            Swap::Chain(chain_swap) => {
+                chain_swap.version = version;
+            }
+            Swap::Send(send_swap) => {
+                send_swap.version = version;
+            }
+            Swap::Receive(receive_swap) => {
+                receive_swap.version = version;
+            }
+        }
+    }
 }
 impl From<ChainSwap> for Swap {
     fn from(swap: ChainSwap) -> Self {
@@ -771,6 +792,8 @@ pub(crate) struct ChainSwap {
     pub(crate) state: PaymentState,
     pub(crate) claim_private_key: String,
     pub(crate) refund_private_key: String,
+    /// Version used for optimistic concurrency control within local db
+    pub(crate) version: u64,
 }
 impl ChainSwap {
     pub(crate) fn get_claim_keypair(&self) -> SdkResult<Keypair> {
@@ -927,6 +950,8 @@ pub(crate) struct SendSwap {
     pub(crate) timeout_block_height: u64,
     pub(crate) state: PaymentState,
     pub(crate) refund_private_key: String,
+    /// Version used for optimistic concurrency control within local db
+    pub(crate) version: u64,
 }
 impl SendSwap {
     pub(crate) fn get_refund_keypair(&self) -> Result<Keypair, SdkError> {
@@ -1021,6 +1046,8 @@ pub(crate) struct ReceiveSwap {
     pub(crate) created_at: u32,
     pub(crate) timeout_block_height: u32,
     pub(crate) state: PaymentState,
+    /// Version used for optimistic concurrency control within local db
+    pub(crate) version: u64,
 }
 impl ReceiveSwap {
     pub(crate) fn get_claim_keypair(&self) -> Result<Keypair, PaymentError> {

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -72,9 +72,10 @@ impl Persister {
                 pair_fees_json = :pair_fees_json,
                 state = :state,
                 actual_payer_amount_sat = :actual_payer_amount_sat,
-                accepted_receiver_amount_sat = COALESCE(accepted_receiver_amount_sat, :accepted_receiver_amount_sat)
+                accepted_receiver_amount_sat = :accepted_receiver_amount_sat
             WHERE
-                id = :id",
+                id = :id AND
+                version = :version",
             named_params! {
                 ":id": &chain_swap.id,
                 ":description": &chain_swap.description,
@@ -88,6 +89,7 @@ impl Persister {
                 ":state": &chain_swap.state,
                 ":actual_payer_amount_sat": &chain_swap.actual_payer_amount_sat,
                 ":accepted_receiver_amount_sat": &chain_swap.accepted_receiver_amount_sat,
+                ":version": &chain_swap.version,
             },
         )?;
 
@@ -153,7 +155,8 @@ impl Persister {
                 state,
                 pair_fees_json,
                 actual_payer_amount_sat,
-                accepted_receiver_amount_sat
+                accepted_receiver_amount_sat,
+                version
             FROM chain_swaps
             {where_clause_str}
             ORDER BY created_at
@@ -205,6 +208,7 @@ impl Persister {
             pair_fees_json: row.get(20)?,
             actual_payer_amount_sat: row.get(21)?,
             accepted_receiver_amount_sat: row.get(22)?,
+            version: row.get(23)?,
         })
     }
 

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -225,5 +225,28 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE receive_swaps ADD COLUMN destination_pubkey TEXT;
         ALTER TABLE send_swaps ADD COLUMN destination_pubkey TEXT;
         ",
+        "
+        ALTER TABLE receive_swaps ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE send_swaps ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE chain_swaps ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
+        CREATE TRIGGER IF NOT EXISTS update_receive_swaps_version
+        AFTER UPDATE ON receive_swaps
+        BEGIN
+            UPDATE receive_swaps SET version = version + 1
+            WHERE id = NEW.id;
+        END;
+        CREATE TRIGGER IF NOT EXISTS update_send_swaps_version
+        AFTER UPDATE ON send_swaps
+        BEGIN
+            UPDATE send_swaps SET version = version + 1
+            WHERE id = NEW.id;
+        END;
+        CREATE TRIGGER IF NOT EXISTS update_chain_swaps_version
+        AFTER UPDATE ON chain_swaps
+        BEGIN
+            UPDATE chain_swaps SET version = version + 1
+            WHERE id = NEW.id;
+        END;
+        ",
     ]
 }

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -69,7 +69,8 @@ impl Persister {
                 mrh_tx_id = :mrh_tx_id,
                 state = :state
             WHERE
-                id = :id",
+                id = :id AND
+                version = :version",
             named_params! {
                 ":id": &receive_swap.id,
                 ":description": &receive_swap.description,
@@ -77,6 +78,7 @@ impl Persister {
                 ":lockup_tx_id": &receive_swap.lockup_tx_id,
                 ":mrh_tx_id": &receive_swap.mrh_tx_id,
                 ":state": &receive_swap.state,
+                ":version": &receive_swap.version,
             },
         )?;
 
@@ -142,7 +144,8 @@ impl Persister {
                 rs.mrh_tx_id,
                 rs.created_at,
                 rs.state,
-                rs.pair_fees_json
+                rs.pair_fees_json,
+                rs.version
             FROM receive_swaps AS rs
             {where_clause_str}
             ORDER BY rs.created_at
@@ -190,6 +193,7 @@ impl Persister {
             created_at: row.get(16)?,
             state: row.get(17)?,
             pair_fees_json: row.get(18)?,
+            version: row.get(19)?,
         })
     }
 

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -65,7 +65,8 @@ impl Persister {
                 refund_tx_id = :refund_tx_id,
                 state = :state
             WHERE
-                id = :id",
+                id = :id AND
+                version = :version",
             named_params! {
                 ":id": &send_swap.id,
                 ":description": &send_swap.description,
@@ -73,6 +74,7 @@ impl Persister {
                 ":lockup_tx_id": &send_swap.lockup_tx_id,
                 ":refund_tx_id": &send_swap.refund_tx_id,
                 ":state": &send_swap.state,
+                ":version": &send_swap.version,
             },
         )?;
 
@@ -154,7 +156,8 @@ impl Persister {
                 refund_tx_id,
                 created_at,
                 state,
-                pair_fees_json
+                pair_fees_json,
+                version
             FROM send_swaps
             {where_clause_str}
             ORDER BY created_at
@@ -197,6 +200,7 @@ impl Persister {
             created_at: row.get(14)?,
             state: row.get(15)?,
             pair_fees_json: row.get(16)?,
+            version: row.get(17)?,
         })
     }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1385,6 +1385,7 @@ impl LiquidSdk {
                     created_at: utils::now(),
                     state: PaymentState::Created,
                     refund_private_key: keypair.display_secret().to_string(),
+                    version: 0,
                 };
                 self.persister.insert_or_update_send_swap(&swap)?;
                 swap
@@ -1674,6 +1675,7 @@ impl LiquidSdk {
             refund_tx_id: None,
             created_at: utils::now(),
             state: PaymentState::Created,
+            version: 0,
         };
         self.persister.insert_or_update_chain_swap(&swap)?;
         self.status_stream.track_swap_id(&swap_id)?;
@@ -2023,6 +2025,7 @@ impl LiquidSdk {
                 mrh_tx_id: None,
                 created_at: utils::now(),
                 state: PaymentState::Created,
+                version: 0,
             })
             .map_err(|_| PaymentError::PersistError)?;
         self.status_stream.track_swap_id(&swap_id)?;
@@ -2122,6 +2125,7 @@ impl LiquidSdk {
             refund_tx_id: None,
             created_at: utils::now(),
             state: PaymentState::Created,
+            version: 0,
         };
         self.persister.insert_or_update_chain_swap(&swap)?;
         self.status_stream.track_swap_id(&swap.id)?;

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -110,6 +110,7 @@ impl From<ChainSyncData> for ChainSwap {
             user_lockup_tx_id: None,
             claim_tx_id: None,
             refund_tx_id: None,
+            version: 0,
         }
     }
 }
@@ -198,6 +199,7 @@ impl From<SendSyncData> for SendSwap {
             state: PaymentState::Created,
             lockup_tx_id: None,
             refund_tx_id: None,
+            version: 0,
         }
     }
 }
@@ -281,6 +283,7 @@ impl From<ReceiveSyncData> for ReceiveSwap {
             claim_tx_id: None,
             lockup_tx_id: None,
             mrh_tx_id: None,
+            version: 0,
         }
     }
 }

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -137,6 +137,7 @@ pub(crate) fn new_chain_swap(
                 }
             }"#
             .to_string(),
+            version: 0
         };
     }
     match direction {
@@ -223,6 +224,7 @@ pub(crate) fn new_chain_swap(
                     }
                 }
             }"#.to_string(),
+            version: 0,
         },
         Direction::Outgoing => ChainSwap {
             id: generate_random_string(4),
@@ -306,6 +308,7 @@ pub(crate) fn new_chain_swap(
                     }
                 }
             }"#.to_string(),
+            version: 0
         }
     }
 }

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -86,6 +86,7 @@ pub(crate) fn new_send_swap(payment_state: Option<PaymentState>) -> SendSwap {
         created_at: utils::now(),
         state: payment_state.unwrap_or(PaymentState::Created),
         refund_private_key: "945affeef55f12227f1d4a3f80a17062a05b229ddc5a01591eb5ddf882df92e3".to_string(),
+        version: 0,
     }
 }
 
@@ -140,6 +141,7 @@ pub(crate) fn new_receive_swap(payment_state: Option<PaymentState>) -> ReceiveSw
         mrh_tx_id: None,
         created_at: utils::now(),
         state: payment_state.unwrap_or(PaymentState::Created),
+        version: 0,
     }
 }
 


### PR DESCRIPTION
Addresses one of the causes of #647 

The idea is to add an incrementing version to the local swap data to check that it didn't change when performing read -> update -> write operations. An incrementing version was preferred instead of a timestamp to avoid potential issues with clock precision, which could cause a write to not be detected.
Triggers are used to make sure any update increases the version. Updates based on a previously read swap only go through if the version didn't change in the meantime.