### PR TITLE
Expose amountless swap fees auto acceptance

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -507,11 +507,11 @@ typedef struct wire_cst_PaymentDetails_Liquid {
 typedef struct wire_cst_PaymentDetails_Bitcoin {
   struct wire_cst_list_prim_u_8_strict *swap_id;
   struct wire_cst_list_prim_u_8_strict *description;
+  bool auto_accepted_fees;
   uint32_t *liquid_expiration_blockheight;
   uint32_t *bitcoin_expiration_blockheight;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;
-  bool auto_accepted_fees;
 } wire_cst_PaymentDetails_Bitcoin;
 
 typedef union PaymentDetailsKind {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -511,6 +511,7 @@ typedef struct wire_cst_PaymentDetails_Bitcoin {
   uint32_t *bitcoin_expiration_blockheight;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;
+  bool auto_accepted_fees;
 } wire_cst_PaymentDetails_Bitcoin;
 
 typedef union PaymentDetailsKind {

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -59,7 +59,7 @@ class SwapUpdatedTask : TaskProtocol {
     func getSwapId(details: PaymentDetails?) -> String? {
         if let details = details {
             switch details {
-            case let .bitcoin(swapId, _, _, _, _, _):
+            case let .bitcoin(swapId, _, _, _, _, _, _):
                 return swapId
             case let .lightning(swapId, _, _, _, _, _, _, _, _, _, _):
                 return swapId

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -582,7 +582,7 @@ dictionary LnUrlInfo {
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
-    Bitcoin(string swap_id, string description, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Bitcoin(string swap_id, string description, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat, boolean auto_accepted_fees);
 };
 
 dictionary Payment {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -582,7 +582,7 @@ dictionary LnUrlInfo {
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string destination, string description);
-    Bitcoin(string swap_id, string description, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat, boolean auto_accepted_fees);
+    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -419,7 +419,8 @@ impl ChainSwapHandler {
                     .inspect_err(|e| {
                         error!("Failed to accept zero-amount swap {id} quote: {e} - trying to erase the accepted receiver amount...");
                         let _ = self.persister.update_accepted_receiver_amount(&id, None);
-                    })
+                    })?;
+                self.persister.set_chain_swap_auto_accepted_fees(&id)
             }
             ValidateAmountlessSwapResult::RequiresUserAction {
                 user_lockup_amount_sat,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3803,19 +3803,19 @@ impl SseDecode for crate::model::PaymentDetails {
             2 => {
                 let mut var_swapId = <String>::sse_decode(deserializer);
                 let mut var_description = <String>::sse_decode(deserializer);
+                let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
                 let mut var_bitcoinExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
-                let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Bitcoin {
                     swap_id: var_swapId,
                     description: var_description,
+                    auto_accepted_fees: var_autoAcceptedFees,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
                     bitcoin_expiration_blockheight: var_bitcoinExpirationBlockheight,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
-                    auto_accepted_fees: var_autoAcceptedFees,
                 };
             }
             _ => {
@@ -5993,20 +5993,20 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
                 description,
+                auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
                 refund_tx_id,
                 refund_tx_amount_sat,
-                auto_accepted_fees,
             } => [
                 2.into_dart(),
                 swap_id.into_into_dart().into_dart(),
                 description.into_into_dart().into_dart(),
+                auto_accepted_fees.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
                 bitcoin_expiration_blockheight.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
-                auto_accepted_fees.into_into_dart().into_dart(),
             ]
             .into_dart(),
             _ => {
@@ -8116,20 +8116,20 @@ impl SseEncode for crate::model::PaymentDetails {
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
                 description,
+                auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
                 refund_tx_id,
                 refund_tx_amount_sat,
-                auto_accepted_fees,
             } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(swap_id, serializer);
                 <String>::sse_encode(description, serializer);
+                <bool>::sse_encode(auto_accepted_fees, serializer);
                 <Option<u32>>::sse_encode(liquid_expiration_blockheight, serializer);
                 <Option<u32>>::sse_encode(bitcoin_expiration_blockheight, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
-                <bool>::sse_encode(auto_accepted_fees, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -10215,6 +10215,7 @@ mod io {
                     crate::model::PaymentDetails::Bitcoin {
                         swap_id: ans.swap_id.cst_decode(),
                         description: ans.description.cst_decode(),
+                        auto_accepted_fees: ans.auto_accepted_fees.cst_decode(),
                         liquid_expiration_blockheight: ans
                             .liquid_expiration_blockheight
                             .cst_decode(),
@@ -10223,7 +10224,6 @@ mod io {
                             .cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
-                        auto_accepted_fees: ans.auto_accepted_fees.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -13817,11 +13817,11 @@ mod io {
     pub struct wire_cst_PaymentDetails_Bitcoin {
         swap_id: *mut wire_cst_list_prim_u_8_strict,
         description: *mut wire_cst_list_prim_u_8_strict,
+        auto_accepted_fees: bool,
         liquid_expiration_blockheight: *mut u32,
         bitcoin_expiration_blockheight: *mut u32,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,
-        auto_accepted_fees: bool,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3807,6 +3807,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_bitcoinExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
+                let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Bitcoin {
                     swap_id: var_swapId,
                     description: var_description,
@@ -3814,6 +3815,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     bitcoin_expiration_blockheight: var_bitcoinExpirationBlockheight,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
+                    auto_accepted_fees: var_autoAcceptedFees,
                 };
             }
             _ => {
@@ -5995,6 +5997,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 bitcoin_expiration_blockheight,
                 refund_tx_id,
                 refund_tx_amount_sat,
+                auto_accepted_fees,
             } => [
                 2.into_dart(),
                 swap_id.into_into_dart().into_dart(),
@@ -6003,6 +6006,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 bitcoin_expiration_blockheight.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
+                auto_accepted_fees.into_into_dart().into_dart(),
             ]
             .into_dart(),
             _ => {
@@ -8116,6 +8120,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 bitcoin_expiration_blockheight,
                 refund_tx_id,
                 refund_tx_amount_sat,
+                auto_accepted_fees,
             } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(swap_id, serializer);
@@ -8124,6 +8129,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <Option<u32>>::sse_encode(bitcoin_expiration_blockheight, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
+                <bool>::sse_encode(auto_accepted_fees, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -10217,6 +10223,7 @@ mod io {
                             .cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
+                        auto_accepted_fees: ans.auto_accepted_fees.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -13814,6 +13821,7 @@ mod io {
         bitcoin_expiration_blockheight: *mut u32,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,
+        auto_accepted_fees: bool,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -788,6 +788,7 @@ pub(crate) struct ChainSwap {
     pub(crate) state: PaymentState,
     pub(crate) claim_private_key: String,
     pub(crate) refund_private_key: String,
+    pub(crate) auto_accepted_fees: bool,
     /// Version used for optimistic concurrency control within local db
     #[derivative(PartialEq = "ignore")]
     pub(crate) version: u64,
@@ -1450,6 +1451,11 @@ pub enum PaymentDetails {
 
         /// For a Send swap which was refunded, this is the refund amount
         refund_tx_amount_sat: Option<u64>,
+
+        /// For an amountless receive swap, this indicates if fees were automatically accepted.
+        /// Fees are auto accepted when the swapper proposes fees that are within the initial
+        /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+        auto_accepted_fees: bool,
     },
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1438,6 +1438,11 @@ pub enum PaymentDetails {
         /// Represents the invoice description
         description: String,
 
+        /// For an amountless receive swap, this indicates if fees were automatically accepted.
+        /// Fees are auto accepted when the swapper proposes fees that are within the initial
+        /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+        auto_accepted_fees: bool,
+
         /// The height of the Liquid block at which the swap will no longer be valid
         /// It should always be populated in case of an outgoing chain swap
         liquid_expiration_blockheight: Option<u32>,
@@ -1451,11 +1456,6 @@ pub enum PaymentDetails {
 
         /// For a Send swap which was refunded, this is the refund amount
         refund_tx_amount_sat: Option<u64>,
-
-        /// For an amountless receive swap, this indicates if fees were automatically accepted.
-        /// Fees are auto accepted when the swapper proposes fees that are within the initial
-        /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
-        auto_accepted_fees: bool,
     },
 }
 

--- a/lib/core/src/persist/migrations.rs
+++ b/lib/core/src/persist/migrations.rs
@@ -248,5 +248,6 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         ALTER TABLE receive_swaps ADD COLUMN destination_pubkey TEXT;
         ALTER TABLE send_swaps ADD COLUMN destination_pubkey TEXT;
         ",
+        "ALTER TABLE chain_swaps ADD COLUMN auto_accepted_fees INTEGER NOT NULL DEFAULT 0;",
     ]
 }

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -407,6 +407,7 @@ impl Persister {
                 cs.pair_fees_json,
                 cs.actual_payer_amount_sat,
                 cs.accepted_receiver_amount_sat,
+                cs.auto_accepted_fees,
                 rtx.amount_sat,
                 pd.destination,
                 pd.description,
@@ -515,12 +516,13 @@ impl Persister {
             maybe_chain_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
         let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(45)?;
         let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(46)?;
+        let maybe_chain_swap_auto_accepted_fees: Option<bool> = row.get(47)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(47)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(48)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(48)?;
-        let maybe_payment_details_description: Option<String> = row.get(49)?;
-        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(50)?;
+        let maybe_payment_details_destination: Option<String> = row.get(49)?;
+        let maybe_payment_details_description: Option<String> = row.get(50)?;
+        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(51)?;
         let maybe_payment_details_lnurl_info: Option<LnUrlInfo> =
             maybe_payment_details_lnurl_info_json.and_then(|info| serde_json::from_str(&info).ok());
 
@@ -701,6 +703,7 @@ impl Persister {
                         Some(Direction::Incoming) => (Some(expiration_blockheight), None),
                         Some(Direction::Outgoing) | None => (None, Some(expiration_blockheight)),
                     };
+                let auto_accepted_fees = maybe_chain_swap_auto_accepted_fees.unwrap_or(false);
 
                 PaymentDetails::Bitcoin {
                     swap_id,
@@ -709,6 +712,7 @@ impl Persister {
                     description: description.unwrap_or("Bitcoin transfer".to_string()),
                     liquid_expiration_blockheight,
                     bitcoin_expiration_blockheight,
+                    auto_accepted_fees,
                 }
             }
             _ => PaymentDetails::Liquid {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1681,6 +1681,7 @@ impl LiquidSdk {
             refund_tx_id: None,
             created_at: utils::now(),
             state: PaymentState::Created,
+            auto_accepted_fees: false,
             version: 0,
         };
         self.persister.insert_or_update_chain_swap(&swap)?;
@@ -2132,6 +2133,7 @@ impl LiquidSdk {
             refund_tx_id: None,
             created_at: utils::now(),
             state: PaymentState::Created,
+            auto_accepted_fees: false,
             version: 0,
         };
         self.persister.insert_or_update_chain_swap(&swap)?;

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -26,6 +26,7 @@ pub(crate) struct ChainSyncData {
     pub(crate) accept_zero_conf: bool,
     pub(crate) created_at: u32,
     pub(crate) description: Option<String>,
+    #[serde(default)]
     pub(crate) auto_accepted_fees: bool,
 }
 

--- a/lib/core/src/sync/model/data.rs
+++ b/lib/core/src/sync/model/data.rs
@@ -26,6 +26,7 @@ pub(crate) struct ChainSyncData {
     pub(crate) accept_zero_conf: bool,
     pub(crate) created_at: u32,
     pub(crate) description: Option<String>,
+    pub(crate) auto_accepted_fees: bool,
 }
 
 impl ChainSyncData {
@@ -35,6 +36,9 @@ impl ChainSyncData {
                 "accept_zero_conf" => self.accept_zero_conf = other.accept_zero_conf,
                 "accepted_receiver_amount_sat" => {
                     self.accepted_receiver_amount_sat = other.accepted_receiver_amount_sat
+                }
+                "auto_accepted_fees" => {
+                    self.auto_accepted_fees = other.auto_accepted_fees;
                 }
                 _ => continue,
             }
@@ -53,6 +57,9 @@ impl ChainSyncData {
                 }
                 if update.accepted_receiver_amount_sat != swap.accepted_receiver_amount_sat {
                     updated_fields.push("accepted_receiver_amount_sat".to_string());
+                }
+                if update.auto_accepted_fees != swap.auto_accepted_fees {
+                    updated_fields.push("auto_accepted_fees".to_string());
                 }
                 Some(updated_fields)
             }
@@ -80,6 +87,7 @@ impl From<ChainSwap> for ChainSyncData {
             accept_zero_conf: value.accept_zero_conf,
             created_at: value.created_at,
             description: value.description,
+            auto_accepted_fees: value.auto_accepted_fees,
         }
     }
 }
@@ -110,6 +118,7 @@ impl From<ChainSyncData> for ChainSwap {
             user_lockup_tx_id: None,
             claim_tx_id: None,
             refund_tx_id: None,
+            auto_accepted_fees: val.auto_accepted_fees,
             version: 0,
         }
     }

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod data;
 
 const MESSAGE_PREFIX: &[u8; 13] = b"realtimesync:";
 lazy_static! {
-    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.2.0").unwrap();
+    static ref CURRENT_SCHEMA_VERSION: Version = Version::parse("0.3.0").unwrap();
 }
 
 #[derive(Copy, Clone)]

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -144,6 +144,7 @@ pub(crate) fn new_chain_swap(
                 }
             }"#
             .to_string(),
+            auto_accepted_fees: false,
             version: 0
         };
     }
@@ -228,6 +229,7 @@ pub(crate) fn new_chain_swap(
                 }
               }
             }"#.to_string(),
+            auto_accepted_fees: false,
             version: 0,
         },
         Direction::Outgoing => ChainSwap {
@@ -310,6 +312,7 @@ pub(crate) fn new_chain_swap(
                 }
               }
             }"#.to_string(),
+            auto_accepted_fees: false,
             version: 0
         }
     }

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -165,5 +165,6 @@ pub(crate) fn new_chain_sync_data(accept_zero_conf: Option<bool>) -> ChainSyncDa
         accept_zero_conf: accept_zero_conf.unwrap_or(true),
         created_at: 0,
         description: None,
+        auto_accepted_fees: false,
     }
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2709,11 +2709,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return PaymentDetails_Bitcoin(
           swapId: dco_decode_String(raw[1]),
           description: dco_decode_String(raw[2]),
-          liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[3]),
-          bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
-          refundTxId: dco_decode_opt_String(raw[5]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[6]),
-          autoAcceptedFees: dco_decode_bool(raw[7]),
+          autoAcceptedFees: dco_decode_bool(raw[3]),
+          liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
+          bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
+          refundTxId: dco_decode_opt_String(raw[6]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[7]),
         );
       default:
         throw Exception("unreachable");
@@ -4900,19 +4900,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         var var_swapId = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
+        var var_autoAcceptedFees = sse_decode_bool(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
         var var_bitcoinExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
-        var var_autoAcceptedFees = sse_decode_bool(deserializer);
         return PaymentDetails_Bitcoin(
             swapId: var_swapId,
             description: var_description,
+            autoAcceptedFees: var_autoAcceptedFees,
             liquidExpirationBlockheight: var_liquidExpirationBlockheight,
             bitcoinExpirationBlockheight: var_bitcoinExpirationBlockheight,
             refundTxId: var_refundTxId,
-            refundTxAmountSat: var_refundTxAmountSat,
-            autoAcceptedFees: var_autoAcceptedFees);
+            refundTxAmountSat: var_refundTxAmountSat);
       default:
         throw UnimplementedError('');
     }
@@ -6918,20 +6918,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case PaymentDetails_Bitcoin(
           swapId: final swapId,
           description: final description,
+          autoAcceptedFees: final autoAcceptedFees,
           liquidExpirationBlockheight: final liquidExpirationBlockheight,
           bitcoinExpirationBlockheight: final bitcoinExpirationBlockheight,
           refundTxId: final refundTxId,
-          refundTxAmountSat: final refundTxAmountSat,
-          autoAcceptedFees: final autoAcceptedFees
+          refundTxAmountSat: final refundTxAmountSat
         ):
         sse_encode_i_32(2, serializer);
         sse_encode_String(swapId, serializer);
         sse_encode_String(description, serializer);
+        sse_encode_bool(autoAcceptedFees, serializer);
         sse_encode_opt_box_autoadd_u_32(liquidExpirationBlockheight, serializer);
         sse_encode_opt_box_autoadd_u_32(bitcoinExpirationBlockheight, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
-        sse_encode_bool(autoAcceptedFees, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2713,6 +2713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
           refundTxId: dco_decode_opt_String(raw[5]),
           refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[6]),
+          autoAcceptedFees: dco_decode_bool(raw[7]),
         );
       default:
         throw Exception("unreachable");
@@ -4903,13 +4904,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_bitcoinExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
+        var var_autoAcceptedFees = sse_decode_bool(deserializer);
         return PaymentDetails_Bitcoin(
             swapId: var_swapId,
             description: var_description,
             liquidExpirationBlockheight: var_liquidExpirationBlockheight,
             bitcoinExpirationBlockheight: var_bitcoinExpirationBlockheight,
             refundTxId: var_refundTxId,
-            refundTxAmountSat: var_refundTxAmountSat);
+            refundTxAmountSat: var_refundTxAmountSat,
+            autoAcceptedFees: var_autoAcceptedFees);
       default:
         throw UnimplementedError('');
     }
@@ -6918,7 +6921,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           liquidExpirationBlockheight: final liquidExpirationBlockheight,
           bitcoinExpirationBlockheight: final bitcoinExpirationBlockheight,
           refundTxId: final refundTxId,
-          refundTxAmountSat: final refundTxAmountSat
+          refundTxAmountSat: final refundTxAmountSat,
+          autoAcceptedFees: final autoAcceptedFees
         ):
         sse_encode_i_32(2, serializer);
         sse_encode_String(swapId, serializer);
@@ -6927,6 +6931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_box_autoadd_u_32(bitcoinExpirationBlockheight, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
+        sse_encode_bool(autoAcceptedFees, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2978,21 +2978,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is PaymentDetails_Bitcoin) {
       var pre_swap_id = cst_encode_String(apiObj.swapId);
       var pre_description = cst_encode_String(apiObj.description);
+      var pre_auto_accepted_fees = cst_encode_bool(apiObj.autoAcceptedFees);
       var pre_liquid_expiration_blockheight =
           cst_encode_opt_box_autoadd_u_32(apiObj.liquidExpirationBlockheight);
       var pre_bitcoin_expiration_blockheight =
           cst_encode_opt_box_autoadd_u_32(apiObj.bitcoinExpirationBlockheight);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
-      var pre_auto_accepted_fees = cst_encode_bool(apiObj.autoAcceptedFees);
       wireObj.tag = 2;
       wireObj.kind.Bitcoin.swap_id = pre_swap_id;
       wireObj.kind.Bitcoin.description = pre_description;
+      wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       wireObj.kind.Bitcoin.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
       wireObj.kind.Bitcoin.bitcoin_expiration_blockheight = pre_bitcoin_expiration_blockheight;
       wireObj.kind.Bitcoin.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Bitcoin.refund_tx_amount_sat = pre_refund_tx_amount_sat;
-      wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       return;
     }
   }
@@ -6411,6 +6411,9 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
+  @ffi.Bool()
+  external bool auto_accepted_fees;
+
   external ffi.Pointer<ffi.Uint32> liquid_expiration_blockheight;
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
@@ -6418,9 +6421,6 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
-
-  @ffi.Bool()
-  external bool auto_accepted_fees;
 }
 
 final class PaymentDetailsKind extends ffi.Union {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2984,6 +2984,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_opt_box_autoadd_u_32(apiObj.bitcoinExpirationBlockheight);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
+      var pre_auto_accepted_fees = cst_encode_bool(apiObj.autoAcceptedFees);
       wireObj.tag = 2;
       wireObj.kind.Bitcoin.swap_id = pre_swap_id;
       wireObj.kind.Bitcoin.description = pre_description;
@@ -2991,6 +2992,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Bitcoin.bitcoin_expiration_blockheight = pre_bitcoin_expiration_blockheight;
       wireObj.kind.Bitcoin.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Bitcoin.refund_tx_amount_sat = pre_refund_tx_amount_sat;
+      wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       return;
     }
   }
@@ -6416,6 +6418,9 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
+
+  @ffi.Bool()
+  external bool auto_accepted_fees;
 }
 
 final class PaymentDetailsKind extends ffi.Union {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -841,6 +841,11 @@ sealed class PaymentDetails with _$PaymentDetails {
 
     /// For a Send swap which was refunded, this is the refund amount
     BigInt? refundTxAmountSat,
+
+    /// For an amountless receive swap, this indicates if fees were automatically accepted.
+    /// Fees are auto accepted when the swapper proposes fees that are within the initial
+    /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+    required bool autoAcceptedFees,
   }) = PaymentDetails_Bitcoin;
 }
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -828,6 +828,11 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// Represents the invoice description
     required String description,
 
