### PR TITLE
Lock free chain service

### DIFF
--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -163,20 +163,6 @@ impl Recoverer {
     /// - `tx_map`: all known onchain txs of this wallet at this time, essentially our own LWK cache.
     /// - `swaps`: immutable data of the swaps for which we want to recover onchain data.
     pub(crate) async fn recover_from_onchain(&self, swaps: &mut [Swap]) -> Result<()> {
-        //println!("swaps: {:?}", swaps.iter().map(|s|s.).collect::<Vec<_>>());
-        for swap in swaps.iter() {
-            match swap {
-                Swap::Send(send_swap) => {
-                    println!("send_swap: {:?}", send_swap.id);
-                }
-                Swap::Receive(receive_swap) => {
-                    println!("receive_swap: {:?}", receive_swap.id);
-                }
-                Swap::Chain(chain_swap) => {
-                    println!("chain_swap: {:?}", chain_swap.id);
-                }
-            }
-        }
         let tx_map = TxMap::from_raw_tx_map(self.onchain_wallet.transactions_by_tx_id().await?);
 
         let swaps_list = swaps.to_vec().try_into()?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -352,8 +352,13 @@ impl LiquidSdk {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
+                      info!("Track blocks loop ticked");
                         // Get the Liquid tip and process a new block
+                        let t0 = Instant::now();
                         let liquid_tip_res = cloned.liquid_chain_service.tip().await;
+                        let duration_ms = Instant::now().duration_since(t0).as_millis();
+                        info!("Fetched liquid tip at ({duration_ms} ms)");
+
                         let is_new_liquid_block = match &liquid_tip_res {
                             Ok(height) => {
                                 debug!("Got Liquid tip: {height}");
@@ -367,7 +372,10 @@ impl LiquidSdk {
                             }
                         };
                         // Get the Bitcoin tip and process a new block
+                        let t0 = Instant::now();
                         let bitcoin_tip_res = cloned.bitcoin_chain_service.lock().await.tip().map(|tip| tip.height as u32);
+                        let duration_ms = Instant::now().duration_since(t0).as_millis();
+                        info!("Fetched bitcoin tip at ({duration_ms} ms)");
                         let is_new_bitcoin_block = match &bitcoin_tip_res {
                             Ok(height) => {
                                 debug!("Got Bitcoin tip: {height}");

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -351,7 +351,7 @@ impl LiquidSdk {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                      info!("Track blocks loop ticked");
+                        info!("Track blocks loop ticked");
                         // Get the Liquid tip and process a new block
                         let t0 = Instant::now();
                         let liquid_tip_res = cloned.liquid_chain_service.tip().await;

--- a/lib/core/src/test_utils/chain.rs
+++ b/lib/core/src/test_utils/chain.rs
@@ -132,42 +132,42 @@ impl LiquidChainService for MockLiquidChainService {
 }
 
 pub(crate) struct MockBitcoinChainService {
-    history: Vec<MockHistory>,
-    txs: Vec<boltz_client::bitcoin::Transaction>,
-    script_balance_sat: u64,
+    history: Mutex<Vec<MockHistory>>,
+    txs: Mutex<Vec<boltz_client::bitcoin::Transaction>>,
+    script_balance_sat: Mutex<u64>,
 }
 
 impl MockBitcoinChainService {
     pub(crate) fn new() -> Self {
         MockBitcoinChainService {
-            history: vec![],
-            txs: vec![],
-            script_balance_sat: 0,
+            history: Mutex::new(vec![]),
+            txs: Mutex::new(vec![]),
+            script_balance_sat: Mutex::new(0),
         }
     }
 
-    pub(crate) fn set_history(&mut self, history: Vec<MockHistory>) -> &mut Self {
-        self.history = history;
+    pub(crate) fn set_history(&self, history: Vec<MockHistory>) -> &Self {
+        *self.history.lock().unwrap() = history;
         self
     }
 
-    pub(crate) fn set_transactions(&mut self, txs: &[&str]) -> &mut Self {
-        self.txs = txs
+    pub(crate) fn set_transactions(&self, txs: &[&str]) -> &Self {
+        *self.txs.lock().unwrap() = txs
             .iter()
             .map(|tx_hex| deserialize(&Vec::<u8>::from_hex(tx_hex).unwrap()).unwrap())
             .collect();
         self
     }
 
-    pub(crate) fn set_script_balance_sat(&mut self, script_balance_sat: u64) -> &mut Self {
-        self.script_balance_sat = script_balance_sat;
+    pub(crate) fn set_script_balance_sat(&self, script_balance_sat: u64) -> &Self {
+        *self.script_balance_sat.lock().unwrap() = script_balance_sat;
         self
     }
 }
 
 #[async_trait]
 impl BitcoinChainService for MockBitcoinChainService {
-    fn tip(&mut self) -> Result<HeaderNotification> {
+    fn tip(&self) -> Result<HeaderNotification> {
         Ok(HeaderNotification {
             height: 0,
             header: genesis_block(lwk_wollet::bitcoin::Network::Testnet).header,
@@ -185,11 +185,18 @@ impl BitcoinChainService for MockBitcoinChainService {
         &self,
         _txids: &[boltz_client::bitcoin::Txid],
     ) -> Result<Vec<boltz_client::bitcoin::Transaction>> {
-        Ok(self.txs.clone())
+        Ok(self.txs.lock().unwrap().clone())
     }
 
     fn get_script_history(&self, _script: &Script) -> Result<Vec<lwk_wollet::History>> {
-        Ok(self.history.clone().into_iter().map(Into::into).collect())
+        Ok(self
+            .history
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     async fn get_script_history_with_retry(
@@ -197,7 +204,14 @@ impl BitcoinChainService for MockBitcoinChainService {
         _script: &Script,
         _retries: u64,
     ) -> Result<Vec<lwk_wollet::History>> {
-        Ok(self.history.clone().into_iter().map(Into::into).collect())
+        Ok(self
+            .history
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     fn get_scripts_history(&self, _scripts: &[&Script]) -> Result<Vec<Vec<History>>> {
@@ -233,7 +247,7 @@ impl BitcoinChainService for MockBitcoinChainService {
         _retries: u64,
     ) -> Result<electrum_client::GetBalanceRes> {
         Ok(GetBalanceRes {
-            confirmed: self.script_balance_sat,
+            confirmed: self.script_balance_sat.lock().unwrap().clone(),
             unconfirmed: 0,
         })
     }

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -34,7 +34,7 @@ pub(crate) fn new_chain_swap_handler(persister: Arc<Persister>) -> Result<ChainS
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(BoltzSwapper::new(config.clone(), None));
-    let liquid_chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
+    let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
 
     ChainSwapHandler::new(

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -6,8 +6,6 @@ use lazy_static::lazy_static;
 use sdk_common::bitcoin::{consensus::deserialize, Transaction};
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
-
 use crate::{
     chain_swap::ChainSwapHandler,
     model::{ChainSwap, Config, Direction, PaymentState, Signer},
@@ -35,7 +33,7 @@ pub(crate) fn new_chain_swap_handler(persister: Arc<Persister>) -> Result<ChainS
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(BoltzSwapper::new(config.clone(), None));
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
-    let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
+    let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
 
     ChainSwapHandler::new(
         config,

--- a/lib/core/src/test_utils/receive_swap.rs
+++ b/lib/core/src/test_utils/receive_swap.rs
@@ -3,8 +3,6 @@
 use anyhow::Result;
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
-
 use crate::{
     model::{Config, Signer},
     persist::Persister,
@@ -22,7 +20,7 @@ pub(crate) fn new_receive_swap_handler(persister: Arc<Persister>) -> Result<Rece
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(MockSwapper::default());
-    let liquid_chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
+    let liquid_chain_service = Arc::new(MockLiquidChainService::new());
 
     Ok(ReceiveSwapHandler::new(
         config,

--- a/lib/core/src/test_utils/recover.rs
+++ b/lib/core/src/test_utils/recover.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::sync::Mutex;
 
 use crate::{
     model::Signer, recover::recoverer::Recoverer, swapper::Swapper, wallet::OnchainWallet,
@@ -15,7 +14,7 @@ pub(crate) fn new_recoverer(
     onchain_wallet: Arc<dyn OnchainWallet>,
 ) -> Result<Recoverer> {
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
-    let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
+    let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
 
     Recoverer::new(
         signer.slip77_master_blinding_key()?,

--- a/lib/core/src/test_utils/recover.rs
+++ b/lib/core/src/test_utils/recover.rs
@@ -14,7 +14,7 @@ pub(crate) fn new_recoverer(
     swapper: Arc<dyn Swapper>,
     onchain_wallet: Arc<dyn OnchainWallet>,
 ) -> Result<Recoverer> {
-    let liquid_chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
+    let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
 
     Recoverer::new(

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use sdk_common::prelude::{BreezServer, STAGING_BREEZSERVER_URL};
 use std::sync::Arc;
 
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{watch, RwLock};
 
 use crate::{
     buy::BuyBitcoinService,
@@ -32,7 +32,7 @@ pub(crate) fn new_liquid_sdk(
     status_stream: Arc<MockStatusStream>,
 ) -> Result<LiquidSdk> {
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
-    let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
+    let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
 
     new_liquid_sdk_with_chain_services(
         persister,
@@ -49,7 +49,7 @@ pub(crate) fn new_liquid_sdk_with_chain_services(
     swapper: Arc<MockSwapper>,
     status_stream: Arc<MockStatusStream>,
     liquid_chain_service: Arc<MockLiquidChainService>,
-    bitcoin_chain_service: Arc<Mutex<MockBitcoinChainService>>,
+    bitcoin_chain_service: Arc<MockBitcoinChainService>,
     onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
 ) -> Result<LiquidSdk> {
     let mut config = Config::testnet(None);

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -31,7 +31,7 @@ pub(crate) fn new_liquid_sdk(
     swapper: Arc<MockSwapper>,
     status_stream: Arc<MockStatusStream>,
 ) -> Result<LiquidSdk> {
-    let liquid_chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
+    let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(Mutex::new(MockBitcoinChainService::new()));
 
     new_liquid_sdk_with_chain_services(
@@ -48,7 +48,7 @@ pub(crate) fn new_liquid_sdk_with_chain_services(
     persister: Arc<Persister>,
     swapper: Arc<MockSwapper>,
     status_stream: Arc<MockStatusStream>,
-    liquid_chain_service: Arc<Mutex<MockLiquidChainService>>,
+    liquid_chain_service: Arc<MockLiquidChainService>,
     bitcoin_chain_service: Arc<Mutex<MockBitcoinChainService>>,
     onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
 ) -> Result<LiquidSdk> {

--- a/lib/core/src/test_utils/send_swap.rs
+++ b/lib/core/src/test_utils/send_swap.rs
@@ -8,7 +8,6 @@ use crate::{
     send_swap::SendSwapHandler,
 };
 use anyhow::Result;
-use tokio::sync::Mutex;
 
 use super::{
     chain::MockLiquidChainService,
@@ -21,7 +20,7 @@ pub(crate) fn new_send_swap_handler(persister: Arc<Persister>) -> Result<SendSwa
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(MockSwapper::default());
-    let chain_service = Arc::new(Mutex::new(MockLiquidChainService::new()));
+    let chain_service = Arc::new(MockLiquidChainService::new());
 
     Ok(SendSwapHandler::new(
         config,


### PR DESCRIPTION
Previously we had a lock wrapping the liquid chain service. This caused every endpoint that was called to block other endpoints. For example when the recoverer from the realtime sync fetching script history (which may take several seconds) was blocking a manual user Sync calls that use the same chain service and both were blocking other endpoint such as rescan_chain_swaps.
This PR removes that lock and only apply a lock internally on the tip endpoint since it is the only one that is mutable.
A dedicated tip_client is used for that as the alternative of creating electrum connection for each tip call is more expensive:
* cached electrum tip: ~70 ms
* new electrum tip: ~600 ms

Edit:  Applied the same approach also for bitcoin chain service.
Another significant bottleneck was get_script_history_with_retry which was internally retrying after 5 seconds. This has locked every concurrent usage of the bitcoin chain service during this waiting time.