### PR TITLE
Switch to pure AES implementation in ecies

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -39,6 +39,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aes-gcm-siv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,14 +1219,15 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0206e602d2645ec8b24ed8307fadbc6c3110e2b11ab2f806fc02fee49327079"
 dependencies = [
+ "aes-gcm",
  "getrandom",
  "hkdf",
  "libsecp256k1",
  "once_cell",
- "openssl",
  "parking_lot 0.12.3",
  "rand_core",
  "sha2",
+ "typenum",
  "wasm-bindgen",
 ]
 
@@ -1655,6 +1670,16 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -39,6 +39,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aes-gcm-siv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,14 +1374,15 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0206e602d2645ec8b24ed8307fadbc6c3110e2b11ab2f806fc02fee49327079"
 dependencies = [
+ "aes-gcm",
  "getrandom",
  "hkdf",
  "libsecp256k1",
  "once_cell",
- "openssl",
  "parking_lot 0.12.3",
  "rand_core 0.6.4",
  "sha2",
+ "typenum",
  "wasm-bindgen",
 ]
 
@@ -1802,6 +1817,16 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -57,7 +57,7 @@ zbase32 = "0.1.2"
 x509-parser = { version = "0.16.0" }
 tempfile = "3"
 prost = "0.13.3"
-ecies = "0.2.7"
+ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
 semver = "1.0.23"
 lazy_static = "1.5.0"
 tonic = { version = "0.12.3", features = ["tls", "tls-webpki-roots"] }


### PR DESCRIPTION
This switches the AES implementation used by `ecies` from OpenSSL to "pure", which should help circumvent issues we see when running the SDK on iOS.

We should keep in mind the penalty we incur with this change: https://docs.rs/ecies/latest/ecies/#benchmark.

I've tested that decrypting old records that were created with the openssl version does work correctly.