### PR TITLE
Use same tx_map for recovery of swaps and liquid payments

### DIFF
--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -162,8 +162,14 @@ impl Recoverer {
     ///
     /// - `tx_map`: all known onchain txs of this wallet at this time, essentially our own LWK cache.
     /// - `swaps`: immutable data of the swaps for which we want to recover onchain data.
-    pub(crate) async fn recover_from_onchain(&self, swaps: &mut [Swap]) -> Result<()> {
-        let tx_map = TxMap::from_raw_tx_map(self.onchain_wallet.transactions_by_tx_id().await?);
+    ///
+    /// Returns the raw onchain tx map used for recovery.
+    pub(crate) async fn recover_from_onchain(
+        &self,
+        swaps: &mut [Swap],
+    ) -> Result<HashMap<Txid, WalletTx>> {
+        let raw_tx_map = self.onchain_wallet.transactions_by_tx_id().await?;
+        let tx_map = TxMap::from_raw_tx_map(raw_tx_map.clone());
 
         let swaps_list = swaps.to_vec().try_into()?;
         let histories = self.fetch_swaps_histories(&swaps_list).await?;
@@ -344,7 +350,7 @@ impl Recoverer {
             }
         }
 
-        Ok(())
+        Ok(raw_tx_map)
     }
 
     /// For a given [SwapList], this fetches the script histories from the chain services

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2655,10 +2655,10 @@ impl LiquidSdk {
     /// it inserts or updates a corresponding entry in our Payments table.
     async fn sync_payments_with_chain_data(&self, partial_sync: bool) -> Result<()> {
         let mut recoverable_swaps = self.get_monitored_swaps_list(partial_sync).await?;
-        self.recoverer
+        let mut tx_map = self
+            .recoverer
             .recover_from_onchain(&mut recoverable_swaps)
             .await?;
-        let mut tx_map = self.onchain_wallet.transactions_by_tx_id().await?;
 
         for swap in recoverable_swaps {
             let swap_id = &swap.id();


### PR DESCRIPTION
Resolves #699

This PR changes chain data payment sync to use the same liquid wallet tx set for swap recovery and liquid payment recovery, preventing a liquid claim tx from only being included in the set used for liquid payment recovery, causing it to be misplaced for an incoming liquid payment.

#### Test notes

- No duplicate payments are shown in any part of an incoming Lightning payment lifecycle. This applies both to a local instance of the SDK (where the swap was created) as well as a concurrent instance that syncs the incoming payment.

