### PR TITLE
Ensure fees are calculated without overflow

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5#3bbc0ddb068df7f12a1b8b37cfbb353f4db36fe5"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=5869f2444280890716b756adaeaef2942b8041a3#5869f2444280890716b756adaeaef2942b8041a3"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1556,7 +1556,9 @@ impl Payment {
             unblinding_data: None,
             timestamp: swap.created_at,
             amount_sat,
-            fees_sat: swap.payer_amount_sat - swap.receiver_amount_sat,
+            fees_sat: swap
+                .payer_amount_sat
+                .saturating_sub(swap.receiver_amount_sat),
             swapper_fees_sat: Some(swap.swapper_fees_sat),
             payment_type,
             status: swap.status,
@@ -1607,8 +1609,8 @@ impl Payment {
                     // For receive swaps, to avoid some edge case issues related to potential past
                     //  overpayments, we use the actual claim value as the final received amount
                     //  for fee calculation.
-                    PaymentType::Receive => s.payer_amount_sat - tx.amount_sat,
-                    PaymentType::Send => s.payer_amount_sat - s.receiver_amount_sat,
+                    PaymentType::Receive => s.payer_amount_sat.saturating_sub(tx.amount_sat),
+                    PaymentType::Send => s.payer_amount_sat.saturating_sub(s.receiver_amount_sat),
                 },
                 None => match tx.payment_type {
                     PaymentType::Receive => 0,


### PR DESCRIPTION
Getting an overflow calculating the payment fees_sat. It's from a incoming chain swap that was underpaid. I have used `saturating_sub` to prevent the overflow.
```
thread 'tokio-runtime-worker' panicked at /Users/rosssavage/Source/Projects/breez-sdk-liquid/lib/core/src/model.rs:1560:23:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This is the PaymentSwapData causing the issue:
```
[2025-01-17 14:56:33.613 DEBUG breez_sdk_liquid::model:1548] Swap ID pending: PaymentSwapData { swap_id: "83CFncYW8e8R", swap_type: Chain, created_at: 1733902652, expiration_blockheight: 874405, preimage: Some("408dd22e5bf613b4d055c22ad2a1a79ba112e03b95237a3dacd305388fcd83f1"), invoice: None, bolt12_offer: None, payment_hash: None, destination_pubkey: None, description: "Bitcoin transfer", payer_amount_sat: 20000, receiver_amount_sat: 47645, swapper_fees_sat: 0, refund_tx_id: Some("fa6699f193043de11e9542496799166b59020416383011f8923837665bde07c1"), refund_tx_amount_sat: None, claim_address: None, status: Failed }
```