### PR TITLE
Misc: Add log header on SDK initialization

### DIFF
--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::ensure_sdk;
 use crate::error::{PaymentError, SdkResult};
@@ -145,6 +145,26 @@ pub(crate) fn increment_invoice_amount_up_to_drain_amount(
     } else {
         invoice_amount_sat
     }
+}
+
+pub(crate) fn log_print_header(init_time_ms: Duration) {
+    log::info!(
+        "
+            ↘↘↘
+         ↘↘↘↘↘↘↘↘       
+           ↘↘↘↘↘↘↘↘    
+     ↘↘↘↘↘       ↘↘↘↘   
+                 ↘↘↘      Breez SDK Nodeless - version {}
+ ↘↘↘↘↘↘↘↘↘  ↘↘↘↘↘↘↘↘↘     Initialization time: {init_time_ms:?}
+                  ↘↘↘↘    Github: https://github.com/breez/breez-sdk-liquid
+   ↘↘↘↘↘↘↘↘↘↘↘↘    ↘↘↘↘   Docs: https://sdk-doc-liquid.breez.technology/
+                  ↘↘↘↘↘ 
+      ↘↘↘↘↘↘↘↘↘↘↘↘↘↘↘   
+        ↘↘↘↘↘↘↘↘↘↘
+            ↘↘↘
+    ",
+        env!("CARGO_PKG_VERSION"),
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR:
- Adds a log on initialization, moving it from the previous `start` method (which only tracked the background thread starting, meaning < 1ms) to the actual `connect` method
- Adds a logo, along with relevant information about the SDK (including the version, which is useful for debugging external logs). 

**Note:** Not sure whether Cargo respects the `CARGO_PKG_VERSION` env variable when using the SDK as a rust dependency. Will test and update.

**Note:** If the logo is overkill we can just log the start time and version, just thought it would be a nice addition. This is how it looks like on the logs:
```
[2025-02-05 03:51:43.927 INFO breez_sdk_liquid::utils:151]                                               
         ↘↘↘↘↘↘↘↘       
           ↘↘↘↘↘↘↘↘    
     ↘↘↘↘↘       ↘↘↘↘   
                 ↘↘↘      Breez SDK Nodeless - version 0.4.0-rc3
 ↘↘↘↘↘↘↘↘↘  ↘↘↘↘↘↘↘↘↘     Initialization time: 1.891762889s
                  ↘↘↘↘    Github: https://github.com/breez/breez-sdk-liquid
   ↘↘↘↘↘↘↘↘↘↘↘↘    ↘↘↘→   Docs: https://sdk-doc-liquid.breez.technology/
                  ↘↘↘↘→ 
      ↘↘↘↘↘↘↘↘↘↘↘↘↘↘→   
        →→→→↘↘→→→

```