### PR TITLE
Extract `description` from `metadata_str` for LNURL payments

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1681,6 +1681,14 @@ impl PaymentDetails {
         }
     }
 
+    pub(crate) fn get_description(&self) -> Option<String> {
+        match self {
+            Self::Lightning { description, .. }
+            | Self::Bitcoin { description, .. }
+            | Self::Liquid { description, .. } => Some(description.clone()),
+        }
+    }
+
     pub(crate) fn is_lbtc_asset_id(&self, network: LiquidNetwork) -> bool {
         match self {
             Self::Liquid { asset_id, .. } => {

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -19,6 +19,7 @@ use crate::sync::model::RecordType;
 use crate::{get_invoice_description, utils};
 use anyhow::{anyhow, Result};
 use boltz_client::boltz::{ChainPair, ReversePair, SubmarinePair};
+use log::warn;
 use lwk_wollet::WalletTx;
 use migrations::current_migrations;
 use model::PaymentTxDetails;
@@ -145,7 +146,7 @@ impl Persister {
                 (asset_id, payment_type, amount)
             }
             None => {
-                log::warn!("Attempted to persist a payment with no balance: tx_id {tx_id}");
+                warn!("Attempted to persist a payment with no balance: tx_id {tx_id}");
                 return Ok(());
             }
         };

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -754,7 +754,8 @@ impl Persister {
                 claim_tx_id: maybe_claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
-                description: description.unwrap_or("Lightning transfer".to_string()),
+                description: maybe_payment_details_description
+                    .unwrap_or(description.unwrap_or("Lightning transfer".to_string())),
                 liquid_expiration_blockheight: expiration_blockheight,
             },
             Some(PaymentSwapData {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -3349,6 +3349,8 @@ impl LiquidSdk {
             None => None,
         };
 
+        let description = extract_description_from_metadata(&prepare_response.data);
+
         let lnurl_pay_domain = match prepare_response.data.ln_address {
             Some(_) => None,
             None => Some(prepare_response.data.domain),
@@ -3360,7 +3362,7 @@ impl LiquidSdk {
                 .insert_or_update_payment_details(PaymentTxDetails {
                     tx_id,
                     destination,
-                    description: prepare_response.comment.clone(),
+                    description,
                     lnurl_info: Some(LnUrlInfo {
                         ln_address: prepare_response.data.ln_address,
                         lnurl_pay_comment: prepare_response.comment,
@@ -3569,6 +3571,18 @@ impl LiquidSdk {
     pub fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>) -> Result<()> {
         crate::logger::init_logging(log_dir, app_logger)
     }
+}
+
+/// Extracts `description` from `metadata_str`
+fn extract_description_from_metadata(request_data: &LnUrlPayRequestData) -> Option<String> {
+    let metadata = request_data.metadata_vec().ok()?;
+    metadata
+        .iter()
+        .find(|item| item.key == "text/plain")
+        .map(|item| {
+            info!("Extracted payment description: '{}'", item.value);
+            item.value.clone()
+        })
 }
 
 #[cfg(test)]

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -3349,7 +3349,10 @@ impl LiquidSdk {
             None => None,
         };
 
-        let description = extract_description_from_metadata(&prepare_response.data);
+        let description = payment
+            .details
+            .get_description()
+            .or_else(|| extract_description_from_metadata(&prepare_response.data));
 
         let lnurl_pay_domain = match prepare_response.data.ln_address {
             Some(_) => None,


### PR DESCRIPTION
Fixes #741 

This PR 
- Uses the invoice's `description` first; if it's empty, falls back to extracting the `description` from `metadata_str` as the `description` value saved to `PaymentTxDetails`.
- Fixes how `description` is persisted for LNURLp payments, as the `description` value saved to `PaymentTxDetails` was previously ignored by the persister.