### PR TITLE
Real-time Sync: Add notifications endpoint

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1035,14 +1035,6 @@ impl LiquidSdk {
                 };
             }
             Ok(InputType::Bolt11 { invoice }) => {
-                if let Some(sync_service) = &self.sync_service {
-                    sync_service
-                        .pull()
-                        .await
-                        .map_err(|err| PaymentError::Generic {
-                            err: format!("Could not pull real-time sync changes: {err:?}"),
-                        })?;
-                }
                 self.ensure_send_is_not_self_transfer(&invoice.bolt11)?;
                 self.validate_bolt11_invoice(&invoice.bolt11)?;
 

--- a/lib/core/src/sync/model/client.rs
+++ b/lib/core/src/sync/model/client.rs
@@ -8,7 +8,10 @@ use lwk_wollet::hashes::hex::DisplayHex as _;
 use openssl::sha::sha256;
 use std::sync::Arc;
 
-use super::{ListChangesRequest, Record, SetRecordRequest, CURRENT_SCHEMA_VERSION, MESSAGE_PREFIX};
+use super::{
+    ListChangesRequest, ListenChangesRequest, Record, SetRecordRequest, CURRENT_SCHEMA_VERSION,
+    MESSAGE_PREFIX,
+};
 
 fn sign_message(msg: &[u8], signer: Arc<Box<dyn Signer>>) -> Result<String, SignerError> {
     let msg = [MESSAGE_PREFIX, msg].concat();
@@ -51,6 +54,17 @@ impl SetRecordRequest {
         trace!("Got signature: {}", signature);
         Ok(Self {
             record: Some(record),
+            request_time,
+            signature,
+        })
+    }
+}
+impl ListenChangesRequest {
+    pub(crate) fn new(signer: Arc<Box<dyn Signer>>) -> Result<Self, SignerError> {
+        let request_time = utils::now();
+        let msg = format!("{}", request_time);
+        let signature = sign_message(msg.as_bytes(), signer)?;
+        Ok(Self {
             request_time,
             signature,
         })

--- a/lib/core/src/sync/proto/sync.proto
+++ b/lib/core/src/sync/proto/sync.proto
@@ -6,7 +6,7 @@ package sync;
 service Syncer {
   rpc SetRecord(SetRecordRequest) returns (SetRecordReply) {}
   rpc ListChanges(ListChangesRequest) returns (ListChangesReply) {}
-  rpc TrackChanges(TrackChangesRequest) returns (stream Record);
+  rpc ListenChanges(ListenChangesRequest) returns (stream Notification);
 }
 
 message Record {
@@ -37,7 +37,9 @@ message ListChangesRequest {
 }
 message ListChangesReply { repeated Record changes = 1; }
 
-message TrackChangesRequest {
+message ListenChangesRequest {
   uint32 request_time = 1;
   string signature = 2;
 }
+
+message Notification {}

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -10,8 +10,8 @@ use crate::{
         client::SyncerClient,
         model::{
             data::{ChainSyncData, ReceiveSyncData, SendSyncData},
-            ListChangesReply, ListChangesRequest, Record, SetRecordReply, SetRecordRequest,
-            SetRecordStatus,
+            ListChangesReply, ListChangesRequest, ListenChangesRequest, Notification, Record,
+            SetRecordReply, SetRecordRequest, SetRecordStatus,
         },
         SyncService,
     },
@@ -22,6 +22,7 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     Mutex,
 };
+use tonic::Streaming;
 
 pub(crate) struct MockSyncerClient {
     pub(crate) incoming_rx: Mutex<Receiver<Record>>,
@@ -77,6 +78,10 @@ impl SyncerClient for MockSyncerClient {
         let mut changes = Vec::with_capacity(3);
         rx.recv_many(&mut changes, 3).await;
         Ok(ListChangesReply { changes })
+    }
+
+    async fn listen(&self, _req: ListenChangesRequest) -> Result<Streaming<Notification>> {
+        todo!()
     }
 
     async fn disconnect(&self) -> Result<()> {


### PR DESCRIPTION
Reflects changes from breez/data-sync@34e551c5cfe1.

This PR adds a notification endpoint `ListenChanges`, which triggers the real-time sync event loop whenever the remote broadcasts a notification through a gRPC stream.

**Testing note:**
Testing this PR is similar to repeating the initial tests for real-time sync. We need to ensure that the payment details fields get populated every time another instance pays. Furthermore, the delay between payment syncs should now be reduced, so you should see the payment appear on both devices much quicker.