### PR TITLE
Chain swap refund tx fee bumping

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.2.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=540b5cb6505a97f1d02d846bf544bd5c1f800b25#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=e3e87186604c818c667b1293149423af5757dfbe#e3e87186604c818c667b1293149423af5757dfbe"
 dependencies = [
  "bip39",
  "bitcoin 0.32.5",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -200,43 +200,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 dependencies = [
  "backtrace",
 ]
@@ -304,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -351,7 +352,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -363,7 +364,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -375,14 +376,14 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -391,24 +392,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -436,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -453,7 +454,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -478,7 +479,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -489,7 +490,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -521,13 +522,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -553,7 +554,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "bitcoin_hashes 0.14.0",
 ]
 
@@ -618,7 +619,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "uniffi 0.23.0",
@@ -639,11 +640,11 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
+checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
 dependencies = [
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -663,22 +664,28 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.0",
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1 0.29.1",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -707,7 +714,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "serde",
 ]
 
@@ -719,12 +726,22 @@ checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -747,7 +764,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "serde",
  "serde_json",
 ]
@@ -760,9 +777,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
@@ -802,10 +819,10 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.2.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=540b5cb6505a97f1d02d846bf544bd5c1f800b25#540b5cb6505a97f1d02d846bf544bd5c1f800b25"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=e3e87186604c818c667b1293149423af5757dfbe#e3e87186604c818c667b1293149423af5757dfbe"
 dependencies = [
  "bip39",
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "electrum-client",
  "elements",
  "env_logger 0.7.1",
@@ -832,7 +849,7 @@ dependencies = [
  "derivative",
  "ecies",
  "electrum-client",
- "env_logger 0.11.5",
+ "env_logger 0.11.6",
  "flutter_rust_bridge",
  "futures-util",
  "glob",
@@ -858,7 +875,7 @@ dependencies = [
  "strum_macros",
  "tempdir",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -880,7 +897,7 @@ dependencies = [
  "glob",
  "log",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uniffi 0.25.3",
  "uniffi_bindgen 0.25.3",
@@ -901,9 +918,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -913,9 +930,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "camino"
@@ -928,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -946,7 +963,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -960,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -972,6 +989,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -999,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1051,23 +1074,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.13",
+ "clap_derive 4.5.24",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.2",
+ "clap_lex 0.7.4",
  "strsim 0.11.1",
 ]
 
@@ -1086,14 +1109,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1107,15 +1130,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -1154,9 +1177,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -1178,9 +1201,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1224,7 +1247,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1296,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "delegate-attr"
@@ -1308,7 +1331,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1373,7 +1396,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1405,11 +1428,11 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0bd443023f9f5c4b7153053721939accc7113cbdf810a024434eed454b3db1"
 dependencies = [
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.12",
+ "rustls 0.23.21",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1423,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ab681914c4d96235d4c30d6a758f4aeb4eace26837f4995ca84bf7ea3189ea"
 dependencies = [
  "bech32 0.11.0",
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1435,7 +1458,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571fa105690f83c7833df2109eb2e14ca0e62d633d2624ffcb166ff18a3da870"
 dependencies = [
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "elements",
  "miniscript",
  "serde",
@@ -1443,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1459,14 +1482,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -1497,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1516,12 +1539,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1538,9 +1561,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
@@ -1565,9 +1588,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1614,7 +1637,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1657,7 +1680,7 @@ dependencies = [
  "md-5",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1707,9 +1730,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1722,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1732,15 +1755,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1749,38 +1772,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1828,15 +1851,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "goblin"
@@ -1861,7 +1884,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1870,17 +1893,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.5.0",
+ "http 1.2.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1907,6 +1930,12 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -1952,6 +1981,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
+name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
@@ -1983,7 +2018,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "ring 0.16.20",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2006,7 +2041,7 @@ dependencies = [
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -2031,11 +2066,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2062,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -2089,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -2100,16 +2135,16 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2134,9 +2169,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2158,15 +2193,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.7",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2179,20 +2214,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
- "rustls 0.23.12",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -2201,7 +2236,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2213,7 +2248,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.5.2",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2227,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2242,9 +2277,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2262,7 +2297,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
 ]
 
@@ -2282,7 +2317,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rust-embed",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
  "walkdir",
 ]
@@ -2304,7 +2339,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.87",
+ "syn 2.0.96",
  "unic-langid",
 ]
 
@@ -2318,14 +2353,14 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2459,7 +2494,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2473,16 +2508,6 @@ name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2540,12 +2565,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2606,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2626,17 +2651,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2660,9 +2695,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libsecp256k1"
@@ -2736,7 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "lightning-invoice 0.32.0",
  "lightning-types",
 ]
@@ -2762,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "lightning-types",
 ]
 
@@ -2773,8 +2808,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.4",
- "hex-conservative",
+ "bitcoin 0.32.5",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -2785,9 +2820,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2807,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru-cache"
@@ -2832,7 +2867,7 @@ dependencies = [
  "getrandom",
  "qr_code",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2841,7 +2876,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f88c9817902800ee931cc42ef91df10df1e98fdb14848c07996463b4c711f80"
 dependencies = [
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
  "rand 0.8.5",
  "tempfile",
  "testcontainers",
@@ -2860,13 +2895,13 @@ dependencies = [
  "lwk_common",
  "lwk_containers",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.12",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-timer",
 ]
 
@@ -2881,7 +2916,7 @@ dependencies = [
  "elements-miniscript",
  "lwk_common",
  "lwk_jade",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2904,10 +2939,10 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "regex-lite",
- "reqwest 0.12.7",
+ "reqwest 0.12.12",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -2968,14 +3003,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd3c9608217b0d6fa9c9c8ddd875b85ab72bd4311cfc8db35e1b5a08fc11f4d"
 dependencies = [
  "bech32 0.11.0",
- "bitcoin 0.32.4",
+ "bitcoin 0.32.5",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -2993,11 +3028,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -3008,6 +3042,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
@@ -3082,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -3122,11 +3162,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3143,7 +3183,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3154,18 +3194,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -3234,7 +3274,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3274,34 +3314,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3311,9 +3351,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plain"
@@ -3377,12 +3417,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3411,9 +3451,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -3446,10 +3486,10 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -3467,16 +3507,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.13.0",
  "log",
- "multimap",
+ "multimap 0.10.0",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.25",
+ "prettyplease 0.2.29",
  "prost 0.13.4",
  "prost-types 0.13.4",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.96",
  "tempfile",
 ]
 
@@ -3487,7 +3527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3500,10 +3540,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3547,45 +3587,49 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls 0.23.12",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.21",
  "socket2",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 2.0.0",
- "rustls 0.23.12",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.21",
+ "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -3595,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3680,11 +3724,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3745,7 +3789,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3770,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3780,11 +3824,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.7",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.2",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -3795,22 +3839,23 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.12",
- "rustls-pemfile 2.1.3",
+ "rustls 0.23.21",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -3860,7 +3905,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3898,7 +3943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.87",
+ "syn 2.0.96",
  "walkdir",
 ]
 
@@ -3926,9 +3971,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc_version"
@@ -3950,15 +3995,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3975,27 +4020,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.7",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4023,35 +4056,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "web-time",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -4060,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -4090,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -4120,7 +4145,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4171,7 +4196,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic 0.8.3",
  "tonic-build 0.8.4",
@@ -4289,18 +4314,18 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -4326,20 +4351,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -4441,9 +4466,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4501,7 +4526,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4523,9 +4548,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4540,9 +4565,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -4555,7 +4580,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4564,7 +4589,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4591,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4636,22 +4661,42 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4665,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -4686,9 +4731,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4706,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4721,9 +4766,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4749,13 +4794,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4781,20 +4826,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.12",
- "rustls-pki-types",
+ "rustls 0.23.21",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4818,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4854,7 +4898,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.32",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
@@ -4885,26 +4929,26 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.7",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.2",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.4",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -4926,12 +4970,12 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
- "prettyplease 0.2.25",
+ "prettyplease 0.2.29",
  "proc-macro2",
  "prost-build 0.13.4",
  "prost-types 0.13.4",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4963,7 +5007,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -4982,9 +5027,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4993,20 +5038,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -5036,13 +5081,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "log",
  "native-tls",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -5083,24 +5128,21 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -5133,7 +5175,7 @@ checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
 dependencies = [
  "anyhow",
  "camino",
- "clap 4.5.17",
+ "clap 4.5.27",
  "uniffi_bindgen 0.25.3",
  "uniffi_build 0.25.3",
  "uniffi_core 0.25.3",
@@ -5174,7 +5216,7 @@ dependencies = [
  "askama 0.12.1",
  "camino",
  "cargo_metadata",
- "clap 4.5.17",
+ "clap 4.5.27",
  "fs-err",
  "glob",
  "goblin",
@@ -5196,7 +5238,7 @@ dependencies = [
  "anyhow",
  "askama 0.12.1",
  "camino",
- "clap 4.5.17",
+ "clap 4.5.27",
  "heck 0.4.1",
  "include_dir",
  "paste",
@@ -5244,7 +5286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5311,7 +5353,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.96",
  "toml",
  "uniffi_build 0.25.3",
  "uniffi_meta 0.25.3",
@@ -5414,31 +5456,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.8.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "flate2",
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
+ "rustls 0.23.21",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -5474,9 +5516,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]
@@ -5520,47 +5562,48 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5568,22 +5611,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-timer"
@@ -5602,9 +5648,19 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5637,9 +5693,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5936,7 +5992,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -5960,7 +6016,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5988,7 +6044,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6008,7 +6064,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -6029,7 +6085,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6051,5 +6107,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -711,6 +711,7 @@ typedef struct wire_cst_refundable_swap {
   struct wire_cst_list_prim_u_8_strict *swap_address;
   uint32_t timestamp;
   uint64_t amount_sat;
+  struct wire_cst_list_prim_u_8_strict *refund_tx_id;
 } wire_cst_refundable_swap;
 
 typedef struct wire_cst_list_refundable_swap {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -711,7 +711,7 @@ typedef struct wire_cst_refundable_swap {
   struct wire_cst_list_prim_u_8_strict *swap_address;
   uint32_t timestamp;
   uint64_t amount_sat;
-  struct wire_cst_list_prim_u_8_strict *refund_tx_id;
+  struct wire_cst_list_prim_u_8_strict *pending_refund_tx_id;
 } wire_cst_refundable_swap;
 
 typedef struct wire_cst_list_refundable_swap {
@@ -1065,7 +1065,7 @@ typedef struct wire_cst_payment_error {
 typedef struct wire_cst_prepare_refund_response {
   uint32_t tx_vsize;
   uint64_t tx_fee_sat;
-  struct wire_cst_list_prim_u_8_strict *refund_tx_id;
+  struct wire_cst_list_prim_u_8_strict *pending_refund_tx_id;
 } wire_cst_prepare_refund_response;
 
 typedef struct wire_cst_receive_payment_response {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -711,7 +711,7 @@ typedef struct wire_cst_refundable_swap {
   struct wire_cst_list_prim_u_8_strict *swap_address;
   uint32_t timestamp;
   uint64_t amount_sat;
-  struct wire_cst_list_prim_u_8_strict *pending_refund_tx_id;
+  struct wire_cst_list_prim_u_8_strict *last_refund_tx_id;
 } wire_cst_refundable_swap;
 
 typedef struct wire_cst_list_refundable_swap {
@@ -1065,7 +1065,7 @@ typedef struct wire_cst_payment_error {
 typedef struct wire_cst_prepare_refund_response {
   uint32_t tx_vsize;
   uint64_t tx_fee_sat;
-  struct wire_cst_list_prim_u_8_strict *pending_refund_tx_id;
+  struct wire_cst_list_prim_u_8_strict *last_refund_tx_id;
 } wire_cst_prepare_refund_response;
 
 typedef struct wire_cst_receive_payment_response {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -618,7 +618,7 @@ dictionary RefundableSwap {
     string swap_address;
     u32 timestamp;
     u64 amount_sat;
-    string? pending_refund_tx_id;
+    string? last_refund_tx_id;
 };
 
 dictionary RecommendedFees {
@@ -638,7 +638,7 @@ dictionary PrepareRefundRequest {
 dictionary PrepareRefundResponse {
     u32 tx_vsize;
     u64 tx_fee_sat;
-    string? pending_refund_tx_id = null;
+    string? last_refund_tx_id = null;
 };
 
 dictionary RefundRequest {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -618,7 +618,7 @@ dictionary RefundableSwap {
     string swap_address;
     u32 timestamp;
     u64 amount_sat;
-    string? refund_tx_id;
+    string? pending_refund_tx_id;
 };
 
 dictionary RecommendedFees {
@@ -638,7 +638,7 @@ dictionary PrepareRefundRequest {
 dictionary PrepareRefundResponse {
     u32 tx_vsize;
     u64 tx_fee_sat;
-    string? refund_tx_id = null;
+    string? pending_refund_tx_id = null;
 };
 
 dictionary RefundRequest {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -618,6 +618,7 @@ dictionary RefundableSwap {
     string swap_address;
     u32 timestamp;
     u64 amount_sat;
+    string? refund_tx_id;
 };
 
 dictionary RecommendedFees {

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bip39 = "2.0.0"
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "540b5cb6505a97f1d02d846bf544bd5c1f800b25" }
+boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "e3e87186604c818c667b1293149423af5757dfbe" }
 chrono = "0.4"
 derivative = "2.2.0"
 env_logger = "0.11"

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -1167,7 +1167,7 @@ impl ChainSwapHandler {
                 err: format!("Cannot transition from {from_state:?} to Refundable state"),
             }),
 
-            (Pending | WaitingFeeAcceptance | Refundable, RefundPending) => Ok(()),
+            (Pending | WaitingFeeAcceptance | Refundable | RefundPending, RefundPending) => Ok(()),
             (_, RefundPending) => Err(PaymentError::Generic {
                 err: format!("Cannot transition from {from_state:?} to RefundPending state"),
             }),
@@ -1530,7 +1530,10 @@ mod tests {
             (TimedOut, HashSet::from([Failed])),
             (Complete, HashSet::from([Refundable])),
             (Refundable, HashSet::from([RefundPending, Failed])),
-            (RefundPending, HashSet::from([Refundable, Complete, Failed])),
+            (
+                RefundPending,
+                HashSet::from([Refundable, Complete, Failed, RefundPending]),
+            ),
             (Failed, HashSet::from([Failed, Refundable])),
         ]);
 

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4211,10 +4211,12 @@ impl SseDecode for crate::model::RefundableSwap {
         let mut var_swapAddress = <String>::sse_decode(deserializer);
         let mut var_timestamp = <u32>::sse_decode(deserializer);
         let mut var_amountSat = <u64>::sse_decode(deserializer);
+        let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::RefundableSwap {
             swap_address: var_swapAddress,
             timestamp: var_timestamp,
             amount_sat: var_amountSat,
+            refund_tx_id: var_refundTxId,
         };
     }
 }
@@ -6522,6 +6524,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::RefundableSwap {
             self.swap_address.into_into_dart().into_dart(),
             self.timestamp.into_into_dart().into_dart(),
             self.amount_sat.into_into_dart().into_dart(),
+            self.refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8435,6 +8438,7 @@ impl SseEncode for crate::model::RefundableSwap {
         <String>::sse_encode(self.swap_address, serializer);
         <u32>::sse_encode(self.timestamp, serializer);
         <u64>::sse_encode(self.amount_sat, serializer);
+        <Option<String>>::sse_encode(self.refund_tx_id, serializer);
     }
 }
 
@@ -10484,6 +10488,7 @@ mod io {
                 swap_address: self.swap_address.cst_decode(),
                 timestamp: self.timestamp.cst_decode(),
                 amount_sat: self.amount_sat.cst_decode(),
+                refund_tx_id: self.refund_tx_id.cst_decode(),
             }
         }
     }
@@ -11793,6 +11798,7 @@ mod io {
                 swap_address: core::ptr::null_mut(),
                 timestamp: Default::default(),
                 amount_sat: Default::default(),
+                refund_tx_id: core::ptr::null_mut(),
             }
         }
     }
@@ -14011,6 +14017,7 @@ mod io {
         swap_address: *mut wire_cst_list_prim_u_8_strict,
         timestamp: u32,
         amount_sat: u64,
+        refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4093,11 +4093,11 @@ impl SseDecode for crate::model::PrepareRefundResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txVsize = <u32>::sse_decode(deserializer);
         let mut var_txFeeSat = <u64>::sse_decode(deserializer);
-        let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
+        let mut var_pendingRefundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::PrepareRefundResponse {
             tx_vsize: var_txVsize,
             tx_fee_sat: var_txFeeSat,
-            refund_tx_id: var_refundTxId,
+            pending_refund_tx_id: var_pendingRefundTxId,
         };
     }
 }
@@ -4211,12 +4211,12 @@ impl SseDecode for crate::model::RefundableSwap {
         let mut var_swapAddress = <String>::sse_decode(deserializer);
         let mut var_timestamp = <u32>::sse_decode(deserializer);
         let mut var_amountSat = <u64>::sse_decode(deserializer);
-        let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
+        let mut var_pendingRefundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::RefundableSwap {
             swap_address: var_swapAddress,
             timestamp: var_timestamp,
             amount_sat: var_amountSat,
-            refund_tx_id: var_refundTxId,
+            pending_refund_tx_id: var_pendingRefundTxId,
         };
     }
 }
@@ -6345,7 +6345,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareRefundResponse {
         [
             self.tx_vsize.into_into_dart().into_dart(),
             self.tx_fee_sat.into_into_dart().into_dart(),
-            self.refund_tx_id.into_into_dart().into_dart(),
+            self.pending_refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6524,7 +6524,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::RefundableSwap {
             self.swap_address.into_into_dart().into_dart(),
             self.timestamp.into_into_dart().into_dart(),
             self.amount_sat.into_into_dart().into_dart(),
-            self.refund_tx_id.into_into_dart().into_dart(),
+            self.pending_refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8361,7 +8361,7 @@ impl SseEncode for crate::model::PrepareRefundResponse {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u32>::sse_encode(self.tx_vsize, serializer);
         <u64>::sse_encode(self.tx_fee_sat, serializer);
-        <Option<String>>::sse_encode(self.refund_tx_id, serializer);
+        <Option<String>>::sse_encode(self.pending_refund_tx_id, serializer);
     }
 }
 
@@ -8438,7 +8438,7 @@ impl SseEncode for crate::model::RefundableSwap {
         <String>::sse_encode(self.swap_address, serializer);
         <u32>::sse_encode(self.timestamp, serializer);
         <u64>::sse_encode(self.amount_sat, serializer);
-        <Option<String>>::sse_encode(self.refund_tx_id, serializer);
+        <Option<String>>::sse_encode(self.pending_refund_tx_id, serializer);
     }
 }
 
@@ -10402,7 +10402,7 @@ mod io {
             crate::model::PrepareRefundResponse {
                 tx_vsize: self.tx_vsize.cst_decode(),
                 tx_fee_sat: self.tx_fee_sat.cst_decode(),
-                refund_tx_id: self.refund_tx_id.cst_decode(),
+                pending_refund_tx_id: self.pending_refund_tx_id.cst_decode(),
             }
         }
     }
@@ -10488,7 +10488,7 @@ mod io {
                 swap_address: self.swap_address.cst_decode(),
                 timestamp: self.timestamp.cst_decode(),
                 amount_sat: self.amount_sat.cst_decode(),
-                refund_tx_id: self.refund_tx_id.cst_decode(),
+                pending_refund_tx_id: self.pending_refund_tx_id.cst_decode(),
             }
         }
     }
@@ -11676,7 +11676,7 @@ mod io {
             Self {
                 tx_vsize: Default::default(),
                 tx_fee_sat: Default::default(),
-                refund_tx_id: core::ptr::null_mut(),
+                pending_refund_tx_id: core::ptr::null_mut(),
             }
         }
     }
@@ -11798,7 +11798,7 @@ mod io {
                 swap_address: core::ptr::null_mut(),
                 timestamp: Default::default(),
                 amount_sat: Default::default(),
-                refund_tx_id: core::ptr::null_mut(),
+                pending_refund_tx_id: core::ptr::null_mut(),
             }
         }
     }
@@ -13958,7 +13958,7 @@ mod io {
     pub struct wire_cst_prepare_refund_response {
         tx_vsize: u32,
         tx_fee_sat: u64,
-        refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
+        pending_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -14017,7 +14017,7 @@ mod io {
         swap_address: *mut wire_cst_list_prim_u_8_strict,
         timestamp: u32,
         amount_sat: u64,
-        refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
+        pending_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4093,11 +4093,11 @@ impl SseDecode for crate::model::PrepareRefundResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txVsize = <u32>::sse_decode(deserializer);
         let mut var_txFeeSat = <u64>::sse_decode(deserializer);
-        let mut var_pendingRefundTxId = <Option<String>>::sse_decode(deserializer);
+        let mut var_lastRefundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::PrepareRefundResponse {
             tx_vsize: var_txVsize,
             tx_fee_sat: var_txFeeSat,
-            pending_refund_tx_id: var_pendingRefundTxId,
+            last_refund_tx_id: var_lastRefundTxId,
         };
     }
 }
@@ -4211,12 +4211,12 @@ impl SseDecode for crate::model::RefundableSwap {
         let mut var_swapAddress = <String>::sse_decode(deserializer);
         let mut var_timestamp = <u32>::sse_decode(deserializer);
         let mut var_amountSat = <u64>::sse_decode(deserializer);
-        let mut var_pendingRefundTxId = <Option<String>>::sse_decode(deserializer);
+        let mut var_lastRefundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::RefundableSwap {
             swap_address: var_swapAddress,
             timestamp: var_timestamp,
             amount_sat: var_amountSat,
-            pending_refund_tx_id: var_pendingRefundTxId,
+            last_refund_tx_id: var_lastRefundTxId,
         };
     }
 }
@@ -6345,7 +6345,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareRefundResponse {
         [
             self.tx_vsize.into_into_dart().into_dart(),
             self.tx_fee_sat.into_into_dart().into_dart(),
-            self.pending_refund_tx_id.into_into_dart().into_dart(),
+            self.last_refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6524,7 +6524,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::RefundableSwap {
             self.swap_address.into_into_dart().into_dart(),
             self.timestamp.into_into_dart().into_dart(),
             self.amount_sat.into_into_dart().into_dart(),
-            self.pending_refund_tx_id.into_into_dart().into_dart(),
+            self.last_refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8361,7 +8361,7 @@ impl SseEncode for crate::model::PrepareRefundResponse {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u32>::sse_encode(self.tx_vsize, serializer);
         <u64>::sse_encode(self.tx_fee_sat, serializer);
-        <Option<String>>::sse_encode(self.pending_refund_tx_id, serializer);
+        <Option<String>>::sse_encode(self.last_refund_tx_id, serializer);
     }
 }
 
@@ -8438,7 +8438,7 @@ impl SseEncode for crate::model::RefundableSwap {
         <String>::sse_encode(self.swap_address, serializer);
         <u32>::sse_encode(self.timestamp, serializer);
         <u64>::sse_encode(self.amount_sat, serializer);
-        <Option<String>>::sse_encode(self.pending_refund_tx_id, serializer);
+        <Option<String>>::sse_encode(self.last_refund_tx_id, serializer);
     }
 }
 
@@ -10402,7 +10402,7 @@ mod io {
             crate::model::PrepareRefundResponse {
                 tx_vsize: self.tx_vsize.cst_decode(),
                 tx_fee_sat: self.tx_fee_sat.cst_decode(),
-                pending_refund_tx_id: self.pending_refund_tx_id.cst_decode(),
+                last_refund_tx_id: self.last_refund_tx_id.cst_decode(),
             }
         }
     }
@@ -10488,7 +10488,7 @@ mod io {
                 swap_address: self.swap_address.cst_decode(),
                 timestamp: self.timestamp.cst_decode(),
                 amount_sat: self.amount_sat.cst_decode(),
-                pending_refund_tx_id: self.pending_refund_tx_id.cst_decode(),
+                last_refund_tx_id: self.last_refund_tx_id.cst_decode(),
             }
         }
     }
@@ -11676,7 +11676,7 @@ mod io {
             Self {
                 tx_vsize: Default::default(),
                 tx_fee_sat: Default::default(),
-                pending_refund_tx_id: core::ptr::null_mut(),
+                last_refund_tx_id: core::ptr::null_mut(),
             }
         }
     }
@@ -11798,7 +11798,7 @@ mod io {
                 swap_address: core::ptr::null_mut(),
                 timestamp: Default::default(),
                 amount_sat: Default::default(),
-                pending_refund_tx_id: core::ptr::null_mut(),
+                last_refund_tx_id: core::ptr::null_mut(),
             }
         }
     }
