### PR TITLE
Remove electrum tip query on start

### DIFF
--- a/lib/core/src/chain/bitcoin.rs
+++ b/lib/core/src/chain/bitcoin.rs
@@ -122,8 +122,7 @@ impl BitcoinChainService for HybridBitcoinChainService {
             }
         };
 
-        let tip = new_tip.ok_or_else(|| anyhow!("Failed to get tip"))?;
-        Ok(tip)
+        new_tip.ok_or_else(|| anyhow!("Failed to get tip"))
     }
 
     fn broadcast(&self, tx: &Transaction) -> Result<Txid> {

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -109,8 +109,7 @@ impl LiquidChainService for HybridLiquidChainService {
             }
         };
 
-        let tip: u32 = new_tip.ok_or_else(|| anyhow!("Failed to get tip"))?;
-        Ok(tip)
+        new_tip.ok_or_else(|| anyhow!("Failed to get tip"))
     }
 
     async fn broadcast(&self, tx: &Transaction) -> Result<Txid> {

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -97,7 +97,7 @@ impl LiquidChainService for HybridLiquidChainService {
         let new_tip: Option<u32> = match maybe_popped_header {
             Some(popped_header) => Some(popped_header.height.try_into()?),
             None => {
-                // https://github.com/bitcoindevkit/rusprintln!("Fetching block headers");t-electrum-client/issues/124
+                // https://github.com/bitcoindevkit/rust-electrum-client/issues/124
                 // It might be that the client has reconnected and subscriptions don't persist
                 // across connections. Calling `client.ping()` won't help here because the
                 // successful retry will prevent us knowing about the reconnect.

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -140,7 +140,7 @@ impl LiquidChainService for HybridLiquidChainService {
             .map(|e| e.into_iter().map(Into::into).collect())
             .collect();
         let h = history_vec.pop();
-        Ok(h.unwrap_or(vec![]))
+        Ok(h.unwrap_or_default())
     }
 
     async fn get_scripts_history(&self, scripts: &[&Script]) -> Result<Vec<Vec<History>>> {

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -90,7 +90,6 @@ impl LiquidChainService for HybridLiquidChainService {
     async fn tip(&self) -> Result<u32> {
         let client = self.get_client()?;
         let mut maybe_popped_header = None;
-        println!("Fetching block headers");
         while let Some(header) = client.block_headers_pop_raw()? {
             maybe_popped_header = Some(header)
         }
@@ -98,17 +97,13 @@ impl LiquidChainService for HybridLiquidChainService {
         let new_tip: Option<u32> = match maybe_popped_header {
             Some(popped_header) => Some(popped_header.height.try_into()?),
             None => {
-                println!("Fetching block headers none");
                 // https://github.com/bitcoindevkit/rusprintln!("Fetching block headers");t-electrum-client/issues/124
                 // It might be that the client has reconnected and subscriptions don't persist
                 // across connections. Calling `client.ping()` won't help here because the
                 // successful retry will prevent us knowing about the reconnect.
                 if let Ok(header) = client.block_headers_subscribe_raw() {
-                    println!("Fetching block headers block_headers_subscribe_raw returned result");
-                    println!("header: {:?}", header.height);
                     Some(header.height.try_into()?)
                 } else {
-                    println!("Fetching block headers block_headers_subscribe_raw returned None");
                     None
                 }
             }


### PR DESCRIPTION
ElecturmClient needs to be initialized with the current tip which forced us to query right on start which caused up to several seconds of sdk initialization.
Since we don't really need lwk ElectrumClient to use electrum this PR shifts to use the underline Client directly and saves this startup time and reduced it to less than a millisecond. 

Edit: It turns out that also Electurm client initialization has some overhead as it tries to connect. I changed the code to use lazy initialization of electrum which causes the startup flow to complete instantly now.