### PR TITLE
Increase onchain fetching retries

### DIFF
--- a/lib/core/src/chain/bitcoin.rs
+++ b/lib/core/src/chain/bitcoin.rs
@@ -282,7 +282,7 @@ impl BitcoinChainService for HybridBitcoinChainService {
         verify_confirmation: bool,
     ) -> Result<Transaction> {
         let script = address.script_pubkey();
-        let script_history = self.get_script_history_with_retry(&script, 5).await?;
+        let script_history = self.get_script_history_with_retry(&script, 10).await?;
         let lockup_tx_history = script_history.iter().find(|h| h.txid.to_hex().eq(tx_id));
 
         match lockup_tx_history {

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -132,7 +132,7 @@ impl LiquidChainService for HybridLiquidChainService {
     }
 
     async fn get_script_utxos(&self, script: &Script) -> Result<Vec<Utxo>> {
-        let history = self.get_script_history_with_retry(script, 3).await?;
+        let history = self.get_script_history_with_retry(script, 10).await?;
 
         let mut utxos: Vec<Utxo> = vec![];
         for history_item in history {

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -1426,7 +1426,7 @@ impl ChainSwapHandler {
         let script_pubkey = address.script_pubkey();
         let script = script_pubkey.as_script();
         self.bitcoin_chain_service
-            .get_script_history_with_retry(script, 5)
+            .get_script_history_with_retry(script, 10)
             .await
     }
 
@@ -1442,7 +1442,7 @@ impl ChainSwapHandler {
         let script = Script::from_hex(hex::encode(address.script_pubkey().as_bytes()).as_str())
             .map_err(|e| anyhow!("Failed to get script from address {e:?}"))?;
         self.liquid_chain_service
-            .get_script_history_with_retry(&script, 5)
+            .get_script_history_with_retry(&script, 10)
             .await
     }
 }


### PR DESCRIPTION
This PR increases the number of retries on all onchain fetching methods that use retries and were retrying less than 10 times. 

I noticed in the wild that while processing a chain swap LockupFailed event, we were setting the status to `Failed` instead of `Refundable` because we would fail to find the user lockup in the 5 retries that were attempted. This should hopefully reduce the likelihood of this kind of issues. 