### PR TITLE
Fix payment tx data cleanup logic

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Not as _;
 use std::time::Instant;
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
@@ -2717,10 +2717,13 @@ impl LiquidSdk {
     /// it inserts or updates a corresponding entry in our Payments table.
     async fn sync_payments_with_chain_data(&self, partial_sync: bool) -> Result<()> {
         let mut recoverable_swaps = self.get_monitored_swaps_list(partial_sync).await?;
-        let mut tx_map = self
+        let mut wallet_tx_map = self
             .recoverer
             .recover_from_onchain(&mut recoverable_swaps)
             .await?;
+
+        let all_wallet_tx_ids: HashSet<String> =
+            wallet_tx_map.keys().map(|txid| txid.to_string()).collect();
 
         for swap in recoverable_swaps {
             let swap_id = &swap.id();
@@ -2735,7 +2738,7 @@ impl LiquidSdk {
                         .collect::<Vec<&String>>()
                     {
                         if let Some(tx) =
-                            tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
+                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
                         {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
@@ -2753,7 +2756,7 @@ impl LiquidSdk {
                         .collect::<Vec<&String>>()
                     {
                         if let Some(tx) =
-                            tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
+                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
                         {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
@@ -2776,7 +2779,7 @@ impl LiquidSdk {
                         .collect::<Vec<&String>>()
                     {
                         if let Some(tx) =
-                            tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
+                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
                         {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
@@ -2789,19 +2792,20 @@ impl LiquidSdk {
             };
         }
 
+        let non_swap_wallet_tx_map = wallet_tx_map;
+
         let payments = self
             .persister
             .get_payments_by_tx_id(&ListPaymentsRequest::default())?;
 
         // We query only these that may need update, should be a fast query.
         let unconfirmed_payment_txs_data = self.persister.list_unconfirmed_payment_txs_data()?;
-        let mut unconfirmed_txs_by_id: HashMap<String, PaymentTxData> =
-            unconfirmed_payment_txs_data
-                .into_iter()
-                .map(|tx| (tx.tx_id.clone(), tx))
-                .collect::<HashMap<String, PaymentTxData>>();
+        let unconfirmed_txs_by_id: HashMap<String, PaymentTxData> = unconfirmed_payment_txs_data
+            .into_iter()
+            .map(|tx| (tx.tx_id.clone(), tx))
+            .collect::<HashMap<String, PaymentTxData>>();
 
-        for tx in tx_map.values() {
+        for tx in non_swap_wallet_tx_map.values() {
             let tx_id = tx.txid.to_string();
             let maybe_payment = payments.get(&tx_id);
             let mut updated = false;
@@ -2829,21 +2833,30 @@ impl LiquidSdk {
                 // An unconfirmed tx that was not found in the payments table
                 self.persister.insert_or_update_payment_with_wallet_tx(tx)?;
             }
-            unconfirmed_txs_by_id.remove(&tx_id);
         }
 
-        for unknown_unconfirmed_tx_data in unconfirmed_txs_by_id.values() {
-            if unknown_unconfirmed_tx_data.timestamp.is_some_and(|t| {
+        let unknown_unconfirmed_txs: Vec<_> = unconfirmed_txs_by_id
+            .iter()
+            .filter(|(txid, _)| !all_wallet_tx_ids.contains(*txid))
+            .map(|(_, tx)| tx)
+            .collect();
+
+        for unknown_unconfirmed_tx in unknown_unconfirmed_txs {
+            if unknown_unconfirmed_tx.timestamp.is_some_and(|t| {
                 (utils::now().saturating_sub(t)) > NETWORK_PROPAGATION_GRACE_PERIOD.as_secs() as u32
             }) {
                 self.persister
-                    .delete_payment_tx_data(&unknown_unconfirmed_tx_data.tx_id)?;
+                    .delete_payment_tx_data(&unknown_unconfirmed_tx.tx_id)?;
                 info!(
                     "Found an unknown unconfirmed tx and deleted it. Txid: {}",
-                    unknown_unconfirmed_tx_data.tx_id
+                    unknown_unconfirmed_tx.tx_id
                 );
             } else {
-                debug!("Found an unknown unconfirmed tx. Keeping it to allow propagation through the network. Txid: {}", unknown_unconfirmed_tx_data.tx_id)
+                debug!(
+                    "Found an unknown unconfirmed tx that was inserted at {:?}. \
+                Keeping it to allow propagation through the network. Txid: {}",
+                    unknown_unconfirmed_tx.timestamp, unknown_unconfirmed_tx.tx_id
+                )
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue introduced in #731.

Unknown unconfirmed txs were previously obtained by filtering `tx_map` txs out of `unconfirmed_txs_by_id`. The issue was that `tx_map` already had all swap-related txs removed, causing some swap transactions to be treated as unknown and potentially deleted (once the grace period elapsed).