+    /// For an amountless receive swap, this indicates if fees were automatically accepted.
+    /// Fees are auto accepted when the swapper proposes fees that are within the initial
+    /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+    required bool autoAcceptedFees,
+
     /// The height of the Liquid block at which the swap will no longer be valid
     /// It should always be populated in case of an outgoing chain swap
     int? liquidExpirationBlockheight,
@@ -841,11 +846,6 @@ sealed class PaymentDetails with _$PaymentDetails {
 
     /// For a Send swap which was refunded, this is the refund amount
     BigInt? refundTxAmountSat,
-
-    /// For an amountless receive swap, this indicates if fees were automatically accepted.
-    /// Fees are auto accepted when the swapper proposes fees that are within the initial
-    /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
-    required bool autoAcceptedFees,
   }) = PaymentDetails_Bitcoin;
 }
 

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1142,7 +1142,8 @@ abstract class _$$PaymentDetails_BitcoinImplCopyWith<$Res> implements $PaymentDe
       int? liquidExpirationBlockheight,
       int? bitcoinExpirationBlockheight,
       String? refundTxId,
-      BigInt? refundTxAmountSat});
+      BigInt? refundTxAmountSat,
+      bool autoAcceptedFees});
 }
 
 /// @nodoc
@@ -1164,6 +1165,7 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
     Object? bitcoinExpirationBlockheight = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
