### PR TITLE
Add SdkEvent for refundable swap

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -545,6 +545,10 @@ typedef struct wire_cst_SdkEvent_PaymentPending {
   struct wire_cst_payment *details;
 } wire_cst_SdkEvent_PaymentPending;
 
+typedef struct wire_cst_SdkEvent_PaymentRefundable {
+  struct wire_cst_payment *details;
+} wire_cst_SdkEvent_PaymentRefundable;
+
 typedef struct wire_cst_SdkEvent_PaymentRefunded {
   struct wire_cst_payment *details;
 } wire_cst_SdkEvent_PaymentRefunded;
@@ -568,6 +572,7 @@ typedef struct wire_cst_SdkEvent_PaymentWaitingFeeAcceptance {
 typedef union SdkEventKind {
   struct wire_cst_SdkEvent_PaymentFailed PaymentFailed;
   struct wire_cst_SdkEvent_PaymentPending PaymentPending;
+  struct wire_cst_SdkEvent_PaymentRefundable PaymentRefundable;
   struct wire_cst_SdkEvent_PaymentRefunded PaymentRefunded;
   struct wire_cst_SdkEvent_PaymentRefundPending PaymentRefundPending;
   struct wire_cst_SdkEvent_PaymentSucceeded PaymentSucceeded;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -654,6 +654,7 @@ dictionary RefundResponse {
 interface SdkEvent {
     PaymentFailed(Payment details);
     PaymentPending(Payment details);
+    PaymentRefundable(Payment details);
     PaymentRefunded(Payment details);
     PaymentRefundPending(Payment details);
     PaymentSucceeded(Payment details);

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4304,35 +4304,41 @@ impl SseDecode for crate::model::SdkEvent {
             }
             2 => {
                 let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
-                return crate::model::SdkEvent::PaymentRefunded {
+                return crate::model::SdkEvent::PaymentRefundable {
                     details: var_details,
                 };
             }
             3 => {
                 let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
-                return crate::model::SdkEvent::PaymentRefundPending {
+                return crate::model::SdkEvent::PaymentRefunded {
                     details: var_details,
                 };
             }
             4 => {
                 let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
-                return crate::model::SdkEvent::PaymentSucceeded {
+                return crate::model::SdkEvent::PaymentRefundPending {
                     details: var_details,
                 };
             }
             5 => {
                 let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
-                return crate::model::SdkEvent::PaymentWaitingConfirmation {
+                return crate::model::SdkEvent::PaymentSucceeded {
                     details: var_details,
                 };
             }
             6 => {
                 let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
-                return crate::model::SdkEvent::PaymentWaitingFeeAcceptance {
+                return crate::model::SdkEvent::PaymentWaitingConfirmation {
                     details: var_details,
                 };
             }
             7 => {
+                let mut var_details = <crate::model::Payment>::sse_decode(deserializer);
+                return crate::model::SdkEvent::PaymentWaitingFeeAcceptance {
+                    details: var_details,
+                };
+            }
+            8 => {
                 return crate::model::SdkEvent::Synced;
             }
             _ => {
@@ -6622,22 +6628,25 @@ impl flutter_rust_bridge::IntoDart for crate::model::SdkEvent {
             crate::model::SdkEvent::PaymentPending { details } => {
                 [1.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::PaymentRefunded { details } => {
+            crate::model::SdkEvent::PaymentRefundable { details } => {
                 [2.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::PaymentRefundPending { details } => {
+            crate::model::SdkEvent::PaymentRefunded { details } => {
                 [3.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::PaymentSucceeded { details } => {
+            crate::model::SdkEvent::PaymentRefundPending { details } => {
                 [4.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::PaymentWaitingConfirmation { details } => {
+            crate::model::SdkEvent::PaymentSucceeded { details } => {
                 [5.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::PaymentWaitingFeeAcceptance { details } => {
+            crate::model::SdkEvent::PaymentWaitingConfirmation { details } => {
                 [6.into_dart(), details.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::SdkEvent::Synced => [7.into_dart()].into_dart(),
+            crate::model::SdkEvent::PaymentWaitingFeeAcceptance { details } => {
+                [7.into_dart(), details.into_into_dart().into_dart()].into_dart()
+            }
+            crate::model::SdkEvent::Synced => [8.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -8493,28 +8502,32 @@ impl SseEncode for crate::model::SdkEvent {
                 <i32>::sse_encode(1, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::PaymentRefunded { details } => {
+            crate::model::SdkEvent::PaymentRefundable { details } => {
                 <i32>::sse_encode(2, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::PaymentRefundPending { details } => {
+            crate::model::SdkEvent::PaymentRefunded { details } => {
                 <i32>::sse_encode(3, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::PaymentSucceeded { details } => {
+            crate::model::SdkEvent::PaymentRefundPending { details } => {
                 <i32>::sse_encode(4, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::PaymentWaitingConfirmation { details } => {
+            crate::model::SdkEvent::PaymentSucceeded { details } => {
                 <i32>::sse_encode(5, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::PaymentWaitingFeeAcceptance { details } => {
+            crate::model::SdkEvent::PaymentWaitingConfirmation { details } => {
                 <i32>::sse_encode(6, serializer);
                 <crate::model::Payment>::sse_encode(details, serializer);
             }
-            crate::model::SdkEvent::Synced => {
+            crate::model::SdkEvent::PaymentWaitingFeeAcceptance { details } => {
                 <i32>::sse_encode(7, serializer);
+                <crate::model::Payment>::sse_encode(details, serializer);
+            }
+            crate::model::SdkEvent::Synced => {
+                <i32>::sse_encode(8, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -10543,36 +10556,42 @@ mod io {
                     }
                 }
                 2 => {
+                    let ans = unsafe { self.kind.PaymentRefundable };
+                    crate::model::SdkEvent::PaymentRefundable {
+                        details: ans.details.cst_decode(),
+                    }
+                }
+                3 => {
                     let ans = unsafe { self.kind.PaymentRefunded };
                     crate::model::SdkEvent::PaymentRefunded {
                         details: ans.details.cst_decode(),
                     }
                 }
-                3 => {
+                4 => {
                     let ans = unsafe { self.kind.PaymentRefundPending };
                     crate::model::SdkEvent::PaymentRefundPending {
                         details: ans.details.cst_decode(),
                     }
                 }
-                4 => {
+                5 => {
                     let ans = unsafe { self.kind.PaymentSucceeded };
                     crate::model::SdkEvent::PaymentSucceeded {
                         details: ans.details.cst_decode(),
                     }
                 }
-                5 => {
+                6 => {
                     let ans = unsafe { self.kind.PaymentWaitingConfirmation };
                     crate::model::SdkEvent::PaymentWaitingConfirmation {
                         details: ans.details.cst_decode(),
                     }
                 }
-                6 => {
+                7 => {
                     let ans = unsafe { self.kind.PaymentWaitingFeeAcceptance };
                     crate::model::SdkEvent::PaymentWaitingFeeAcceptance {
                         details: ans.details.cst_decode(),
                     }
                 }
-                7 => crate::model::SdkEvent::Synced,
+                8 => crate::model::SdkEvent::Synced,
                 _ => unreachable!(),
             }
         }
@@ -14048,6 +14067,7 @@ mod io {
     pub union SdkEventKind {
         PaymentFailed: wire_cst_SdkEvent_PaymentFailed,
         PaymentPending: wire_cst_SdkEvent_PaymentPending,
+        PaymentRefundable: wire_cst_SdkEvent_PaymentRefundable,
         PaymentRefunded: wire_cst_SdkEvent_PaymentRefunded,
         PaymentRefundPending: wire_cst_SdkEvent_PaymentRefundPending,
         PaymentSucceeded: wire_cst_SdkEvent_PaymentSucceeded,
@@ -14063,6 +14083,11 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_SdkEvent_PaymentPending {
+        details: *mut wire_cst_payment,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_SdkEvent_PaymentRefundable {
         details: *mut wire_cst_payment,
     }
     #[repr(C)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -241,6 +241,7 @@ pub trait EventListener: Send + Sync {
 pub enum SdkEvent {
     PaymentFailed { details: Payment },
     PaymentPending { details: Payment },
+    PaymentRefundable { details: Payment },
     PaymentRefunded { details: Payment },
     PaymentRefundPending { details: Payment },
     PaymentSucceeded { details: Payment },

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -584,6 +584,12 @@ impl LiquidSdk {
                             })
                             .await?;
                         }
+                        Refundable => {
+                            self.notify_event_listeners(SdkEvent::PaymentRefundable {
+                                details: payment,
+                            })
+                            .await?
+                        }
                         RefundPending => {
                             // The swap state has changed to RefundPending
                             self.notify_event_listeners(SdkEvent::PaymentRefundPending {

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -3105,26 +3105,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 2:
-        return SdkEvent_PaymentRefunded(
+        return SdkEvent_PaymentRefundable(
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 3:
-        return SdkEvent_PaymentRefundPending(
+        return SdkEvent_PaymentRefunded(
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 4:
-        return SdkEvent_PaymentSucceeded(
+        return SdkEvent_PaymentRefundPending(
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 5:
-        return SdkEvent_PaymentWaitingConfirmation(
+        return SdkEvent_PaymentSucceeded(
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 6:
-        return SdkEvent_PaymentWaitingFeeAcceptance(
+        return SdkEvent_PaymentWaitingConfirmation(
           details: dco_decode_box_autoadd_payment(raw[1]),
         );
       case 7:
+        return SdkEvent_PaymentWaitingFeeAcceptance(
+          details: dco_decode_box_autoadd_payment(raw[1]),
+        );
+      case 8:
         return SdkEvent_Synced();
       default:
         throw Exception("unreachable");
@@ -5265,20 +5269,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return SdkEvent_PaymentPending(details: var_details);
       case 2:
         var var_details = sse_decode_box_autoadd_payment(deserializer);
-        return SdkEvent_PaymentRefunded(details: var_details);
+        return SdkEvent_PaymentRefundable(details: var_details);
       case 3:
         var var_details = sse_decode_box_autoadd_payment(deserializer);
-        return SdkEvent_PaymentRefundPending(details: var_details);
+        return SdkEvent_PaymentRefunded(details: var_details);
       case 4:
         var var_details = sse_decode_box_autoadd_payment(deserializer);
-        return SdkEvent_PaymentSucceeded(details: var_details);
+        return SdkEvent_PaymentRefundPending(details: var_details);
       case 5:
         var var_details = sse_decode_box_autoadd_payment(deserializer);
-        return SdkEvent_PaymentWaitingConfirmation(details: var_details);
+        return SdkEvent_PaymentSucceeded(details: var_details);
       case 6:
         var var_details = sse_decode_box_autoadd_payment(deserializer);
-        return SdkEvent_PaymentWaitingFeeAcceptance(details: var_details);
+        return SdkEvent_PaymentWaitingConfirmation(details: var_details);
       case 7:
+        var var_details = sse_decode_box_autoadd_payment(deserializer);
+        return SdkEvent_PaymentWaitingFeeAcceptance(details: var_details);
+      case 8:
         return SdkEvent_Synced();
       default:
         throw UnimplementedError('');
@@ -7195,23 +7202,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case SdkEvent_PaymentPending(details: final details):
         sse_encode_i_32(1, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_PaymentRefunded(details: final details):
+      case SdkEvent_PaymentRefundable(details: final details):
         sse_encode_i_32(2, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_PaymentRefundPending(details: final details):
+      case SdkEvent_PaymentRefunded(details: final details):
         sse_encode_i_32(3, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_PaymentSucceeded(details: final details):
+      case SdkEvent_PaymentRefundPending(details: final details):
         sse_encode_i_32(4, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_PaymentWaitingConfirmation(details: final details):
+      case SdkEvent_PaymentSucceeded(details: final details):
         sse_encode_i_32(5, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_PaymentWaitingFeeAcceptance(details: final details):
+      case SdkEvent_PaymentWaitingConfirmation(details: final details):
         sse_encode_i_32(6, serializer);
         sse_encode_box_autoadd_payment(details, serializer);
-      case SdkEvent_Synced():
+      case SdkEvent_PaymentWaitingFeeAcceptance(details: final details):
         sse_encode_i_32(7, serializer);
+        sse_encode_box_autoadd_payment(details, serializer);
+      case SdkEvent_Synced():
+        sse_encode_i_32(8, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3309,38 +3309,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.PaymentPending.details = pre_details;
       return;
     }
-    if (apiObj is SdkEvent_PaymentRefunded) {
+    if (apiObj is SdkEvent_PaymentRefundable) {
       var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
       wireObj.tag = 2;
+      wireObj.kind.PaymentRefundable.details = pre_details;
+      return;
+    }
+    if (apiObj is SdkEvent_PaymentRefunded) {
+      var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
+      wireObj.tag = 3;
       wireObj.kind.PaymentRefunded.details = pre_details;
       return;
     }
     if (apiObj is SdkEvent_PaymentRefundPending) {
       var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
-      wireObj.tag = 3;
+      wireObj.tag = 4;
       wireObj.kind.PaymentRefundPending.details = pre_details;
       return;
     }
     if (apiObj is SdkEvent_PaymentSucceeded) {
       var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
-      wireObj.tag = 4;
+      wireObj.tag = 5;
       wireObj.kind.PaymentSucceeded.details = pre_details;
       return;
     }
     if (apiObj is SdkEvent_PaymentWaitingConfirmation) {
       var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
-      wireObj.tag = 5;
+      wireObj.tag = 6;
       wireObj.kind.PaymentWaitingConfirmation.details = pre_details;
       return;
     }
     if (apiObj is SdkEvent_PaymentWaitingFeeAcceptance) {
       var pre_details = cst_encode_box_autoadd_payment(apiObj.details);
-      wireObj.tag = 6;
+      wireObj.tag = 7;
       wireObj.kind.PaymentWaitingFeeAcceptance.details = pre_details;
       return;
     }
     if (apiObj is SdkEvent_Synced) {
-      wireObj.tag = 7;
+      wireObj.tag = 8;
       return;
     }
   }
@@ -6461,6 +6467,10 @@ final class wire_cst_SdkEvent_PaymentPending extends ffi.Struct {
   external ffi.Pointer<wire_cst_payment> details;
 }
 
+final class wire_cst_SdkEvent_PaymentRefundable extends ffi.Struct {
+  external ffi.Pointer<wire_cst_payment> details;
+}
+
 final class wire_cst_SdkEvent_PaymentRefunded extends ffi.Struct {
   external ffi.Pointer<wire_cst_payment> details;
 }
@@ -6485,6 +6495,8 @@ final class SdkEventKind extends ffi.Union {
   external wire_cst_SdkEvent_PaymentFailed PaymentFailed;
 
   external wire_cst_SdkEvent_PaymentPending PaymentPending;
+
+  external wire_cst_SdkEvent_PaymentRefundable PaymentRefundable;
 
   external wire_cst_SdkEvent_PaymentRefunded PaymentRefunded;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1486,6 +1486,9 @@ sealed class SdkEvent with _$SdkEvent {
   const factory SdkEvent.paymentPending({
     required Payment details,
   }) = SdkEvent_PaymentPending;
+  const factory SdkEvent.paymentRefundable({
+    required Payment details,
+  }) = SdkEvent_PaymentRefundable;
   const factory SdkEvent.paymentRefunded({
     required Payment details,
   }) = SdkEvent_PaymentRefunded;

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1484,6 +1484,86 @@ abstract class SdkEvent_PaymentPending extends SdkEvent {
 }
 
 /// @nodoc
+abstract class _$$SdkEvent_PaymentRefundableImplCopyWith<$Res> {
+  factory _$$SdkEvent_PaymentRefundableImplCopyWith(
+          _$SdkEvent_PaymentRefundableImpl value, $Res Function(_$SdkEvent_PaymentRefundableImpl) then) =
+      __$$SdkEvent_PaymentRefundableImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Payment details});
+}
+
+/// @nodoc
+class __$$SdkEvent_PaymentRefundableImplCopyWithImpl<$Res>
+    extends _$SdkEventCopyWithImpl<$Res, _$SdkEvent_PaymentRefundableImpl>
+    implements _$$SdkEvent_PaymentRefundableImplCopyWith<$Res> {
+  __$$SdkEvent_PaymentRefundableImplCopyWithImpl(
+      _$SdkEvent_PaymentRefundableImpl _value, $Res Function(_$SdkEvent_PaymentRefundableImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? details = null,
+  }) {
+    return _then(_$SdkEvent_PaymentRefundableImpl(
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as Payment,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SdkEvent_PaymentRefundableImpl extends SdkEvent_PaymentRefundable {
+  const _$SdkEvent_PaymentRefundableImpl({required this.details}) : super._();
+
+  @override
+  final Payment details;
+
+  @override
+  String toString() {
+    return 'SdkEvent.paymentRefundable(details: $details)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SdkEvent_PaymentRefundableImpl &&
+            (identical(other.details, details) || other.details == details));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, details);
+
+  /// Create a copy of SdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SdkEvent_PaymentRefundableImplCopyWith<_$SdkEvent_PaymentRefundableImpl> get copyWith =>
+      __$$SdkEvent_PaymentRefundableImplCopyWithImpl<_$SdkEvent_PaymentRefundableImpl>(this, _$identity);
+}
+
+abstract class SdkEvent_PaymentRefundable extends SdkEvent {
+  const factory SdkEvent_PaymentRefundable({required final Payment details}) =
+      _$SdkEvent_PaymentRefundableImpl;
+  const SdkEvent_PaymentRefundable._() : super._();
+
+  Payment get details;
+
+  /// Create a copy of SdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SdkEvent_PaymentRefundableImplCopyWith<_$SdkEvent_PaymentRefundableImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 abstract class _$$SdkEvent_PaymentRefundedImplCopyWith<$Res> {
   factory _$$SdkEvent_PaymentRefundedImplCopyWith(
           _$SdkEvent_PaymentRefundedImpl value, $Res Function(_$SdkEvent_PaymentRefundedImpl) then) =

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4790,6 +4790,10 @@ final class wire_cst_SdkEvent_PaymentPending extends ffi.Struct {
   external ffi.Pointer<wire_cst_payment> details;
 }
 
+final class wire_cst_SdkEvent_PaymentRefundable extends ffi.Struct {
+  external ffi.Pointer<wire_cst_payment> details;
+}
+
 final class wire_cst_SdkEvent_PaymentRefunded extends ffi.Struct {
   external ffi.Pointer<wire_cst_payment> details;
 }
@@ -4814,6 +4818,8 @@ final class SdkEventKind extends ffi.Union {
   external wire_cst_SdkEvent_PaymentFailed PaymentFailed;
 
   external wire_cst_SdkEvent_PaymentPending PaymentPending;
+
+  external wire_cst_SdkEvent_PaymentRefundable PaymentRefundable;
 
   external wire_cst_SdkEvent_PaymentRefunded PaymentRefunded;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3436,6 +3436,10 @@ fun asSdkEvent(sdkEvent: ReadableMap): SdkEvent? {
         val details = sdkEvent.getMap("details")?.let { asPayment(it) }!!
         return SdkEvent.PaymentPending(details)
     }
+    if (type == "paymentRefundable") {
+        val details = sdkEvent.getMap("details")?.let { asPayment(it) }!!
+        return SdkEvent.PaymentRefundable(details)
+    }
     if (type == "paymentRefunded") {
         val details = sdkEvent.getMap("details")?.let { asPayment(it) }!!
         return SdkEvent.PaymentRefunded(details)
@@ -3471,6 +3475,10 @@ fun readableMapOf(sdkEvent: SdkEvent): ReadableMap? {
         }
         is SdkEvent.PaymentPending -> {
             pushToMap(map, "type", "paymentPending")
+            pushToMap(map, "details", readableMapOf(sdkEvent.details))
+        }
+        is SdkEvent.PaymentRefundable -> {
+            pushToMap(map, "type", "paymentRefundable")
             pushToMap(map, "details", readableMapOf(sdkEvent.details))
         }
         is SdkEvent.PaymentRefunded -> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4249,6 +4249,14 @@ enum BreezSDKLiquidMapper {
 
             return SdkEvent.paymentPending(details: _details)
         }
+        if type == "paymentRefundable" {
+            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+            }
+            let _details = try asPayment(payment: detailsTmp)
+
+            return SdkEvent.paymentRefundable(details: _details)
+        }
         if type == "paymentRefunded" {
             guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
@@ -4311,6 +4319,14 @@ enum BreezSDKLiquidMapper {
         ):
             return [
                 "type": "paymentPending",
+                "details": dictionaryOf(payment: details),
+            ]
+
+        case let .paymentRefundable(
+            details
+        ):
+            return [
+                "type": "paymentRefundable",
                 "details": dictionaryOf(payment: details),
             ]
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -691,6 +691,7 @@ export enum PaymentType {
 export enum SdkEventVariant {
     PAYMENT_FAILED = "paymentFailed",
     PAYMENT_PENDING = "paymentPending",
+    PAYMENT_REFUNDABLE = "paymentRefundable",
     PAYMENT_REFUNDED = "paymentRefunded",
     PAYMENT_REFUND_PENDING = "paymentRefundPending",
     PAYMENT_SUCCEEDED = "paymentSucceeded",
@@ -704,6 +705,9 @@ export type SdkEvent = {
     details: Payment
 } | {
     type: SdkEventVariant.PAYMENT_PENDING,
+    details: Payment
+} | {
+    type: SdkEventVariant.PAYMENT_REFUNDABLE,
     details: Payment
 } | {
     type: SdkEventVariant.PAYMENT_REFUNDED,


### PR DESCRIPTION
This adds a new PaymentRefundable event for when a swap gets into the state Refundable. Integrators can use it to trigger a refresh of the refundable swap list.