@@ -13958,7 +13958,7 @@ mod io {
     pub struct wire_cst_prepare_refund_response {
         tx_vsize: u32,
         tx_fee_sat: u64,
-        pending_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
+        last_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -14017,7 +14017,7 @@ mod io {
         swap_address: *mut wire_cst_list_prim_u_8_strict,
         timestamp: u32,
         amount_sat: u64,
-        pending_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
+        last_refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -513,7 +513,8 @@ pub struct PrepareRefundRequest {
 pub struct PrepareRefundResponse {
     pub tx_vsize: u32,
     pub tx_fee_sat: u64,
-    pub refund_tx_id: Option<String>,
+    /// The txid of an existing pending refund tx, if any
+    pub pending_refund_tx_id: Option<String>,
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::refund].
@@ -874,7 +875,7 @@ impl ChainSwap {
             swap_address: self.lockup_address.clone(),
             timestamp: self.created_at,
             amount_sat: refundable_amount_sat,
-            refund_tx_id: self.refund_tx_id.clone(),
+            pending_refund_tx_id: self.refund_tx_id.clone(),
         }
     }
 
@@ -1120,7 +1121,8 @@ pub struct RefundableSwap {
     pub timestamp: u32,
     /// Amount that is refundable, from all UTXOs
     pub amount_sat: u64,
-    pub refund_tx_id: Option<String>,
+    /// The txid of an existing pending refund tx, if any
+    pub pending_refund_tx_id: Option<String>,
 }
 
 /// The payment state of an individual payment.

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -874,6 +874,7 @@ impl ChainSwap {
             swap_address: self.lockup_address.clone(),
             timestamp: self.created_at,
             amount_sat: refundable_amount_sat,
+            refund_tx_id: self.refund_tx_id.clone(),
         }
     }
 
@@ -1119,6 +1120,7 @@ pub struct RefundableSwap {
     pub timestamp: u32,
     /// Amount that is refundable, from all UTXOs
     pub amount_sat: u64,
+    pub refund_tx_id: Option<String>,
 }
 
 /// The payment state of an individual payment.
@@ -1232,7 +1234,9 @@ impl PaymentState {
     pub(crate) fn is_refundable(&self) -> bool {
         matches!(
             self,
-            PaymentState::Refundable | PaymentState::WaitingFeeAcceptance
+            PaymentState::Refundable
+                | PaymentState::RefundPending
+                | PaymentState::WaitingFeeAcceptance
         )
     }
 }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -513,8 +513,8 @@ pub struct PrepareRefundRequest {
 pub struct PrepareRefundResponse {
     pub tx_vsize: u32,
     pub tx_fee_sat: u64,
-    /// The txid of an existing pending refund tx, if any
-    pub pending_refund_tx_id: Option<String>,
+    /// The txid of the last broadcasted refund tx, if any
+    pub last_refund_tx_id: Option<String>,
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::refund].
@@ -875,7 +875,7 @@ impl ChainSwap {
             swap_address: self.lockup_address.clone(),
             timestamp: self.created_at,
             amount_sat: refundable_amount_sat,
-            pending_refund_tx_id: self.refund_tx_id.clone(),
+            last_refund_tx_id: self.refund_tx_id.clone(),
         }
     }
 
@@ -1121,8 +1121,8 @@ pub struct RefundableSwap {
     pub timestamp: u32,
     /// Amount that is refundable, from all UTXOs
     pub amount_sat: u64,
-    /// The txid of an existing pending refund tx, if any
-    pub pending_refund_tx_id: Option<String>,
+    /// The txid of the last broadcasted refund tx, if any
+    pub last_refund_tx_id: Option<String>,
 }
 
 /// The payment state of an individual payment.

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -268,7 +268,7 @@ impl Persister {
     }
 
     pub(crate) fn list_refundable_chain_swaps(&self) -> Result<Vec<ChainSwap>> {
-        self.list_chain_swaps_by_state(vec![PaymentState::Refundable])
+        self.list_chain_swaps_by_state(vec![PaymentState::Refundable, PaymentState::RefundPending])
     }
 
     pub(crate) fn list_local_chain_swaps(&self) -> Result<Vec<ChainSwap>> {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2227,7 +2227,7 @@ impl LiquidSdk {
         Ok(PrepareRefundResponse {
             tx_vsize,
             tx_fee_sat,
-            refund_tx_id,
+            pending_refund_tx_id: refund_tx_id,
         })
     }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2227,7 +2227,7 @@ impl LiquidSdk {
         Ok(PrepareRefundResponse {
             tx_vsize,
             tx_fee_sat,
-            pending_refund_tx_id: refund_tx_id,
+            last_refund_tx_id: refund_tx_id,
         })
     }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -3027,11 +3027,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RefundableSwap dco_decode_refundable_swap(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return RefundableSwap(
       swapAddress: dco_decode_String(arr[0]),
       timestamp: dco_decode_u_32(arr[1]),
       amountSat: dco_decode_u_64(arr[2]),
+      refundTxId: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -5197,7 +5198,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_swapAddress = sse_decode_String(deserializer);
     var var_timestamp = sse_decode_u_32(deserializer);
     var var_amountSat = sse_decode_u_64(deserializer);
-    return RefundableSwap(swapAddress: var_swapAddress, timestamp: var_timestamp, amountSat: var_amountSat);
+    var var_refundTxId = sse_decode_opt_String(deserializer);
+    return RefundableSwap(
+        swapAddress: var_swapAddress,
+        timestamp: var_timestamp,
+        amountSat: var_amountSat,
+        refundTxId: var_refundTxId);
   }
 
   @protected
@@ -7149,6 +7155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.swapAddress, serializer);
     sse_encode_u_32(self.timestamp, serializer);
     sse_encode_u_64(self.amountSat, serializer);
+    sse_encode_opt_String(self.refundTxId, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2928,7 +2928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return PrepareRefundResponse(
       txVsize: dco_decode_u_32(arr[0]),
       txFeeSat: dco_decode_u_64(arr[1]),
-      refundTxId: dco_decode_opt_String(arr[2]),
+      pendingRefundTxId: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -3032,7 +3032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       swapAddress: dco_decode_String(arr[0]),
       timestamp: dco_decode_u_32(arr[1]),
       amountSat: dco_decode_u_64(arr[2]),
-      refundTxId: dco_decode_opt_String(arr[3]),
+      pendingRefundTxId: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -5110,8 +5110,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_txVsize = sse_decode_u_32(deserializer);
     var var_txFeeSat = sse_decode_u_64(deserializer);
-    var var_refundTxId = sse_decode_opt_String(deserializer);
-    return PrepareRefundResponse(txVsize: var_txVsize, txFeeSat: var_txFeeSat, refundTxId: var_refundTxId);
+    var var_pendingRefundTxId = sse_decode_opt_String(deserializer);
+    return PrepareRefundResponse(
+        txVsize: var_txVsize, txFeeSat: var_txFeeSat, pendingRefundTxId: var_pendingRefundTxId);
   }
 
   @protected
@@ -5198,12 +5199,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_swapAddress = sse_decode_String(deserializer);
     var var_timestamp = sse_decode_u_32(deserializer);
     var var_amountSat = sse_decode_u_64(deserializer);
-    var var_refundTxId = sse_decode_opt_String(deserializer);
+    var var_pendingRefundTxId = sse_decode_opt_String(deserializer);
     return RefundableSwap(
         swapAddress: var_swapAddress,
         timestamp: var_timestamp,
         amountSat: var_amountSat,
-        refundTxId: var_refundTxId);
+        pendingRefundTxId: var_pendingRefundTxId);
   }
 
   @protected
@@ -7087,7 +7088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.txVsize, serializer);
     sse_encode_u_64(self.txFeeSat, serializer);
-    sse_encode_opt_String(self.refundTxId, serializer);
+    sse_encode_opt_String(self.pendingRefundTxId, serializer);
   }
 
   @protected
