### PR TITLE
Consider PairLimits in is_refundable condition

### DIFF
--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -246,7 +246,7 @@ impl RecoveredOnchainDataChainReceive {
                 }
                 (None, None) => match is_refundable {
                     true => Some(PaymentState::Refundable),
-                    false => match is_waiting_fee_acceptance {
+                    false => match is_waiting_fee_acceptance && !amount_out_of_bounds {
                         true => Some(PaymentState::WaitingFeeAcceptance),
                         false => Some(PaymentState::Pending),
                     },

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -284,12 +284,14 @@ impl Recoverer {
                         }
                         let is_expired =
                             bitcoin_tip.height as u32 >= chain_swap.timeout_block_height;
-                        let expected_user_lockup_amount_sat = match chain_swap.payer_amount_sat {
-                            0 => None,
-                            expected => Some(expected),
-                        };
+                        let (expected_user_lockup_amount_sat, swap_limits) =
+                            match chain_swap.payer_amount_sat {
+                                0 => (None, Some(chain_swap.get_boltz_pair()?.limits)),
+                                expected => (Some(expected), None),
+                            };
                         if let Some(new_state) = recovered_data.derive_partial_state(
                             expected_user_lockup_amount_sat,
+                            swap_limits,
                             is_expired,
                             chain_swap.is_waiting_fee_acceptance(),
                         ) {


### PR DESCRIPTION
This PR adds a PairLimits check in the `is_refundable` condition when deriving the current state of a chain swap. Without it, an amountless swap for which the user locks up too little/too much funds will not be correctly derived as refundable.

Test notes:

- Create an amountless receive to BTC address and send an amount below the indicated minimum. After the Bitcoin tx confirms, the payment should be shown as refundable.