### PR TITLE
Remove min 0-conf fee rate

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -23,11 +23,6 @@ typedef struct _Dart_Handle* Dart_Handle;
 #define LIQUID_FEE_RATE_MSAT_PER_VBYTE (float)(LIQUID_FEE_RATE_SAT_PER_VBYTE * 1000.0)
 
 /**
- * The minimum acceptable fee rate when claiming using zero-conf
- */
-#define DEFAULT_ZERO_CONF_MIN_FEE_RATE 100
-
-/**
  * The maximum acceptable amount in satoshi when claiming using zero-conf
  */
 #define DEFAULT_ZERO_CONF_MAX_SAT 1000000
@@ -663,7 +658,6 @@ typedef struct wire_cst_config {
   struct wire_cst_list_prim_u_8_strict *cache_dir;
   int32_t network;
   uint64_t payment_timeout_sec;
-  uint32_t zero_conf_min_fee_rate_msat;
   struct wire_cst_list_prim_u_8_strict *sync_service_url;
   uint64_t *zero_conf_max_amount_sat;
   struct wire_cst_list_prim_u_8_strict *breez_api_key;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -333,7 +333,6 @@ dictionary Config {
     string working_dir;
     LiquidNetwork network;
     u64 payment_timeout_sec;
-    u32 zero_conf_min_fee_rate_msat;
     string? sync_service_url;
     string? breez_api_key;
     string? cache_dir;

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2553,7 +2553,6 @@ impl SseDecode for crate::model::Config {
         let mut var_cacheDir = <Option<String>>::sse_decode(deserializer);
         let mut var_network = <crate::model::LiquidNetwork>::sse_decode(deserializer);
         let mut var_paymentTimeoutSec = <u64>::sse_decode(deserializer);
-        let mut var_zeroConfMinFeeRateMsat = <u32>::sse_decode(deserializer);
         let mut var_syncServiceUrl = <Option<String>>::sse_decode(deserializer);
         let mut var_zeroConfMaxAmountSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_breezApiKey = <Option<String>>::sse_decode(deserializer);
@@ -2571,7 +2570,6 @@ impl SseDecode for crate::model::Config {
             cache_dir: var_cacheDir,
             network: var_network,
             payment_timeout_sec: var_paymentTimeoutSec,
-            zero_conf_min_fee_rate_msat: var_zeroConfMinFeeRateMsat,
             sync_service_url: var_syncServiceUrl,
             zero_conf_max_amount_sat: var_zeroConfMaxAmountSat,
             breez_api_key: var_breezApiKey,
@@ -5157,9 +5155,6 @@ impl flutter_rust_bridge::IntoDart for crate::model::Config {
             self.cache_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
             self.payment_timeout_sec.into_into_dart().into_dart(),
-            self.zero_conf_min_fee_rate_msat
-                .into_into_dart()
-                .into_dart(),
             self.sync_service_url.into_into_dart().into_dart(),
             self.zero_conf_max_amount_sat.into_into_dart().into_dart(),
             self.breez_api_key.into_into_dart().into_dart(),
@@ -7483,7 +7478,6 @@ impl SseEncode for crate::model::Config {
         <Option<String>>::sse_encode(self.cache_dir, serializer);
         <crate::model::LiquidNetwork>::sse_encode(self.network, serializer);
         <u64>::sse_encode(self.payment_timeout_sec, serializer);
-        <u32>::sse_encode(self.zero_conf_min_fee_rate_msat, serializer);
         <Option<String>>::sse_encode(self.sync_service_url, serializer);
         <Option<u64>>::sse_encode(self.zero_conf_max_amount_sat, serializer);
         <Option<String>>::sse_encode(self.breez_api_key, serializer);
@@ -9911,7 +9905,6 @@ mod io {
                 cache_dir: self.cache_dir.cst_decode(),
                 network: self.network.cst_decode(),
                 payment_timeout_sec: self.payment_timeout_sec.cst_decode(),
-                zero_conf_min_fee_rate_msat: self.zero_conf_min_fee_rate_msat.cst_decode(),
                 sync_service_url: self.sync_service_url.cst_decode(),
                 zero_conf_max_amount_sat: self.zero_conf_max_amount_sat.cst_decode(),
                 breez_api_key: self.breez_api_key.cst_decode(),
@@ -11609,7 +11602,6 @@ mod io {
                 cache_dir: core::ptr::null_mut(),
                 network: Default::default(),
                 payment_timeout_sec: Default::default(),
-                zero_conf_min_fee_rate_msat: Default::default(),
                 sync_service_url: core::ptr::null_mut(),
                 zero_conf_max_amount_sat: core::ptr::null_mut(),
                 breez_api_key: core::ptr::null_mut(),
@@ -13864,7 +13856,6 @@ mod io {
         cache_dir: *mut wire_cst_list_prim_u_8_strict,
         network: i32,
         payment_timeout_sec: u64,
-        zero_conf_min_fee_rate_msat: u32,
         sync_service_url: *mut wire_cst_list_prim_u_8_strict,
         zero_conf_max_amount_sat: *mut u64,
         breez_api_key: *mut wire_cst_list_prim_u_8_strict,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -24,7 +24,7 @@ use strum_macros::{Display, EnumString};
 
 use crate::error::{PaymentError, SdkError, SdkResult};
 use crate::prelude::DEFAULT_EXTERNAL_INPUT_PARSERS;
-use crate::receive_swap::{DEFAULT_ZERO_CONF_MAX_SAT, DEFAULT_ZERO_CONF_MIN_FEE_RATE};
+use crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT;
 use crate::utils;
 
 // Uses f64 for the maximum precision when converting between units
@@ -48,8 +48,6 @@ pub struct Config {
     pub network: LiquidNetwork,
     /// Send payment timeout. See [LiquidSdk::send_payment](crate::sdk::LiquidSdk::send_payment)
     pub payment_timeout_sec: u64,
-    /// Zero-conf minimum accepted fee-rate in millisatoshis per vbyte
-    pub zero_conf_min_fee_rate_msat: u32,
     /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
     /// Setting this field to `None` will disable the service
     pub sync_service_url: Option<String>,
@@ -90,7 +88,6 @@ impl Config {
             cache_dir: None,
             network: LiquidNetwork::Mainnet,
             payment_timeout_sec: 15,
-            zero_conf_min_fee_rate_msat: DEFAULT_ZERO_CONF_MIN_FEE_RATE,
             sync_service_url: Some(BREEZ_SYNC_SERVICE_URL.to_string()),
             zero_conf_max_amount_sat: None,
             breez_api_key,
@@ -110,7 +107,6 @@ impl Config {
             cache_dir: None,
             network: LiquidNetwork::Testnet,
             payment_timeout_sec: 15,
-            zero_conf_min_fee_rate_msat: DEFAULT_ZERO_CONF_MIN_FEE_RATE,
             sync_service_url: Some(BREEZ_SYNC_SERVICE_URL.to_string()),
             zero_conf_max_amount_sat: None,
             breez_api_key,
@@ -130,7 +126,6 @@ impl Config {
             cache_dir: None,
             network: LiquidNetwork::Regtest,
             payment_timeout_sec: 15,
-            zero_conf_min_fee_rate_msat: DEFAULT_ZERO_CONF_MIN_FEE_RATE,
             sync_service_url: Some("http://localhost:8088".to_string()),
             zero_conf_max_amount_sat: None,
             breez_api_key: None,

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -21,8 +21,6 @@ use crate::{
     wallet::OnchainWallet,
 };
 
-/// The minimum acceptable fee rate when claiming using zero-conf
-pub const DEFAULT_ZERO_CONF_MIN_FEE_RATE: u32 = 100;
 /// The maximum acceptable amount in satoshi when claiming using zero-conf
 pub const DEFAULT_ZERO_CONF_MAX_SAT: u64 = 1_000_000;
 
@@ -166,21 +164,7 @@ impl ReceiveSwapHandler {
                     warn!("[Receive Swap {id}] Lockup transaction signals RBF. Waiting for confirmation...");
                     return Ok(());
                 }
-
                 debug!("[Receive Swap {id}] Lockup tx does not signal RBF. Proceeding...");
-
-                // If the fees are higher than our estimated value
-                let tx_fees: u64 = lockup_tx.all_fees().values().sum();
-                let min_fee_rate = self.config.zero_conf_min_fee_rate_msat as f32 / 1000.0;
-                let lower_bound_estimated_fees =
-                    lockup_tx.discount_vsize() as f32 * min_fee_rate * 0.8;
-
-                if lower_bound_estimated_fees > tx_fees as f32 {
-                    warn!("[Receive Swap {id}] Lockup tx fees are too low: Expected at least {lower_bound_estimated_fees} sat, got {tx_fees} sat. Waiting for confirmation...");
-                    return Ok(());
-                }
-
-                debug!("[Receive Swap {id}] Lockup tx fees are within acceptable range ({tx_fees} > {lower_bound_estimated_fees} sat). Proceeding with claim.");
 
                 if receive_swap.metadata.is_local {
                     // Only claim a local swap

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1841,7 +1841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Config dco_decode_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+    if (arr.length != 14) throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return Config(
       liquidElectrumUrl: dco_decode_String(arr[0]),
       bitcoinElectrumUrl: dco_decode_String(arr[1]),
@@ -1850,14 +1850,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       cacheDir: dco_decode_opt_String(arr[4]),
       network: dco_decode_liquid_network(arr[5]),
       paymentTimeoutSec: dco_decode_u_64(arr[6]),
-      zeroConfMinFeeRateMsat: dco_decode_u_32(arr[7]),
-      syncServiceUrl: dco_decode_opt_String(arr[8]),
-      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[9]),
-      breezApiKey: dco_decode_opt_String(arr[10]),
-      externalInputParsers: dco_decode_opt_list_external_input_parser(arr[11]),
-      useDefaultExternalInputParsers: dco_decode_bool(arr[12]),
-      onchainFeeRateLeewaySatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[13]),
-      assetMetadata: dco_decode_opt_list_asset_metadata(arr[14]),
+      syncServiceUrl: dco_decode_opt_String(arr[7]),
+      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[8]),
+      breezApiKey: dco_decode_opt_String(arr[9]),
+      externalInputParsers: dco_decode_opt_list_external_input_parser(arr[10]),
+      useDefaultExternalInputParsers: dco_decode_bool(arr[11]),
+      onchainFeeRateLeewaySatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[12]),
+      assetMetadata: dco_decode_opt_list_asset_metadata(arr[13]),
     );
   }
 
@@ -4016,7 +4015,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_cacheDir = sse_decode_opt_String(deserializer);
     var var_network = sse_decode_liquid_network(deserializer);
     var var_paymentTimeoutSec = sse_decode_u_64(deserializer);
-    var var_zeroConfMinFeeRateMsat = sse_decode_u_32(deserializer);
     var var_syncServiceUrl = sse_decode_opt_String(deserializer);
     var var_zeroConfMaxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_breezApiKey = sse_decode_opt_String(deserializer);
@@ -4032,7 +4030,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         cacheDir: var_cacheDir,
         network: var_network,
         paymentTimeoutSec: var_paymentTimeoutSec,
-        zeroConfMinFeeRateMsat: var_zeroConfMinFeeRateMsat,
         syncServiceUrl: var_syncServiceUrl,
         zeroConfMaxAmountSat: var_zeroConfMaxAmountSat,
         breezApiKey: var_breezApiKey,
@@ -6417,7 +6414,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.cacheDir, serializer);
     sse_encode_liquid_network(self.network, serializer);
     sse_encode_u_64(self.paymentTimeoutSec, serializer);
-    sse_encode_u_32(self.zeroConfMinFeeRateMsat, serializer);
     sse_encode_opt_String(self.syncServiceUrl, serializer);
     sse_encode_opt_box_autoadd_u_64(self.zeroConfMaxAmountSat, serializer);
     sse_encode_opt_String(self.breezApiKey, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2533,7 +2533,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.cache_dir = cst_encode_opt_String(apiObj.cacheDir);
     wireObj.network = cst_encode_liquid_network(apiObj.network);
     wireObj.payment_timeout_sec = cst_encode_u_64(apiObj.paymentTimeoutSec);
-    wireObj.zero_conf_min_fee_rate_msat = cst_encode_u_32(apiObj.zeroConfMinFeeRateMsat);
     wireObj.sync_service_url = cst_encode_opt_String(apiObj.syncServiceUrl);
     wireObj.zero_conf_max_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.zeroConfMaxAmountSat);
     wireObj.breez_api_key = cst_encode_opt_String(apiObj.breezApiKey);
@@ -6955,9 +6954,6 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Uint64()
   external int payment_timeout_sec;
 
-  @ffi.Uint32()
-  external int zero_conf_min_fee_rate_msat;
-
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> sync_service_url;
 
   external ffi.Pointer<ffi.Uint64> zero_conf_max_amount_sat;
@@ -7647,8 +7643,6 @@ const int ESTIMATED_BTC_LOCKUP_TX_VSIZE = 154;
 const double LIQUID_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LIQUID_FEE_RATE_MSAT_PER_VBYTE = 100.0;
-
-const int DEFAULT_ZERO_CONF_MIN_FEE_RATE = 100;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 1000000;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -275,9 +275,6 @@ class Config {
   /// Send payment timeout. See [LiquidSdk::send_payment](crate::sdk::LiquidSdk::send_payment)
   final BigInt paymentTimeoutSec;
 
-  /// Zero-conf minimum accepted fee-rate in millisatoshis per vbyte
-  final int zeroConfMinFeeRateMsat;
-
   /// The url of the real-time sync service. Defaults to [BREEZ_SYNC_SERVICE_URL]
   /// Setting this field to `None` will disable the service
   final String? syncServiceUrl;
@@ -321,7 +318,6 @@ class Config {
     this.cacheDir,
     required this.network,
     required this.paymentTimeoutSec,
-    required this.zeroConfMinFeeRateMsat,
     this.syncServiceUrl,
     this.zeroConfMaxAmountSat,
     this.breezApiKey,
@@ -340,7 +336,6 @@ class Config {
       cacheDir.hashCode ^
       network.hashCode ^
       paymentTimeoutSec.hashCode ^
-      zeroConfMinFeeRateMsat.hashCode ^
       syncServiceUrl.hashCode ^
       zeroConfMaxAmountSat.hashCode ^
       breezApiKey.hashCode ^
@@ -361,7 +356,6 @@ class Config {
           cacheDir == other.cacheDir &&
           network == other.network &&
           paymentTimeoutSec == other.paymentTimeoutSec &&
-          zeroConfMinFeeRateMsat == other.zeroConfMinFeeRateMsat &&
           syncServiceUrl == other.syncServiceUrl &&
           zeroConfMaxAmountSat == other.zeroConfMaxAmountSat &&
           breezApiKey == other.breezApiKey &&

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5011,9 +5011,6 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Uint64()
   external int payment_timeout_sec;
 
-  @ffi.Uint32()
-  external int zero_conf_min_fee_rate_msat;
-
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> sync_service_url;
 
   external ffi.Pointer<ffi.Uint64> zero_conf_max_amount_sat;
@@ -5744,8 +5741,6 @@ const int ESTIMATED_BTC_LOCKUP_TX_VSIZE = 154;
 const double LIQUID_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LIQUID_FEE_RATE_MSAT_PER_VBYTE = 100.0;
-
-const int DEFAULT_ZERO_CONF_MIN_FEE_RATE = 100;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 1000000;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -424,7 +424,6 @@ fun asConfig(config: ReadableMap): Config? {
                 "workingDir",
                 "network",
                 "paymentTimeoutSec",
-                "zeroConfMinFeeRateMsat",
                 "useDefaultExternalInputParsers",
             ),
         )
@@ -437,7 +436,6 @@ fun asConfig(config: ReadableMap): Config? {
     val workingDir = config.getString("workingDir")!!
     val network = config.getString("network")?.let { asLiquidNetwork(it) }!!
     val paymentTimeoutSec = config.getDouble("paymentTimeoutSec").toULong()
-    val zeroConfMinFeeRateMsat = config.getInt("zeroConfMinFeeRateMsat").toUInt()
     val syncServiceUrl = if (hasNonNullKey(config, "syncServiceUrl")) config.getString("syncServiceUrl") else null
     val breezApiKey = if (hasNonNullKey(config, "breezApiKey")) config.getString("breezApiKey") else null
     val cacheDir = if (hasNonNullKey(config, "cacheDir")) config.getString("cacheDir") else null
@@ -487,7 +485,6 @@ fun asConfig(config: ReadableMap): Config? {
         workingDir,
         network,
         paymentTimeoutSec,
-        zeroConfMinFeeRateMsat,
         syncServiceUrl,
         breezApiKey,
         cacheDir,
@@ -507,7 +504,6 @@ fun readableMapOf(config: Config): ReadableMap =
         "workingDir" to config.workingDir,
         "network" to config.network.name.lowercase(),
         "paymentTimeoutSec" to config.paymentTimeoutSec,
-        "zeroConfMinFeeRateMsat" to config.zeroConfMinFeeRateMsat,
         "syncServiceUrl" to config.syncServiceUrl,
         "breezApiKey" to config.breezApiKey,
         "cacheDir" to config.cacheDir,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -512,9 +512,6 @@ enum BreezSDKLiquidMapper {
         guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTimeoutSec", typeName: "Config"))
         }
-        guard let zeroConfMinFeeRateMsat = config["zeroConfMinFeeRateMsat"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "zeroConfMinFeeRateMsat", typeName: "Config"))
-        }
         var syncServiceUrl: String?
         if hasNonNilKey(data: config, key: "syncServiceUrl") {
             guard let syncServiceUrlTmp = config["syncServiceUrl"] as? String else {
@@ -563,7 +560,7 @@ enum BreezSDKLiquidMapper {
             assetMetadata = try asAssetMetadataList(arr: assetMetadataTmp)
         }
 
-        return Config(liquidElectrumUrl: liquidElectrumUrl, bitcoinElectrumUrl: bitcoinElectrumUrl, mempoolspaceUrl: mempoolspaceUrl, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, zeroConfMinFeeRateMsat: zeroConfMinFeeRateMsat, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, cacheDir: cacheDir, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySatPerVbyte: onchainFeeRateLeewaySatPerVbyte, assetMetadata: assetMetadata)
+        return Config(liquidElectrumUrl: liquidElectrumUrl, bitcoinElectrumUrl: bitcoinElectrumUrl, mempoolspaceUrl: mempoolspaceUrl, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, cacheDir: cacheDir, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySatPerVbyte: onchainFeeRateLeewaySatPerVbyte, assetMetadata: assetMetadata)
     }
 
     static func dictionaryOf(config: Config) -> [String: Any?] {
@@ -574,7 +571,6 @@ enum BreezSDKLiquidMapper {
             "workingDir": config.workingDir,
             "network": valueOf(liquidNetwork: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,
-            "zeroConfMinFeeRateMsat": config.zeroConfMinFeeRateMsat,
             "syncServiceUrl": config.syncServiceUrl == nil ? nil : config.syncServiceUrl,
             "breezApiKey": config.breezApiKey == nil ? nil : config.breezApiKey,
             "cacheDir": config.cacheDir == nil ? nil : config.cacheDir,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -94,7 +94,6 @@ export interface Config {
     workingDir: string
     network: LiquidNetwork
     paymentTimeoutSec: number
-    zeroConfMinFeeRateMsat: number
     syncServiceUrl?: string
     breezApiKey?: string
     cacheDir?: string


### PR DESCRIPTION
Resolves #734.

This removes the min 0-conf fee rate. Given that, for now, Liquid blocks are practically empty, there is no need to check the fees. If, in the future, a fee market develops, we would want the minimum 0-conf fee rate to depend on current fee conditions, so the current solution wouldn't be helpful. 