@@ -7155,7 +7156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.swapAddress, serializer);
     sse_encode_u_32(self.timestamp, serializer);
     sse_encode_u_64(self.amountSat, serializer);
-    sse_encode_opt_String(self.refundTxId, serializer);
+    sse_encode_opt_String(self.pendingRefundTxId, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2928,7 +2928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return PrepareRefundResponse(
       txVsize: dco_decode_u_32(arr[0]),
       txFeeSat: dco_decode_u_64(arr[1]),
-      pendingRefundTxId: dco_decode_opt_String(arr[2]),
+      lastRefundTxId: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -3032,7 +3032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       swapAddress: dco_decode_String(arr[0]),
       timestamp: dco_decode_u_32(arr[1]),
       amountSat: dco_decode_u_64(arr[2]),
-      pendingRefundTxId: dco_decode_opt_String(arr[3]),
+      lastRefundTxId: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -5110,9 +5110,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_txVsize = sse_decode_u_32(deserializer);
     var var_txFeeSat = sse_decode_u_64(deserializer);
-    var var_pendingRefundTxId = sse_decode_opt_String(deserializer);
+    var var_lastRefundTxId = sse_decode_opt_String(deserializer);
     return PrepareRefundResponse(
-        txVsize: var_txVsize, txFeeSat: var_txFeeSat, pendingRefundTxId: var_pendingRefundTxId);
+        txVsize: var_txVsize, txFeeSat: var_txFeeSat, lastRefundTxId: var_lastRefundTxId);
   }
 
   @protected
