### PR TITLE
Add `sort_ascending` flag to list_payments

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use breez_sdk_liquid::prelude::*;
-use clap::{arg, Parser};
+use clap::{arg, ArgAction, Parser};
 use qrcode_rs::render::unicode;
 use qrcode_rs::{EcLevel, QrCode};
 use rustyline::highlight::Highlighter;
@@ -125,6 +125,10 @@ pub(crate) enum Command {
         /// Optional Liquid/Bitcoin address for Bitcoin payment method
         #[clap(short = 'a', long = "address")]
         address: Option<String>,
+
+        /// Whether or not to sort the payments by ascending timestamp
+        #[clap(long = "ascending", action = ArgAction::SetTrue)]
+        sort_ascending: Option<bool>,
     },
     /// Retrieve a payment
     GetPayment {
@@ -490,6 +494,7 @@ pub(crate) async fn handle_command(
             offset,
             destination,
             address,
+            sort_ascending,
         } => {
             let details = match (destination, address) {
                 (Some(destination), None) => Some(ListPaymentDetails::Liquid { destination }),
@@ -506,6 +511,7 @@ pub(crate) async fn handle_command(
                     limit,
                     offset,
                     details,
+                    sort_ascending,
                 })
                 .await?;
             command_result!(payments)

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -127,6 +127,7 @@ typedef struct wire_cst_list_payments_request {
   uint32_t *offset;
   uint32_t *limit;
   struct wire_cst_list_payment_details *details;
+  bool *sort_ascending;
 } wire_cst_list_payments_request;
 
 typedef struct wire_cst_ln_url_auth_request_data {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -539,6 +539,7 @@ dictionary ListPaymentsRequest {
     u32? offset = null;
     u32? limit = null;
     ListPaymentDetails? details = null;
+    boolean? sort_ascending = null;
 };
 
 [Enum]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2928,6 +2928,7 @@ impl SseDecode for crate::model::ListPaymentsRequest {
         let mut var_offset = <Option<u32>>::sse_decode(deserializer);
         let mut var_limit = <Option<u32>>::sse_decode(deserializer);
         let mut var_details = <Option<crate::model::ListPaymentDetails>>::sse_decode(deserializer);
+        let mut var_sortAscending = <Option<bool>>::sse_decode(deserializer);
         return crate::model::ListPaymentsRequest {
             filters: var_filters,
             states: var_states,
@@ -2936,6 +2937,7 @@ impl SseDecode for crate::model::ListPaymentsRequest {
             offset: var_offset,
             limit: var_limit,
             details: var_details,
+            sort_ascending: var_sortAscending,
         };
     }
 }
@@ -5243,6 +5245,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::ListPaymentsRequest {
             self.offset.into_into_dart().into_dart(),
             self.limit.into_into_dart().into_dart(),
             self.details.into_into_dart().into_dart(),
+            self.sort_ascending.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -7405,6 +7408,7 @@ impl SseEncode for crate::model::ListPaymentsRequest {
         <Option<u32>>::sse_encode(self.offset, serializer);
         <Option<u32>>::sse_encode(self.limit, serializer);
         <Option<crate::model::ListPaymentDetails>>::sse_encode(self.details, serializer);
+        <Option<bool>>::sse_encode(self.sort_ascending, serializer);
     }
 }
 
@@ -9644,6 +9648,7 @@ mod io {
                 offset: self.offset.cst_decode(),
                 limit: self.limit.cst_decode(),
                 details: self.details.cst_decode(),
+                sort_ascending: self.sort_ascending.cst_decode(),
             }
         }
     }
@@ -11089,6 +11094,7 @@ mod io {
                 offset: core::ptr::null_mut(),
                 limit: core::ptr::null_mut(),
                 details: core::ptr::null_mut(),
+                sort_ascending: core::ptr::null_mut(),
             }
         }
     }
@@ -13304,6 +13310,7 @@ mod io {
         offset: *mut u32,
         limit: *mut u32,
         details: *mut wire_cst_list_payment_details,
+        sort_ascending: *mut bool,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -620,6 +620,7 @@ pub struct ListPaymentsRequest {
     pub offset: Option<u32>,
     pub limit: Option<u32>,
     pub details: Option<ListPaymentDetails>,
+    pub sort_ascending: Option<bool>,
 }
 
 /// An argument of [ListPaymentsRequest] when calling [crate::sdk::LiquidSdk::list_payments].

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2092,7 +2092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ListPaymentsRequest dco_decode_list_payments_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 8) throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return ListPaymentsRequest(
       filters: dco_decode_opt_list_payment_type(arr[0]),
       states: dco_decode_opt_list_payment_state(arr[1]),
@@ -2101,6 +2101,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       offset: dco_decode_opt_box_autoadd_u_32(arr[4]),
       limit: dco_decode_opt_box_autoadd_u_32(arr[5]),
       details: dco_decode_opt_box_autoadd_list_payment_details(arr[6]),
+      sortAscending: dco_decode_opt_box_autoadd_bool(arr[7]),
     );
   }
 
@@ -4179,6 +4180,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_offset = sse_decode_opt_box_autoadd_u_32(deserializer);
     var var_limit = sse_decode_opt_box_autoadd_u_32(deserializer);
     var var_details = sse_decode_opt_box_autoadd_list_payment_details(deserializer);
