### PR TITLE
Set payment destination as mandatory

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -489,8 +489,8 @@ typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *swap_id;
   struct wire_cst_list_prim_u_8_strict *description;
   uint32_t liquid_expiration_blockheight;
-  struct wire_cst_list_prim_u_8_strict *preimage;
   struct wire_cst_list_prim_u_8_strict *invoice;
+  struct wire_cst_list_prim_u_8_strict *preimage;
   struct wire_cst_list_prim_u_8_strict *bolt12_offer;
   struct wire_cst_list_prim_u_8_strict *payment_hash;
   struct wire_cst_list_prim_u_8_strict *destination_pubkey;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -580,12 +580,13 @@ dictionary LnUrlInfo {
 
 [Enum]
 interface PaymentDetails {
-    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string invoice, string? preimage, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
     Bitcoin(string swap_id, string description, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {
+    string destination;
     u32 timestamp;
     u64 amount_sat;
     u64 fees_sat;
@@ -593,7 +594,6 @@ dictionary Payment {
     PaymentState status;
     PaymentDetails details;
     u64? swapper_fees_sat = null;
-    string? destination = null;
     string? tx_id = null;
     string? unblinding_data = null;
 };

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3736,7 +3736,7 @@ impl SseDecode for crate::model::PayOnchainRequest {
 impl SseDecode for crate::model::Payment {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_destination = <Option<String>>::sse_decode(deserializer);
+        let mut var_destination = <String>::sse_decode(deserializer);
         let mut var_txId = <Option<String>>::sse_decode(deserializer);
         let mut var_unblindingData = <Option<String>>::sse_decode(deserializer);
         let mut var_timestamp = <u32>::sse_decode(deserializer);
@@ -3770,8 +3770,8 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_swapId = <String>::sse_decode(deserializer);
                 let mut var_description = <String>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <u32>::sse_decode(deserializer);
+                let mut var_invoice = <String>::sse_decode(deserializer);
                 let mut var_preimage = <Option<String>>::sse_decode(deserializer);
-                let mut var_invoice = <Option<String>>::sse_decode(deserializer);
                 let mut var_bolt12Offer = <Option<String>>::sse_decode(deserializer);
                 let mut var_paymentHash = <Option<String>>::sse_decode(deserializer);
                 let mut var_destinationPubkey = <Option<String>>::sse_decode(deserializer);
@@ -3782,8 +3782,8 @@ impl SseDecode for crate::model::PaymentDetails {
                     swap_id: var_swapId,
                     description: var_description,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
-                    preimage: var_preimage,
                     invoice: var_invoice,
+                    preimage: var_preimage,
                     bolt12_offer: var_bolt12Offer,
                     payment_hash: var_paymentHash,
                     destination_pubkey: var_destinationPubkey,
@@ -5954,8 +5954,8 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 swap_id,
                 description,
                 liquid_expiration_blockheight,
-                preimage,
                 invoice,
+                preimage,
                 bolt12_offer,
                 payment_hash,
                 destination_pubkey,
@@ -5967,8 +5967,8 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 swap_id.into_into_dart().into_dart(),
                 description.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
-                preimage.into_into_dart().into_dart(),
                 invoice.into_into_dart().into_dart(),
+                preimage.into_into_dart().into_dart(),
                 bolt12_offer.into_into_dart().into_dart(),
                 payment_hash.into_into_dart().into_dart(),
                 destination_pubkey.into_into_dart().into_dart(),
@@ -8055,7 +8055,7 @@ impl SseEncode for crate::model::PayOnchainRequest {
 impl SseEncode for crate::model::Payment {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <Option<String>>::sse_encode(self.destination, serializer);
+        <String>::sse_encode(self.destination, serializer);
         <Option<String>>::sse_encode(self.tx_id, serializer);
         <Option<String>>::sse_encode(self.unblinding_data, serializer);
         <u32>::sse_encode(self.timestamp, serializer);
@@ -8076,8 +8076,8 @@ impl SseEncode for crate::model::PaymentDetails {
                 swap_id,
                 description,
                 liquid_expiration_blockheight,
-                preimage,
                 invoice,
+                preimage,
                 bolt12_offer,
                 payment_hash,
                 destination_pubkey,
@@ -8089,8 +8089,8 @@ impl SseEncode for crate::model::PaymentDetails {
                 <String>::sse_encode(swap_id, serializer);
                 <String>::sse_encode(description, serializer);
                 <u32>::sse_encode(liquid_expiration_blockheight, serializer);
+                <String>::sse_encode(invoice, serializer);
                 <Option<String>>::sse_encode(preimage, serializer);
-                <Option<String>>::sse_encode(invoice, serializer);
                 <Option<String>>::sse_encode(bolt12_offer, serializer);
                 <Option<String>>::sse_encode(payment_hash, serializer);
                 <Option<String>>::sse_encode(destination_pubkey, serializer);
@@ -10183,8 +10183,8 @@ mod io {
                         liquid_expiration_blockheight: ans
                             .liquid_expiration_blockheight
                             .cst_decode(),
-                        preimage: ans.preimage.cst_decode(),
                         invoice: ans.invoice.cst_decode(),
+                        preimage: ans.preimage.cst_decode(),
                         bolt12_offer: ans.bolt12_offer.cst_decode(),
                         payment_hash: ans.payment_hash.cst_decode(),
                         destination_pubkey: ans.destination_pubkey.cst_decode(),
@@ -13784,8 +13784,8 @@ mod io {
         swap_id: *mut wire_cst_list_prim_u_8_strict,
         description: *mut wire_cst_list_prim_u_8_strict,
         liquid_expiration_blockheight: u32,
-        preimage: *mut wire_cst_list_prim_u_8_strict,
         invoice: *mut wire_cst_list_prim_u_8_strict,
+        preimage: *mut wire_cst_list_prim_u_8_strict,
         bolt12_offer: *mut wire_cst_list_prim_u_8_strict,
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
         destination_pubkey: *mut wire_cst_list_prim_u_8_strict,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2910,13 +2910,11 @@ impl LiquidSdk {
             Some(_) => None,
             None => Some(prepare_response.data.domain),
         };
-        if let (Some(tx_id), Some(destination)) =
-            (payment.tx_id.clone(), payment.destination.clone())
-        {
+        if let Some(tx_id) = payment.tx_id.clone() {
             self.persister
                 .insert_or_update_payment_details(PaymentTxDetails {
                     tx_id,
-                    destination,
+                    destination: payment.destination.clone(),
                     description: prepare_response.comment.clone(),
                     lnurl_info: Some(LnUrlInfo {
                         ln_address: prepare_response.data.ln_address,

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2669,7 +2669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final arr = raw as List<dynamic>;
     if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return Payment(
-      destination: dco_decode_opt_String(arr[0]),
+      destination: dco_decode_String(arr[0]),
       txId: dco_decode_opt_String(arr[1]),
       unblindingData: dco_decode_opt_String(arr[2]),
       timestamp: dco_decode_u_32(arr[3]),
@@ -2691,8 +2691,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           swapId: dco_decode_String(raw[1]),
           description: dco_decode_String(raw[2]),
           liquidExpirationBlockheight: dco_decode_u_32(raw[3]),
-          preimage: dco_decode_opt_String(raw[4]),
-          invoice: dco_decode_opt_String(raw[5]),
+          invoice: dco_decode_String(raw[4]),
+          preimage: dco_decode_opt_String(raw[5]),
           bolt12Offer: dco_decode_opt_String(raw[6]),
           paymentHash: dco_decode_opt_String(raw[7]),
           destinationPubkey: dco_decode_opt_String(raw[8]),
@@ -4838,7 +4838,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Payment sse_decode_payment(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_destination = sse_decode_opt_String(deserializer);
+    var var_destination = sse_decode_String(deserializer);
     var var_txId = sse_decode_opt_String(deserializer);
     var var_unblindingData = sse_decode_opt_String(deserializer);
     var var_timestamp = sse_decode_u_32(deserializer);
@@ -4871,8 +4871,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_swapId = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_u_32(deserializer);
+        var var_invoice = sse_decode_String(deserializer);
         var var_preimage = sse_decode_opt_String(deserializer);
-        var var_invoice = sse_decode_opt_String(deserializer);
         var var_bolt12Offer = sse_decode_opt_String(deserializer);
         var var_paymentHash = sse_decode_opt_String(deserializer);
         var var_destinationPubkey = sse_decode_opt_String(deserializer);
@@ -4883,8 +4883,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             swapId: var_swapId,
             description: var_description,
             liquidExpirationBlockheight: var_liquidExpirationBlockheight,
-            preimage: var_preimage,
             invoice: var_invoice,
+            preimage: var_preimage,
             bolt12Offer: var_bolt12Offer,
             paymentHash: var_paymentHash,
             destinationPubkey: var_destinationPubkey,
@@ -6860,7 +6860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_payment(Payment self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_opt_String(self.destination, serializer);
+    sse_encode_String(self.destination, serializer);
     sse_encode_opt_String(self.txId, serializer);
     sse_encode_opt_String(self.unblindingData, serializer);
     sse_encode_u_32(self.timestamp, serializer);
@@ -6880,8 +6880,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           swapId: final swapId,
           description: final description,
           liquidExpirationBlockheight: final liquidExpirationBlockheight,
-          preimage: final preimage,
           invoice: final invoice,
+          preimage: final preimage,
           bolt12Offer: final bolt12Offer,
           paymentHash: final paymentHash,
           destinationPubkey: final destinationPubkey,
@@ -6893,8 +6893,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(swapId, serializer);
         sse_encode_String(description, serializer);
         sse_encode_u_32(liquidExpirationBlockheight, serializer);
+        sse_encode_String(invoice, serializer);
         sse_encode_opt_String(preimage, serializer);
-        sse_encode_opt_String(invoice, serializer);
         sse_encode_opt_String(bolt12Offer, serializer);
         sse_encode_opt_String(paymentHash, serializer);
         sse_encode_opt_String(destinationPubkey, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2927,7 +2927,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_payment(Payment apiObj, wire_cst_payment wireObj) {
-    wireObj.destination = cst_encode_opt_String(apiObj.destination);
+    wireObj.destination = cst_encode_String(apiObj.destination);
     wireObj.tx_id = cst_encode_opt_String(apiObj.txId);
     wireObj.unblinding_data = cst_encode_opt_String(apiObj.unblindingData);
     wireObj.timestamp = cst_encode_u_32(apiObj.timestamp);
@@ -2945,8 +2945,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_swap_id = cst_encode_String(apiObj.swapId);
       var pre_description = cst_encode_String(apiObj.description);
       var pre_liquid_expiration_blockheight = cst_encode_u_32(apiObj.liquidExpirationBlockheight);
+      var pre_invoice = cst_encode_String(apiObj.invoice);
       var pre_preimage = cst_encode_opt_String(apiObj.preimage);
-      var pre_invoice = cst_encode_opt_String(apiObj.invoice);
       var pre_bolt12_offer = cst_encode_opt_String(apiObj.bolt12Offer);
       var pre_payment_hash = cst_encode_opt_String(apiObj.paymentHash);
       var pre_destination_pubkey = cst_encode_opt_String(apiObj.destinationPubkey);
@@ -2957,8 +2957,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.swap_id = pre_swap_id;
       wireObj.kind.Lightning.description = pre_description;
       wireObj.kind.Lightning.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
-      wireObj.kind.Lightning.preimage = pre_preimage;
       wireObj.kind.Lightning.invoice = pre_invoice;
+      wireObj.kind.Lightning.preimage = pre_preimage;
       wireObj.kind.Lightning.bolt12_offer = pre_bolt12_offer;
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
       wireObj.kind.Lightning.destination_pubkey = pre_destination_pubkey;
@@ -6380,9 +6380,9 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   @ffi.Uint32()
   external int liquid_expiration_blockheight;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
-
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> invoice;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -678,7 +678,7 @@ class PayOnchainRequest {
 class Payment {
   /// The destination associated with the payment, if it was created via our SDK.
   /// Can be either a Liquid/Bitcoin address, a Liquid BIP21 URI or an invoice
-  final String? destination;
+  final String destination;
   final String? txId;
 
   /// Data to use in the `blinded` param when unblinding the transaction in an explorer.
@@ -731,7 +731,7 @@ class Payment {
   final PaymentDetails details;
 
   const Payment({
-    this.destination,
+    required this.destination,
     this.txId,
     this.unblindingData,
     required this.timestamp,
@@ -787,13 +787,11 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// The height of the block at which the swap will no longer be valid
     required int liquidExpirationBlockheight,
 
+    /// Represents the Bolt11/Bolt12 invoice associated with a payment
+    required String invoice,
+
     /// The preimage of the paid invoice (proof of payment).
     String? preimage,
-
-    /// Represents the Bolt11/Bolt12 invoice associated with a payment
-    /// In the case of a Send payment, this is the invoice paid by the swapper
-    /// In the case of a Receive payment, this is the invoice paid by the user
-    String? invoice,
     String? bolt12Offer,
 
     /// The payment hash of the invoice

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -792,8 +792,8 @@ abstract class _$$PaymentDetails_LightningImplCopyWith<$Res> implements $Payment
       {String swapId,
       String description,
       int liquidExpirationBlockheight,
+      String invoice,
       String? preimage,
-      String? invoice,
       String? bolt12Offer,
       String? paymentHash,
       String? destinationPubkey,
@@ -818,8 +818,8 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
     Object? swapId = null,
     Object? description = null,
     Object? liquidExpirationBlockheight = null,
+    Object? invoice = null,
     Object? preimage = freezed,
-    Object? invoice = freezed,
     Object? bolt12Offer = freezed,
     Object? paymentHash = freezed,
     Object? destinationPubkey = freezed,
@@ -840,13 +840,13 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
           ? _value.liquidExpirationBlockheight
           : liquidExpirationBlockheight // ignore: cast_nullable_to_non_nullable
               as int,
+      invoice: null == invoice
+          ? _value.invoice
+          : invoice // ignore: cast_nullable_to_non_nullable
+              as String,
       preimage: freezed == preimage
           ? _value.preimage
           : preimage // ignore: cast_nullable_to_non_nullable
-              as String?,
-      invoice: freezed == invoice
-          ? _value.invoice
-          : invoice // ignore: cast_nullable_to_non_nullable
               as String?,
       bolt12Offer: freezed == bolt12Offer
           ? _value.bolt12Offer
@@ -883,8 +883,8 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
       {required this.swapId,
       required this.description,
       required this.liquidExpirationBlockheight,
+      required this.invoice,
       this.preimage,
-      this.invoice,
       this.bolt12Offer,
       this.paymentHash,
       this.destinationPubkey,
@@ -904,15 +904,13 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   @override
   final int liquidExpirationBlockheight;
 
+  /// Represents the Bolt11/Bolt12 invoice associated with a payment
+  @override
+  final String invoice;
+
   /// The preimage of the paid invoice (proof of payment).
   @override
   final String? preimage;
-
-  /// Represents the Bolt11/Bolt12 invoice associated with a payment
-  /// In the case of a Send payment, this is the invoice paid by the swapper
-  /// In the case of a Receive payment, this is the invoice paid by the user
-  @override
-  final String? invoice;
   @override
   final String? bolt12Offer;
 
@@ -938,7 +936,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   String toString() {
-    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, preimage: $preimage, invoice: $invoice, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, destinationPubkey: $destinationPubkey, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, invoice: $invoice, preimage: $preimage, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, destinationPubkey: $destinationPubkey, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -950,8 +948,8 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
             (identical(other.description, description) || other.description == description) &&
             (identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) ||
                 other.liquidExpirationBlockheight == liquidExpirationBlockheight) &&
-            (identical(other.preimage, preimage) || other.preimage == preimage) &&
             (identical(other.invoice, invoice) || other.invoice == invoice) &&
+            (identical(other.preimage, preimage) || other.preimage == preimage) &&
             (identical(other.bolt12Offer, bolt12Offer) || other.bolt12Offer == bolt12Offer) &&
             (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash) &&
             (identical(other.destinationPubkey, destinationPubkey) ||
@@ -963,8 +961,8 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight, preimage,
-      invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat);
+  int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight, invoice,
+      preimage, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -980,8 +978,8 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
       {required final String swapId,
       required final String description,
       required final int liquidExpirationBlockheight,
+      required final String invoice,
       final String? preimage,
-      final String? invoice,
       final String? bolt12Offer,
       final String? paymentHash,
       final String? destinationPubkey,
@@ -999,13 +997,11 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
   /// The height of the block at which the swap will no longer be valid
   int get liquidExpirationBlockheight;
 
+  /// Represents the Bolt11/Bolt12 invoice associated with a payment
+  String get invoice;
+
   /// The preimage of the paid invoice (proof of payment).
   String? get preimage;
-
-  /// Represents the Bolt11/Bolt12 invoice associated with a payment
-  /// In the case of a Send payment, this is the invoice paid by the swapper
-  /// In the case of a Receive payment, this is the invoice paid by the user
-  String? get invoice;
   String? get bolt12Offer;
 
   /// The payment hash of the invoice

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4703,9 +4703,9 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
   @ffi.Uint32()
   external int liquid_expiration_blockheight;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
-
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> invoice;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> preimage;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> bolt12_offer;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1628,6 +1628,7 @@ fun asPayment(payment: ReadableMap): Payment? {
     if (!validateMandatoryFields(
             payment,
             arrayOf(
+                "destination",
                 "timestamp",
                 "amountSat",
                 "feesSat",
@@ -1639,6 +1640,7 @@ fun asPayment(payment: ReadableMap): Payment? {
     ) {
         return null
     }
+    val destination = payment.getString("destination")!!
     val timestamp = payment.getInt("timestamp").toUInt()
     val amountSat = payment.getDouble("amountSat").toULong()
     val feesSat = payment.getDouble("feesSat").toULong()
@@ -1646,14 +1648,14 @@ fun asPayment(payment: ReadableMap): Payment? {
     val status = payment.getString("status")?.let { asPaymentState(it) }!!
     val details = payment.getMap("details")?.let { asPaymentDetails(it) }!!
     val swapperFeesSat = if (hasNonNullKey(payment, "swapperFeesSat")) payment.getDouble("swapperFeesSat").toULong() else null
-    val destination = if (hasNonNullKey(payment, "destination")) payment.getString("destination") else null
     val txId = if (hasNonNullKey(payment, "txId")) payment.getString("txId") else null
     val unblindingData = if (hasNonNullKey(payment, "unblindingData")) payment.getString("unblindingData") else null
-    return Payment(timestamp, amountSat, feesSat, paymentType, status, details, swapperFeesSat, destination, txId, unblindingData)
+    return Payment(destination, timestamp, amountSat, feesSat, paymentType, status, details, swapperFeesSat, txId, unblindingData)
 }
 
 fun readableMapOf(payment: Payment): ReadableMap =
     readableMapOf(
+        "destination" to payment.destination,
         "timestamp" to payment.timestamp,
         "amountSat" to payment.amountSat,
         "feesSat" to payment.feesSat,
@@ -1661,7 +1663,6 @@ fun readableMapOf(payment: Payment): ReadableMap =
         "status" to payment.status.name.lowercase(),
         "details" to readableMapOf(payment.details),
         "swapperFeesSat" to payment.swapperFeesSat,
-        "destination" to payment.destination,
         "txId" to payment.txId,
         "unblindingData" to payment.unblindingData,
     )
@@ -3240,8 +3241,8 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
         val swapId = paymentDetails.getString("swapId")!!
         val description = paymentDetails.getString("description")!!
         val liquidExpirationBlockheight = paymentDetails.getInt("liquidExpirationBlockheight").toUInt()
+        val invoice = paymentDetails.getString("invoice")!!
         val preimage = if (hasNonNullKey(paymentDetails, "preimage")) paymentDetails.getString("preimage") else null
-        val invoice = if (hasNonNullKey(paymentDetails, "invoice")) paymentDetails.getString("invoice") else null
         val bolt12Offer = if (hasNonNullKey(paymentDetails, "bolt12Offer")) paymentDetails.getString("bolt12Offer") else null
         val paymentHash = if (hasNonNullKey(paymentDetails, "paymentHash")) paymentDetails.getString("paymentHash") else null
         val destinationPubkey =
@@ -3279,8 +3280,8 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             swapId,
             description,
             liquidExpirationBlockheight,
-            preimage,
             invoice,
+            preimage,
             bolt12Offer,
             paymentHash,
             destinationPubkey,
@@ -3348,8 +3349,8 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "swapId", paymentDetails.swapId)
             pushToMap(map, "description", paymentDetails.description)
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
-            pushToMap(map, "preimage", paymentDetails.preimage)
             pushToMap(map, "invoice", paymentDetails.invoice)
+            pushToMap(map, "preimage", paymentDetails.preimage)
             pushToMap(map, "bolt12Offer", paymentDetails.bolt12Offer)
             pushToMap(map, "paymentHash", paymentDetails.paymentHash)
             pushToMap(map, "destinationPubkey", paymentDetails.destinationPubkey)

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1888,6 +1888,9 @@ enum BreezSDKLiquidMapper {
     }
 
     static func asPayment(payment: [String: Any?]) throws -> Payment {
+        guard let destination = payment["destination"] as? String else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "Payment"))
+        }
         guard let timestamp = payment["timestamp"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "Payment"))
         }
@@ -1919,13 +1922,6 @@ enum BreezSDKLiquidMapper {
             }
             swapperFeesSat = swapperFeesSatTmp
         }
-        var destination: String?
-        if hasNonNilKey(data: payment, key: "destination") {
-            guard let destinationTmp = payment["destination"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "destination"))
-            }
-            destination = destinationTmp
-        }
         var txId: String?
         if hasNonNilKey(data: payment, key: "txId") {
             guard let txIdTmp = payment["txId"] as? String else {
@@ -1941,11 +1937,12 @@ enum BreezSDKLiquidMapper {
             unblindingData = unblindingDataTmp
         }
 
-        return Payment(timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, destination: destination, txId: txId, unblindingData: unblindingData)
+        return Payment(destination: destination, timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, txId: txId, unblindingData: unblindingData)
     }
 
     static func dictionaryOf(payment: Payment) -> [String: Any?] {
         return [
+            "destination": payment.destination,
             "timestamp": payment.timestamp,
             "amountSat": payment.amountSat,
             "feesSat": payment.feesSat,
@@ -1953,7 +1950,6 @@ enum BreezSDKLiquidMapper {
             "status": valueOf(paymentState: payment.status),
             "details": dictionaryOf(paymentDetails: payment.details),
             "swapperFeesSat": payment.swapperFeesSat == nil ? nil : payment.swapperFeesSat,
-            "destination": payment.destination == nil ? nil : payment.destination,
             "txId": payment.txId == nil ? nil : payment.txId,
             "unblindingData": payment.unblindingData == nil ? nil : payment.unblindingData,
         ]
@@ -3960,9 +3956,10 @@ enum BreezSDKLiquidMapper {
             guard let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32 else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidExpirationBlockheight", typeName: "PaymentDetails"))
             }
+            guard let _invoice = paymentDetails["invoice"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "PaymentDetails"))
+            }
             let _preimage = paymentDetails["preimage"] as? String
-
-            let _invoice = paymentDetails["invoice"] as? String
 
             let _bolt12Offer = paymentDetails["bolt12Offer"] as? String
 
@@ -3979,7 +3976,7 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, invoice: _invoice, preimage: _preimage, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
         if type == "liquid" {
             guard let _destination = paymentDetails["destination"] as? String else {
@@ -4014,15 +4011,15 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
         switch paymentDetails {
         case let .lightning(
-            swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat
+            swapId, description, liquidExpirationBlockheight, invoice, preimage, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "lightning",
                 "swapId": swapId,
                 "description": description,
                 "liquidExpirationBlockheight": liquidExpirationBlockheight,
+                "invoice": invoice,
                 "preimage": preimage == nil ? nil : preimage,
-                "invoice": invoice == nil ? nil : invoice,
                 "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
                 "paymentHash": paymentHash == nil ? nil : paymentHash,
                 "destinationPubkey": destinationPubkey == nil ? nil : destinationPubkey,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -286,6 +286,7 @@ export interface PayOnchainRequest {
 }
 
 export interface Payment {
+    destination: string
     timestamp: number
     amountSat: number
     feesSat: number
@@ -293,7 +294,6 @@ export interface Payment {
     status: PaymentState
     details: PaymentDetails
     swapperFeesSat?: number
-    destination?: string
     txId?: string
     unblindingData?: string
 }
@@ -644,8 +644,8 @@ export type PaymentDetails = {
     swapId: string
     description: string
     liquidExpirationBlockheight: number
+    invoice: string
     preimage?: string
-    invoice?: string
     bolt12Offer?: string
     paymentHash?: string
     destinationPubkey?: string


### PR DESCRIPTION
Closes #481.

This PR:
- [X] Changes the `PaymentSwapData` structure to an enum, to better predict which fields are going to be present at any point during execution, especially when calculating the destination
- [x] Selects a `claim_address` in case of a Receive Chain swap on creation, so that we may display to the user where they will receive their funds