@@ -5199,12 +5199,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_swapAddress = sse_decode_String(deserializer);
     var var_timestamp = sse_decode_u_32(deserializer);
     var var_amountSat = sse_decode_u_64(deserializer);
-    var var_pendingRefundTxId = sse_decode_opt_String(deserializer);
+    var var_lastRefundTxId = sse_decode_opt_String(deserializer);
     return RefundableSwap(
         swapAddress: var_swapAddress,
         timestamp: var_timestamp,
         amountSat: var_amountSat,
-        pendingRefundTxId: var_pendingRefundTxId);
+        lastRefundTxId: var_lastRefundTxId);
   }
 
   @protected
@@ -7088,7 +7088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.txVsize, serializer);
     sse_encode_u_64(self.txFeeSat, serializer);
-    sse_encode_opt_String(self.pendingRefundTxId, serializer);
+    sse_encode_opt_String(self.lastRefundTxId, serializer);
   }
 
   @protected
@@ -7156,7 +7156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.swapAddress, serializer);
     sse_encode_u_32(self.timestamp, serializer);
     sse_encode_u_64(self.amountSat, serializer);
-    sse_encode_opt_String(self.pendingRefundTxId, serializer);
+    sse_encode_opt_String(self.lastRefundTxId, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3185,7 +3185,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PrepareRefundResponse apiObj, wire_cst_prepare_refund_response wireObj) {
     wireObj.tx_vsize = cst_encode_u_32(apiObj.txVsize);
     wireObj.tx_fee_sat = cst_encode_u_64(apiObj.txFeeSat);
-    wireObj.refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
+    wireObj.pending_refund_tx_id = cst_encode_opt_String(apiObj.pendingRefundTxId);
   }
 
   @protected