+    Object? autoAcceptedFees = null,
   }) {
     return _then(_$PaymentDetails_BitcoinImpl(
       swapId: null == swapId
@@ -1190,6 +1192,10 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
           ? _value.refundTxAmountSat
           : refundTxAmountSat // ignore: cast_nullable_to_non_nullable
               as BigInt?,
+      autoAcceptedFees: null == autoAcceptedFees
+          ? _value.autoAcceptedFees
+          : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -1203,7 +1209,8 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
       this.liquidExpirationBlockheight,
       this.bitcoinExpirationBlockheight,
       this.refundTxId,
-      this.refundTxAmountSat})
+      this.refundTxAmountSat,
+      required this.autoAcceptedFees})
       : super._();
 
   @override
@@ -1231,9 +1238,15 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
   @override
   final BigInt? refundTxAmountSat;
 
+  /// For an amountless receive swap, this indicates if fees were automatically accepted.
+  /// Fees are auto accepted when the swapper proposes fees that are within the initial
+  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+  @override
+  final bool autoAcceptedFees;
+
   @override
   String toString() {
-    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat, autoAcceptedFees: $autoAcceptedFees)';
   }
 
   @override
@@ -1249,12 +1262,14 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
                 other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
-                other.refundTxAmountSat == refundTxAmountSat));
+                other.refundTxAmountSat == refundTxAmountSat) &&
+            (identical(other.autoAcceptedFees, autoAcceptedFees) ||
+                other.autoAcceptedFees == autoAcceptedFees));
   }
 
   @override
   int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight,
