### PR TITLE
Recovery: Ensure wallet and chain service tips are within leeway

### DIFF
--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -173,7 +173,7 @@ impl Recoverer {
         &self,
         swaps: &mut [Swap],
     ) -> Result<HashMap<Txid, WalletTx>> {
-        let wallet_tip = self.onchain_wallet.tip().await.height();
+        let wallet_tip = self.onchain_wallet.tip().await;
         let liquid_tip = self.liquid_chain_service.tip().await?;
         if wallet_tip.abs_diff(liquid_tip) > LIQUID_TIP_LEEWAY {
             let msg = format!("Skipping recovery: wallet and liquid chain service tips are too far apart - chain_service_tip {liquid_tip} wallet_tip {wallet_tip}");

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -176,9 +176,8 @@ impl Recoverer {
         let wallet_tip = self.onchain_wallet.tip().await;
         let liquid_tip = self.liquid_chain_service.tip().await?;
         if wallet_tip.abs_diff(liquid_tip) > LIQUID_TIP_LEEWAY {
-            let msg = format!("Skipping recovery: wallet and liquid chain service tips are too far apart - chain_service_tip {liquid_tip} wallet_tip {wallet_tip}");
-            log::debug!("{msg}");
-            anyhow::bail!(msg)
+            log::debug!("Wallet and liquid chain service tips are too far apart, starting manual wallet sync");
+            self.onchain_wallet.full_scan().await?;
         }
 
         let recovery_started_at = utils::now();

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -488,7 +488,7 @@ impl SendSwapHandler {
         }
 
         let swap_script = swap.get_swap_script()?;
-        let current_height = self.onchain_wallet.tip().await.height();
+        let current_height = self.onchain_wallet.tip().await;
         let locktime_from_height = LockTime::from_height(current_height)?;
 
         info!("Checking Send Swap {} expiration: locktime_from_height = {locktime_from_height:?},  swap_script.locktime = {:?}", swap.id, swap_script.locktime);

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -22,7 +22,7 @@ use lwk_wollet::{
     elements::{hex::ToHex, Address, Transaction, Txid},
     elements_miniscript::{slip77::MasterBlindingKey, ToPublicKey as _},
     secp256k1::{All, Message},
-    Tip, WalletTx,
+    WalletTx,
 };
 
 pub(crate) struct MockWallet {
@@ -85,8 +85,8 @@ impl OnchainWallet for MockWallet {
         Ok(TEST_P2TR_ADDR.clone())
     }
 
-    async fn tip(&self) -> Tip {
-        unimplemented!()
+    async fn tip(&self) -> u32 {
+        0
     }
 
     fn pubkey(&self) -> Result<String> {

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -15,8 +15,7 @@ use lwk_wollet::elements::{AssetId, Txid};
 use lwk_wollet::ElectrumOptions;
 use lwk_wollet::{
     elements::{hex::ToHex, Address, Transaction},
-    ElectrumClient, ElectrumUrl, ElementsNetwork, FsPersister, Tip, WalletTx, Wollet,
-    WolletDescriptor,
+    ElectrumClient, ElectrumUrl, ElementsNetwork, FsPersister, WalletTx, Wollet, WolletDescriptor,
 };
 use sdk_common::bitcoin::hashes::{sha256, Hash};
 use sdk_common::bitcoin::secp256k1::PublicKey;
@@ -81,7 +80,7 @@ pub trait OnchainWallet: Send + Sync {
     async fn next_unused_address(&self) -> Result<Address, PaymentError>;
 
     /// Get the current tip of the blockchain the wallet is aware of
-    async fn tip(&self) -> Tip;
+    async fn tip(&self) -> u32;
 
     /// Get the public key of the wallet
     fn pubkey(&self) -> Result<String>;
@@ -313,7 +312,7 @@ impl OnchainWallet for LiquidOnchainWallet {
 
     /// Get the next unused address in the wallet
     async fn next_unused_address(&self) -> Result<Address, PaymentError> {
-        let tip = self.tip().await.height();
+        let tip = self.tip().await;
         let address = match self.persister.next_expired_reserved_address(tip)? {
             Some(reserved_address) => {
                 debug!(
@@ -343,8 +342,8 @@ impl OnchainWallet for LiquidOnchainWallet {
     }
 
     /// Get the current tip of the blockchain the wallet is aware of
-    async fn tip(&self) -> Tip {
-        self.wallet.lock().await.tip()
+    async fn tip(&self) -> u32 {
+        self.wallet.lock().await.tip().height()
     }
 
     /// Get the public key of the wallet


### PR DESCRIPTION
This PR:
- Ensures the wallet and chain service tips are aligned (with 3 block leeway) when calling the `recover_from_onchain` method
- Ensure the error is handled properly depending on the caller:
  1. Real-time sync: We want to throw an error and retry on next event loop
  2. SDK sync loop: We want to handle the error gracefully and ensure we are not disabling event notifications