@@ -3248,7 +3248,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.swap_address = cst_encode_String(apiObj.swapAddress);
     wireObj.timestamp = cst_encode_u_32(apiObj.timestamp);
     wireObj.amount_sat = cst_encode_u_64(apiObj.amountSat);
-    wireObj.refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
+    wireObj.pending_refund_tx_id = cst_encode_opt_String(apiObj.pendingRefundTxId);
   }
 
   @protected
@@ -6703,7 +6703,7 @@ final class wire_cst_refundable_swap extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {
@@ -7139,7 +7139,7 @@ final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint64()
   external int tx_fee_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
 }
 
 final class wire_cst_receive_payment_response extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3248,6 +3248,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.swap_address = cst_encode_String(apiObj.swapAddress);
     wireObj.timestamp = cst_encode_u_32(apiObj.timestamp);
     wireObj.amount_sat = cst_encode_u_64(apiObj.amountSat);
+    wireObj.refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
   }
 
   @protected
@@ -6701,6 +6702,8 @@ final class wire_cst_refundable_swap extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3185,7 +3185,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PrepareRefundResponse apiObj, wire_cst_prepare_refund_response wireObj) {
     wireObj.tx_vsize = cst_encode_u_32(apiObj.txVsize);
     wireObj.tx_fee_sat = cst_encode_u_64(apiObj.txFeeSat);
-    wireObj.pending_refund_tx_id = cst_encode_opt_String(apiObj.pendingRefundTxId);
+    wireObj.last_refund_tx_id = cst_encode_opt_String(apiObj.lastRefundTxId);
   }
 
   @protected
