### PR TITLE
Cache last known tip

### DIFF
--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -114,9 +114,9 @@ impl LiquidChainService for HybridLiquidChainService {
         let mut last_tip: std::sync::MutexGuard<'_, Option<u32>> =
             self.last_known_tip.lock().unwrap();
         match new_tip {
-            Some(header) => {
-                *last_tip = Some(header);
-                Ok(header)
+            Some(height) => {
+                *last_tip = Some(height);
+                Ok(height)
             }
             None => last_tip.ok_or_else(|| anyhow!("Failed to get tip")),
         }


### PR DESCRIPTION
Until we have proper redundancy of chain services the tip endpoint that is used frequently may fail if electrum is not responsive or disconnected which is likely to happen in mobile environment.
This PR brings back the previous behavior where we keep the last known tip and return it on error.