### PR TITLE
Consider only confirmed transactions for wallet balance

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2519,6 +2519,7 @@ impl LiquidSdk {
         let transactions = self.onchain_wallet.transactions().await?;
         let wallet_amount_sat = transactions
             .into_iter()
+            .filter(|tx| tx.height.is_some())
             .map(|tx| {
                 tx.balance
                     .into_iter()


### PR DESCRIPTION
While the pending balance calculation uses the local database, the confirmed balance uses LWK. We need to filter LWK's transactions based on whether or not they're confirmed.