@@ -3248,7 +3248,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.swap_address = cst_encode_String(apiObj.swapAddress);
     wireObj.timestamp = cst_encode_u_32(apiObj.timestamp);
     wireObj.amount_sat = cst_encode_u_64(apiObj.amountSat);
-    wireObj.pending_refund_tx_id = cst_encode_opt_String(apiObj.pendingRefundTxId);
+    wireObj.last_refund_tx_id = cst_encode_opt_String(apiObj.lastRefundTxId);
   }
 
   @protected
@@ -6703,7 +6703,7 @@ final class wire_cst_refundable_swap extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> last_refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {
@@ -7139,7 +7139,7 @@ final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint64()
   external int tx_fee_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> last_refund_tx_id;
 }
 
 final class wire_cst_receive_payment_response extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1439,15 +1439,17 @@ class RefundableSwap {
 
   /// Amount that is refundable, from all UTXOs
   final BigInt amountSat;
+  final String? refundTxId;
 
   const RefundableSwap({
     required this.swapAddress,
     required this.timestamp,
     required this.amountSat,
+    this.refundTxId,
   });
 
   @override
-  int get hashCode => swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode;
+  int get hashCode => swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode ^ refundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1456,7 +1458,8 @@ class RefundableSwap {
           runtimeType == other.runtimeType &&
           swapAddress == other.swapAddress &&
           timestamp == other.timestamp &&
-          amountSat == other.amountSat;
+          amountSat == other.amountSat &&
+          refundTxId == other.refundTxId;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::restore].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1232,17 +1232,17 @@ class PrepareRefundResponse {
   final int txVsize;
   final BigInt txFeeSat;
 
-  /// The txid of an existing pending refund tx, if any
-  final String? pendingRefundTxId;
+  /// The txid of the last broadcasted refund tx, if any
+  final String? lastRefundTxId;
 
   const PrepareRefundResponse({
     required this.txVsize,
     required this.txFeeSat,
-    this.pendingRefundTxId,
+    this.lastRefundTxId,
   });
 
   @override
-  int get hashCode => txVsize.hashCode ^ txFeeSat.hashCode ^ pendingRefundTxId.hashCode;
+  int get hashCode => txVsize.hashCode ^ txFeeSat.hashCode ^ lastRefundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1251,7 +1251,7 @@ class PrepareRefundResponse {
           runtimeType == other.runtimeType &&
           txVsize == other.txVsize &&
           txFeeSat == other.txFeeSat &&
-          pendingRefundTxId == other.pendingRefundTxId;
+          lastRefundTxId == other.lastRefundTxId;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_send_payment].
@@ -1442,19 +1442,19 @@ class RefundableSwap {
   /// Amount that is refundable, from all UTXOs
   final BigInt amountSat;
 
-  /// The txid of an existing pending refund tx, if any
-  final String? pendingRefundTxId;
+  /// The txid of the last broadcasted refund tx, if any
+  final String? lastRefundTxId;
 
   const RefundableSwap({
     required this.swapAddress,
     required this.timestamp,
     required this.amountSat,
-    this.pendingRefundTxId,
+    this.lastRefundTxId,
   });
 
   @override
   int get hashCode =>
-      swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode ^ pendingRefundTxId.hashCode;
+      swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode ^ lastRefundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1464,7 +1464,7 @@ class RefundableSwap {
           swapAddress == other.swapAddress &&
           timestamp == other.timestamp &&
           amountSat == other.amountSat &&
-          pendingRefundTxId == other.pendingRefundTxId;
+          lastRefundTxId == other.lastRefundTxId;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::restore].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1231,16 +1231,18 @@ class PrepareRefundRequest {
 class PrepareRefundResponse {
   final int txVsize;
   final BigInt txFeeSat;
-  final String? refundTxId;
+
+  /// The txid of an existing pending refund tx, if any
+  final String? pendingRefundTxId;
 
   const PrepareRefundResponse({
     required this.txVsize,
     required this.txFeeSat,
-    this.refundTxId,
+    this.pendingRefundTxId,
   });
 
   @override
-  int get hashCode => txVsize.hashCode ^ txFeeSat.hashCode ^ refundTxId.hashCode;
+  int get hashCode => txVsize.hashCode ^ txFeeSat.hashCode ^ pendingRefundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1249,7 +1251,7 @@ class PrepareRefundResponse {
           runtimeType == other.runtimeType &&
           txVsize == other.txVsize &&
           txFeeSat == other.txFeeSat &&
-          refundTxId == other.refundTxId;
+          pendingRefundTxId == other.pendingRefundTxId;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::prepare_send_payment].
@@ -1439,17 +1441,20 @@ class RefundableSwap {
 
   /// Amount that is refundable, from all UTXOs
   final BigInt amountSat;
-  final String? refundTxId;
+
+  /// The txid of an existing pending refund tx, if any
+  final String? pendingRefundTxId;
 
   const RefundableSwap({
     required this.swapAddress,
     required this.timestamp,
     required this.amountSat,
-    this.refundTxId,
+    this.pendingRefundTxId,
   });
 
   @override
-  int get hashCode => swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode ^ refundTxId.hashCode;
+  int get hashCode =>
+      swapAddress.hashCode ^ timestamp.hashCode ^ amountSat.hashCode ^ pendingRefundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1459,7 +1464,7 @@ class RefundableSwap {
           swapAddress == other.swapAddress &&
           timestamp == other.timestamp &&
           amountSat == other.amountSat &&
-          refundTxId == other.refundTxId;
+          pendingRefundTxId == other.pendingRefundTxId;
 }
 
 /// An argument when calling [crate::sdk::LiquidSdk::restore].

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5024,6 +5024,8 @@ final class wire_cst_refundable_swap extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5025,7 +5025,7 @@ final class wire_cst_refundable_swap extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {
@@ -5461,7 +5461,7 @@ final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint64()
   external int tx_fee_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
 }
 
 final class wire_cst_receive_payment_response extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5025,7 +5025,7 @@ final class wire_cst_refundable_swap extends ffi.Struct {
   @ffi.Uint64()
   external int amount_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> last_refund_tx_id;
 }
 
 final class wire_cst_list_refundable_swap extends ffi.Struct {
@@ -5461,7 +5461,7 @@ final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint64()
   external int tx_fee_sat;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> pending_refund_tx_id;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> last_refund_tx_id;
 }
 
 final class wire_cst_receive_payment_response extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2083,24 +2083,24 @@ fun asPrepareRefundResponse(prepareRefundResponse: ReadableMap): PrepareRefundRe
     }
     val txVsize = prepareRefundResponse.getInt("txVsize").toUInt()
     val txFeeSat = prepareRefundResponse.getDouble("txFeeSat").toULong()
-    val pendingRefundTxId =
+    val lastRefundTxId =
         if (hasNonNullKey(
                 prepareRefundResponse,
-                "pendingRefundTxId",
+                "lastRefundTxId",
             )
         ) {
-            prepareRefundResponse.getString("pendingRefundTxId")
+            prepareRefundResponse.getString("lastRefundTxId")
         } else {
             null
         }
-    return PrepareRefundResponse(txVsize, txFeeSat, pendingRefundTxId)
+    return PrepareRefundResponse(txVsize, txFeeSat, lastRefundTxId)
 }
 
 fun readableMapOf(prepareRefundResponse: PrepareRefundResponse): ReadableMap =
     readableMapOf(
         "txVsize" to prepareRefundResponse.txVsize,
         "txFeeSat" to prepareRefundResponse.txFeeSat,
-        "pendingRefundTxId" to prepareRefundResponse.pendingRefundTxId,
+        "lastRefundTxId" to prepareRefundResponse.lastRefundTxId,
     )
 
 fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse> {
@@ -2408,8 +2408,8 @@ fun asRefundableSwap(refundableSwap: ReadableMap): RefundableSwap? {
     val swapAddress = refundableSwap.getString("swapAddress")!!
     val timestamp = refundableSwap.getInt("timestamp").toUInt()
     val amountSat = refundableSwap.getDouble("amountSat").toULong()
-    val pendingRefundTxId = if (hasNonNullKey(refundableSwap, "pendingRefundTxId")) refundableSwap.getString("pendingRefundTxId") else null
-    return RefundableSwap(swapAddress, timestamp, amountSat, pendingRefundTxId)
+    val lastRefundTxId = if (hasNonNullKey(refundableSwap, "lastRefundTxId")) refundableSwap.getString("lastRefundTxId") else null
+    return RefundableSwap(swapAddress, timestamp, amountSat, lastRefundTxId)
 }
 
 fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
@@ -2417,7 +2417,7 @@ fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
         "swapAddress" to refundableSwap.swapAddress,
         "timestamp" to refundableSwap.timestamp,
         "amountSat" to refundableSwap.amountSat,
-        "pendingRefundTxId" to refundableSwap.pendingRefundTxId,
+        "lastRefundTxId" to refundableSwap.lastRefundTxId,
     )
 
 fun asRefundableSwapList(arr: ReadableArray): List<RefundableSwap> {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2399,7 +2399,8 @@ fun asRefundableSwap(refundableSwap: ReadableMap): RefundableSwap? {
     val swapAddress = refundableSwap.getString("swapAddress")!!
     val timestamp = refundableSwap.getInt("timestamp").toUInt()
     val amountSat = refundableSwap.getDouble("amountSat").toULong()
-    return RefundableSwap(swapAddress, timestamp, amountSat)
+    val refundTxId = if (hasNonNullKey(refundableSwap, "refundTxId")) refundableSwap.getString("refundTxId") else null
+    return RefundableSwap(swapAddress, timestamp, amountSat, refundTxId)
 }
 
 fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
@@ -2407,6 +2408,7 @@ fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
         "swapAddress" to refundableSwap.swapAddress,
         "timestamp" to refundableSwap.timestamp,
         "amountSat" to refundableSwap.amountSat,
+        "refundTxId" to refundableSwap.refundTxId,
     )
 
 fun asRefundableSwapList(arr: ReadableArray): List<RefundableSwap> {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2083,15 +2083,24 @@ fun asPrepareRefundResponse(prepareRefundResponse: ReadableMap): PrepareRefundRe
     }
     val txVsize = prepareRefundResponse.getInt("txVsize").toUInt()
     val txFeeSat = prepareRefundResponse.getDouble("txFeeSat").toULong()
-    val refundTxId = if (hasNonNullKey(prepareRefundResponse, "refundTxId")) prepareRefundResponse.getString("refundTxId") else null
-    return PrepareRefundResponse(txVsize, txFeeSat, refundTxId)
+    val pendingRefundTxId =
+        if (hasNonNullKey(
+                prepareRefundResponse,
+                "pendingRefundTxId",
+            )
+        ) {
+            prepareRefundResponse.getString("pendingRefundTxId")
+        } else {
+            null
+        }
+    return PrepareRefundResponse(txVsize, txFeeSat, pendingRefundTxId)
 }
 
 fun readableMapOf(prepareRefundResponse: PrepareRefundResponse): ReadableMap =
     readableMapOf(
         "txVsize" to prepareRefundResponse.txVsize,
         "txFeeSat" to prepareRefundResponse.txFeeSat,
-        "refundTxId" to prepareRefundResponse.refundTxId,
+        "pendingRefundTxId" to prepareRefundResponse.pendingRefundTxId,
     )
 
 fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse> {
@@ -2399,8 +2408,8 @@ fun asRefundableSwap(refundableSwap: ReadableMap): RefundableSwap? {
     val swapAddress = refundableSwap.getString("swapAddress")!!
     val timestamp = refundableSwap.getInt("timestamp").toUInt()
     val amountSat = refundableSwap.getDouble("amountSat").toULong()
-    val refundTxId = if (hasNonNullKey(refundableSwap, "refundTxId")) refundableSwap.getString("refundTxId") else null
-    return RefundableSwap(swapAddress, timestamp, amountSat, refundTxId)
+    val pendingRefundTxId = if (hasNonNullKey(refundableSwap, "pendingRefundTxId")) refundableSwap.getString("pendingRefundTxId") else null
+    return RefundableSwap(swapAddress, timestamp, amountSat, pendingRefundTxId)
 }
 
 fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
@@ -2408,7 +2417,7 @@ fun readableMapOf(refundableSwap: RefundableSwap): ReadableMap =
         "swapAddress" to refundableSwap.swapAddress,
         "timestamp" to refundableSwap.timestamp,
         "amountSat" to refundableSwap.amountSat,
-        "refundTxId" to refundableSwap.refundTxId,
+        "pendingRefundTxId" to refundableSwap.pendingRefundTxId,
     )
 
 fun asRefundableSwapList(arr: ReadableArray): List<RefundableSwap> {

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2399,22 +2399,22 @@ enum BreezSDKLiquidMapper {
         guard let txFeeSat = prepareRefundResponse["txFeeSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRefundResponse"))
         }
-        var refundTxId: String?
-        if hasNonNilKey(data: prepareRefundResponse, key: "refundTxId") {
-            guard let refundTxIdTmp = prepareRefundResponse["refundTxId"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "refundTxId"))
+        var pendingRefundTxId: String?
+        if hasNonNilKey(data: prepareRefundResponse, key: "pendingRefundTxId") {
+            guard let pendingRefundTxIdTmp = prepareRefundResponse["pendingRefundTxId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "pendingRefundTxId"))
             }
-            refundTxId = refundTxIdTmp
+            pendingRefundTxId = pendingRefundTxIdTmp
         }
 
-        return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, refundTxId: refundTxId)
+        return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, pendingRefundTxId: pendingRefundTxId)
     }
 
     static func dictionaryOf(prepareRefundResponse: PrepareRefundResponse) -> [String: Any?] {
         return [
             "txVsize": prepareRefundResponse.txVsize,
             "txFeeSat": prepareRefundResponse.txFeeSat,
-            "refundTxId": prepareRefundResponse.refundTxId == nil ? nil : prepareRefundResponse.refundTxId,
+            "pendingRefundTxId": prepareRefundResponse.pendingRefundTxId == nil ? nil : prepareRefundResponse.pendingRefundTxId,
         ]
     }
 