-      bitcoinExpirationBlockheight, refundTxId, refundTxAmountSat);
+      bitcoinExpirationBlockheight, refundTxId, refundTxAmountSat, autoAcceptedFees);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1272,7 +1287,8 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
       final int? liquidExpirationBlockheight,
       final int? bitcoinExpirationBlockheight,
       final String? refundTxId,
-      final BigInt? refundTxAmountSat}) = _$PaymentDetails_BitcoinImpl;
+      final BigInt? refundTxAmountSat,
+      required final bool autoAcceptedFees}) = _$PaymentDetails_BitcoinImpl;
   const PaymentDetails_Bitcoin._() : super._();
 
   String get swapId;
@@ -1294,6 +1310,11 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
 
   /// For a Send swap which was refunded, this is the refund amount
   BigInt? get refundTxAmountSat;
+
+  /// For an amountless receive swap, this indicates if fees were automatically accepted.
+  /// Fees are auto accepted when the swapper proposes fees that are within the initial
+  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+  bool get autoAcceptedFees;
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1139,11 +1139,11 @@ abstract class _$$PaymentDetails_BitcoinImplCopyWith<$Res> implements $PaymentDe
   $Res call(
       {String swapId,
       String description,
+      bool autoAcceptedFees,
       int? liquidExpirationBlockheight,
       int? bitcoinExpirationBlockheight,
       String? refundTxId,
-      BigInt? refundTxAmountSat,
-      bool autoAcceptedFees});
+      BigInt? refundTxAmountSat});
 }
 
 /// @nodoc
