### PR TITLE
Allow incoming chain swap refund tx id overwrite

### DIFF
--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -308,28 +308,17 @@ impl Persister {
         mrh_tx_id: Option<&str>,
         mrh_amount_sat: Option<u64>,
     ) -> Result<(), PaymentError> {
-        // Do not overwrite claim_tx_id or lockup_tx_id
+        // Do not overwrite claim_tx_id, lockup_tx_id, mrh_tx_id
         let mut con = self.get_connection()?;
         let tx = con.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
         tx.execute(
             "UPDATE receive_swaps
             SET
-                claim_tx_id =
-                    CASE
-                        WHEN claim_tx_id IS NULL THEN :claim_tx_id
-                        ELSE claim_tx_id
-                    END,
-                lockup_tx_id = 
-                    CASE
-                        WHEN lockup_tx_id IS NULL THEN :lockup_tx_id
-                        ELSE lockup_tx_id
-                    END,
-                mrh_tx_id = 
-                    CASE
-                        WHEN mrh_tx_id IS NULL THEN :mrh_tx_id
-                        ELSE mrh_tx_id
-                    END,
+                claim_tx_id = COALESCE(claim_tx_id, :claim_tx_id),
+                lockup_tx_id = COALESCE(lockup_tx_id, :lockup_tx_id),
+                mrh_tx_id = COALESCE(mrh_tx_id, :mrh_tx_id),
+
                 payer_amount_sat = COALESCE(:mrh_amount_sat, payer_amount_sat),
                 receiver_amount_sat = COALESCE(:mrh_amount_sat, receiver_amount_sat),
                 state = :state

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -265,24 +265,9 @@ impl Persister {
         tx.execute(
             "UPDATE send_swaps
             SET
-                preimage =
-                    CASE
-                        WHEN preimage IS NULL THEN :preimage
-                        ELSE preimage
-                    END,
-
-                lockup_tx_id =
-                    CASE
-                        WHEN lockup_tx_id IS NULL THEN :lockup_tx_id
-                        ELSE lockup_tx_id
-                    END,
-
-                refund_tx_id =
-                    CASE
-                        WHEN refund_tx_id IS NULL THEN :refund_tx_id
-                        ELSE refund_tx_id
-                    END,
-
+                preimage = COALESCE(preimage, :preimage),
+                lockup_tx_id = COALESCE(lockup_tx_id, :lockup_tx_id),
+                refund_tx_id = COALESCE(refund_tx_id, :refund_tx_id),
                 state = :state
             WHERE
                 id = :id",


### PR DESCRIPTION
This PR changes the chain swap update query to allow overwrites of the refund tx id, which can now change due to potential fee bumps using RBF. 

Additionally, it simplifies the code using coalesce in the same query and the analogous ones from the other swap types.