### PR TITLE
Fix amountless receiver amount and waiting fee acceptance condition

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -772,7 +772,7 @@ pub(crate) struct ChainSwap {
     pub(crate) actual_payer_amount_sat: Option<u64>,
     /// Receiver amount defined at swap creation
     pub(crate) receiver_amount_sat: u64,
-    /// The final receiver amount, in case of an over/underpayment that has been accepted
+    /// The final receiver amount, in case of an amountless swap for which fees have been accepted
     pub(crate) accepted_receiver_amount_sat: Option<u64>,
     pub(crate) claim_fees_sat: u64,
     /// The [ChainPair] chosen on swap creation
@@ -901,15 +901,8 @@ impl ChainSwap {
         Ok(create_response_json)
     }
 
-    pub(crate) fn is_amount_mismatch(&self) -> bool {
-        match self.actual_payer_amount_sat {
-            Some(actual_amount) => actual_amount != self.payer_amount_sat,
-            None => false,
-        }
-    }
-
     pub(crate) fn is_waiting_fee_acceptance(&self) -> bool {
-        self.is_amount_mismatch() && self.accepted_receiver_amount_sat.is_none()
+        self.payer_amount_sat == 0 && self.accepted_receiver_amount_sat.is_none()
     }
 }
 

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -597,7 +597,7 @@ impl Persister {
                                     maybe_chain_swap_actual_payer_amount_sat,
                                     maybe_chain_swap_payer_amount_sat,
                                 ) {
-                                    (Some(actual), Some(expected)) if actual != expected => actual, // For over/underpaid chain swaps WaitingFeeAcceptance, show zero fees
+                                    (Some(actual), Some(0)) => actual, // For amountless chain swaps WaitingFeeAcceptance, show zero fees
                                     _ => maybe_chain_swap_receiver_amount_sat.unwrap_or(0),
                                 },
                             };


### PR DESCRIPTION
This PR:

- Fixes receiver amount calculation - before, an over/underpaid swap could be shown as having 0 fees.
- Fixes `is_waiting_fee_acceptance()` - before, an over/underpaid swap could get to the state of WaitingFeeAcceptance