### PR TITLE
Fix receive chain swap `is_refundable` condition

### DIFF
--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -200,12 +200,15 @@ pub(crate) struct RecoveredOnchainDataChainReceive {
 impl RecoveredOnchainDataChainReceive {
     pub(crate) fn derive_partial_state(
         &self,
-        min_lockup_amount_sat: u64,
+        expected_user_lockup_amount_sat: Option<u64>,
         is_expired: bool,
         is_waiting_fee_acceptance: bool,
     ) -> Option<PaymentState> {
         let is_refundable = self.btc_user_lockup_address_balance_sat > 0
-            && (is_expired || self.btc_user_lockup_amount_sat < min_lockup_amount_sat); // TODO: this does not support accepting over/underpayments
+            && (is_expired
+                || expected_user_lockup_amount_sat.map_or(false, |expected_lockup_amount_sat| {
+                    expected_lockup_amount_sat != self.btc_user_lockup_amount_sat
+                }));
         match &self.btc_user_lockup_tx_id {
             Some(_) => match (&self.lbtc_claim_tx_id, &self.btc_refund_tx_id) {
                 (Some(lbtc_claim_tx_id), None) => match lbtc_claim_tx_id.confirmed() {

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -284,9 +284,12 @@ impl Recoverer {
                         }
                         let is_expired =
                             bitcoin_tip.height as u32 >= chain_swap.timeout_block_height;
-                        let min_lockup_amount_sat = chain_swap.payer_amount_sat;
+                        let expected_user_lockup_amount_sat = match chain_swap.payer_amount_sat {
+                            0 => None,
+                            expected => Some(expected),
+                        };
                         if let Some(new_state) = recovered_data.derive_partial_state(
-                            min_lockup_amount_sat,
+                            expected_user_lockup_amount_sat,
                             is_expired,
                             chain_swap.is_waiting_fee_acceptance(),
                         ) {


### PR DESCRIPTION
This fixes the derivation of an incoming chain swap state from onchain data. Specifically, the `is_refundable` condition, which should detect any over/underpayment as a refundable, but was only covering underpayments. 