### PR TITLE
Lazily initialize Boltz client

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -194,7 +194,7 @@ impl LiquidSdk {
         }
         let cached_swapper_proxy_url = persister.get_swapper_proxy_url()?;
         let swapper = Arc::new(BoltzSwapper::new(config.clone(), cached_swapper_proxy_url));
-        let status_stream = Arc::<dyn SwapperStatusStream>::from(swapper.create_status_stream());
+        let status_stream = Arc::<dyn SwapperStatusStream>::from(swapper.create_status_stream()?);
 
         let recoverer = Arc::new(Recoverer::new(
             signer.slip77_master_blinding_key()?,

--- a/lib/core/src/swapper/boltz/bitcoin.rs
+++ b/lib/core/src/swapper/boltz/bitcoin.rs
@@ -30,7 +30,7 @@ impl BoltzSwapper {
                         swap_script.as_bitcoin_script()?,
                         refund_address,
                         &self.bitcoin_electrum_config,
-                        self.boltz_url.clone(),
+                        self.get_client()?.url.clone(),
                         swap.id.clone(),
                     )
                 }
@@ -91,7 +91,7 @@ impl BoltzSwapper {
         let broadcast_fees_sat = (refund_tx_size as f64 * broadcast_fee_rate_sat_per_vb) as u64;
 
         let cooperative = match is_cooperative {
-            true => self.get_cooperative_details(swap.id.clone(), None, None),
+            true => self.get_cooperative_details(swap.id.clone(), None, None)?,
             false => None,
         };
 
@@ -114,7 +114,7 @@ impl BoltzSwapper {
             claim_swap_script,
             claim_address,
             &self.bitcoin_electrum_config,
-            self.boltz_url.clone(),
+            self.get_client()?.url.clone(),
             swap.id.clone(),
         )?;
 
@@ -124,7 +124,7 @@ impl BoltzSwapper {
             &claim_keypair,
             &Preimage::from_str(&swap.preimage)?,
             Fee::Absolute(swap.claim_fees_sat),
-            self.get_cooperative_details(swap.id.clone(), Some(pub_nonce), Some(partial_sig)),
+            self.get_cooperative_details(swap.id.clone(), Some(pub_nonce), Some(partial_sig))?,
         )?;
 
         Ok(signed_tx)

--- a/lib/core/src/swapper/boltz/liquid.rs
+++ b/lib/core/src/swapper/boltz/liquid.rs
@@ -41,7 +41,7 @@ impl BoltzSwapper {
             swap_script,
             claim_address,
             &self.liquid_electrum_config,
-            self.boltz_url.clone(),
+            self.get_client()?.url.clone(),
             swap.id.clone(),
         )?;
 
@@ -49,7 +49,7 @@ impl BoltzSwapper {
             &swap.get_claim_keypair()?,
             &Preimage::from_str(&swap.preimage)?,
             Fee::Absolute(swap.claim_fees_sat),
-            self.get_cooperative_details(swap.id.clone(), None, None),
+            self.get_cooperative_details(swap.id.clone(), None, None)?,
             true,
         )?;
 
@@ -67,7 +67,7 @@ impl BoltzSwapper {
             swap_script,
             claim_address,
             &self.liquid_electrum_config,
-            self.boltz_url.clone(),
+            self.get_client()?.url.clone(),
             swap.id.clone(),
         )?;
 
@@ -77,7 +77,7 @@ impl BoltzSwapper {
             &claim_keypair,
             &Preimage::from_str(&swap.preimage)?,
             Fee::Absolute(swap.claim_fees_sat),
-            self.get_cooperative_details(swap.id.clone(), Some(pub_nonce), Some(partial_sig)),
+            self.get_cooperative_details(swap.id.clone(), Some(pub_nonce), Some(partial_sig))?,
             true,
         )?;
 
@@ -107,7 +107,7 @@ impl BoltzSwapper {
                         swap_script.as_liquid_script()?,
                         refund_address,
                         &self.liquid_electrum_config,
-                        self.boltz_url.clone(),
+                        self.get_client()?.url.clone(),
                         swap.id.clone(),
                     )
                 }
@@ -118,7 +118,7 @@ impl BoltzSwapper {
                     swap_script,
                     refund_address,
                     &self.liquid_electrum_config,
-                    self.boltz_url.clone(),
+                    self.get_client()?.url.clone(),
                     swap.id.clone(),
                 )
             }