@@ -2750,15 +2750,15 @@ enum BreezSDKLiquidMapper {
         guard let amountSat = refundableSwap["amountSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "RefundableSwap"))
         }
-        var refundTxId: String?
-        if hasNonNilKey(data: refundableSwap, key: "refundTxId") {
-            guard let refundTxIdTmp = refundableSwap["refundTxId"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "refundTxId"))
+        var pendingRefundTxId: String?
+        if hasNonNilKey(data: refundableSwap, key: "pendingRefundTxId") {
+            guard let pendingRefundTxIdTmp = refundableSwap["pendingRefundTxId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "pendingRefundTxId"))
             }
-            refundTxId = refundTxIdTmp
+            pendingRefundTxId = pendingRefundTxIdTmp
         }
 
-        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, refundTxId: refundTxId)
+        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, pendingRefundTxId: pendingRefundTxId)
     }
 
     static func dictionaryOf(refundableSwap: RefundableSwap) -> [String: Any?] {
@@ -2766,7 +2766,7 @@ enum BreezSDKLiquidMapper {
             "swapAddress": refundableSwap.swapAddress,
             "timestamp": refundableSwap.timestamp,
             "amountSat": refundableSwap.amountSat,
-            "refundTxId": refundableSwap.refundTxId == nil ? nil : refundableSwap.refundTxId,
+            "pendingRefundTxId": refundableSwap.pendingRefundTxId == nil ? nil : refundableSwap.pendingRefundTxId,
         ]
     }
 

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2750,8 +2750,15 @@ enum BreezSDKLiquidMapper {
         guard let amountSat = refundableSwap["amountSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "RefundableSwap"))
         }
+        var refundTxId: String?
+        if hasNonNilKey(data: refundableSwap, key: "refundTxId") {
+            guard let refundTxIdTmp = refundableSwap["refundTxId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "refundTxId"))
+            }
+            refundTxId = refundTxIdTmp
+        }
 
-        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat)
+        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, refundTxId: refundTxId)
     }
 
     static func dictionaryOf(refundableSwap: RefundableSwap) -> [String: Any?] {
@@ -2759,6 +2766,7 @@ enum BreezSDKLiquidMapper {
             "swapAddress": refundableSwap.swapAddress,
             "timestamp": refundableSwap.timestamp,
             "amountSat": refundableSwap.amountSat,
+            "refundTxId": refundableSwap.refundTxId == nil ? nil : refundableSwap.refundTxId,
         ]
     }
 

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2399,22 +2399,22 @@ enum BreezSDKLiquidMapper {
         guard let txFeeSat = prepareRefundResponse["txFeeSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRefundResponse"))
         }
