### PR TITLE
Send Swap recovery fixes

### DIFF
--- a/lib/core/src/persist/address.rs
+++ b/lib/core/src/persist/address.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use log::debug;
 use rusqlite::{Connection, Row, TransactionBehavior};
 
-use crate::error::PaymentError;
+use crate::{error::PaymentError, persist::where_clauses_to_string};
 
 use super::{Persister, ReservedAddress};
 
@@ -29,11 +29,7 @@ impl Persister {
     }
 
     fn get_reserved_address_query(where_clauses: Vec<String>) -> String {
-        let mut where_clause_str = String::new();
-        if !where_clauses.is_empty() {
-            where_clause_str = String::from("WHERE ");
-            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
-        }
+        let where_clause_str = where_clauses_to_string(where_clauses);
 
         format!(
             "

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::ensure_sdk;
 use crate::error::PaymentError;
 use crate::model::*;
-use crate::persist::{get_where_clause_state_in, Persister};
+use crate::persist::{get_where_clause_state_in, where_clauses_to_string, Persister};
 use crate::sync::model::data::ChainSyncData;
 use crate::sync::model::RecordType;
 
@@ -128,11 +128,7 @@ impl Persister {
     }
 
     fn list_chain_swaps_query(where_clauses: Vec<String>) -> String {
-        let mut where_clause_str = String::new();
-        if !where_clauses.is_empty() {
-            where_clause_str = String::from("WHERE ");
-            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
-        }
+        let where_clause_str = where_clauses_to_string(where_clauses);
 
         format!(
             "

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -50,6 +50,15 @@ fn get_where_clause_state_in(allowed_states: &[PaymentState]) -> String {
     )
 }
 
+fn where_clauses_to_string(where_clauses: Vec<String>) -> String {
+    let mut where_clause_str = String::new();
+    if !where_clauses.is_empty() {
+        where_clause_str = String::from("WHERE ");
+        where_clause_str.push_str(where_clauses.join(" AND ").as_str());
+    }
+    where_clause_str
+}
+
 impl Persister {
     pub fn new(
         working_dir: &str,

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::ensure_sdk;
 use crate::error::PaymentError;
 use crate::model::*;
-use crate::persist::{get_where_clause_state_in, Persister};
+use crate::persist::{get_where_clause_state_in, where_clauses_to_string, Persister};
 use crate::sync::model::data::ReceiveSyncData;
 use crate::sync::model::RecordType;
 
@@ -128,11 +128,7 @@ impl Persister {
     }
 
     fn list_receive_swaps_query(where_clauses: Vec<String>) -> String {
-        let mut where_clause_str = String::new();
-        if !where_clauses.is_empty() {
-            where_clause_str = String::from("WHERE ");
-            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
-        }
+        let where_clause_str = where_clauses_to_string(where_clauses);
 
         format!(
             "

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -123,10 +123,11 @@ impl Persister {
         let con = self.get_connection()?;
         let mut where_clauses = vec!["state = :from_state".to_string()];
         if let Some(is_local) = is_local {
-            where_clauses.push(format!(
-                "(sync_state.is_local = {} OR sync_state.is_local IS NULL)",
-                is_local as i8
-            ));
+            let mut where_is_local = format!("sync_state.is_local = {}", is_local as u8);
+            if is_local {
+                where_is_local = format!("({} OR sync_state.is_local IS NULL)", where_is_local);
+            }
+            where_clauses.push(where_is_local);
         }
 
         let where_clause_str = where_clauses_to_string(where_clauses);

--- a/lib/core/src/persist/sync.rs
+++ b/lib/core/src/persist/sync.rs
@@ -7,6 +7,7 @@ use rusqlite::{
 
 use super::{cache::KEY_LAST_DERIVATION_INDEX, PaymentTxDetails, Persister, Swap};
 use crate::{
+    persist::where_clauses_to_string,
     sync::model::{
         data::LAST_DERIVATION_INDEX_DATA_ID, Record, RecordType, SyncOutgoingChanges, SyncSettings,
         SyncState,
@@ -16,11 +17,7 @@ use crate::{
 
 impl Persister {
     fn select_sync_state_query(where_clauses: Vec<String>) -> String {
-        let mut where_clause_str = String::new();
-        if !where_clauses.is_empty() {
-            where_clause_str = String::from("WHERE ");
-            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
-        }
+        let where_clause_str = where_clauses_to_string(where_clauses);
 
         format!(
             "
@@ -289,11 +286,7 @@ impl Persister {
     }
 
     fn select_sync_outgoing_changes_query(where_clauses: Vec<String>) -> String {
-        let mut where_clause_str = String::new();
-        if !where_clauses.is_empty() {
-            where_clause_str = String::from("WHERE ");
-            where_clause_str.push_str(where_clauses.join(" AND ").as_str());
-        }
+        let where_clause_str = where_clauses_to_string(where_clauses);
 
         format!(
             "

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -281,7 +281,7 @@ impl LiquidSdk {
     async fn start(self: &Arc<LiquidSdk>) -> SdkResult<()> {
         let mut is_started = self.is_started.write().await;
         self.persister
-            .update_send_swaps_by_state(Created, TimedOut)
+            .update_send_swaps_by_state(Created, TimedOut, Some(true))
             .inspect_err(|e| error!("Failed to update send swaps by state: {:?}", e))?;
 
         self.start_background_tasks()


### PR DESCRIPTION
This PR fixes some issues found in send swap recovery:
1.  Fixes an issue where the lockup tx is seen as the claim tx if the non-local wallet has not yet seen the lockup tx (its not in the tx_map)
2. Fixes an issue where the non local swap has not yet had time to recover (is in state Created) and the SDK is restarted (set to TimedOut and no longer monitored)

**Testing notes:**
1.  Not directly testable, nothing occurs in the UI
2.  Previously the issue is seen on the non-local device where the send swap is always shown as a liquid payment. 
    - Send a lightning payment on the local device
    - On the non-local device wait for the liquid payment
    - Force quit the app
    - Reopen and check if the payment swap data recovers