@@ -189,7 +189,7 @@ impl BoltzSwapper {
         let broadcast_fees_sat = self.calculate_refund_fees(refund_tx_size);
 
         let cooperative = match is_cooperative {
-            true => self.get_cooperative_details(swap_id.clone(), None, None),
+            true => self.get_cooperative_details(swap_id.clone(), None, None)?,
             false => None,
         };
 

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -1,5 +1,6 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::OnceLock};
 
+use anyhow::Result;
 use boltz_client::{
     boltz::{
         BoltzApiClientV2, ChainPair, Cooperative, CreateChainRequest, CreateChainResponse,
@@ -28,10 +29,15 @@ pub(crate) mod bitcoin;
 pub(crate) mod liquid;
 pub mod status_stream;
 
-pub struct BoltzSwapper {
-    client: BoltzApiClientV2,
-    boltz_url: String,
+pub(crate) struct BoltzClient {
+    url: String,
     referral_id: Option<String>,
+    inner: BoltzApiClientV2,
+}
+
+pub struct BoltzSwapper {
+    client: OnceLock<BoltzClient>,
+    swapper_proxy_url: Option<String>,
     config: Config,
     liquid_electrum_config: ElectrumConfig,
     bitcoin_electrum_config: ElectrumConfig,
@@ -39,37 +45,9 @@ pub struct BoltzSwapper {
 
 impl BoltzSwapper {
     pub fn new(config: Config, swapper_proxy_url: Option<String>) -> Self {
-        let (boltz_api_base_url, referral_id) = match &config.network {
-            LiquidNetwork::Testnet => (None, None),
-            LiquidNetwork::Mainnet => match &swapper_proxy_url {
-                Some(swapper_proxy_url) => Url::parse(swapper_proxy_url)
-                    .map(|url| match url.query() {
-                        None => (None, None),
-                        Some(query) => {
-                            let api_base_url =
-                                url.domain().map(|domain| format!("https://{domain}/v2"));
-                            let parts: Vec<String> = query.split('=').map(Into::into).collect();
-                            let referral_id = parts.get(1).cloned();
-                            (api_base_url, referral_id)
-                        }
-                    })
-                    .unwrap_or_default(),
-                None => (None, None),
-            },
-        };
-
-        let boltz_url = boltz_api_base_url.unwrap_or(
-            match config.network {
-                LiquidNetwork::Mainnet => BOLTZ_MAINNET_URL_V2,
-                LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
-            }
-            .to_string(),
-        );
-
         Self {
-            client: BoltzApiClientV2::new(&boltz_url),
-            boltz_url,
-            referral_id,
+            client: OnceLock::new(),
+            swapper_proxy_url,
             config: config.clone(),
             liquid_electrum_config: ElectrumConfig::new(
                 config.network.into(),
@@ -88,6 +66,46 @@ impl BoltzSwapper {
         }
     }
 
+    fn get_client(&self) -> Result<&BoltzClient> {
+        if let Some(client) = self.client.get() {
+            return Ok(client);
+        }
+
+        let (boltz_api_base_url, referral_id) = match &self.config.network {
+            LiquidNetwork::Testnet => (None, None),
+            LiquidNetwork::Mainnet => match &self.swapper_proxy_url {
+                Some(swapper_proxy_url) => Url::parse(swapper_proxy_url)
+                    .map(|url| match url.query() {
+                        None => (None, None),
+                        Some(query) => {
+                            let api_base_url =
+                                url.domain().map(|domain| format!("https://{domain}/v2"));
+                            let parts: Vec<String> = query.split('=').map(Into::into).collect();
+                            let referral_id = parts.get(1).cloned();
+                            (api_base_url, referral_id)
+                        }
+                    })
+                    .unwrap_or_default(),
+                None => (None, None),
+            },
+        };
+
+        let boltz_url = boltz_api_base_url.unwrap_or(
+            match self.config.network {
+                LiquidNetwork::Mainnet => BOLTZ_MAINNET_URL_V2,
+                LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
+            }
+            .to_string(),
+        );
+
+        let client = self.client.get_or_init(|| BoltzClient {
+            inner: BoltzApiClientV2::new(&boltz_url),
+            url: boltz_url,
+            referral_id,
+        });
+        Ok(client)
+    }
+
     fn get_claim_partial_sig(
         &self,
         swap: &ChainSwap,
@@ -98,7 +116,10 @@ impl BoltzSwapper {
         // We need it to calculate the musig partial sig for the claim tx from the other chain
         let lockup_address = &swap.lockup_address;
 
-        let claim_tx_details = self.client.get_chain_claim_tx_details(&swap.id)?;
+        let claim_tx_details = self
+            .get_client()?
+            .inner
+            .get_chain_claim_tx_details(&swap.id)?;
         match swap.direction {
             Direction::Incoming => {
                 let refund_tx_wrapper =
@@ -129,13 +150,13 @@ impl BoltzSwapper {
         swap_id: String,
         pub_nonce: Option<MusigPubNonce>,
         partial_sig: Option<MusigPartialSignature>,
-    ) -> Option<Cooperative> {
-        Some(Cooperative {
-            boltz_api: &self.client,
+    ) -> Result<Option<Cooperative>> {
+        Ok(Some(Cooperative {
+            boltz_api: &self.get_client()?.inner,
             swap_id,
             pub_nonce,
             partial_sig,
-        })
+        }))
     }
 }
 
@@ -145,11 +166,12 @@ impl Swapper for BoltzSwapper {
         &self,
         req: CreateChainRequest,
     ) -> Result<CreateChainResponse, PaymentError> {
+        let client = self.get_client()?;
         let modified_req = CreateChainRequest {
-            referral_id: self.referral_id.clone(),
+            referral_id: client.referral_id.clone(),
             ..req.clone()
         };
-        Ok(self.client.post_chain_req(modified_req)?)
+        Ok(client.inner.post_chain_req(modified_req)?)
     }
 
     /// Create a new send swap
@@ -157,15 +179,16 @@ impl Swapper for BoltzSwapper {
         &self,
         req: CreateSubmarineRequest,
     ) -> Result<CreateSubmarineResponse, PaymentError> {
+        let client = self.get_client()?;
         let modified_req = CreateSubmarineRequest {
-            referral_id: self.referral_id.clone(),
+            referral_id: client.referral_id.clone(),
             ..req.clone()
         };
-        Ok(self.client.post_swap_req(&modified_req)?)
+        Ok(client.inner.post_swap_req(&modified_req)?)
     }
 
     fn get_chain_pair(&self, direction: Direction) -> Result<Option<ChainPair>, PaymentError> {
-        let pairs = self.client.get_chain_pairs()?;
+        let pairs = self.get_client()?.inner.get_chain_pairs()?;
         let pair = match direction {
             Direction::Incoming => pairs.get_btc_to_lbtc_pair(),
             Direction::Outgoing => pairs.get_lbtc_to_btc_pair(),
@@ -174,14 +197,15 @@ impl Swapper for BoltzSwapper {
     }
 
     fn get_chain_pairs(&self) -> Result<(Option<ChainPair>, Option<ChainPair>), PaymentError> {
-        let pairs = self.client.get_chain_pairs()?;
+        let pairs = self.get_client()?.inner.get_chain_pairs()?;
         let pair_outgoing = pairs.get_lbtc_to_btc_pair();
         let pair_incoming = pairs.get_btc_to_lbtc_pair();
         Ok((pair_outgoing, pair_incoming))
     }
 
     fn get_zero_amount_chain_swap_quote(&self, swap_id: &str) -> Result<Amount, SdkError> {
-        self.client
+        self.get_client()?
+            .inner
             .get_quote(swap_id)
             .map(|r| Amount::from_sat(r.amount))
             .map_err(Into::into)
@@ -192,19 +216,28 @@ impl Swapper for BoltzSwapper {
         swap_id: &str,
         server_lockup_sat: u64,
     ) -> Result<(), PaymentError> {
-        self.client
+        self.get_client()?
+            .inner
             .accept_quote(swap_id, server_lockup_sat)
             .map_err(Into::into)
     }
 
     /// Get a submarine pair information
     fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError> {
-        Ok(self.client.get_submarine_pairs()?.get_lbtc_to_btc_pair())
+        Ok(self
+            .get_client()?
+            .inner
+            .get_submarine_pairs()?
+            .get_lbtc_to_btc_pair())
     }
 
     /// Get a submarine swap's preimage
     fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError> {
-        Ok(self.client.get_submarine_preimage(swap_id)?.preimage)
+        Ok(self
+            .get_client()?
+            .inner
+            .get_submarine_preimage(swap_id)?
+            .preimage)
     }
 
     /// Get claim tx details which includes the preimage as a proof of payment.
@@ -214,7 +247,10 @@ impl Swapper for BoltzSwapper {
         &self,
         swap: &SendSwap,
     ) -> Result<SubmarineClaimTxResponse, PaymentError> {
-        let claim_tx_response = self.client.get_submarine_claim_tx_details(&swap.id)?;
+        let claim_tx_response = self
+            .get_client()?
+            .inner
+            .get_submarine_claim_tx_details(&swap.id)?;
         info!("Received claim tx details: {:?}", &claim_tx_response);
 
         self.validate_send_swap_preimage(&swap.id, &swap.invoice, &claim_tx_response.preimage)?;
@@ -242,7 +278,7 @@ impl Swapper for BoltzSwapper {
             &claim_tx_response.transaction_hash,
         )?;
 
-        self.client.post_submarine_claim_tx_details(
+        self.get_client()?.inner.post_submarine_claim_tx_details(
             &swap_id.to_string(),
             pub_nonce,
             partial_sig,
@@ -256,16 +292,21 @@ impl Swapper for BoltzSwapper {
         &self,
         req: CreateReverseRequest,
     ) -> Result<CreateReverseResponse, PaymentError> {
+        let client = self.get_client()?;
         let modified_req = CreateReverseRequest {
-            referral_id: self.referral_id.clone(),
+            referral_id: client.referral_id.clone(),
             ..req.clone()
         };
-        Ok(self.client.post_reverse_req(modified_req)?)
+        Ok(client.inner.post_reverse_req(modified_req)?)
     }
 
     // Get a reverse pair information
     fn get_reverse_swap_pairs(&self) -> Result<Option<ReversePair>, PaymentError> {
-        Ok(self.client.get_reverse_pairs()?.get_btc_to_lbtc_pair())
+        Ok(self
+            .get_client()?
+            .inner
+            .get_reverse_pairs()?
+            .get_btc_to_lbtc_pair())
     }
 
     /// Create a claim transaction for a receive or chain swap
@@ -408,7 +449,10 @@ impl Swapper for BoltzSwapper {
     }
 
     fn broadcast_tx(&self, chain: Chain, tx_hex: &str) -> Result<String, PaymentError> {
-        let response = self.client.broadcast_tx(chain, &tx_hex.into())?;
+        let response = self
+            .get_client()?
+            .inner
+            .broadcast_tx(chain, &tx_hex.into())?;
         let err = format!("Unexpected response from Boltz server: {response}");
         let tx_id = response
             .as_object()
@@ -421,8 +465,8 @@ impl Swapper for BoltzSwapper {
         Ok(tx_id)
     }
 
-    fn create_status_stream(&self) -> Box<dyn SwapperStatusStream> {
-        Box::new(BoltzStatusStream::new(&self.boltz_url))
+    fn create_status_stream(&self) -> Result<Box<dyn SwapperStatusStream>> {
+        Ok(Box::new(BoltzStatusStream::new(&self.get_client()?.url)))
     }
 
     fn check_for_mrh(
@@ -430,7 +474,7 @@ impl Swapper for BoltzSwapper {
         invoice: &str,
     ) -> Result<Option<(String, boltz_client::bitcoin::Amount)>, PaymentError> {
         boltz_client::swaps::magic_routing::check_for_mrh(
-            &self.client,
+            &self.get_client()?.inner,
             invoice,
             self.config.network.into(),
         )
@@ -438,7 +482,10 @@ impl Swapper for BoltzSwapper {
     }
 
     fn get_bolt12_invoice(&self, offer: &str, amount_sat: u64) -> Result<String, PaymentError> {
-        let invoice_res = self.client.get_bolt12_invoice(offer, amount_sat)?;
+        let invoice_res = self
+            .get_client()?
+            .inner
+            .get_bolt12_invoice(offer, amount_sat)?;
         info!("Received BOLT12 invoice response: {invoice_res:?}");
         Ok(invoice_res.invoice)
     }

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Result;
 use async_trait::async_trait;
 use boltz_client::{
     boltz::{
@@ -114,7 +115,7 @@ pub trait Swapper: Send + Sync {
     /// Broadcasts a transaction and returns its id
     fn broadcast_tx(&self, chain: Chain, tx_hex: &str) -> Result<String, PaymentError>;
 
-    fn create_status_stream(&self) -> Box<dyn SwapperStatusStream>;
+    fn create_status_stream(&self) -> Result<Box<dyn SwapperStatusStream>>;
 
     /// Look for a valid Magic Routing Hint. If found, validate it and extract the BIP21 info (amount, address).
     fn check_for_mrh(

--- a/lib/core/src/test_utils/chain.rs
+++ b/lib/core/src/test_utils/chain.rs
@@ -247,7 +247,7 @@ impl BitcoinChainService for MockBitcoinChainService {
         _retries: u64,
     ) -> Result<electrum_client::GetBalanceRes> {
         Ok(GetBalanceRes {
-            confirmed: self.script_balance_sat.lock().unwrap().clone(),
+            confirmed: *self.script_balance_sat.lock().unwrap(),
             unconfirmed: 0,
         })
     }

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -31,7 +31,7 @@ pub(crate) fn new_chain_swap_handler(persister: Arc<Persister>) -> Result<ChainS
     let config = Config::testnet(None);
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
-    let swapper = Arc::new(BoltzSwapper::new(config.clone(), None));
+    let swapper = Arc::new(BoltzSwapper::new(config.clone(), persister.clone()));
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
 

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use anyhow::Result;
 use boltz_client::{
     boltz::{
         ChainFees, ChainMinerFees, ChainPair, ChainSwapDetails, CreateChainResponse,
@@ -332,8 +333,8 @@ impl Swapper for MockSwapper {
         Ok(tx.txid().to_string())
     }
 
-    fn create_status_stream(&self) -> Box<dyn crate::swapper::SwapperStatusStream> {
-        Box::new(MockStatusStream::new())
+    fn create_status_stream(&self) -> Result<Box<dyn crate::swapper::SwapperStatusStream>> {
+        Ok(Box::new(MockStatusStream::new()))
     }
 
     fn check_for_mrh(


### PR DESCRIPTION
Closes #710.
This PR makes sure the Boltz client (along with its url and referral id) are only initialized when required.