### PR TITLE
Clean payment txs data on sync

### DIFF
--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -270,6 +270,14 @@ impl Persister {
         Ok(())
     }
 
+    pub(crate) fn delete_payment_tx_data(&self, tx_id: &str) -> Result<()> {
+        let con = self.get_connection()?;
+
+        con.execute("DELETE FROM payment_tx_data WHERE tx_id = ?", [tx_id])?;
+
+        Ok(())
+    }
+
     fn insert_or_update_payment_details_inner(
         con: &Connection,
         payment_tx_details: &PaymentTxDetails,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -387,10 +387,6 @@ impl LiquidSdk {
                             .unwrap_or_else(|err| warn!("Could not update local tips: {err:?}"));
                         };
 
-                        if let Err(err) = cloned.onchain_wallet.full_scan().await {
-                          error!("Failed to scan wallet: {err:?}");
-                        }
-
                         // Only partial sync when there are no new Liquid or Bitcoin blocks
                         let partial_sync = (is_new_liquid_block || is_new_bitcoin_block).not();
                         _ = cloned.sync(partial_sync).await;
@@ -3020,6 +3016,11 @@ impl LiquidSdk {
         self.ensure_is_started().await?;
 
         let t0 = Instant::now();
+
+        if let Err(err) = self.onchain_wallet.full_scan().await {
+            error!("Failed to scan wallet: {err:?}");
+        }
+
         let is_first_sync = !self
             .persister
             .get_is_first_sync_complete()?


### PR DESCRIPTION
This addresses part of #725 by adding a stale payment tx data cleanup. 

The idea is to look for pending payment txs that the liquid wallet does not recognize and delete them if they are older than a certain grace period (to allow for tx propagation through the network). 