### PR TITLE
Fix: prevent non-local chain swap claim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,12 @@ jobs:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup dotnet
+        if: ${{ !inputs.skip-tests }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.0.x'
+
       - name: Build bindings
         working-directory: lib/bindings
         run: cargo build

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#68ff15b0f80abfa54d8dca4c11c8c2794e4b6921"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5#3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -121,7 +121,7 @@ impl ChainSwapHandler {
     async fn claim_incoming(&self, height: u32) -> Result<()> {
         let chain_swaps: Vec<ChainSwap> = self
             .persister
-            .list_chain_swaps()?
+            .list_local_chain_swaps()?
             .into_iter()
             .filter(|s| {
                 s.direction == Direction::Incoming && s.state == Pending && s.claim_tx_id.is_none()
@@ -146,7 +146,7 @@ impl ChainSwapHandler {
     async fn claim_outgoing(&self, height: u32) -> Result<()> {
         let chain_swaps: Vec<ChainSwap> = self
             .persister
-            .list_chain_swaps()?
+            .list_local_chain_swaps()?
             .into_iter()
             .filter(|s| {
                 s.direction == Direction::Outgoing && s.state == Pending && s.claim_tx_id.is_none()


### PR DESCRIPTION
This fixes an issue where multiple instances compete for broadcasting the claim tx of a chain swap. We defined that only the instance that created a swap should be able to broadcast a TX associated with that swap.