+    var var_sortAscending = sse_decode_opt_box_autoadd_bool(deserializer);
     return ListPaymentsRequest(
         filters: var_filters,
         states: var_states,
@@ -4186,7 +4188,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         toTimestamp: var_toTimestamp,
         offset: var_offset,
         limit: var_limit,
-        details: var_details);
+        details: var_details,
+        sortAscending: var_sortAscending);
   }
 
   @protected
@@ -6321,6 +6324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_32(self.offset, serializer);
     sse_encode_opt_box_autoadd_u_32(self.limit, serializer);
     sse_encode_opt_box_autoadd_list_payment_details(self.details, serializer);
+    sse_encode_opt_box_autoadd_bool(self.sortAscending, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2554,6 +2554,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.offset = cst_encode_opt_box_autoadd_u_32(apiObj.offset);
     wireObj.limit = cst_encode_opt_box_autoadd_u_32(apiObj.limit);
     wireObj.details = cst_encode_opt_box_autoadd_list_payment_details(apiObj.details);
+    wireObj.sort_ascending = cst_encode_opt_box_autoadd_bool(apiObj.sortAscending);
   }
 
   @protected
@@ -5860,6 +5861,8 @@ final class wire_cst_list_payments_request extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> limit;
 
   external ffi.Pointer<wire_cst_list_payment_details> details;
+
+  external ffi.Pointer<ffi.Bool> sort_ascending;
 }
 
 final class wire_cst_ln_url_auth_request_data extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -453,6 +453,7 @@ class ListPaymentsRequest {
   final int? offset;
   final int? limit;
   final ListPaymentDetails? details;
+  final bool? sortAscending;
 
   const ListPaymentsRequest({
     this.filters,
@@ -462,6 +463,7 @@ class ListPaymentsRequest {
     this.offset,
     this.limit,
     this.details,
+    this.sortAscending,
   });
 
   @override
@@ -472,7 +474,8 @@ class ListPaymentsRequest {
       toTimestamp.hashCode ^
       offset.hashCode ^
       limit.hashCode ^
-      details.hashCode;
+      details.hashCode ^
+      sortAscending.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -485,7 +488,8 @@ class ListPaymentsRequest {
           toTimestamp == other.toTimestamp &&
           offset == other.offset &&
           limit == other.limit &&
-          details == other.details;
+          details == other.details &&
+          sortAscending == other.sortAscending;
 }
 
 /// Represents the payment LNURL info

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4190,6 +4190,8 @@ final class wire_cst_list_payments_request extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> limit;
 
   external ffi.Pointer<wire_cst_list_payment_details> details;
+
+  external ffi.Pointer<ffi.Bool> sort_ascending;
 }
 
 final class wire_cst_ln_url_auth_request_data extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -957,7 +957,8 @@ fun asListPaymentsRequest(listPaymentsRequest: ReadableMap): ListPaymentsRequest
         } else {
             null
         }
-    return ListPaymentsRequest(filters, states, fromTimestamp, toTimestamp, offset, limit, details)
+    val sortAscending = if (hasNonNullKey(listPaymentsRequest, "sortAscending")) listPaymentsRequest.getBoolean("sortAscending") else null
+    return ListPaymentsRequest(filters, states, fromTimestamp, toTimestamp, offset, limit, details, sortAscending)
 }
 
 fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap =
@@ -969,6 +970,7 @@ fun readableMapOf(listPaymentsRequest: ListPaymentsRequest): ReadableMap =
         "offset" to listPaymentsRequest.offset,
         "limit" to listPaymentsRequest.limit,
         "details" to listPaymentsRequest.details?.let { readableMapOf(it) },
+        "sortAscending" to listPaymentsRequest.sortAscending,
     )
 
 fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1135,7 +1135,15 @@ enum BreezSDKLiquidMapper {
             details = try asListPaymentDetails(listPaymentDetails: detailsTmp)
         }
 
-        return ListPaymentsRequest(filters: filters, states: states, fromTimestamp: fromTimestamp, toTimestamp: toTimestamp, offset: offset, limit: limit, details: details)
+        var sortAscending: Bool?
+        if hasNonNilKey(data: listPaymentsRequest, key: "sortAscending") {
+            guard let sortAscendingTmp = listPaymentsRequest["sortAscending"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "sortAscending"))
+            }
+            sortAscending = sortAscendingTmp
+        }
+
+        return ListPaymentsRequest(filters: filters, states: states, fromTimestamp: fromTimestamp, toTimestamp: toTimestamp, offset: offset, limit: limit, details: details, sortAscending: sortAscending)
     }
 
     static func dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
@@ -1147,6 +1155,7 @@ enum BreezSDKLiquidMapper {
             "offset": listPaymentsRequest.offset == nil ? nil : listPaymentsRequest.offset,
             "limit": listPaymentsRequest.limit == nil ? nil : listPaymentsRequest.limit,
             "details": listPaymentsRequest.details == nil ? nil : dictionaryOf(listPaymentDetails: listPaymentsRequest.details!),
+            "sortAscending": listPaymentsRequest.sortAscending == nil ? nil : listPaymentsRequest.sortAscending,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -183,6 +183,7 @@ export interface ListPaymentsRequest {
     offset?: number
     limit?: number
     details?: ListPaymentDetails
+    sortAscending?: boolean
 }
 
 export interface LnOfferBlindedPath {


### PR DESCRIPTION
This PR adds the ability to sort payments by ascending/descending timestamp (defaulting to descending, as it was up until now).