@@ -1161,11 +1161,11 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
   $Res call({
     Object? swapId = null,
     Object? description = null,
+    Object? autoAcceptedFees = null,
     Object? liquidExpirationBlockheight = freezed,
     Object? bitcoinExpirationBlockheight = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
-    Object? autoAcceptedFees = null,
   }) {
     return _then(_$PaymentDetails_BitcoinImpl(
       swapId: null == swapId
@@ -1176,6 +1176,10 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String,
+      autoAcceptedFees: null == autoAcceptedFees
+          ? _value.autoAcceptedFees
+          : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
+              as bool,
       liquidExpirationBlockheight: freezed == liquidExpirationBlockheight
           ? _value.liquidExpirationBlockheight
           : liquidExpirationBlockheight // ignore: cast_nullable_to_non_nullable
@@ -1192,10 +1196,6 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
           ? _value.refundTxAmountSat
           : refundTxAmountSat // ignore: cast_nullable_to_non_nullable
               as BigInt?,
-      autoAcceptedFees: null == autoAcceptedFees
-          ? _value.autoAcceptedFees
-          : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }
@@ -1206,11 +1206,11 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
   const _$PaymentDetails_BitcoinImpl(
       {required this.swapId,
       required this.description,
+      required this.autoAcceptedFees,
       this.liquidExpirationBlockheight,
       this.bitcoinExpirationBlockheight,
       this.refundTxId,
-      this.refundTxAmountSat,
-      required this.autoAcceptedFees})
+      this.refundTxAmountSat})
       : super._();
 
   @override
