### PR TITLE
Set specific rev for Boltz client crate

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.2.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=540b5cb6505a97f1d02d846bf544bd5c1f800b25#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
 dependencies = [
  "bip39",
  "bitcoin 0.32.4",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", branch = "trunk" }
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "540b5cb6505a97f1d02d846bf544bd5c1f800b25" }
 chrono = "0.4"
 derivative = "2.2.0"
 env_logger = "0.11"
@@ -49,7 +49,7 @@ futures-util = { version = "0.3.28", default-features = false, features = [
 async-trait = "0.1.80"
 hex = "0.4"
 reqwest = { version = "=0.11.20", features = ["json"] }
-electrum-client = { version = "0.21.0", default-features=false, features = [
+electrum-client = { version = "0.21.0", default-features = false, features = [
     "use-rustls-ring",
     "proxy",
 ] }


### PR DESCRIPTION
This prevents issues with using the SDK as a rust dependency. When added to a new project, the dependencies are not locked, causing issues if boltz client suffers some non-backward compatible change to the interface.

CI was currently failing for this exact reason. #682 also fixes the CI failure by upgrading the SDK, but we should specify the rev regardless.