### PR TITLE
Remove preimage field from real-time sync send data

### DIFF
--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod sync;
 
 const MESSAGE_PREFIX: &[u8; 13] = b"realtimesync:";
 lazy_static! {
-    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.2.0").unwrap();
+    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.3.0").unwrap();
 }
 
 #[derive(Copy, Clone)]

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -132,7 +132,7 @@ pub(crate) fn new_receive_sync_data() -> ReceiveSyncData {
     }
 }
 
-pub(crate) fn new_send_sync_data(preimage: Option<String>) -> SendSyncData {
+pub(crate) fn new_send_sync_data() -> SendSyncData {
     SendSyncData {
         swap_id: "send-swap".to_string(),
         invoice: "".to_string(),
@@ -143,7 +143,6 @@ pub(crate) fn new_send_sync_data(preimage: Option<String>) -> SendSyncData {
         receiver_amount_sat: 0,
         timeout_block_height: 1459611,
         created_at: 0,
-        preimage,
         payment_hash: None,
         description: None,
         bolt12_offer: None,


### PR DESCRIPTION
Since the preimage is now fully recovered from Boltz's claim there is no reason to add it to the real-time sync payload. 