@@ -1219,6 +1219,12 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
   /// Represents the invoice description
   @override
   final String description;
+
+  /// For an amountless receive swap, this indicates if fees were automatically accepted.
+  /// Fees are auto accepted when the swapper proposes fees that are within the initial
+  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+  @override
+  final bool autoAcceptedFees;
 
   /// The height of the Liquid block at which the swap will no longer be valid
   /// It should always be populated in case of an outgoing chain swap
@@ -1238,15 +1244,9 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
   @override
   final BigInt? refundTxAmountSat;
 
-  /// For an amountless receive swap, this indicates if fees were automatically accepted.
-  /// Fees are auto accepted when the swapper proposes fees that are within the initial
-  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
-  @override
-  final bool autoAcceptedFees;
-
   @override
   String toString() {
-    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat, autoAcceptedFees: $autoAcceptedFees)';
+    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -1256,20 +1256,20 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
             other is _$PaymentDetails_BitcoinImpl &&
             (identical(other.swapId, swapId) || other.swapId == swapId) &&
             (identical(other.description, description) || other.description == description) &&
+            (identical(other.autoAcceptedFees, autoAcceptedFees) ||
+                other.autoAcceptedFees == autoAcceptedFees) &&
             (identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) ||
                 other.liquidExpirationBlockheight == liquidExpirationBlockheight) &&
             (identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) ||
                 other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