-        var pendingRefundTxId: String?
-        if hasNonNilKey(data: prepareRefundResponse, key: "pendingRefundTxId") {
-            guard let pendingRefundTxIdTmp = prepareRefundResponse["pendingRefundTxId"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "pendingRefundTxId"))
+        var lastRefundTxId: String?
+        if hasNonNilKey(data: prepareRefundResponse, key: "lastRefundTxId") {
+            guard let lastRefundTxIdTmp = prepareRefundResponse["lastRefundTxId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lastRefundTxId"))
             }
-            pendingRefundTxId = pendingRefundTxIdTmp
+            lastRefundTxId = lastRefundTxIdTmp
         }
 
-        return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, pendingRefundTxId: pendingRefundTxId)
+        return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, lastRefundTxId: lastRefundTxId)
     }
 
     static func dictionaryOf(prepareRefundResponse: PrepareRefundResponse) -> [String: Any?] {
         return [
             "txVsize": prepareRefundResponse.txVsize,
             "txFeeSat": prepareRefundResponse.txFeeSat,
-            "pendingRefundTxId": prepareRefundResponse.pendingRefundTxId == nil ? nil : prepareRefundResponse.pendingRefundTxId,
+            "lastRefundTxId": prepareRefundResponse.lastRefundTxId == nil ? nil : prepareRefundResponse.lastRefundTxId,
         ]
     }
 
@@ -2750,15 +2750,15 @@ enum BreezSDKLiquidMapper {
         guard let amountSat = refundableSwap["amountSat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "RefundableSwap"))
         }
-        var pendingRefundTxId: String?
-        if hasNonNilKey(data: refundableSwap, key: "pendingRefundTxId") {
-            guard let pendingRefundTxIdTmp = refundableSwap["pendingRefundTxId"] as? String else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "pendingRefundTxId"))
+        var lastRefundTxId: String?
+        if hasNonNilKey(data: refundableSwap, key: "lastRefundTxId") {
+            guard let lastRefundTxIdTmp = refundableSwap["lastRefundTxId"] as? String else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "lastRefundTxId"))
             }
-            pendingRefundTxId = pendingRefundTxIdTmp
+            lastRefundTxId = lastRefundTxIdTmp
         }
 
-        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, pendingRefundTxId: pendingRefundTxId)
+        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, lastRefundTxId: lastRefundTxId)
     }
 
     static func dictionaryOf(refundableSwap: RefundableSwap) -> [String: Any?] {
@@ -2766,7 +2766,7 @@ enum BreezSDKLiquidMapper {
             "swapAddress": refundableSwap.swapAddress,
             "timestamp": refundableSwap.timestamp,
             "amountSat": refundableSwap.amountSat,
-            "pendingRefundTxId": refundableSwap.pendingRefundTxId == nil ? nil : refundableSwap.pendingRefundTxId,
+            "lastRefundTxId": refundableSwap.lastRefundTxId == nil ? nil : refundableSwap.lastRefundTxId,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -358,7 +358,7 @@ export interface PrepareRefundRequest {
 export interface PrepareRefundResponse {
     txVsize: number
     txFeeSat: number
-    pendingRefundTxId?: string
+    lastRefundTxId?: string
 }
 
 export interface PrepareSendRequest {
@@ -408,7 +408,7 @@ export interface RefundableSwap {
     swapAddress: string
     timestamp: number
     amountSat: number
-    pendingRefundTxId?: string
+    lastRefundTxId?: string
 }
 
 export interface RestoreRequest {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -408,6 +408,7 @@ export interface RefundableSwap {
     swapAddress: string
     timestamp: number
     amountSat: number
+    refundTxId?: string
 }
 
 export interface RestoreRequest {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -358,7 +358,7 @@ export interface PrepareRefundRequest {
 export interface PrepareRefundResponse {
     txVsize: number
     txFeeSat: number
-    refundTxId?: string
+    pendingRefundTxId?: string
 }
 
 export interface PrepareSendRequest {
@@ -408,7 +408,7 @@ export interface RefundableSwap {
     swapAddress: string
     timestamp: number
     amountSat: number
-    refundTxId?: string
+    pendingRefundTxId?: string
 }
 
 export interface RestoreRequest {


### PR DESCRIPTION
Resolves #539

This PR:

- Reimplements UTXO listing in order for only confirmed txs to be considered (both in the SDK, as well as in boltz-client - [upstream PR](https://github.com/SatoshiPortal/boltz-rust/pull/87))
- Sets RefundPending as a refundable state
- Adds the refund tx id to the items returned by `list_refundables` so that pending refunds can be easily distinguished from refunds

~~Note: still have to test if this works for non-coop refunds. Need to wait for the timelock to expire.~~ Works well for non-coop refunds as well

Test notes:

- After a refund has been started for a certain swap, it should still be shown as available for refund. New refunds can be prepared and broadcast.