### PR TITLE
fix persist error on initialization

### DIFF
--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -148,7 +148,8 @@ impl LiquidOnchainWallet {
         match wollet_res {
             Ok(wollet) => Ok(wollet),
             Err(
-                lwk_wollet::Error::UpdateHeightTooOld { .. }
+                lwk_wollet::Error::PersistError(_)
+                | lwk_wollet::Error::UpdateHeightTooOld { .. }
                 | lwk_wollet::Error::UpdateOnDifferentStatus { .. },
             ) => {
                 warn!("Update error initialising wollet, wipping storage and retrying: {wollet_res:?}");


### PR DESCRIPTION
Turns out lwk wallet sometimes returns general persist error when one of the internal folders doesn't exist.
This leads to an unrecovered error on sdk initialization.