### PR TITLE
Real-time Sync: Avoid running event loop on local changes

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "url",
+ "uuid",
  "x509-parser",
  "zbase32",
 ]
@@ -1220,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0206e602d2645ec8b24ed8307fadbc6c3110e2b11ab2f806fc02fee49327079"
 dependencies = [
  "aes-gcm",
- "getrandom",
+ "getrandom 0.2.14",
  "hkdf",
  "libsecp256k1",
  "once_cell",
@@ -1668,8 +1669,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2655,7 +2668,7 @@ dependencies = [
  "base64 0.21.7",
  "elements",
  "elements-miniscript",
- "getrandom",
+ "getrandom 0.2.14",
  "qr_code",
  "rand",
  "thiserror 1.0.69",
@@ -2818,7 +2831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3395,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.14",
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
@@ -3468,7 +3481,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -3640,7 +3653,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.14",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4966,6 +4979,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,6 +5023,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5382,6 +5413,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -61,11 +61,11 @@ ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
 semver = "1.0.23"
 lazy_static = "1.5.0"
 tonic = { version = "0.12.3", features = ["tls", "tls-webpki-roots"] }
+uuid = { version = "1.8.0", features = ["v4"] }
 
 [dev-dependencies]
 paste = "1.0.15"
 tempdir = "0.3.7"
-uuid = { version = "1.8.0", features = ["v4"] }
 
 [build-dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }

--- a/lib/core/src/sync/model/client.rs
+++ b/lib/core/src/sync/model/client.rs
@@ -40,6 +40,7 @@ impl SetRecordRequest {
         record: Record,
         request_time: u32,
         signer: Arc<Box<dyn Signer>>,
+        client_id: String,
     ) -> Result<Self, SignerError> {
         let msg = format!(
             "{}-{}-{}-{}-{}",
@@ -56,6 +57,7 @@ impl SetRecordRequest {
             record: Some(record),
             request_time,
             signature,
+            client_id: Some(client_id),
         })
     }
 }

--- a/lib/core/src/sync/proto/sync.proto
+++ b/lib/core/src/sync/proto/sync.proto
@@ -20,6 +20,7 @@ message SetRecordRequest {
   Record record = 1;
   uint32 request_time = 2;
   string signature = 3;
+  optional string client_id = 4;
 }
 enum SetRecordStatus {
   SUCCESS = 0;
@@ -42,4 +43,4 @@ message ListenChangesRequest {
   string signature = 2;
 }
 
-message Notification {}
+message Notification { optional string client_id = 1; }


### PR DESCRIPTION
This PR makes sure that we're not running the event loop when we're the broadcasters of a record.

**Note:** If the record is pulled (non-local), even if we're the ones broadcasting the changes on top we'll still execute the flow. This only applies when we're the initiators.

@roeierez **Explanation:** The reason for omitting `new_revision` from the `Notification` object is that we run into a race condition between the remote listener and push threads. The notification from the remote may be received before we persist the pushed record (and its state), so we need to `lock_outgoing_record` before pushing, using a mock revision. Since we then have a mock revision there would be no need to compare that with the notification's `new_revision` field.