### PR TITLE
Recoverer: Add cooperative preimage recovery and optimize flow

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5#3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=5869f2444280890716b756adaeaef2942b8041a3#5869f2444280890716b756adaeaef2942b8041a3"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5" }
+boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "5869f2444280890716b756adaeaef2942b8041a3" }
 chrono = "0.4"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.7.0", features = [

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -65,6 +65,7 @@ pub(crate) struct RecoveredOnchainDataSend {
     pub(crate) lockup_tx_id: Option<HistoryTxId>,
     pub(crate) claim_tx_id: Option<HistoryTxId>,
     pub(crate) refund_tx_id: Option<HistoryTxId>,
+    pub(crate) preimage: Option<String>,
 }
 
 impl RecoveredOnchainDataSend {

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -202,6 +202,11 @@ impl Swapper for BoltzSwapper {
         Ok(self.client.get_submarine_pairs()?.get_lbtc_to_btc_pair())
     }
 
+    /// Get a submarine swap's preimage
+    fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError> {
+        Ok(self.client.get_submarine_preimage(swap_id)?.preimage)
+    }
+
     /// Get claim tx details which includes the preimage as a proof of payment.
     /// It is used to validate the preimage before claiming which is the reason why we need to separate
     /// the claim into two steps.

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -57,6 +57,9 @@ pub trait Swapper: Send + Sync {
     /// Get a submarine pair information
     fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError>;
 
+    /// Get a submarine swap's preimage
+    fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError>;
+
     /// Get send swap claim tx details which includes the preimage as a proof of payment.
     /// It is used to validate the preimage before claiming which is the reason why we need to separate
     /// the claim into two steps.

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -455,6 +455,7 @@ mod tests {
             chain_swap::new_chain_swap,
             persist::{create_persister, new_receive_swap, new_send_swap},
             recover::new_recoverer,
+            swapper::MockSwapper,
             sync::{
                 new_chain_sync_data, new_receive_sync_data, new_send_sync_data, new_sync_service,
             },
@@ -468,8 +469,13 @@ mod tests {
     async fn test_incoming_sync_create_and_update() -> Result<()> {
         create_persister!(persister);
         let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
+        let swapper = Arc::new(MockSwapper::new());
         let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
-        let recoverer = Arc::new(new_recoverer(signer.clone(), onchain_wallet.clone())?);
+        let recoverer = Arc::new(new_recoverer(
+            signer.clone(),
+            swapper.clone(),
+            onchain_wallet.clone(),
+        )?);
 
         let sync_data = vec![
             SyncData::Receive(new_receive_sync_data()),
@@ -563,8 +569,13 @@ mod tests {
     async fn test_outgoing_sync() -> Result<()> {
         create_persister!(persister);
         let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
+        let swapper = Arc::new(MockSwapper::new());
         let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
-        let recoverer = Arc::new(new_recoverer(signer.clone(), onchain_wallet.clone())?);
+        let recoverer = Arc::new(new_recoverer(
+            signer.clone(),
+            swapper.clone(),
+            onchain_wallet.clone(),
+        )?);
 
         let (_incoming_tx, outgoing_records, sync_service) =
             new_sync_service(persister.clone(), recoverer, signer.clone())?;
@@ -676,8 +687,13 @@ mod tests {
     async fn test_sync_clean() -> Result<()> {
         create_persister!(persister);
         let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
+        let swapper = Arc::new(MockSwapper::new());
         let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
-        let recoverer = Arc::new(new_recoverer(signer.clone(), onchain_wallet.clone())?);
+        let recoverer = Arc::new(new_recoverer(
+            signer.clone(),
+            swapper.clone(),
+            onchain_wallet.clone(),
+        )?);
 
         let (incoming_tx, _outgoing_records, sync_service) =
             new_sync_service(persister.clone(), recoverer, signer.clone())?;
@@ -738,8 +754,13 @@ mod tests {
     async fn test_last_derivation_index_update() -> Result<()> {
         create_persister!(persister);
         let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
+        let swapper = Arc::new(MockSwapper::new());
         let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
-        let recoverer = Arc::new(new_recoverer(signer.clone(), onchain_wallet.clone())?);
+        let recoverer = Arc::new(new_recoverer(
+            signer.clone(),
+            swapper.clone(),
+            onchain_wallet.clone(),
+        )?);
 
         let (incoming_tx, outgoing_records, sync_service) =
             new_sync_service(persister.clone(), recoverer, signer.clone())?;

--- a/lib/core/src/test_utils/recover.rs
+++ b/lib/core/src/test_utils/recover.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use anyhow::Result;
 use tokio::sync::Mutex;
 
-use crate::{model::Signer, recover::recoverer::Recoverer, wallet::OnchainWallet};
+use crate::{
+    model::Signer, recover::recoverer::Recoverer, swapper::Swapper, wallet::OnchainWallet,
+};
 
 use super::chain::{MockBitcoinChainService, MockLiquidChainService};
 
 pub(crate) fn new_recoverer(
     signer: Arc<Box<dyn Signer>>,
+    swapper: Arc<dyn Swapper>,
     onchain_wallet: Arc<dyn OnchainWallet>,
 ) -> Result<Recoverer> {
     let liquid_chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
@@ -16,6 +19,7 @@ pub(crate) fn new_recoverer(
 
     Recoverer::new(
         signer.slip77_master_blinding_key()?,
+        swapper,
         onchain_wallet,
         liquid_chain_service,
         bitcoin_chain_service,

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -90,6 +90,7 @@ pub(crate) fn new_liquid_sdk_with_chain_services(
 
     let recoverer = Arc::new(Recoverer::new(
         signer.slip77_master_blinding_key()?,
+        swapper.clone(),
         onchain_wallet.clone(),
         liquid_chain_service.clone(),
         bitcoin_chain_service.clone(),

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -178,6 +178,10 @@ impl Swapper for MockSwapper {
         Ok((test_pair.clone(), test_pair))
     }
 
+    fn get_submarine_preimage(&self, _swap_id: &str) -> Result<String, PaymentError> {
+        Ok(Preimage::new().to_string().unwrap())
+    }
+
     fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError> {
         Ok(Some(SubmarinePair {
             hash: generate_random_string(10),


### PR DESCRIPTION
This PR adds the recovery of a submarine swap's preimage from the swapper/blockchain, with the following fallbacks:
  - Swap has preimage: Don't recover
  - Swap has no preimage: Recover cooperatively (single request)
  - Swap has no preimage and cannot recover cooperatively: Recover non-cooperatively (batch request)

**Note:** Had to switch to a local fork as there is a pending PR to include these changes on Boltz's side

**Note:** It would be nice to have batch requests also for the Boltz API to reduce overhead, maybe something for them to consider adding
