### PR TITLE
Validate refund address input

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.2.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=540b5cb6505a97f1d02d846bf544bd5c1f800b25#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
 dependencies = [
  "bip39",
  "bitcoin 0.32.5",


### PR DESCRIPTION
This adds validation of the refund_address input for the refund methods. Besides leading to more comprehensible errors in case of an invalid input, it also allows the use of the BIP21 format as input.