### PR TITLE
Prevent missing notifications due to concurrent SDK instances

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -156,14 +156,14 @@ pub(crate) enum Command {
         sort_ascending: Option<bool>,
     },
     /// Retrieve a payment
-    #[command(group = clap::ArgGroup::new("payment_identifiers").args(&["payment_hash", "swap_id_hash"]).required(true))]
+    #[command(group = clap::ArgGroup::new("payment_identifiers").args(&["payment_hash", "swap_id"]).required(true))]
     GetPayment {
         /// Lightning payment hash
         #[arg(long, short = 'p')]
         payment_hash: Option<String>,
-        /// Swap ID hash
+        /// Swap ID or its hash
         #[arg(long, short = 's')]
-        swap_id_hash: Option<String>,
+        swap_id: Option<String>,
     },
     /// Get and potentially accept proposed fees for WaitingFeeAcceptance Payment
     ReviewPaymentProposedFees { swap_id: String },
@@ -575,17 +575,17 @@ pub(crate) async fn handle_command(
         }
         Command::GetPayment {
             payment_hash,
-            swap_id_hash,
+            swap_id,
         } => {
-            if payment_hash.is_none() && swap_id_hash.is_none() {
+            if payment_hash.is_none() && swap_id.is_none() {
                 bail!("No payment identifiers provided.");
             }
 
             let maybe_payment = if let Some(payment_hash) = payment_hash {
-                sdk.get_payment(&GetPaymentRequest::Lightning { payment_hash })
+                sdk.get_payment(&GetPaymentRequest::PaymentHash { payment_hash })
                     .await?
-            } else if let Some(swap_id_hash) = swap_id_hash {
-                sdk.get_payment(&GetPaymentRequest::SwapIdHash { hash: swap_id_hash })
+            } else if let Some(swap_id) = swap_id {
+                sdk.get_payment(&GetPaymentRequest::SwapId { swap_id })
                     .await?
             } else {
                 None

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
@@ -2,8 +2,10 @@ package breez_sdk_liquid_notification.job
 
 import android.content.Context
 import breez_sdk_liquid.BindingLiquidSdk
+import breez_sdk_liquid.GetPaymentRequest
 import breez_sdk_liquid.Payment
 import breez_sdk_liquid.PaymentDetails
+import breez_sdk_liquid.PaymentState
 import breez_sdk_liquid.PaymentType
 import breez_sdk_liquid.SdkEvent
 import breez_sdk_liquid_notification.Constants.DEFAULT_PAYMENT_RECEIVED_NOTIFICATION_TEXT
@@ -27,6 +29,11 @@ import breez_sdk_liquid_notification.NotificationHelper.Companion.notifyChannel
 import breez_sdk_liquid_notification.ResourceHelper.Companion.getString
 import breez_sdk_liquid_notification.SdkForegroundService
 import breez_sdk_liquid_notification.ServiceLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest
@@ -42,9 +49,12 @@ class SwapUpdatedJob(
     private val fgService: SdkForegroundService,
     private val payload: String,
     private val logger: ServiceLogger,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ) : Job {
     private var swapIdHash: String? = null
     private var notified: Boolean = false
+    private var pollingJob: kotlinx.coroutines.Job? = null
+    private val pollingInterval: Long = 5000
 
     companion object {
         private const val TAG = "SwapUpdatedJob"
@@ -54,8 +64,52 @@ class SwapUpdatedJob(
         try {
             val request = Json.decodeFromString(SwapUpdatedRequest.serializer(), payload)
             this.swapIdHash = request.id
+            startPolling(liquidSDK)
         } catch (e: Exception) {
             logger.log(TAG, "Failed to decode payload: ${e.message}", "WARN")
+        }
+    }
+
+    private fun startPolling(liquidSDK: BindingLiquidSdk) {
+        pollingJob = scope.launch {
+            while (isActive) {
+                try {
+                    if (swapIdHash == null) {
+                        stopPolling(Exception("Missing swap ID"))
+                        return@launch
+                    }
+
+                    liquidSDK.getPayment(GetPaymentRequest.SwapIdHash(swapIdHash!!))?.let { payment ->
+                        when (payment.status) {
+                            PaymentState.COMPLETE -> {
+                                onEvent(SdkEvent.PaymentSucceeded(payment))
+                                stopPolling()
+                                return@launch
+                            }
+                            PaymentState.WAITING_FEE_ACCEPTANCE -> {
+                                onEvent(SdkEvent.PaymentWaitingFeeAcceptance(payment))
+                                stopPolling()
+                                return@launch
+                            }
+                            else -> { }
+                        }
+                    }
+                    delay(pollingInterval)
+                } catch (e: Exception) {
+                    stopPolling(e)
+                    return@launch
+                }
+            }
+        }
+    }
+
+    private fun stopPolling(error: Exception? = null) {
+        pollingJob?.cancel()
+        pollingJob = null
+
+        error?.let {
+            logger.log(TAG, "Polling stopped with error: ${it.message}", "ERROR")
+            onShutdown()
         }
     }
 

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
@@ -79,7 +79,7 @@ class SwapUpdatedJob(
                         return@launch
                     }
 
-                    liquidSDK.getPayment(GetPaymentRequest.SwapIdHash(swapIdHash!!))?.let { payment ->
+                    liquidSDK.getPayment(GetPaymentRequest.SwapId(swapIdHash!!))?.let { payment ->
                         when (payment.status) {
                             PaymentState.COMPLETE -> {
                                 onEvent(SdkEvent.PaymentSucceeded(payment))

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/SwapUpdated.kt
@@ -91,6 +91,13 @@ class SwapUpdatedJob(
                                 stopPolling()
                                 return@launch
                             }
+                            PaymentState.PENDING -> {
+                                if (paymentClaimIsBroadcasted(payment.details)) {
+                                    onEvent(SdkEvent.PaymentWaitingConfirmation(payment))
+                                    stopPolling()
+                                    return@launch
+                                }
+                            }
                             else -> { }
                         }
                     }
@@ -140,6 +147,14 @@ class SwapUpdatedJob(
             is PaymentDetails.Bitcoin -> details.swapId
             is PaymentDetails.Lightning -> details.swapId
             else -> null
+        }
+    }
+
+    private fun paymentClaimIsBroadcasted(details: PaymentDetails?): Boolean {
+        return when (details) {
+            is PaymentDetails.Bitcoin -> details.claimTxId != null
+            is PaymentDetails.Lightning -> details.claimTxId != null
+            else -> false
         }
     }
 

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -78,17 +78,17 @@ typedef struct wire_cst_fetch_payment_proposed_fees_request {
   struct wire_cst_list_prim_u_8_strict *swap_id;
 } wire_cst_fetch_payment_proposed_fees_request;
 
-typedef struct wire_cst_GetPaymentRequest_Lightning {
+typedef struct wire_cst_GetPaymentRequest_PaymentHash {
   struct wire_cst_list_prim_u_8_strict *payment_hash;
-} wire_cst_GetPaymentRequest_Lightning;
+} wire_cst_GetPaymentRequest_PaymentHash;
 
-typedef struct wire_cst_GetPaymentRequest_SwapIdHash {
-  struct wire_cst_list_prim_u_8_strict *hash;
-} wire_cst_GetPaymentRequest_SwapIdHash;
+typedef struct wire_cst_GetPaymentRequest_SwapId {
+  struct wire_cst_list_prim_u_8_strict *swap_id;
+} wire_cst_GetPaymentRequest_SwapId;
 
 typedef union GetPaymentRequestKind {
-  struct wire_cst_GetPaymentRequest_Lightning Lightning;
-  struct wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
+  struct wire_cst_GetPaymentRequest_PaymentHash PaymentHash;
+  struct wire_cst_GetPaymentRequest_SwapId SwapId;
 } GetPaymentRequestKind;
 
 typedef struct wire_cst_get_payment_request {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -82,8 +82,13 @@ typedef struct wire_cst_GetPaymentRequest_Lightning {
   struct wire_cst_list_prim_u_8_strict *payment_hash;
 } wire_cst_GetPaymentRequest_Lightning;
 
+typedef struct wire_cst_GetPaymentRequest_SwapIdHash {
+  struct wire_cst_list_prim_u_8_strict *hash;
+} wire_cst_GetPaymentRequest_SwapIdHash;
+
 typedef union GetPaymentRequestKind {
   struct wire_cst_GetPaymentRequest_Lightning Lightning;
+  struct wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
 } GetPaymentRequestKind;
 
 typedef struct wire_cst_get_payment_request {

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -527,6 +527,7 @@ typedef struct wire_cst_PaymentDetails_Lightning {
   struct wire_cst_list_prim_u_8_strict *payment_hash;
   struct wire_cst_list_prim_u_8_strict *destination_pubkey;
   struct wire_cst_ln_url_info *lnurl_info;
+  struct wire_cst_list_prim_u_8_strict *claim_tx_id;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;
 } wire_cst_PaymentDetails_Lightning;
@@ -550,6 +551,7 @@ typedef struct wire_cst_PaymentDetails_Bitcoin {
   bool auto_accepted_fees;
   uint32_t *liquid_expiration_blockheight;
   uint32_t *bitcoin_expiration_blockheight;
+  struct wire_cst_list_prim_u_8_strict *claim_tx_id;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;
 } wire_cst_PaymentDetails_Bitcoin;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -9,12 +9,15 @@ struct SwapUpdatedRequest: Codable {
 class SwapUpdatedTask : TaskProtocol {
     fileprivate let TAG = "SwapUpdatedTask"
     
+    private let pollingInterval: TimeInterval = 5.0
+    
     internal var payload: String
     internal var contentHandler: ((UNNotificationContent) -> Void)?
     internal var bestAttemptContent: UNMutableNotificationContent?
     internal var logger: ServiceLogger
     internal var request: SwapUpdatedRequest? = nil
     internal var notified: Bool = false
+    private var pollingTimer: Timer?
     
     init(payload: String, logger: ServiceLogger, contentHandler: ((UNNotificationContent) -> Void)? = nil, bestAttemptContent: UNMutableNotificationContent? = nil) {
         self.payload = payload
@@ -30,6 +33,47 @@ class SwapUpdatedTask : TaskProtocol {
             self.logger.log(tag: TAG, line: "Failed to decode payload: \(e)", level: "ERROR")
             self.onShutdown()
             throw e
+        }
+
+        startPolling(liquidSDK: liquidSDK)
+    }
+
+    func startPolling(liquidSDK: BindingLiquidSdk) {
+        pollingTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            do {
+                guard let request = self.request else {
+                    self.stopPolling(withError: NSError(domain: "SwapUpdatedTask", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing swap updated request"]))
+                    return
+                }
+
+                if let payment = try liquidSDK.getPayment(req: .swapIdHash(hash: request.id)) {
+                    switch payment.status {
+                    case .complete:
+                        onEvent(e: SdkEvent.paymentSucceeded(details: payment))
+                        self.stopPolling()
+                    case .waitingFeeAcceptance:
+                        onEvent(e: SdkEvent.paymentWaitingFeeAcceptance(details: payment))
+                        self.stopPolling()
+                    default:
+                        break
+                    }
+                }
+            } catch {
+                self.stopPolling(withError: error)
+            }
+        }
+
+        pollingTimer?.fire()
+    }
+    
+    private func stopPolling(withError error: Error? = nil) {
+        pollingTimer?.invalidate()
+        pollingTimer = nil
+        
+        if let error = error {
+            logger.log(tag: TAG, line: "Polling stopped with error: \(error)", level: "ERROR")
+            onShutdown()
         }
     }
 

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -47,7 +47,7 @@ class SwapUpdatedTask : TaskProtocol {
                     return
                 }
 
-                if let payment = try liquidSDK.getPayment(req: .swapIdHash(hash: request.id)) {
+                if let payment = try liquidSDK.getPayment(req: .swapId(swapId: request.id)) {
                     switch payment.status {
                     case .complete:
                         onEvent(e: SdkEvent.paymentSucceeded(details: payment))

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -570,6 +570,7 @@ interface ListPaymentDetails {
 [Enum]
 interface GetPaymentRequest {
     Lightning(string payment_hash);
+    SwapIdHash(string hash);
 };
 
 dictionary FetchPaymentProposedFeesRequest {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -606,9 +606,9 @@ dictionary AssetInfo {
 
 [Enum]
 interface PaymentDetails {
-    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string asset_id, string destination, string description, AssetInfo? asset_info);
-    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -569,8 +569,8 @@ interface ListPaymentDetails {
 
 [Enum]
 interface GetPaymentRequest {
-    Lightning(string payment_hash);
-    SwapIdHash(string hash);
+    PaymentHash(string payment_hash);
+    SwapId(string swap_id);
 };
 
 dictionary FetchPaymentProposedFeesRequest {

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3901,6 +3901,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_paymentHash = <Option<String>>::sse_decode(deserializer);
                 let mut var_destinationPubkey = <Option<String>>::sse_decode(deserializer);
                 let mut var_lnurlInfo = <Option<crate::model::LnUrlInfo>>::sse_decode(deserializer);
+                let mut var_claimTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Lightning {
@@ -3913,6 +3914,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     payment_hash: var_paymentHash,
                     destination_pubkey: var_destinationPubkey,
                     lnurl_info: var_lnurlInfo,
+                    claim_tx_id: var_claimTxId,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
                 };
@@ -3935,6 +3937,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
                 let mut var_bitcoinExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
+                let mut var_claimTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Bitcoin {
@@ -3943,6 +3946,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     auto_accepted_fees: var_autoAcceptedFees,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
                     bitcoin_expiration_blockheight: var_bitcoinExpirationBlockheight,
+                    claim_tx_id: var_claimTxId,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
                 };
@@ -6205,6 +6209,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 payment_hash,
                 destination_pubkey,
                 lnurl_info,
+                claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => [
@@ -6218,6 +6223,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 payment_hash.into_into_dart().into_dart(),
                 destination_pubkey.into_into_dart().into_dart(),
                 lnurl_info.into_into_dart().into_dart(),
+                claim_tx_id.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
             ]
@@ -6241,6 +6247,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
+                claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => [
@@ -6250,6 +6257,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 auto_accepted_fees.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
                 bitcoin_expiration_blockheight.into_into_dart().into_dart(),
+                claim_tx_id.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
             ]
@@ -8468,6 +8476,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 payment_hash,
                 destination_pubkey,
                 lnurl_info,
+                claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => {
@@ -8481,6 +8490,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <Option<String>>::sse_encode(payment_hash, serializer);
                 <Option<String>>::sse_encode(destination_pubkey, serializer);
                 <Option<crate::model::LnUrlInfo>>::sse_encode(lnurl_info, serializer);
+                <Option<String>>::sse_encode(claim_tx_id, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
             }
@@ -8502,6 +8512,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
+                claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
             } => {
@@ -8511,6 +8522,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <bool>::sse_encode(auto_accepted_fees, serializer);
                 <Option<u32>>::sse_encode(liquid_expiration_blockheight, serializer);
                 <Option<u32>>::sse_encode(bitcoin_expiration_blockheight, serializer);
+                <Option<String>>::sse_encode(claim_tx_id, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
             }
@@ -10693,6 +10705,7 @@ mod io {
                         payment_hash: ans.payment_hash.cst_decode(),
                         destination_pubkey: ans.destination_pubkey.cst_decode(),
                         lnurl_info: ans.lnurl_info.cst_decode(),
+                        claim_tx_id: ans.claim_tx_id.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
                     }
@@ -10718,6 +10731,7 @@ mod io {
                         bitcoin_expiration_blockheight: ans
                             .bitcoin_expiration_blockheight
                             .cst_decode(),
+                        claim_tx_id: ans.claim_tx_id.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
                     }
@@ -14484,6 +14498,7 @@ mod io {
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
         destination_pubkey: *mut wire_cst_list_prim_u_8_strict,
         lnurl_info: *mut wire_cst_ln_url_info,
+        claim_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,
     }
@@ -14503,6 +14518,7 @@ mod io {
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: *mut u32,
         bitcoin_expiration_blockheight: *mut u32,
+        claim_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,
     }

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2691,6 +2691,10 @@ impl SseDecode for crate::model::GetPaymentRequest {
                     payment_hash: var_paymentHash,
                 };
             }
+            1 => {
+                let mut var_hash = <String>::sse_decode(deserializer);
+                return crate::model::GetPaymentRequest::SwapIdHash { hash: var_hash };
+            }
             _ => {
                 unimplemented!("");
             }
@@ -5282,6 +5286,9 @@ impl flutter_rust_bridge::IntoDart for crate::model::GetPaymentRequest {
             crate::model::GetPaymentRequest::Lightning { payment_hash } => {
                 [0.into_dart(), payment_hash.into_into_dart().into_dart()].into_dart()
             }
+            crate::model::GetPaymentRequest::SwapIdHash { hash } => {
+                [1.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -7490,6 +7497,10 @@ impl SseEncode for crate::model::GetPaymentRequest {
             crate::model::GetPaymentRequest::Lightning { payment_hash } => {
                 <i32>::sse_encode(0, serializer);
                 <String>::sse_encode(payment_hash, serializer);
+            }
+            crate::model::GetPaymentRequest::SwapIdHash { hash } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(hash, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -9886,6 +9897,12 @@ mod io {
                     let ans = unsafe { self.kind.Lightning };
                     crate::model::GetPaymentRequest::Lightning {
                         payment_hash: ans.payment_hash.cst_decode(),
+                    }
+                }
+                1 => {
+                    let ans = unsafe { self.kind.SwapIdHash };
+                    crate::model::GetPaymentRequest::SwapIdHash {
+                        hash: ans.hash.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -13791,12 +13808,18 @@ mod io {
     #[derive(Clone, Copy)]
     pub union GetPaymentRequestKind {
         Lightning: wire_cst_GetPaymentRequest_Lightning,
+        SwapIdHash: wire_cst_GetPaymentRequest_SwapIdHash,
         nil__: (),
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_GetPaymentRequest_Lightning {
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_GetPaymentRequest_SwapIdHash {
+        hash: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2687,13 +2687,15 @@ impl SseDecode for crate::model::GetPaymentRequest {
         match tag_ {
             0 => {
                 let mut var_paymentHash = <String>::sse_decode(deserializer);
-                return crate::model::GetPaymentRequest::Lightning {
+                return crate::model::GetPaymentRequest::PaymentHash {
                     payment_hash: var_paymentHash,
                 };
             }
             1 => {
-                let mut var_hash = <String>::sse_decode(deserializer);
-                return crate::model::GetPaymentRequest::SwapIdHash { hash: var_hash };
+                let mut var_swapId = <String>::sse_decode(deserializer);
+                return crate::model::GetPaymentRequest::SwapId {
+                    swap_id: var_swapId,
+                };
             }
             _ => {
                 unimplemented!("");
@@ -5287,11 +5289,11 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::GetInfoResponse>
 impl flutter_rust_bridge::IntoDart for crate::model::GetPaymentRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
-            crate::model::GetPaymentRequest::Lightning { payment_hash } => {
+            crate::model::GetPaymentRequest::PaymentHash { payment_hash } => {
                 [0.into_dart(), payment_hash.into_into_dart().into_dart()].into_dart()
             }
-            crate::model::GetPaymentRequest::SwapIdHash { hash } => {
-                [1.into_dart(), hash.into_into_dart().into_dart()].into_dart()
+            crate::model::GetPaymentRequest::SwapId { swap_id } => {
+                [1.into_dart(), swap_id.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -7502,13 +7504,13 @@ impl SseEncode for crate::model::GetPaymentRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         match self {
-            crate::model::GetPaymentRequest::Lightning { payment_hash } => {
+            crate::model::GetPaymentRequest::PaymentHash { payment_hash } => {
                 <i32>::sse_encode(0, serializer);
                 <String>::sse_encode(payment_hash, serializer);
             }
-            crate::model::GetPaymentRequest::SwapIdHash { hash } => {
+            crate::model::GetPaymentRequest::SwapId { swap_id } => {
                 <i32>::sse_encode(1, serializer);
-                <String>::sse_encode(hash, serializer);
+                <String>::sse_encode(swap_id, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -9906,15 +9908,15 @@ mod io {
         fn cst_decode(self) -> crate::model::GetPaymentRequest {
             match self.tag {
                 0 => {
-                    let ans = unsafe { self.kind.Lightning };
-                    crate::model::GetPaymentRequest::Lightning {
+                    let ans = unsafe { self.kind.PaymentHash };
+                    crate::model::GetPaymentRequest::PaymentHash {
                         payment_hash: ans.payment_hash.cst_decode(),
                     }
                 }
                 1 => {
-                    let ans = unsafe { self.kind.SwapIdHash };
-                    crate::model::GetPaymentRequest::SwapIdHash {
-                        hash: ans.hash.cst_decode(),
+                    let ans = unsafe { self.kind.SwapId };
+                    crate::model::GetPaymentRequest::SwapId {
+                        swap_id: ans.swap_id.cst_decode(),
                     }
                 }
                 _ => unreachable!(),
@@ -13821,19 +13823,19 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub union GetPaymentRequestKind {
-        Lightning: wire_cst_GetPaymentRequest_Lightning,
-        SwapIdHash: wire_cst_GetPaymentRequest_SwapIdHash,
+        PaymentHash: wire_cst_GetPaymentRequest_PaymentHash,
+        SwapId: wire_cst_GetPaymentRequest_SwapId,
         nil__: (),
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_GetPaymentRequest_Lightning {
+    pub struct wire_cst_GetPaymentRequest_PaymentHash {
         payment_hash: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
-    pub struct wire_cst_GetPaymentRequest_SwapIdHash {
-        hash: *mut wire_cst_list_prim_u_8_strict,
+    pub struct wire_cst_GetPaymentRequest_SwapId {
+        swap_id: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -722,10 +722,10 @@ pub enum ListPaymentDetails {
 /// An argument when calling [crate::sdk::LiquidSdk::get_payment].
 #[derive(Debug, Serialize)]
 pub enum GetPaymentRequest {
-    /// The Lightning payment hash of the payment
-    Lightning { payment_hash: String },
-    /// The SHA256-hash of the swap id in hex
-    SwapIdHash { hash: String },
+    /// The payment hash of a Lightning payment
+    PaymentHash { payment_hash: String },
+    /// A swap id or its SHA256 hash
+    SwapId { swap_id: String },
 }
 
 /// Trait that can be used to react to new blocks from Bitcoin and Liquid chains

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -724,6 +724,8 @@ pub enum ListPaymentDetails {
 pub enum GetPaymentRequest {
     /// The Lightning payment hash of the payment
     Lightning { payment_hash: String },
+    /// The SHA256-hash of the swap id in hex
+    SwapIdHash { hash: String },
 }
 
 /// Trait that can be used to react to new blocks from Bitcoin and Liquid chains

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1544,6 +1544,9 @@ pub enum PaymentDetails {
         /// The payment LNURL info
         lnurl_info: Option<LnUrlInfo>,
 
+        /// For a Receive payment, this is the claim tx id in case it has already been broadcast
+        claim_tx_id: Option<String>,
+
         /// For a Send swap which was refunded, this is the refund tx id
         refund_tx_id: Option<String>,
 
@@ -1583,6 +1586,9 @@ pub enum PaymentDetails {
         /// The height of the Bitcoin block at which the swap will no longer be valid
         /// It should always be populated in case of an incoming chain swap
         bitcoin_expiration_blockheight: Option<u32>,
+
+        /// The claim tx id in case it has already been broadcast
+        claim_tx_id: Option<String>,
 
         /// For a Send swap which was refunded, this is the refund tx id
         refund_tx_id: Option<String>,

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -823,6 +823,10 @@ impl Persister {
                 "(rs.payment_hash = ?1 OR ss.payment_hash = ?1)",
                 payment_hash,
             ),
+            GetPaymentRequest::SwapIdHash { hash } => (
+                "(rs.id_hash = ?1 OR ss.id_hash = ?1 OR cs.id_hash = ?1)",
+                hash,
+            ),
         };
         Ok(self
             .get_connection()?

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -404,6 +404,7 @@ impl Persister {
                 rs.receiver_amount_sat,
                 rs.state,
                 rs.pair_fees_json,
+                rs.claim_tx_id,
                 ss.id,
                 ss.created_at,
                 ss.timeout_block_height,
@@ -433,6 +434,7 @@ impl Persister {
                 cs.actual_payer_amount_sat,
                 cs.accepted_receiver_amount_sat,
                 cs.auto_accepted_fees,
+                cs.claim_tx_id,
                 rtx.amount,
                 pd.destination,
                 pd.description,
@@ -513,53 +515,55 @@ impl Persister {
         let maybe_receive_swap_pair_fees_json: Option<String> = row.get(19)?;
         let maybe_receive_swap_pair_fees: Option<ReversePair> =
             maybe_receive_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
+        let maybe_receive_swap_claim_tx_id: Option<String> = row.get(20)?;
 
-        let maybe_send_swap_id: Option<String> = row.get(20)?;
-        let maybe_send_swap_created_at: Option<u32> = row.get(21)?;
-        let maybe_send_swap_timeout_block_height: Option<u32> = row.get(22)?;
-        let maybe_send_swap_invoice: Option<String> = row.get(23)?;
-        let maybe_send_swap_bolt12_offer: Option<String> = row.get(24)?;
-        let maybe_send_swap_payment_hash: Option<String> = row.get(25)?;
-        let maybe_send_swap_destination_pubkey: Option<String> = row.get(26)?;
-        let maybe_send_swap_description: Option<String> = row.get(27)?;
-        let maybe_send_swap_preimage: Option<String> = row.get(28)?;
-        let maybe_send_swap_refund_tx_id: Option<String> = row.get(29)?;
-        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(30)?;
-        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(31)?;
-        let maybe_send_swap_state: Option<PaymentState> = row.get(32)?;
-        let maybe_send_swap_pair_fees_json: Option<String> = row.get(33)?;
+        let maybe_send_swap_id: Option<String> = row.get(21)?;
+        let maybe_send_swap_created_at: Option<u32> = row.get(22)?;
+        let maybe_send_swap_timeout_block_height: Option<u32> = row.get(23)?;
+        let maybe_send_swap_invoice: Option<String> = row.get(24)?;
+        let maybe_send_swap_bolt12_offer: Option<String> = row.get(25)?;
+        let maybe_send_swap_payment_hash: Option<String> = row.get(26)?;
+        let maybe_send_swap_destination_pubkey: Option<String> = row.get(27)?;
+        let maybe_send_swap_description: Option<String> = row.get(28)?;
+        let maybe_send_swap_preimage: Option<String> = row.get(29)?;
+        let maybe_send_swap_refund_tx_id: Option<String> = row.get(30)?;
+        let maybe_send_swap_payer_amount_sat: Option<u64> = row.get(31)?;
+        let maybe_send_swap_receiver_amount_sat: Option<u64> = row.get(32)?;
+        let maybe_send_swap_state: Option<PaymentState> = row.get(33)?;
+        let maybe_send_swap_pair_fees_json: Option<String> = row.get(34)?;
         let maybe_send_swap_pair_fees: Option<SubmarinePair> =
             maybe_send_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
 
-        let maybe_chain_swap_id: Option<String> = row.get(34)?;
-        let maybe_chain_swap_created_at: Option<u32> = row.get(35)?;
-        let maybe_chain_swap_timeout_block_height: Option<u32> = row.get(36)?;
-        let maybe_chain_swap_direction: Option<Direction> = row.get(37)?;
-        let maybe_chain_swap_preimage: Option<String> = row.get(38)?;
-        let maybe_chain_swap_description: Option<String> = row.get(39)?;
-        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(40)?;
-        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(41)?;
-        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(42)?;
-        let maybe_chain_swap_claim_address: Option<String> = row.get(43)?;
-        let maybe_chain_swap_state: Option<PaymentState> = row.get(44)?;
-        let maybe_chain_swap_pair_fees_json: Option<String> = row.get(45)?;
+        let maybe_chain_swap_id: Option<String> = row.get(35)?;
+        let maybe_chain_swap_created_at: Option<u32> = row.get(36)?;
+        let maybe_chain_swap_timeout_block_height: Option<u32> = row.get(37)?;
+        let maybe_chain_swap_direction: Option<Direction> = row.get(38)?;
+        let maybe_chain_swap_preimage: Option<String> = row.get(39)?;
+        let maybe_chain_swap_description: Option<String> = row.get(40)?;
+        let maybe_chain_swap_refund_tx_id: Option<String> = row.get(41)?;
+        let maybe_chain_swap_payer_amount_sat: Option<u64> = row.get(42)?;
+        let maybe_chain_swap_receiver_amount_sat: Option<u64> = row.get(43)?;
+        let maybe_chain_swap_claim_address: Option<String> = row.get(44)?;
+        let maybe_chain_swap_state: Option<PaymentState> = row.get(45)?;
+        let maybe_chain_swap_pair_fees_json: Option<String> = row.get(46)?;
         let maybe_chain_swap_pair_fees: Option<ChainPair> =
             maybe_chain_swap_pair_fees_json.and_then(|pair| serde_json::from_str(&pair).ok());
-        let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(46)?;
-        let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(47)?;
-        let maybe_chain_swap_auto_accepted_fees: Option<bool> = row.get(48)?;
+        let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(47)?;
+        let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(48)?;
+        let maybe_chain_swap_auto_accepted_fees: Option<bool> = row.get(49)?;
+        let maybe_chain_swap_claim_tx_id: Option<String> = row.get(50)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(49)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(51)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(50)?;
-        let maybe_payment_details_description: Option<String> = row.get(51)?;
-        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(52)?;
+        let maybe_payment_details_destination: Option<String> = row.get(52)?;
+        let maybe_payment_details_description: Option<String> = row.get(53)?;
+        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(54)?;
         let maybe_payment_details_lnurl_info: Option<LnUrlInfo> =
             maybe_payment_details_lnurl_info_json.and_then(|info| serde_json::from_str(&info).ok());
 
-        let maybe_asset_metadata_name: Option<String> = row.get(53)?;
-        let maybe_asset_metadata_ticker: Option<String> = row.get(54)?;
-        let maybe_asset_metadata_precision: Option<u8> = row.get(55)?;
+        let maybe_asset_metadata_name: Option<String> = row.get(55)?;
+        let maybe_asset_metadata_ticker: Option<String> = row.get(56)?;
+        let maybe_asset_metadata_precision: Option<u8> = row.get(57)?;
 
         let (swap, payment_type) = match maybe_receive_swap_id {
             Some(receive_swap_id) => {
@@ -679,6 +683,7 @@ impl Persister {
             },
         };
 
+        let maybe_claim_tx_id = maybe_receive_swap_claim_tx_id.or(maybe_chain_swap_claim_tx_id);
         let description = swap.as_ref().map(|s| s.description.clone());
         let payment_details = match swap.clone() {
             Some(
@@ -720,6 +725,7 @@ impl Persister {
                     })
                 }),
                 lnurl_info: maybe_payment_details_lnurl_info,
+                claim_tx_id: maybe_claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
                 description: description.unwrap_or("Lightning transfer".to_string()),
@@ -742,6 +748,7 @@ impl Persister {
 
                 PaymentDetails::Bitcoin {
                     swap_id,
+                    claim_tx_id: maybe_claim_tx_id,
                     refund_tx_id,
                     refund_tx_amount_sat,
                     description: description.unwrap_or("Bitcoin transfer".to_string()),

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -826,13 +826,14 @@ impl Persister {
 
     pub fn get_payment_by_request(&self, req: &GetPaymentRequest) -> Result<Option<Payment>> {
         let (where_clause, param) = match req {
-            GetPaymentRequest::Lightning { payment_hash } => (
+            GetPaymentRequest::PaymentHash { payment_hash } => (
                 "(rs.payment_hash = ?1 OR ss.payment_hash = ?1)",
                 payment_hash,
             ),
-            GetPaymentRequest::SwapIdHash { hash } => (
-                "(rs.id_hash = ?1 OR ss.id_hash = ?1 OR cs.id_hash = ?1)",
-                hash,
+            GetPaymentRequest::SwapId { swap_id } => (
+                "(rs.id = ?1 OR ss.id = ?1 OR cs.id = ?1 OR \
+                rs.id_hash = ?1 OR ss.id_hash = ?1 OR cs.id_hash = ?1)",
+                swap_id,
             ),
         };
         Ok(self

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1959,6 +1959,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return GetPaymentRequest_Lightning(
           paymentHash: dco_decode_String(raw[1]),
         );
+      case 1:
+        return GetPaymentRequest_SwapIdHash(
+          hash: dco_decode_String(raw[1]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -4114,6 +4118,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 0:
         var var_paymentHash = sse_decode_String(deserializer);
         return GetPaymentRequest_Lightning(paymentHash: var_paymentHash);
+      case 1:
+        var var_hash = sse_decode_String(deserializer);
+        return GetPaymentRequest_SwapIdHash(hash: var_hash);
       default:
         throw UnimplementedError('');
     }
@@ -6448,6 +6455,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case GetPaymentRequest_Lightning(paymentHash: final paymentHash):
         sse_encode_i_32(0, serializer);
         sse_encode_String(paymentHash, serializer);
+      case GetPaymentRequest_SwapIdHash(hash: final hash):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(hash, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1956,12 +1956,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
       case 0:
-        return GetPaymentRequest_Lightning(
+        return GetPaymentRequest_PaymentHash(
           paymentHash: dco_decode_String(raw[1]),
         );
       case 1:
-        return GetPaymentRequest_SwapIdHash(
-          hash: dco_decode_String(raw[1]),
+        return GetPaymentRequest_SwapId(
+          swapId: dco_decode_String(raw[1]),
         );
       default:
         throw Exception("unreachable");
@@ -4119,10 +4119,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     switch (tag_) {
       case 0:
         var var_paymentHash = sse_decode_String(deserializer);
-        return GetPaymentRequest_Lightning(paymentHash: var_paymentHash);
+        return GetPaymentRequest_PaymentHash(paymentHash: var_paymentHash);
       case 1:
-        var var_hash = sse_decode_String(deserializer);
-        return GetPaymentRequest_SwapIdHash(hash: var_hash);
+        var var_swapId = sse_decode_String(deserializer);
+        return GetPaymentRequest_SwapId(swapId: var_swapId);
       default:
         throw UnimplementedError('');
     }
@@ -6458,12 +6458,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_get_payment_request(GetPaymentRequest self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
-      case GetPaymentRequest_Lightning(paymentHash: final paymentHash):
+      case GetPaymentRequest_PaymentHash(paymentHash: final paymentHash):
         sse_encode_i_32(0, serializer);
         sse_encode_String(paymentHash, serializer);
-      case GetPaymentRequest_SwapIdHash(hash: final hash):
+      case GetPaymentRequest_SwapId(swapId: final swapId):
         sse_encode_i_32(1, serializer);
-        sse_encode_String(hash, serializer);
+        sse_encode_String(swapId, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2790,8 +2790,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           paymentHash: dco_decode_opt_String(raw[7]),
           destinationPubkey: dco_decode_opt_String(raw[8]),
           lnurlInfo: dco_decode_opt_box_autoadd_ln_url_info(raw[9]),
-          refundTxId: dco_decode_opt_String(raw[10]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[11]),
+          claimTxId: dco_decode_opt_String(raw[10]),
+          refundTxId: dco_decode_opt_String(raw[11]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[12]),
         );
       case 1:
         return PaymentDetails_Liquid(
@@ -2807,8 +2808,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           autoAcceptedFees: dco_decode_bool(raw[3]),
           liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
           bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
-          refundTxId: dco_decode_opt_String(raw[6]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[7]),
+          claimTxId: dco_decode_opt_String(raw[6]),
+          refundTxId: dco_decode_opt_String(raw[7]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[8]),
         );
       default:
         throw Exception("unreachable");
@@ -5113,6 +5115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_paymentHash = sse_decode_opt_String(deserializer);
         var var_destinationPubkey = sse_decode_opt_String(deserializer);
         var var_lnurlInfo = sse_decode_opt_box_autoadd_ln_url_info(deserializer);
+        var var_claimTxId = sse_decode_opt_String(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
         return PaymentDetails_Lightning(
@@ -5125,6 +5128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             paymentHash: var_paymentHash,
             destinationPubkey: var_destinationPubkey,
             lnurlInfo: var_lnurlInfo,
+            claimTxId: var_claimTxId,
             refundTxId: var_refundTxId,
             refundTxAmountSat: var_refundTxAmountSat);
       case 1:
@@ -5143,6 +5147,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_autoAcceptedFees = sse_decode_bool(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
         var var_bitcoinExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
+        var var_claimTxId = sse_decode_opt_String(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
         return PaymentDetails_Bitcoin(
@@ -5151,6 +5156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             autoAcceptedFees: var_autoAcceptedFees,
             liquidExpirationBlockheight: var_liquidExpirationBlockheight,
             bitcoinExpirationBlockheight: var_bitcoinExpirationBlockheight,
+            claimTxId: var_claimTxId,
             refundTxId: var_refundTxId,
             refundTxAmountSat: var_refundTxAmountSat);
       default:
@@ -7256,6 +7262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           paymentHash: final paymentHash,
           destinationPubkey: final destinationPubkey,
           lnurlInfo: final lnurlInfo,
+          claimTxId: final claimTxId,
           refundTxId: final refundTxId,
           refundTxAmountSat: final refundTxAmountSat
         ):
@@ -7269,6 +7276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_String(paymentHash, serializer);
         sse_encode_opt_String(destinationPubkey, serializer);
         sse_encode_opt_box_autoadd_ln_url_info(lnurlInfo, serializer);
+        sse_encode_opt_String(claimTxId, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
       case PaymentDetails_Liquid(
@@ -7288,6 +7296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           autoAcceptedFees: final autoAcceptedFees,
           liquidExpirationBlockheight: final liquidExpirationBlockheight,
           bitcoinExpirationBlockheight: final bitcoinExpirationBlockheight,
+          claimTxId: final claimTxId,
           refundTxId: final refundTxId,
           refundTxAmountSat: final refundTxAmountSat
         ):
@@ -7297,6 +7306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_bool(autoAcceptedFees, serializer);
         sse_encode_opt_box_autoadd_u_32(liquidExpirationBlockheight, serializer);
         sse_encode_opt_box_autoadd_u_32(bitcoinExpirationBlockheight, serializer);
+        sse_encode_opt_String(claimTxId, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);
     }

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3125,6 +3125,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_payment_hash = cst_encode_opt_String(apiObj.paymentHash);
       var pre_destination_pubkey = cst_encode_opt_String(apiObj.destinationPubkey);
       var pre_lnurl_info = cst_encode_opt_box_autoadd_ln_url_info(apiObj.lnurlInfo);
+      var pre_claim_tx_id = cst_encode_opt_String(apiObj.claimTxId);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
       wireObj.tag = 0;
@@ -3137,6 +3138,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
       wireObj.kind.Lightning.destination_pubkey = pre_destination_pubkey;
       wireObj.kind.Lightning.lnurl_info = pre_lnurl_info;
+      wireObj.kind.Lightning.claim_tx_id = pre_claim_tx_id;
       wireObj.kind.Lightning.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Lightning.refund_tx_amount_sat = pre_refund_tx_amount_sat;
       return;
@@ -3161,6 +3163,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_opt_box_autoadd_u_32(apiObj.liquidExpirationBlockheight);
       var pre_bitcoin_expiration_blockheight =
           cst_encode_opt_box_autoadd_u_32(apiObj.bitcoinExpirationBlockheight);
+      var pre_claim_tx_id = cst_encode_opt_String(apiObj.claimTxId);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
       wireObj.tag = 2;
@@ -3169,6 +3172,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       wireObj.kind.Bitcoin.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
       wireObj.kind.Bitcoin.bitcoin_expiration_blockheight = pre_bitcoin_expiration_blockheight;
+      wireObj.kind.Bitcoin.claim_tx_id = pre_claim_tx_id;
       wireObj.kind.Bitcoin.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Bitcoin.refund_tx_amount_sat = pre_refund_tx_amount_sat;
       return;
@@ -6722,6 +6726,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
@@ -6757,6 +6763,8 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> liquid_expiration_blockheight;
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2587,16 +2587,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_get_payment_request(
       GetPaymentRequest apiObj, wire_cst_get_payment_request wireObj) {
-    if (apiObj is GetPaymentRequest_Lightning) {
+    if (apiObj is GetPaymentRequest_PaymentHash) {
       var pre_payment_hash = cst_encode_String(apiObj.paymentHash);
       wireObj.tag = 0;
-      wireObj.kind.Lightning.payment_hash = pre_payment_hash;
+      wireObj.kind.PaymentHash.payment_hash = pre_payment_hash;
       return;
     }
-    if (apiObj is GetPaymentRequest_SwapIdHash) {
-      var pre_hash = cst_encode_String(apiObj.hash);
+    if (apiObj is GetPaymentRequest_SwapId) {
+      var pre_swap_id = cst_encode_String(apiObj.swapId);
       wireObj.tag = 1;
-      wireObj.kind.SwapIdHash.hash = pre_hash;
+      wireObj.kind.SwapId.swap_id = pre_swap_id;
       return;
     }
   }
@@ -6094,18 +6094,18 @@ final class wire_cst_fetch_payment_proposed_fees_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 }
 
-final class wire_cst_GetPaymentRequest_Lightning extends ffi.Struct {
+final class wire_cst_GetPaymentRequest_PaymentHash extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 }
 
-final class wire_cst_GetPaymentRequest_SwapIdHash extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+final class wire_cst_GetPaymentRequest_SwapId extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 }
 
 final class GetPaymentRequestKind extends ffi.Union {
-  external wire_cst_GetPaymentRequest_Lightning Lightning;
+  external wire_cst_GetPaymentRequest_PaymentHash PaymentHash;
 
-  external wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
+  external wire_cst_GetPaymentRequest_SwapId SwapId;
 }
 
 final class wire_cst_get_payment_request extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2593,6 +2593,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Lightning.payment_hash = pre_payment_hash;
       return;
     }
+    if (apiObj is GetPaymentRequest_SwapIdHash) {
+      var pre_hash = cst_encode_String(apiObj.hash);
+      wireObj.tag = 1;
+      wireObj.kind.SwapIdHash.hash = pre_hash;
+      return;
+    }
   }
 
   @protected
@@ -6088,8 +6094,14 @@ final class wire_cst_GetPaymentRequest_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 }
 
+final class wire_cst_GetPaymentRequest_SwapIdHash extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
 final class GetPaymentRequestKind extends ffi.Union {
   external wire_cst_GetPaymentRequest_Lightning Lightning;
+
+  external wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
 }
 
 final class wire_cst_get_payment_request extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -932,6 +932,9 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// The payment LNURL info
     LnUrlInfo? lnurlInfo,
 
+    /// For a Receive payment, this is the claim tx id in case it has already been broadcast
+    String? claimTxId,
+
     /// For a Send swap which was refunded, this is the refund tx id
     String? refundTxId,
 
@@ -973,6 +976,9 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// The height of the Bitcoin block at which the swap will no longer be valid
     /// It should always be populated in case of an incoming chain swap
     int? bitcoinExpirationBlockheight,
+
+    /// The claim tx id in case it has already been broadcast
+    String? claimTxId,
 
     /// For a Send swap which was refunded, this is the refund tx id
     String? refundTxId,

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -470,15 +470,15 @@ class GetInfoResponse {
 sealed class GetPaymentRequest with _$GetPaymentRequest {
   const GetPaymentRequest._();
 
-  /// The Lightning payment hash of the payment
-  const factory GetPaymentRequest.lightning({
+  /// The payment hash of a Lightning payment
+  const factory GetPaymentRequest.paymentHash({
     required String paymentHash,
-  }) = GetPaymentRequest_Lightning;
+  }) = GetPaymentRequest_PaymentHash;
 
-  /// The SHA256-hash of the swap id in hex
-  const factory GetPaymentRequest.swapIdHash({
-    required String hash,
-  }) = GetPaymentRequest_SwapIdHash;
+  /// A swap id or its SHA256 hash
+  const factory GetPaymentRequest.swapId({
+    required String swapId,
+  }) = GetPaymentRequest_SwapId;
 }
 
 /// Returned when calling [crate::sdk::LiquidSdk::fetch_lightning_limits].

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -474,6 +474,11 @@ sealed class GetPaymentRequest with _$GetPaymentRequest {
   const factory GetPaymentRequest.lightning({
     required String paymentHash,
   }) = GetPaymentRequest_Lightning;
+
+  /// The SHA256-hash of the swap id in hex
+  const factory GetPaymentRequest.swapIdHash({
+    required String hash,
+  }) = GetPaymentRequest_SwapIdHash;
 }
 
 /// Returned when calling [crate::sdk::LiquidSdk::fetch_lightning_limits].

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -38,20 +38,20 @@ class _$GetPaymentRequestCopyWithImpl<$Res, $Val extends GetPaymentRequest>
 }
 
 /// @nodoc
-abstract class _$$GetPaymentRequest_LightningImplCopyWith<$Res> {
-  factory _$$GetPaymentRequest_LightningImplCopyWith(
-          _$GetPaymentRequest_LightningImpl value, $Res Function(_$GetPaymentRequest_LightningImpl) then) =
-      __$$GetPaymentRequest_LightningImplCopyWithImpl<$Res>;
+abstract class _$$GetPaymentRequest_PaymentHashImplCopyWith<$Res> {
+  factory _$$GetPaymentRequest_PaymentHashImplCopyWith(_$GetPaymentRequest_PaymentHashImpl value,
+          $Res Function(_$GetPaymentRequest_PaymentHashImpl) then) =
+      __$$GetPaymentRequest_PaymentHashImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String paymentHash});
 }
 
 /// @nodoc
-class __$$GetPaymentRequest_LightningImplCopyWithImpl<$Res>
-    extends _$GetPaymentRequestCopyWithImpl<$Res, _$GetPaymentRequest_LightningImpl>
-    implements _$$GetPaymentRequest_LightningImplCopyWith<$Res> {
-  __$$GetPaymentRequest_LightningImplCopyWithImpl(
-      _$GetPaymentRequest_LightningImpl _value, $Res Function(_$GetPaymentRequest_LightningImpl) _then)
+class __$$GetPaymentRequest_PaymentHashImplCopyWithImpl<$Res>
+    extends _$GetPaymentRequestCopyWithImpl<$Res, _$GetPaymentRequest_PaymentHashImpl>
+    implements _$$GetPaymentRequest_PaymentHashImplCopyWith<$Res> {
+  __$$GetPaymentRequest_PaymentHashImplCopyWithImpl(
+      _$GetPaymentRequest_PaymentHashImpl _value, $Res Function(_$GetPaymentRequest_PaymentHashImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of GetPaymentRequest
@@ -61,7 +61,7 @@ class __$$GetPaymentRequest_LightningImplCopyWithImpl<$Res>
   $Res call({
     Object? paymentHash = null,
   }) {
-    return _then(_$GetPaymentRequest_LightningImpl(
+    return _then(_$GetPaymentRequest_PaymentHashImpl(
       paymentHash: null == paymentHash
           ? _value.paymentHash
           : paymentHash // ignore: cast_nullable_to_non_nullable
@@ -72,22 +72,22 @@ class __$$GetPaymentRequest_LightningImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$GetPaymentRequest_LightningImpl extends GetPaymentRequest_Lightning {
-  const _$GetPaymentRequest_LightningImpl({required this.paymentHash}) : super._();
+class _$GetPaymentRequest_PaymentHashImpl extends GetPaymentRequest_PaymentHash {
+  const _$GetPaymentRequest_PaymentHashImpl({required this.paymentHash}) : super._();
 
   @override
   final String paymentHash;
 
   @override
   String toString() {
-    return 'GetPaymentRequest.lightning(paymentHash: $paymentHash)';
+    return 'GetPaymentRequest.paymentHash(paymentHash: $paymentHash)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPaymentRequest_LightningImpl &&
+            other is _$GetPaymentRequest_PaymentHashImpl &&
             (identical(other.paymentHash, paymentHash) || other.paymentHash == paymentHash));
   }
 
@@ -99,39 +99,40 @@ class _$GetPaymentRequest_LightningImpl extends GetPaymentRequest_Lightning {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPaymentRequest_LightningImplCopyWith<_$GetPaymentRequest_LightningImpl> get copyWith =>
-      __$$GetPaymentRequest_LightningImplCopyWithImpl<_$GetPaymentRequest_LightningImpl>(this, _$identity);
+  _$$GetPaymentRequest_PaymentHashImplCopyWith<_$GetPaymentRequest_PaymentHashImpl> get copyWith =>
+      __$$GetPaymentRequest_PaymentHashImplCopyWithImpl<_$GetPaymentRequest_PaymentHashImpl>(
+          this, _$identity);
 }
 
-abstract class GetPaymentRequest_Lightning extends GetPaymentRequest {
-  const factory GetPaymentRequest_Lightning({required final String paymentHash}) =
-      _$GetPaymentRequest_LightningImpl;
-  const GetPaymentRequest_Lightning._() : super._();
+abstract class GetPaymentRequest_PaymentHash extends GetPaymentRequest {
+  const factory GetPaymentRequest_PaymentHash({required final String paymentHash}) =
+      _$GetPaymentRequest_PaymentHashImpl;
+  const GetPaymentRequest_PaymentHash._() : super._();
 
   String get paymentHash;
 
   /// Create a copy of GetPaymentRequest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GetPaymentRequest_LightningImplCopyWith<_$GetPaymentRequest_LightningImpl> get copyWith =>
+  _$$GetPaymentRequest_PaymentHashImplCopyWith<_$GetPaymentRequest_PaymentHashImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$GetPaymentRequest_SwapIdHashImplCopyWith<$Res> {
-  factory _$$GetPaymentRequest_SwapIdHashImplCopyWith(
-          _$GetPaymentRequest_SwapIdHashImpl value, $Res Function(_$GetPaymentRequest_SwapIdHashImpl) then) =
-      __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>;
+abstract class _$$GetPaymentRequest_SwapIdImplCopyWith<$Res> {
+  factory _$$GetPaymentRequest_SwapIdImplCopyWith(
+          _$GetPaymentRequest_SwapIdImpl value, $Res Function(_$GetPaymentRequest_SwapIdImpl) then) =
+      __$$GetPaymentRequest_SwapIdImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({String hash});
+  $Res call({String swapId});
 }
 
 /// @nodoc
-class __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>
-    extends _$GetPaymentRequestCopyWithImpl<$Res, _$GetPaymentRequest_SwapIdHashImpl>
-    implements _$$GetPaymentRequest_SwapIdHashImplCopyWith<$Res> {
-  __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl(
-      _$GetPaymentRequest_SwapIdHashImpl _value, $Res Function(_$GetPaymentRequest_SwapIdHashImpl) _then)
+class __$$GetPaymentRequest_SwapIdImplCopyWithImpl<$Res>
+    extends _$GetPaymentRequestCopyWithImpl<$Res, _$GetPaymentRequest_SwapIdImpl>
+    implements _$$GetPaymentRequest_SwapIdImplCopyWith<$Res> {
+  __$$GetPaymentRequest_SwapIdImplCopyWithImpl(
+      _$GetPaymentRequest_SwapIdImpl _value, $Res Function(_$GetPaymentRequest_SwapIdImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of GetPaymentRequest
@@ -139,12 +140,12 @@ class __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? hash = null,
+    Object? swapId = null,
   }) {
-    return _then(_$GetPaymentRequest_SwapIdHashImpl(
-      hash: null == hash
-          ? _value.hash
-          : hash // ignore: cast_nullable_to_non_nullable
+    return _then(_$GetPaymentRequest_SwapIdImpl(
+      swapId: null == swapId
+          ? _value.swapId
+          : swapId // ignore: cast_nullable_to_non_nullable
               as String,
     ));
   }
@@ -152,48 +153,47 @@ class __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$GetPaymentRequest_SwapIdHashImpl extends GetPaymentRequest_SwapIdHash {
-  const _$GetPaymentRequest_SwapIdHashImpl({required this.hash}) : super._();
+class _$GetPaymentRequest_SwapIdImpl extends GetPaymentRequest_SwapId {
+  const _$GetPaymentRequest_SwapIdImpl({required this.swapId}) : super._();
 
   @override
-  final String hash;
+  final String swapId;
 
   @override
   String toString() {
-    return 'GetPaymentRequest.swapIdHash(hash: $hash)';
+    return 'GetPaymentRequest.swapId(swapId: $swapId)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPaymentRequest_SwapIdHashImpl &&
-            (identical(other.hash, hash) || other.hash == hash));
+            other is _$GetPaymentRequest_SwapIdImpl &&
+            (identical(other.swapId, swapId) || other.swapId == swapId));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, hash);
+  int get hashCode => Object.hash(runtimeType, swapId);
 
   /// Create a copy of GetPaymentRequest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPaymentRequest_SwapIdHashImplCopyWith<_$GetPaymentRequest_SwapIdHashImpl> get copyWith =>
-      __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<_$GetPaymentRequest_SwapIdHashImpl>(this, _$identity);
+  _$$GetPaymentRequest_SwapIdImplCopyWith<_$GetPaymentRequest_SwapIdImpl> get copyWith =>
+      __$$GetPaymentRequest_SwapIdImplCopyWithImpl<_$GetPaymentRequest_SwapIdImpl>(this, _$identity);
 }
 
-abstract class GetPaymentRequest_SwapIdHash extends GetPaymentRequest {
-  const factory GetPaymentRequest_SwapIdHash({required final String hash}) =
-      _$GetPaymentRequest_SwapIdHashImpl;
-  const GetPaymentRequest_SwapIdHash._() : super._();
+abstract class GetPaymentRequest_SwapId extends GetPaymentRequest {
+  const factory GetPaymentRequest_SwapId({required final String swapId}) = _$GetPaymentRequest_SwapIdImpl;
+  const GetPaymentRequest_SwapId._() : super._();
 
-  String get hash;
+  String get swapId;
 
   /// Create a copy of GetPaymentRequest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GetPaymentRequest_SwapIdHashImplCopyWith<_$GetPaymentRequest_SwapIdHashImpl> get copyWith =>
+  _$$GetPaymentRequest_SwapIdImplCopyWith<_$GetPaymentRequest_SwapIdImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -958,6 +958,7 @@ abstract class _$$PaymentDetails_LightningImplCopyWith<$Res> implements $Payment
       String? paymentHash,
       String? destinationPubkey,
       LnUrlInfo? lnurlInfo,
+      String? claimTxId,
       String? refundTxId,
       BigInt? refundTxAmountSat});
 }
@@ -984,6 +985,7 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
     Object? paymentHash = freezed,
     Object? destinationPubkey = freezed,
     Object? lnurlInfo = freezed,
+    Object? claimTxId = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
   }) {
@@ -1024,6 +1026,10 @@ class __$$PaymentDetails_LightningImplCopyWithImpl<$Res>
           ? _value.lnurlInfo
           : lnurlInfo // ignore: cast_nullable_to_non_nullable
               as LnUrlInfo?,
+      claimTxId: freezed == claimTxId
+          ? _value.claimTxId
+          : claimTxId // ignore: cast_nullable_to_non_nullable
+              as String?,
       refundTxId: freezed == refundTxId
           ? _value.refundTxId
           : refundTxId // ignore: cast_nullable_to_non_nullable
@@ -1049,6 +1055,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
       this.paymentHash,
       this.destinationPubkey,
       this.lnurlInfo,
+      this.claimTxId,
       this.refundTxId,
       this.refundTxAmountSat})
       : super._();
@@ -1088,6 +1095,10 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
   @override
   final LnUrlInfo? lnurlInfo;
 
+  /// For a Receive payment, this is the claim tx id in case it has already been broadcast
+  @override
+  final String? claimTxId;
+
   /// For a Send swap which was refunded, this is the refund tx id
   @override
   final String? refundTxId;
@@ -1098,7 +1109,7 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
 
   @override
   String toString() {
-    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, preimage: $preimage, invoice: $invoice, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, destinationPubkey: $destinationPubkey, lnurlInfo: $lnurlInfo, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.lightning(swapId: $swapId, description: $description, liquidExpirationBlockheight: $liquidExpirationBlockheight, preimage: $preimage, invoice: $invoice, bolt12Offer: $bolt12Offer, paymentHash: $paymentHash, destinationPubkey: $destinationPubkey, lnurlInfo: $lnurlInfo, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -1117,14 +1128,27 @@ class _$PaymentDetails_LightningImpl extends PaymentDetails_Lightning {
             (identical(other.destinationPubkey, destinationPubkey) ||
                 other.destinationPubkey == destinationPubkey) &&
             (identical(other.lnurlInfo, lnurlInfo) || other.lnurlInfo == lnurlInfo) &&
+            (identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
                 other.refundTxAmountSat == refundTxAmountSat));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, swapId, description, liquidExpirationBlockheight, preimage,
-      invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat);
+  int get hashCode => Object.hash(
+      runtimeType,
+      swapId,
+      description,
+      liquidExpirationBlockheight,
+      preimage,
+      invoice,
+      bolt12Offer,
+      paymentHash,
+      destinationPubkey,
+      lnurlInfo,
+      claimTxId,
+      refundTxId,
+      refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1146,6 +1170,7 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
       final String? paymentHash,
       final String? destinationPubkey,
       final LnUrlInfo? lnurlInfo,
+      final String? claimTxId,
       final String? refundTxId,
       final BigInt? refundTxAmountSat}) = _$PaymentDetails_LightningImpl;
   const PaymentDetails_Lightning._() : super._();
@@ -1176,6 +1201,9 @@ abstract class PaymentDetails_Lightning extends PaymentDetails {
 
   /// The payment LNURL info
   LnUrlInfo? get lnurlInfo;
+
+  /// For a Receive payment, this is the claim tx id in case it has already been broadcast
+  String? get claimTxId;
 
   /// For a Send swap which was refunded, this is the refund tx id
   String? get refundTxId;
@@ -1333,6 +1361,7 @@ abstract class _$$PaymentDetails_BitcoinImplCopyWith<$Res> implements $PaymentDe
       bool autoAcceptedFees,
       int? liquidExpirationBlockheight,
       int? bitcoinExpirationBlockheight,
+      String? claimTxId,
       String? refundTxId,
       BigInt? refundTxAmountSat});
 }
@@ -1355,6 +1384,7 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
     Object? autoAcceptedFees = null,
     Object? liquidExpirationBlockheight = freezed,
     Object? bitcoinExpirationBlockheight = freezed,
+    Object? claimTxId = freezed,
     Object? refundTxId = freezed,
     Object? refundTxAmountSat = freezed,
   }) {
@@ -1379,6 +1409,10 @@ class __$$PaymentDetails_BitcoinImplCopyWithImpl<$Res>
           ? _value.bitcoinExpirationBlockheight
           : bitcoinExpirationBlockheight // ignore: cast_nullable_to_non_nullable
               as int?,
+      claimTxId: freezed == claimTxId
+          ? _value.claimTxId
+          : claimTxId // ignore: cast_nullable_to_non_nullable
+              as String?,
       refundTxId: freezed == refundTxId
           ? _value.refundTxId
           : refundTxId // ignore: cast_nullable_to_non_nullable
@@ -1400,6 +1434,7 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
       required this.autoAcceptedFees,
       this.liquidExpirationBlockheight,
       this.bitcoinExpirationBlockheight,
+      this.claimTxId,
       this.refundTxId,
       this.refundTxAmountSat})
       : super._();
@@ -1427,6 +1462,10 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
   @override
   final int? bitcoinExpirationBlockheight;
 
+  /// The claim tx id in case it has already been broadcast
+  @override
+  final String? claimTxId;
+
   /// For a Send swap which was refunded, this is the refund tx id
   @override
   final String? refundTxId;
@@ -1437,7 +1476,7 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
 
   @override
   String toString() {
-    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+    return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
   }
 
   @override
@@ -1453,6 +1492,7 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
                 other.liquidExpirationBlockheight == liquidExpirationBlockheight) &&
             (identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) ||
                 other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight) &&
+            (identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId) &&
             (identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId) &&
             (identical(other.refundTxAmountSat, refundTxAmountSat) ||
                 other.refundTxAmountSat == refundTxAmountSat));
@@ -1460,7 +1500,7 @@ class _$PaymentDetails_BitcoinImpl extends PaymentDetails_Bitcoin {
 
   @override
   int get hashCode => Object.hash(runtimeType, swapId, description, autoAcceptedFees,
-      liquidExpirationBlockheight, bitcoinExpirationBlockheight, refundTxId, refundTxAmountSat);
+      liquidExpirationBlockheight, bitcoinExpirationBlockheight, claimTxId, refundTxId, refundTxAmountSat);
 
   /// Create a copy of PaymentDetails
   /// with the given fields replaced by the non-null parameter values.
@@ -1478,6 +1518,7 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
       required final bool autoAcceptedFees,
       final int? liquidExpirationBlockheight,
       final int? bitcoinExpirationBlockheight,
+      final String? claimTxId,
       final String? refundTxId,
       final BigInt? refundTxAmountSat}) = _$PaymentDetails_BitcoinImpl;
   const PaymentDetails_Bitcoin._() : super._();
@@ -1500,6 +1541,9 @@ abstract class PaymentDetails_Bitcoin extends PaymentDetails {
   /// The height of the Bitcoin block at which the swap will no longer be valid
   /// It should always be populated in case of an incoming chain swap
   int? get bitcoinExpirationBlockheight;
+
+  /// The claim tx id in case it has already been broadcast
+  String? get claimTxId;
 
   /// For a Send swap which was refunded, this is the refund tx id
   String? get refundTxId;

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -15,21 +15,12 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
-mixin _$GetPaymentRequest {
-  String get paymentHash => throw _privateConstructorUsedError;
-
-  /// Create a copy of GetPaymentRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $GetPaymentRequestCopyWith<GetPaymentRequest> get copyWith => throw _privateConstructorUsedError;
-}
+mixin _$GetPaymentRequest {}
 
 /// @nodoc
 abstract class $GetPaymentRequestCopyWith<$Res> {
   factory $GetPaymentRequestCopyWith(GetPaymentRequest value, $Res Function(GetPaymentRequest) then) =
       _$GetPaymentRequestCopyWithImpl<$Res, GetPaymentRequest>;
-  @useResult
-  $Res call({String paymentHash});
 }
 
 /// @nodoc
@@ -44,26 +35,13 @@ class _$GetPaymentRequestCopyWithImpl<$Res, $Val extends GetPaymentRequest>
 
   /// Create a copy of GetPaymentRequest
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? paymentHash = null,
-  }) {
-    return _then(_value.copyWith(
-      paymentHash: null == paymentHash
-          ? _value.paymentHash
-          : paymentHash // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
 }
 
 /// @nodoc
-abstract class _$$GetPaymentRequest_LightningImplCopyWith<$Res> implements $GetPaymentRequestCopyWith<$Res> {
+abstract class _$$GetPaymentRequest_LightningImplCopyWith<$Res> {
   factory _$$GetPaymentRequest_LightningImplCopyWith(
           _$GetPaymentRequest_LightningImpl value, $Res Function(_$GetPaymentRequest_LightningImpl) then) =
       __$$GetPaymentRequest_LightningImplCopyWithImpl<$Res>;
-  @override
   @useResult
   $Res call({String paymentHash});
 }
@@ -130,14 +108,92 @@ abstract class GetPaymentRequest_Lightning extends GetPaymentRequest {
       _$GetPaymentRequest_LightningImpl;
   const GetPaymentRequest_Lightning._() : super._();
 
-  @override
   String get paymentHash;
 
   /// Create a copy of GetPaymentRequest
   /// with the given fields replaced by the non-null parameter values.
-  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GetPaymentRequest_LightningImplCopyWith<_$GetPaymentRequest_LightningImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GetPaymentRequest_SwapIdHashImplCopyWith<$Res> {
+  factory _$$GetPaymentRequest_SwapIdHashImplCopyWith(
+          _$GetPaymentRequest_SwapIdHashImpl value, $Res Function(_$GetPaymentRequest_SwapIdHashImpl) then) =
+      __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String hash});
+}
+
+/// @nodoc
+class __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<$Res>
+    extends _$GetPaymentRequestCopyWithImpl<$Res, _$GetPaymentRequest_SwapIdHashImpl>
+    implements _$$GetPaymentRequest_SwapIdHashImplCopyWith<$Res> {
+  __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl(
+      _$GetPaymentRequest_SwapIdHashImpl _value, $Res Function(_$GetPaymentRequest_SwapIdHashImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of GetPaymentRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? hash = null,
+  }) {
+    return _then(_$GetPaymentRequest_SwapIdHashImpl(
+      hash: null == hash
+          ? _value.hash
+          : hash // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$GetPaymentRequest_SwapIdHashImpl extends GetPaymentRequest_SwapIdHash {
+  const _$GetPaymentRequest_SwapIdHashImpl({required this.hash}) : super._();
+
+  @override
+  final String hash;
+
+  @override
+  String toString() {
+    return 'GetPaymentRequest.swapIdHash(hash: $hash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GetPaymentRequest_SwapIdHashImpl &&
+            (identical(other.hash, hash) || other.hash == hash));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, hash);
+
+  /// Create a copy of GetPaymentRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GetPaymentRequest_SwapIdHashImplCopyWith<_$GetPaymentRequest_SwapIdHashImpl> get copyWith =>
+      __$$GetPaymentRequest_SwapIdHashImplCopyWithImpl<_$GetPaymentRequest_SwapIdHashImpl>(this, _$identity);
+}
+
+abstract class GetPaymentRequest_SwapIdHash extends GetPaymentRequest {
+  const factory GetPaymentRequest_SwapIdHash({required final String hash}) =
+      _$GetPaymentRequest_SwapIdHashImpl;
+  const GetPaymentRequest_SwapIdHash._() : super._();
+
+  String get hash;
+
+  /// Create a copy of GetPaymentRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GetPaymentRequest_SwapIdHashImplCopyWith<_$GetPaymentRequest_SwapIdHashImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4810,6 +4810,8 @@ final class wire_cst_PaymentDetails_Lightning extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_ln_url_info> lnurl_info;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 
   external ffi.Pointer<ffi.Uint64> refund_tx_amount_sat;
@@ -4845,6 +4847,8 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> liquid_expiration_blockheight;
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4178,18 +4178,18 @@ final class wire_cst_fetch_payment_proposed_fees_request extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 }
 
-final class wire_cst_GetPaymentRequest_Lightning extends ffi.Struct {
+final class wire_cst_GetPaymentRequest_PaymentHash extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 }
 
-final class wire_cst_GetPaymentRequest_SwapIdHash extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+final class wire_cst_GetPaymentRequest_SwapId extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 }
 
 final class GetPaymentRequestKind extends ffi.Union {
-  external wire_cst_GetPaymentRequest_Lightning Lightning;
+  external wire_cst_GetPaymentRequest_PaymentHash PaymentHash;
 
-  external wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
+  external wire_cst_GetPaymentRequest_SwapId SwapId;
 }
 
 final class wire_cst_get_payment_request extends ffi.Struct {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4182,8 +4182,14 @@ final class wire_cst_GetPaymentRequest_Lightning extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> payment_hash;
 }
 
+final class wire_cst_GetPaymentRequest_SwapIdHash extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> hash;
+}
+
 final class GetPaymentRequestKind extends ffi.Union {
   external wire_cst_GetPaymentRequest_Lightning Lightning;
+
+  external wire_cst_GetPaymentRequest_SwapIdHash SwapIdHash;
 }
 
 final class wire_cst_get_payment_request extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3422,6 +3422,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
+        val claimTxId = if (hasNonNullKey(paymentDetails, "claimTxId")) paymentDetails.getString("claimTxId") else null
         val refundTxId = if (hasNonNullKey(paymentDetails, "refundTxId")) paymentDetails.getString("refundTxId") else null
         val refundTxAmountSat =
             if (hasNonNullKey(
@@ -3443,6 +3444,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             paymentHash,
             destinationPubkey,
             lnurlInfo,
+            claimTxId,
             refundTxId,
             refundTxAmountSat,
         )
@@ -3487,6 +3489,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
+        val claimTxId = if (hasNonNullKey(paymentDetails, "claimTxId")) paymentDetails.getString("claimTxId") else null
         val refundTxId = if (hasNonNullKey(paymentDetails, "refundTxId")) paymentDetails.getString("refundTxId") else null
         val refundTxAmountSat =
             if (hasNonNullKey(
@@ -3504,6 +3507,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             autoAcceptedFees,
             bitcoinExpirationBlockheight,
             liquidExpirationBlockheight,
+            claimTxId,
             refundTxId,
             refundTxAmountSat,
         )
@@ -3525,6 +3529,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "paymentHash", paymentDetails.paymentHash)
             pushToMap(map, "destinationPubkey", paymentDetails.destinationPubkey)
             pushToMap(map, "lnurlInfo", paymentDetails.lnurlInfo?.let { readableMapOf(it) })
+            pushToMap(map, "claimTxId", paymentDetails.claimTxId)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)
         }
@@ -3542,6 +3547,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
             pushToMap(map, "bitcoinExpirationBlockheight", paymentDetails.bitcoinExpirationBlockheight)
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
+            pushToMap(map, "claimTxId", paymentDetails.claimTxId)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)
         }

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3000,13 +3000,13 @@ fun asBuyBitcoinProviderList(arr: ReadableArray): List<BuyBitcoinProvider> {
 fun asGetPaymentRequest(getPaymentRequest: ReadableMap): GetPaymentRequest? {
     val type = getPaymentRequest.getString("type")
 
-    if (type == "lightning") {
+    if (type == "paymentHash") {
         val paymentHash = getPaymentRequest.getString("paymentHash")!!
-        return GetPaymentRequest.Lightning(paymentHash)
+        return GetPaymentRequest.PaymentHash(paymentHash)
     }
-    if (type == "swapIdHash") {
-        val hash = getPaymentRequest.getString("hash")!!
-        return GetPaymentRequest.SwapIdHash(hash)
+    if (type == "swapId") {
+        val swapId = getPaymentRequest.getString("swapId")!!
+        return GetPaymentRequest.SwapId(swapId)
     }
     return null
 }
@@ -3014,13 +3014,13 @@ fun asGetPaymentRequest(getPaymentRequest: ReadableMap): GetPaymentRequest? {
 fun readableMapOf(getPaymentRequest: GetPaymentRequest): ReadableMap? {
     val map = Arguments.createMap()
     when (getPaymentRequest) {
-        is GetPaymentRequest.Lightning -> {
-            pushToMap(map, "type", "lightning")
+        is GetPaymentRequest.PaymentHash -> {
+            pushToMap(map, "type", "paymentHash")
             pushToMap(map, "paymentHash", getPaymentRequest.paymentHash)
         }
-        is GetPaymentRequest.SwapIdHash -> {
-            pushToMap(map, "type", "swapIdHash")
-            pushToMap(map, "hash", getPaymentRequest.hash)
+        is GetPaymentRequest.SwapId -> {
+            pushToMap(map, "type", "swapId")
+            pushToMap(map, "swapId", getPaymentRequest.swapId)
         }
     }
     return map

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3004,6 +3004,10 @@ fun asGetPaymentRequest(getPaymentRequest: ReadableMap): GetPaymentRequest? {
         val paymentHash = getPaymentRequest.getString("paymentHash")!!
         return GetPaymentRequest.Lightning(paymentHash)
     }
+    if (type == "swapIdHash") {
+        val hash = getPaymentRequest.getString("hash")!!
+        return GetPaymentRequest.SwapIdHash(hash)
+    }
     return null
 }
 
@@ -3013,6 +3017,10 @@ fun readableMapOf(getPaymentRequest: GetPaymentRequest): ReadableMap? {
         is GetPaymentRequest.Lightning -> {
             pushToMap(map, "type", "lightning")
             pushToMap(map, "paymentHash", getPaymentRequest.paymentHash)
+        }
+        is GetPaymentRequest.SwapIdHash -> {
+            pushToMap(map, "type", "swapIdHash")
+            pushToMap(map, "hash", getPaymentRequest.hash)
         }
     }
     return map

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4170,11 +4170,13 @@ enum BreezSDKLiquidMapper {
                 _lnurlInfo = try asLnUrlInfo(lnUrlInfo: lnurlInfoTmp)
             }
 
+            let _claimTxId = paymentDetails["claimTxId"] as? String
+
             let _refundTxId = paymentDetails["refundTxId"] as? String
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
         if type == "liquid" {
             guard let _assetId = paymentDetails["assetId"] as? String else {
@@ -4207,11 +4209,13 @@ enum BreezSDKLiquidMapper {
 
             let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32
 
+            let _claimTxId = paymentDetails["claimTxId"] as? String
+
             let _refundTxId = paymentDetails["refundTxId"] as? String
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4220,7 +4224,7 @@ enum BreezSDKLiquidMapper {
     static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
         switch paymentDetails {
         case let .lightning(
-            swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, refundTxId, refundTxAmountSat
+            swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, claimTxId, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "lightning",
@@ -4233,6 +4237,7 @@ enum BreezSDKLiquidMapper {
                 "paymentHash": paymentHash == nil ? nil : paymentHash,
                 "destinationPubkey": destinationPubkey == nil ? nil : destinationPubkey,
                 "lnurlInfo": lnurlInfo == nil ? nil : dictionaryOf(lnUrlInfo: lnurlInfo!),
+                "claimTxId": claimTxId == nil ? nil : claimTxId,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
             ]
@@ -4249,7 +4254,7 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, refundTxId, refundTxAmountSat
+            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, claimTxId, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "bitcoin",
@@ -4258,6 +4263,7 @@ enum BreezSDKLiquidMapper {
                 "autoAcceptedFees": autoAcceptedFees,
                 "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,
                 "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
+                "claimTxId": claimTxId == nil ? nil : claimTxId,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
             ]

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -3493,17 +3493,17 @@ enum BreezSDKLiquidMapper {
 
     static func asGetPaymentRequest(getPaymentRequest: [String: Any?]) throws -> GetPaymentRequest {
         let type = getPaymentRequest["type"] as! String
-        if type == "lightning" {
+        if type == "paymentHash" {
             guard let _paymentHash = getPaymentRequest["paymentHash"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "GetPaymentRequest"))
             }
-            return GetPaymentRequest.lightning(paymentHash: _paymentHash)
+            return GetPaymentRequest.paymentHash(paymentHash: _paymentHash)
         }
-        if type == "swapIdHash" {
-            guard let _hash = getPaymentRequest["hash"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hash", typeName: "GetPaymentRequest"))
+        if type == "swapId" {
+            guard let _swapId = getPaymentRequest["swapId"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "GetPaymentRequest"))
             }
-            return GetPaymentRequest.swapIdHash(hash: _hash)
+            return GetPaymentRequest.swapId(swapId: _swapId)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum GetPaymentRequest")
@@ -3511,20 +3511,20 @@ enum BreezSDKLiquidMapper {
 
     static func dictionaryOf(getPaymentRequest: GetPaymentRequest) -> [String: Any?] {
         switch getPaymentRequest {
-        case let .lightning(
+        case let .paymentHash(
             paymentHash
         ):
             return [
-                "type": "lightning",
+                "type": "paymentHash",
                 "paymentHash": paymentHash,
             ]
 
-        case let .swapIdHash(
-            hash
+        case let .swapId(
+            swapId
         ):
             return [
-                "type": "swapIdHash",
-                "hash": hash,
+                "type": "swapId",
+                "swapId": swapId,
             ]
         }
     }

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -3499,6 +3499,12 @@ enum BreezSDKLiquidMapper {
             }
             return GetPaymentRequest.lightning(paymentHash: _paymentHash)
         }
+        if type == "swapIdHash" {
+            guard let _hash = getPaymentRequest["hash"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hash", typeName: "GetPaymentRequest"))
+            }
+            return GetPaymentRequest.swapIdHash(hash: _hash)
+        }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum GetPaymentRequest")
     }
@@ -3511,6 +3517,14 @@ enum BreezSDKLiquidMapper {
             return [
                 "type": "lightning",
                 "paymentHash": paymentHash,
+            ]
+
+        case let .swapIdHash(
+            hash
+        ):
+            return [
+                "type": "swapIdHash",
+                "hash": hash,
             ]
         }
     }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -522,16 +522,16 @@ export enum BuyBitcoinProvider {
 }
 
 export enum GetPaymentRequestVariant {
-    LIGHTNING = "lightning",
-    SWAP_ID_HASH = "swapIdHash"
+    PAYMENT_HASH = "paymentHash",
+    SWAP_ID = "swapId"
 }
 
 export type GetPaymentRequest = {
-    type: GetPaymentRequestVariant.LIGHTNING,
+    type: GetPaymentRequestVariant.PAYMENT_HASH,
     paymentHash: string
 } | {
-    type: GetPaymentRequestVariant.SWAP_ID_HASH,
-    hash: string
+    type: GetPaymentRequestVariant.SWAP_ID,
+    swapId: string
 }
 
 export enum InputTypeVariant {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -522,12 +522,16 @@ export enum BuyBitcoinProvider {
 }
 
 export enum GetPaymentRequestVariant {
-    LIGHTNING = "lightning"
+    LIGHTNING = "lightning",
+    SWAP_ID_HASH = "swapIdHash"
 }
 
-export interface GetPaymentRequest {
+export type GetPaymentRequest = {
     type: GetPaymentRequestVariant.LIGHTNING,
     paymentHash: string
+} | {
+    type: GetPaymentRequestVariant.SWAP_ID_HASH,
+    hash: string
 }
 
 export enum InputTypeVariant {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -685,6 +685,7 @@ export type PaymentDetails = {
     paymentHash?: string
     destinationPubkey?: string
     lnurlInfo?: LnUrlInfo
+    claimTxId?: string
     refundTxId?: string
     refundTxAmountSat?: number
 } | {
@@ -700,6 +701,7 @@ export type PaymentDetails = {
     autoAcceptedFees: boolean
     bitcoinExpirationBlockheight?: number
     liquidExpirationBlockheight?: number
+    claimTxId?: string
     refundTxId?: string
     refundTxAmountSat?: number
 }


### PR DESCRIPTION
Resolves #636 

This PR prevents a potential issue where notifications might be missed due to the SDK instance of a backgrounded app still being able to issue an event. Changes:

- Adds the swap id hash as a possible identifier for the `get_payment` method
- Exposes the claim tx id in payments to allow determining if the claim has been broadcasted
- Notification plugins, in addition to listening to events, now also poll the payment state

#### Test notes

- With the app in the background, payment notifications should work reliably without missed or duplicate notifications
    - Lightning payments
    - Onchain payments