### PR TITLE
Fix swap structs PartialEq implementation

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "bip39",
  "boltz-client",
  "chrono",
+ "derivative",
  "ecies",
  "electrum-client",
  "env_logger 0.11.5",
@@ -1052,6 +1053,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "bip39",
  "boltz-client",
  "chrono",
+ "derivative",
  "ecies",
  "electrum-client",
  "env_logger 0.11.5",
@@ -1232,6 +1233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 bip39 = "2.0.0"
 boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5" }
 chrono = "0.4"
+derivative = "2.2.0"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.7.0", features = [
     "chrono",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -13,6 +13,7 @@ use boltz_client::{
     ToHex,
 };
 use boltz_client::{BtcSwapScript, Keypair, LBtcSwapScript};
+use derivative::Derivative;
 use lwk_wollet::{bitcoin::bip32, ElementsNetwork};
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
 use rusqlite::ToSql;
@@ -755,7 +756,8 @@ impl FromSql for Direction {
 /// A chain swap
 ///
 /// See <https://docs.boltz.exchange/v/api/lifecycle#chain-swaps>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(PartialEq)]
 pub(crate) struct ChainSwap {
     pub(crate) id: String,
     pub(crate) direction: Direction,
@@ -793,6 +795,7 @@ pub(crate) struct ChainSwap {
     pub(crate) claim_private_key: String,
     pub(crate) refund_private_key: String,
     /// Version used for optimistic concurrency control within local db
+    #[derivative(PartialEq = "ignore")]
     pub(crate) version: u64,
 }
 impl ChainSwap {
@@ -925,7 +928,8 @@ pub(crate) struct ChainSwapUpdate {
 }
 
 /// A submarine swap, used for Send
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(PartialEq)]
 pub(crate) struct SendSwap {
     pub(crate) id: String,
     /// Bolt11 or Bolt12 invoice. This is determined by whether `bolt12_offer` is set or not.
@@ -951,6 +955,7 @@ pub(crate) struct SendSwap {
     pub(crate) state: PaymentState,
     pub(crate) refund_private_key: String,
     /// Version used for optimistic concurrency control within local db
+    #[derivative(PartialEq = "ignore")]
     pub(crate) version: u64,
 }
 impl SendSwap {
@@ -1016,7 +1021,8 @@ impl SendSwap {
 }
 
 /// A reverse swap, used for Receive
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(PartialEq)]
 pub(crate) struct ReceiveSwap {
     pub(crate) id: String,
     pub(crate) preimage: String,
@@ -1047,6 +1053,7 @@ pub(crate) struct ReceiveSwap {
     pub(crate) timeout_block_height: u32,
     pub(crate) state: PaymentState,
     /// Version used for optimistic concurrency control within local db
+    #[derivative(PartialEq = "ignore")]
     pub(crate) version: u64,
 }
 impl ReceiveSwap {


### PR DESCRIPTION
We compare swap instances at least in the methods `update_swap()` and `update_swap_info()` in order to know if an update needs to be or was made. Given the introduction of the `version` field in #652, these comparisons may not work as expected because, in an update where all updated fields don't produce changes, the version will still be incremented. In this case, an update would triggered/detected even when that shouldn't be the case.

This PR makes use of the crate `derivative` to implement `PartialEq` while ignoring the `version` field.