### PR TITLE
Use cached electrum client connection for full_scan

### DIFF
--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -166,7 +166,6 @@ impl Recoverer {
     /// - `tx_map`: all known onchain txs of this wallet at this time, essentially our own LWK cache.
     /// - `swaps`: immutable data of the swaps for which we want to recover onchain data.
     pub(crate) async fn recover_from_onchain(&self, swaps: &mut [Swap]) -> Result<()> {
-        self.onchain_wallet.full_scan().await?;
         let tx_map = TxMap::from_raw_tx_map(self.onchain_wallet.transactions_by_tx_id().await?);
 
         let swaps_list = swaps.to_vec().try_into()?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -390,6 +390,10 @@ impl LiquidSdk {
                             .unwrap_or_else(|err| warn!("Could not update local tips: {err:?}"));
                         };
 
+                        if let Err(err) = cloned.onchain_wallet.full_scan().await {
+                          error!("Failed to scan wallet: {err:?}");
+                        }
+
                         // Only partial sync when there are no new Liquid or Bitcoin blocks
                         let partial_sync = (is_new_liquid_block || is_new_bitcoin_block).not();
                         _ = cloned.sync(partial_sync).await;

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -365,7 +365,11 @@ impl OnchainWallet for LiquidOnchainWallet {
             let electrum_url = ElectrumUrl::new(&self.config.liquid_electrum_url, true, true)?;
             *electrum_client = Some(ElectrumClient::new(&electrum_url)?);
         }
-        let client = electrum_client.as_mut().unwrap();
+        let client = electrum_client
+            .as_mut()
+            .ok_or_else(|| PaymentError::Generic {
+                err: "Electrum client not initialized".to_string(),
+            })?;
 
         // Use the cached derivation index with a buffer of 5 to perform the scan
         let index = self


### PR DESCRIPTION
This PR does 2 things:
1. Use a single point to scan the lwk_wallet (from the background task)
2. Use a cached electrum client (and connection) to scan the wallet. It saves the connection creation on each scan.

The ElectrumClient wraps a Client (from electrum-client) crate which holds the tcp connection.
I think we should aim for holding one client with reasonable timeout and on top of it we can instantiate several ElectrumClient when we need. The goal of the high level ElectrumClient is only to implement the API in a more convenient way (just a wrapper) by implementing BlockchainBackend for lwk_wallet. Currently the API doesn't allow it and I will work on that in a following PR.

Testing Notes: Test sync with two devices for send/receive