-                other.refundTxAmountSat == refundTxAmountSat) &&
-            (identical(other.autoAcceptedFees, autoAcceptedFees) ||
-                other.autoAcceptedFees == autoAcceptedFees));
+                other.refundTxAmountSat == refundTxAmountSat));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight,
-      bitcoinExpirationBlockheight, refundTxId, refundTxAmountSat, autoAcceptedFees);
+  int get hashCode => Object.hash(runtimeType, swapId, description, autoAcceptedFees,
+      liquidExpirationBlockheight, bitcoinExpirationBlockheight, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1284,11 +1284,11 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
   const factory PaymentDetails_Bitcoin(
       {required final String swapId,
       required final String description,
+      required final bool autoAcceptedFees,
       final int? liquidExpirationBlockheight,
       final int? bitcoinExpirationBlockheight,
       final String? refundTxId,
-      final BigInt? refundTxAmountSat,
-      required final bool autoAcceptedFees}) = _$PaymentDetails_BitcoinImpl;
+      final BigInt? refundTxAmountSat}) = _$PaymentDetails_BitcoinImpl;
   const PaymentDetails_Bitcoin._() : super._();
 
   String get swapId;
@@ -1296,6 +1296,11 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
   /// Represents the invoice description
   @override
   String get description;
+
+  /// For an amountless receive swap, this indicates if fees were automatically accepted.
+  /// Fees are auto accepted when the swapper proposes fees that are within the initial
+  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
+  bool get autoAcceptedFees;
 
   /// The height of the Liquid block at which the swap will no longer be valid
   /// It should always be populated in case of an outgoing chain swap
@@ -1310,11 +1315,6 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
 
   /// For a Send swap which was refunded, this is the refund amount
   BigInt? get refundTxAmountSat;
