### PR TITLE
Clarify refund address input docs

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -62,7 +62,7 @@ pub struct Config {
     /// external parsing.
     pub external_input_parsers: Option<Vec<ExternalInputParser>>,
     /// The SDK includes some default external input parsers
-    /// ([DEFAULT_EXTERNAL_INPUT_PARSERS](crate::sdk::DEFAULT_EXTERNAL_INPUT_PARSERS)).
+    /// ([DEFAULT_EXTERNAL_INPUT_PARSERS].
     /// Set this to false in order to prevent their use.
     pub use_default_external_input_parsers: bool,
     /// For payments where the onchain fees can only be estimated on creation, this can be used
@@ -1320,7 +1320,7 @@ pub struct PaymentTxData {
     pub is_confirmed: bool,
 
     /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
-    /// See: https://docs.liquid.net/docs/unblinding-transactions
+    /// See: <https://docs.liquid.net/docs/unblinding-transactions>
     pub unblinding_data: Option<String>,
 }
 
@@ -1490,7 +1490,7 @@ pub struct Payment {
     pub tx_id: Option<String>,
 
     /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
-    /// See: https://docs.liquid.net/docs/unblinding-transactions
+    /// See: <https://docs.liquid.net/docs/unblinding-transactions>
     pub unblinding_data: Option<String>,
 
     /// Composite timestamp that can be used for sorting or displaying the payment.

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -502,7 +502,10 @@ pub struct PayOnchainRequest {
 pub struct PrepareRefundRequest {
     /// The address where the swap funds are locked up
     pub swap_address: String,
-    /// The address to refund the swap funds to
+    /// The Bitcoin address to refund to. To ensure a valid address is
+    /// provided, user input should be validated using
+    /// [LiquidSdk::parse](crate::sdk::LiquidSdk::parse), and `refund_address`
+    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     pub refund_address: String,
     /// The fee rate in sat/vB for the refund transaction
     pub fee_rate_sat_per_vbyte: u32,
@@ -521,7 +524,10 @@ pub struct PrepareRefundResponse {
 pub struct RefundRequest {
     /// The address where the swap funds are locked up
     pub swap_address: String,
-    /// The address to refund the swap funds to
+    /// The Bitcoin address to refund to. To ensure a valid address is
+    /// provided, user input should be validated using
+    /// [LiquidSdk::parse](crate::sdk::LiquidSdk::parse), and `refund_address`
+    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     pub refund_address: String,
     /// The fee rate in sat/vB for the refund transaction
     pub fee_rate_sat_per_vbyte: u32,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2203,7 +2203,9 @@ impl LiquidSdk {
     ///
     /// * `req` - the [PrepareRefundRequest] containing:
     ///     * `swap_address` - the swap address to refund from [RefundableSwap::swap_address]
-    ///     * `refund_address` - the Bitcoin address to refund to
+    ///     * `refund_address` - the Bitcoin address to refund to. To ensure a valid address is
+    /// provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
+    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     ///     * `fee_rate_sat_per_vbyte` - the fee rate at which to broadcast the refund transaction
     pub async fn prepare_refund(
         &self,
@@ -2230,7 +2232,9 @@ impl LiquidSdk {
     ///
     /// * `req` - the [RefundRequest] containing:
     ///     * `swap_address` - the swap address to refund from [RefundableSwap::swap_address]
-    ///     * `refund_address` - the Bitcoin address to refund to
+    ///     * `refund_address` - the Bitcoin address to refund to. To ensure a valid address is
+    /// provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
+    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     ///     * `fee_rate_sat_per_vbyte` - the fee rate at which to broadcast the refund transaction
     pub async fn refund(&self, req: &RefundRequest) -> Result<RefundResponse, PaymentError> {
         let refund_tx_id = self

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2204,8 +2204,8 @@ impl LiquidSdk {
     /// * `req` - the [PrepareRefundRequest] containing:
     ///     * `swap_address` - the swap address to refund from [RefundableSwap::swap_address]
     ///     * `refund_address` - the Bitcoin address to refund to. To ensure a valid address is
-    /// provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
-    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
+    ///         provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
+    ///         should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     ///     * `fee_rate_sat_per_vbyte` - the fee rate at which to broadcast the refund transaction
     pub async fn prepare_refund(
         &self,
@@ -2233,8 +2233,8 @@ impl LiquidSdk {
     /// * `req` - the [RefundRequest] containing:
     ///     * `swap_address` - the swap address to refund from [RefundableSwap::swap_address]
     ///     * `refund_address` - the Bitcoin address to refund to. To ensure a valid address is
-    /// provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
-    /// should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
+    ///         provided, user input should be validated using [LiquidSdk::parse], and `refund_address`
+    ///         should be obtained from the [BitcoinAddressData] in [InputType::BitcoinAddress].
     ///     * `fee_rate_sat_per_vbyte` - the fee rate at which to broadcast the refund transaction
     pub async fn refund(&self, req: &RefundRequest) -> Result<RefundResponse, PaymentError> {
         let refund_tx_id = self


### PR DESCRIPTION
This adds documentation suggesting that integrators provide a refund address as parsed by the parse method.

Also, it fixes some warnings from cargo doc.