### PR TITLE
Fix: Add L-BTC asset matching network type

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -108,7 +108,7 @@ impl Persister {
             .balance
             .iter()
             .filter_map(|(asset_id, balance)| {
-                if *asset_id == lwk_wollet::elements::AssetId::LIQUID_BTC {
+                if *asset_id == utils::lbtc_asset_id(self.network) {
                     return Some(balance);
                 }
                 None

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -14,7 +14,6 @@ use futures_util::{StreamExt, TryFutureExt};
 use lnurl::auth::SdkLnurlAuthSigner;
 use log::{debug, error, info, warn};
 use lwk_wollet::bitcoin::base64::Engine as _;
-use lwk_wollet::elements::AssetId;
 use lwk_wollet::elements_miniscript::elements::bitcoin::bip32::Xpub;
 use lwk_wollet::hashes::{sha256, Hash};
 use lwk_wollet::secp256k1::ThirtyTwoByteHash;
@@ -1882,7 +1881,7 @@ impl LiquidSdk {
                         address: address.to_string(),
                         network: self.config.network.into(),
                         amount_sat: Some(*amount_sat),
-                        asset_id: Some(AssetId::LIQUID_BTC.to_hex()),
+                        asset_id: Some(utils::lbtc_asset_id(self.config.network).to_string()),
                         label: None,
                         message: req.description.clone(),
                     }
@@ -2524,7 +2523,7 @@ impl LiquidSdk {
                 tx.balance
                     .into_iter()
                     .filter_map(|(asset_id, balance)| {
-                        if asset_id == lwk_wollet::elements::AssetId::LIQUID_BTC {
+                        if asset_id == utils::lbtc_asset_id(self.config.network) {
                             return Some(balance);
                         }
                         None

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -3,11 +3,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::ensure_sdk;
 use crate::error::{PaymentError, SdkResult};
+use crate::prelude::LiquidNetwork;
 use anyhow::{anyhow, ensure, Result};
 use boltz_client::util::secrets::Preimage;
 use boltz_client::ToHex;
+use lazy_static::lazy_static;
 use lwk_wollet::elements::encode::deserialize;
 use lwk_wollet::elements::hex::FromHex;
+use lwk_wollet::elements::AssetId;
 use lwk_wollet::elements::{
     LockTime::{self, *},
     Transaction,
@@ -16,6 +19,12 @@ use sdk_common::bitcoin::bech32;
 use sdk_common::bitcoin::bech32::FromBase32;
 use sdk_common::lightning_125::offers::invoice::Bolt12Invoice;
 use sdk_common::lightning_invoice::Bolt11Invoice;
+
+lazy_static! {
+    static ref LBTC_TESTNET_ASSET_ID: AssetId =
+        AssetId::from_str("144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49")
+            .unwrap();
+}
 
 pub(crate) fn now() -> u32 {
     SystemTime::now()
@@ -108,6 +117,13 @@ pub(crate) fn verify_payment_hash(
     );
 
     Ok(())
+}
+
+pub(crate) fn lbtc_asset_id(network: LiquidNetwork) -> AssetId {
+    match network {
+        LiquidNetwork::Mainnet => AssetId::LIQUID_BTC,
+        LiquidNetwork::Testnet => *LBTC_TESTNET_ASSET_ID,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#630 introduced a regression on testnet, as the asset ID between testnet and mainnet L-BTC is different. 
This PR fixes this temporarily. should become unnecessary once #645 is merged.