-
-  /// For an amountless receive swap, this indicates if fees were automatically accepted.
-  /// Fees are auto accepted when the swapper proposes fees that are within the initial
-  /// estimate, plus the `onchain_fee_rate_leeway_sat_per_vbyte` set in the [Config], if any.
-  bool get autoAcceptedFees;
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4738,6 +4738,9 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
+
+  @ffi.Bool()
+  external bool auto_accepted_fees;
 }
 
 final class PaymentDetailsKind extends ffi.Union {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4731,6 +4731,9 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
+  @ffi.Bool()
+  external bool auto_accepted_fees;
+
   external ffi.Pointer<ffi.Uint32> liquid_expiration_blockheight;
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
@@ -4738,9 +4741,6 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
-
-  @ffi.Bool()
-  external bool auto_accepted_fees;
 }
 
 final class PaymentDetailsKind extends ffi.Union {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3308,6 +3308,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
     if (type == "bitcoin") {
         val swapId = paymentDetails.getString("swapId")!!
         val description = paymentDetails.getString("description")!!
+        val autoAcceptedFees = paymentDetails.getBoolean("autoAcceptedFees")
         val bitcoinExpirationBlockheight =
             if (hasNonNullKey(
                     paymentDetails,
@@ -3339,15 +3340,14 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
-        val autoAcceptedFees = paymentDetails.getBoolean("autoAcceptedFees")
         return PaymentDetails.Bitcoin(
             swapId,
             description,
+            autoAcceptedFees,
             bitcoinExpirationBlockheight,
             liquidExpirationBlockheight,
             refundTxId,
             refundTxAmountSat,
-            autoAcceptedFees,
         )
     }
     return null
@@ -3379,11 +3379,11 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "type", "bitcoin")
             pushToMap(map, "swapId", paymentDetails.swapId)
             pushToMap(map, "description", paymentDetails.description)
+            pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
             pushToMap(map, "bitcoinExpirationBlockheight", paymentDetails.bitcoinExpirationBlockheight)
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)
-            pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
         }
     }
     return map

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3339,6 +3339,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
+        val autoAcceptedFees = paymentDetails.getBoolean("autoAcceptedFees")
         return PaymentDetails.Bitcoin(
             swapId,
             description,
@@ -3346,6 +3347,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             liquidExpirationBlockheight,
             refundTxId,
             refundTxAmountSat,
+            autoAcceptedFees,
         )
     }
     return null
@@ -3381,6 +3383,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)
+            pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
         }
     }
     return map

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4013,7 +4013,10 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            guard let _autoAcceptedFees = paymentDetails["autoAcceptedFees"] as? Bool else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "autoAcceptedFees", typeName: "PaymentDetails"))
+            }
+            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat, autoAcceptedFees: _autoAcceptedFees)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4049,7 +4052,7 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, description, bitcoinExpirationBlockheight, liquidExpirationBlockheight, refundTxId, refundTxAmountSat
+            swapId, description, bitcoinExpirationBlockheight, liquidExpirationBlockheight, refundTxId, refundTxAmountSat, autoAcceptedFees
         ):
             return [
                 "type": "bitcoin",
@@ -4059,6 +4062,7 @@ enum BreezSDKLiquidMapper {
                 "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
+                "autoAcceptedFees": autoAcceptedFees,
             ]
         }
     }

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4005,6 +4005,9 @@ enum BreezSDKLiquidMapper {
             guard let _description = paymentDetails["description"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
             }
+            guard let _autoAcceptedFees = paymentDetails["autoAcceptedFees"] as? Bool else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "autoAcceptedFees", typeName: "PaymentDetails"))
+            }
             let _bitcoinExpirationBlockheight = paymentDetails["bitcoinExpirationBlockheight"] as? UInt32
 
             let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32
@@ -4013,10 +4016,7 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            guard let _autoAcceptedFees = paymentDetails["autoAcceptedFees"] as? Bool else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "autoAcceptedFees", typeName: "PaymentDetails"))
-            }
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat, autoAcceptedFees: _autoAcceptedFees)
+            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4052,17 +4052,17 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, description, bitcoinExpirationBlockheight, liquidExpirationBlockheight, refundTxId, refundTxAmountSat, autoAcceptedFees
+            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "bitcoin",
                 "swapId": swapId,
                 "description": description,
+                "autoAcceptedFees": autoAcceptedFees,
                 "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,
                 "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
-                "autoAcceptedFees": autoAcceptedFees,
             ]
         }
     }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -665,6 +665,7 @@ export type PaymentDetails = {
     liquidExpirationBlockheight?: number
     refundTxId?: string
     refundTxAmountSat?: number
+    autoAcceptedFees: boolean
 }
 
 export enum PaymentMethod {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -661,11 +661,11 @@ export type PaymentDetails = {
     type: PaymentDetailsVariant.BITCOIN,
     swapId: string
     description: string
+    autoAcceptedFees: boolean
     bitcoinExpirationBlockheight?: number
     liquidExpirationBlockheight?: number
     refundTxId?: string
     refundTxAmountSat?: number
-    autoAcceptedFees: boolean
 }
 
 export enum PaymentMethod {


### PR DESCRIPTION
Resolves #631.

This PR adds a boolean field to BTC address payments that indicates if an amountless swap had its fees auto-accepted. This is added to the synced fields so that other instances of the SDK can learn about it.