### PR TITLE
Refactor recoverer

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "lwk_signer",
  "lwk_wollet",
  "maybe-sync",
+ "mockall",
  "prost 0.13.5",
  "reqwest",
  "rusqlite",
@@ -1192,6 +1193,12 @@ dependencies = [
  "byteorder",
  "quick-error",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "ecies"
@@ -2796,6 +2803,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3199,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4292,6 +4351,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "lwk_signer",
  "lwk_wollet",
  "maybe-sync",
+ "mockall",
  "paste",
  "prost 0.13.4",
  "reqwest",
@@ -1364,6 +1365,12 @@ dependencies = [
  "byteorder",
  "quick-error",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "ecies"
@@ -3012,6 +3019,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,6 +3403,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4635,6 +4694,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -71,6 +71,7 @@ tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 tonic = { version = "0.12.3", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
+mockall = "0.13.1"
 
 # WASM dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -13,11 +13,13 @@ use lwk_wollet::{
     hashes::{sha256, Hash},
     ElectrumUrl, History,
 };
+use mockall::automock;
 
 use crate::model::LiquidNetwork;
 use crate::prelude::Utxo;
 use crate::{model::Config, utils};
 
+#[automock]
 #[sdk_macros::async_trait]
 pub trait LiquidChainService: Send + Sync {
     /// Get the blockchain latest block
@@ -38,7 +40,7 @@ pub trait LiquidChainService: Send + Sync {
     /// Get the transactions involved in a list of scripts.
     ///
     /// The data is fetched in a single call from the Electrum endpoint.
-    async fn get_scripts_history(&self, scripts: &[&Script]) -> Result<Vec<Vec<History>>>;
+    async fn get_scripts_history(&self, scripts: &[Script]) -> Result<Vec<Vec<History>>>;
 
     /// Get the transactions involved in a list of scripts
     async fn get_script_history_with_retry(
@@ -169,7 +171,7 @@ impl LiquidChainService for HybridLiquidChainService {
         Ok(h.unwrap_or_default())
     }
 
-    async fn get_scripts_history(&self, scripts: &[&Script]) -> Result<Vec<Vec<History>>> {
+    async fn get_scripts_history(&self, scripts: &[Script]) -> Result<Vec<Vec<History>>> {
         let scripts: Vec<&bitcoin::Script> = scripts
             .iter()
             .map(|t| bitcoin::Script::from_bytes(t.as_bytes()))

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -10,7 +10,7 @@ use boltz_client::{
 };
 use boltz_client::{BtcSwapScript, Keypair, LBtcSwapScript};
 use derivative::Derivative;
-use lwk_wollet::elements::AssetId;
+use lwk_wollet::elements::{script, AssetId};
 use lwk_wollet::{bitcoin::bip32, ElementsNetwork};
 use maybe_sync::{MaybeSend, MaybeSync};
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef};
@@ -1212,6 +1212,14 @@ pub(crate) struct ReceiveSwap {
 impl ReceiveSwap {
     pub(crate) fn get_claim_keypair(&self) -> Result<Keypair, PaymentError> {
         utils::decode_keypair(&self.claim_private_key).map_err(Into::into)
+    }
+
+    pub(crate) fn claim_script(&self) -> Result<script::Script> {
+        Ok(self
+            .get_swap_script()?
+            .funding_addrs
+            .ok_or(anyhow!("No funding address found"))?
+            .script_pubkey())
     }
 
     pub(crate) fn get_boltz_create_response(&self) -> Result<CreateReverseResponse, PaymentError> {

--- a/lib/core/src/recover/handlers/handle_chain_receive_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_receive_swap.rs
@@ -1,0 +1,446 @@
+use anyhow::Result;
+use boltz_client::boltz::PairLimits;
+use boltz_client::ElementsAddress;
+use electrum_client::GetBalanceRes;
+use log::{debug, warn};
+use lwk_wollet::elements::{secp256k1_zkp, AddressParams, Txid};
+use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
+use tonic::async_trait;
+
+use crate::prelude::*;
+use crate::recover::model::*;
+
+/// Handler for updating chain receive swaps with recovered data
+pub(crate) struct ChainReceiveSwapHandler;
+
+#[async_trait]
+impl SwapRecoverHandler for ChainReceiveSwapHandler {
+    async fn recover_swap(
+        &self,
+        swap: &mut Swap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<bool> {
+        if let Swap::Chain(chain_receive_swap) = swap {
+            if chain_receive_swap.direction == Direction::Incoming {
+                return Self::recover_and_update_swap(
+                    chain_receive_swap,
+                    context,
+                    is_local_within_grace_period,
+                )
+                .map(|_| true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl ChainReceiveSwapHandler {
+    /// Check if chain receive swap recovery should be skipped
+    pub fn should_skip_recovery(
+        chain_swap: &ChainSwap,
+        recovered_data: &RecoveredOnchainDataChainReceive,
+        is_local_within_grace_period: bool,
+    ) -> bool {
+        let swap_id = &chain_swap.id;
+
+        let claim_is_cleared =
+            chain_swap.claim_tx_id.is_some() && recovered_data.lbtc_claim_tx_id.is_none();
+        let refund_is_cleared =
+            chain_swap.refund_tx_id.is_some() && recovered_data.btc_refund_tx_id.is_none();
+
+        if is_local_within_grace_period && (claim_is_cleared || refund_is_cleared) {
+            warn!(
+                "Local incoming chain swap {swap_id} was updated recently - skipping recovery \
+                as it would clear a tx that may have been broadcasted by us. Claim clear: \
+                {claim_is_cleared} - Refund clear: {refund_is_cleared}"
+            );
+            return true;
+        }
+
+        false
+    }
+
+    /// Recover and update a chain receive swap with data from the chain
+    pub fn recover_and_update_swap(
+        chain_swap: &mut ChainSwap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        let swap_id = &chain_swap.id.clone();
+        debug!("[Recover Chain Receive] Recovering data for swap {swap_id}");
+
+        // Extract lockup script from swap
+        let lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .ok()
+            .and_then(|script| script.as_bitcoin_script().ok())
+            .and_then(|script| script.funding_addrs.map(|addr| addr.script_pubkey()))
+            .ok_or_else(|| {
+                anyhow::anyhow!("BTC lockup script not found for Onchain Receive Swap {swap_id}")
+            })?;
+
+        let claim_script = chain_swap
+            .get_claim_swap_script()
+            .ok()
+            .and_then(|script| script.as_liquid_script().ok())
+            .and_then(|script| script.funding_addrs.map(|addr| addr.script_pubkey()))
+            .ok_or_else(|| {
+                anyhow::anyhow!("BTC claim script not found for Onchain Send Swap {swap_id}")
+            })?;
+
+        let history = &ReceiveChainSwapHistory {
+            lbtc_claim_script_history: context
+                .lbtc_script_to_history_map
+                .get(&claim_script)
+                .cloned()
+                .unwrap_or_default(),
+            btc_lockup_script_history: context
+                .btc_script_to_history_map
+                .get(&lockup_script)
+                .cloned()
+                .unwrap_or(Vec::new()),
+            btc_lockup_script_txs: context
+                .btc_script_to_txs_map
+                .get(&lockup_script)
+                .cloned()
+                .unwrap_or(Vec::new()),
+            btc_lockup_script_balance: context
+                .btc_script_to_balance_map
+                .get(&lockup_script)
+                .cloned(),
+        };
+
+        // First obtain transaction IDs from the history
+        let recovered_data = Self::recover_onchain_data(
+            &context.tx_map,
+            history,
+            &lockup_script,
+            &context.master_blinding_key,
+        )?;
+
+        // Update the swap with recovered data
+        Self::update_swap(
+            chain_swap,
+            swap_id,
+            &recovered_data,
+            context.bitcoin_tip_height,
+            is_local_within_grace_period,
+        )
+    }
+
+    /// Update a chain receive swap with recovered data
+    pub fn update_swap(
+        chain_swap: &mut ChainSwap,
+        _: &str,
+        recovered_data: &RecoveredOnchainDataChainReceive,
+        current_block_height: u32,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        // Skip updating if within grace period and would clear transactions
+        if Self::should_skip_recovery(chain_swap, recovered_data, is_local_within_grace_period) {
+            return Ok(());
+        }
+
+        // Update amount if available
+        if recovered_data.btc_user_lockup_amount_sat > 0 {
+            chain_swap.actual_payer_amount_sat = Some(recovered_data.btc_user_lockup_amount_sat);
+        }
+
+        // Update state based on chain tip
+        let is_expired = current_block_height >= chain_swap.timeout_block_height;
+        let (expected_user_lockup_amount_sat, swap_limits) = match chain_swap.payer_amount_sat {
+            0 => (None, Some(chain_swap.get_boltz_pair()?.limits)),
+            expected => (Some(expected), None),
+        };
+
+        if let Some(new_state) = recovered_data.derive_partial_state(
+            expected_user_lockup_amount_sat,
+            swap_limits,
+            is_expired,
+            chain_swap.is_waiting_fee_acceptance(),
+        ) {
+            chain_swap.state = new_state;
+        }
+
+        // Update transaction IDs
+        chain_swap.server_lockup_tx_id = recovered_data
+            .lbtc_server_lockup_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.claim_address = recovered_data.lbtc_claim_address.clone();
+        chain_swap.user_lockup_tx_id = recovered_data
+            .btc_user_lockup_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.claim_tx_id = recovered_data
+            .lbtc_claim_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.refund_tx_id = recovered_data
+            .btc_refund_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+
+        Ok(())
+    }
+
+    /// Reconstruct Chain Receive Swap tx IDs from the onchain data
+    ///
+    /// The implementation tolerates a `tx_map` that is older than the history in the sense that
+    /// no incorrect data is recovered. Transactions that are missing from `tx_map` are simply not recovered.
+    fn recover_onchain_data(
+        tx_map: &TxMap,
+        history: &ReceiveChainSwapHistory,
+        lockup_script: &BtcScript,
+        master_blinding_key: &MasterBlindingKey,
+    ) -> Result<RecoveredOnchainDataChainReceive> {
+        let secp = secp256k1_zkp::Secp256k1::new();
+
+        // Determine lockup and claim txs
+        let (lbtc_server_lockup_tx_id, lbtc_claim_tx_id) =
+            determine_incoming_lockup_and_claim_txs(&history.lbtc_claim_script_history, tx_map);
+
+        // Get claim address from tx
+        let lbtc_claim_address = if let Some(claim_tx_id) = &lbtc_claim_tx_id {
+            tx_map
+                .incoming_tx_map
+                .get(&claim_tx_id.txid)
+                .and_then(|tx| {
+                    tx.outputs
+                        .iter()
+                        .find(|output| output.is_some())
+                        .and_then(|output| output.clone().map(|o| o.script_pubkey))
+                })
+                .and_then(|script| {
+                    ElementsAddress::from_script(
+                        &script,
+                        Some(master_blinding_key.blinding_key(&secp, &script)),
+                        &AddressParams::LIQUID,
+                    )
+                    .map(|addr| addr.to_string())
+                })
+        } else {
+            None
+        };
+
+        // Get current confirmed amount for lockup script
+        let btc_user_lockup_address_balance_sat = history
+            .btc_lockup_script_balance
+            .as_ref()
+            .map(|balance| balance.confirmed)
+            .unwrap_or_default();
+
+        // Process Bitcoin transactions
+        let (btc_lockup_incoming_txs, btc_lockup_outgoing_txs): (Vec<_>, Vec<_>) =
+            history.btc_lockup_script_txs.iter().partition(|tx| {
+                tx.output
+                    .iter()
+                    .any(|out| matches!(&out.script_pubkey, x if x == lockup_script))
+            });
+
+        // Get user lockup tx from first incoming tx
+        let btc_user_lockup_tx_id = btc_lockup_incoming_txs
+            .first()
+            .and_then(|tx| {
+                history
+                    .btc_lockup_script_history
+                    .iter()
+                    .find(|h| h.txid.as_raw_hash() == tx.compute_txid().as_raw_hash())
+            })
+            .cloned();
+
+        // Get the lockup amount
+        let btc_user_lockup_amount_sat = btc_lockup_incoming_txs
+            .first()
+            .and_then(|tx| {
+                tx.output
+                    .iter()
+                    .find(|out| out.script_pubkey == *lockup_script)
+                    .map(|out| out.value)
+            })
+            .unwrap_or_default()
+            .to_sat();
+
+        // Collect outgoing tx IDs
+        let btc_outgoing_tx_ids: Vec<HistoryTxId> = btc_lockup_outgoing_txs
+            .iter()
+            .filter_map(|tx| {
+                history
+                    .btc_lockup_script_history
+                    .iter()
+                    .find(|h| h.txid.as_raw_hash() == tx.compute_txid().as_raw_hash())
+            })
+            .cloned()
+            .collect();
+
+        // Get last unconfirmed tx or last tx
+        let btc_last_outgoing_tx_id = btc_outgoing_tx_ids
+            .iter()
+            .rev()
+            .find(|h| h.height == 0)
+            .or(btc_outgoing_tx_ids.last())
+            .cloned();
+
+        // Determine the refund tx based on claim status
+        let btc_refund_tx_id = match lbtc_claim_tx_id.is_some() {
+            true => match btc_lockup_outgoing_txs.len() > 1 {
+                true => btc_last_outgoing_tx_id,
+                false => None,
+            },
+            false => btc_last_outgoing_tx_id,
+        };
+
+        Ok(RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id,
+            lbtc_claim_tx_id,
+            lbtc_claim_address,
+            btc_user_lockup_tx_id,
+            btc_user_lockup_address_balance_sat,
+            btc_user_lockup_amount_sat,
+            btc_refund_tx_id,
+        })
+    }
+}
+
+/// Helper function for determining lockup and claim transactions in incoming swaps
+fn determine_incoming_lockup_and_claim_txs(
+    history: &[HistoryTxId],
+    tx_map: &TxMap,
+) -> (Option<HistoryTxId>, Option<HistoryTxId>) {
+    match history.len() {
+        // Only lockup tx available
+        1 => (Some(history[0].clone()), None),
+        2 => {
+            let first = history[0].clone();
+            let second = history[1].clone();
+
+            if tx_map.incoming_tx_map.contains_key::<Txid>(&first.txid) {
+                // If the first tx is a known incoming tx, it's the claim tx and the second is the lockup
+                (Some(second), Some(first))
+            } else if tx_map.incoming_tx_map.contains_key::<Txid>(&second.txid) {
+                // If the second tx is a known incoming tx, it's the claim tx and the first is the lockup
+                (Some(first), Some(second))
+            } else {
+                // If none of the 2 txs is the claim tx, then the txs are lockup and swapper refund
+                // If so, we expect them to be confirmed at different heights
+                let first_conf_height = first.height;
+                let second_conf_height = second.height;
+                match (first.confirmed(), second.confirmed()) {
+                    // If they're both confirmed, the one with the lowest confirmation height is the lockup
+                    (true, true) => match first_conf_height < second_conf_height {
+                        true => (Some(first), None),
+                        false => (Some(second), None),
+                    },
+
+                    // If only one tx is confirmed, then that is the lockup
+                    (true, false) => (Some(first), None),
+                    (false, true) => (Some(second), None),
+
+                    // If neither is confirmed, this is an edge-case, and the most likely cause is an
+                    // out of date wallet tx_map that doesn't yet include one of the txs.
+                    (false, false) => {
+                        log::warn!(
+                            "Found 2 unconfirmed txs in the claim script history. \
+                            Unable to determine if they include a swapper refund or a user claim"
+                        );
+                        (None, None)
+                    }
+                }
+            }
+        }
+        n => {
+            log::warn!("Unexpected script history length {n} while recovering data for swap");
+            (None, None)
+        }
+    }
+}
+
+pub(crate) struct RecoveredOnchainDataChainReceive {
+    /// LBTC tx locking up funds by the swapper
+    pub(crate) lbtc_server_lockup_tx_id: Option<HistoryTxId>,
+    /// LBTC tx that claims to our wallet. The final step in a successful swap.
+    pub(crate) lbtc_claim_tx_id: Option<HistoryTxId>,
+    /// LBTC tx out address for the claim tx.
+    pub(crate) lbtc_claim_address: Option<String>,
+    /// BTC tx initiated by the payer (the "user" as per Boltz), sending funds to the swap funding address.
+    pub(crate) btc_user_lockup_tx_id: Option<HistoryTxId>,
+    /// BTC total funds currently available at the swap funding address.
+    pub(crate) btc_user_lockup_address_balance_sat: u64,
+    /// BTC sent to lockup address as part of lockup tx.
+    pub(crate) btc_user_lockup_amount_sat: u64,
+    /// BTC tx initiated by the SDK to a user-chosen address, in case the initial funds have to be refunded.
+    pub(crate) btc_refund_tx_id: Option<HistoryTxId>,
+}
+
+impl RecoveredOnchainDataChainReceive {
+    pub(crate) fn derive_partial_state(
+        &self,
+        expected_user_lockup_amount_sat: Option<u64>,
+        swap_limits: Option<PairLimits>,
+        is_expired: bool,
+        is_waiting_fee_acceptance: bool,
+    ) -> Option<PaymentState> {
+        let unexpected_amount =
+            expected_user_lockup_amount_sat.is_some_and(|expected_lockup_amount_sat| {
+                expected_lockup_amount_sat != self.btc_user_lockup_amount_sat
+            });
+        let amount_out_of_bounds = swap_limits.is_some_and(|limits| {
+            self.btc_user_lockup_amount_sat < limits.minimal
+                || self.btc_user_lockup_amount_sat > limits.maximal
+        });
+        let is_expired_refundable = is_expired && self.btc_user_lockup_address_balance_sat > 0;
+        let is_refundable = is_expired_refundable || unexpected_amount || amount_out_of_bounds;
+        match &self.btc_user_lockup_tx_id {
+            Some(_) => match (&self.lbtc_claim_tx_id, &self.btc_refund_tx_id) {
+                (Some(lbtc_claim_tx_id), None) => match lbtc_claim_tx_id.confirmed() {
+                    true => match is_expired_refundable {
+                        true => Some(PaymentState::Refundable),
+                        false => Some(PaymentState::Complete),
+                    },
+                    false => Some(PaymentState::Pending),
+                },
+                (None, Some(btc_refund_tx_id)) => match btc_refund_tx_id.confirmed() {
+                    true => match is_expired_refundable {
+                        true => Some(PaymentState::Refundable),
+                        false => Some(PaymentState::Failed),
+                    },
+                    false => Some(PaymentState::RefundPending),
+                },
+                (Some(lbtc_claim_tx_id), Some(btc_refund_tx_id)) => {
+                    match lbtc_claim_tx_id.confirmed() {
+                        true => match btc_refund_tx_id.confirmed() {
+                            true => match is_expired_refundable {
+                                true => Some(PaymentState::Refundable),
+                                false => Some(PaymentState::Complete),
+                            },
+                            false => Some(PaymentState::RefundPending),
+                        },
+                        false => Some(PaymentState::Pending),
+                    }
+                }
+                (None, None) => match is_refundable {
+                    true => Some(PaymentState::Refundable),
+                    false => match is_waiting_fee_acceptance {
+                        true => Some(PaymentState::WaitingFeeAcceptance),
+                        false => Some(PaymentState::Pending),
+                    },
+                },
+            },
+            None => match is_expired {
+                true => Some(PaymentState::Failed),
+                // We have no onchain data to support deriving the state as the swap could
+                // potentially be Created. In this case we return None.
+                false => None,
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ReceiveChainSwapHistory {
+    pub(crate) lbtc_claim_script_history: Vec<HistoryTxId>,
+    pub(crate) btc_lockup_script_history: Vec<HistoryTxId>,
+    pub(crate) btc_lockup_script_txs: Vec<boltz_client::bitcoin::Transaction>,
+    pub(crate) btc_lockup_script_balance: Option<GetBalanceRes>,
+}

--- a/lib/core/src/recover/handlers/handle_chain_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_send_swap.rs
@@ -1,0 +1,281 @@
+use anyhow::Result;
+use log::{debug, error, warn};
+use lwk_wollet::elements::Txid;
+use tonic::async_trait;
+
+use crate::prelude::*;
+use crate::recover::model::*;
+
+/// Handler for updating chain send swaps with recovered data
+pub(crate) struct ChainSendSwapHandler;
+
+#[async_trait]
+impl SwapRecoverHandler for ChainSendSwapHandler {
+    async fn recover_swap(
+        &self,
+        swap: &mut Swap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<bool> {
+        if let Swap::Chain(chain_send_swap) = swap {
+            if chain_send_swap.direction == Direction::Outgoing {
+                return Self::recover_and_update_swap(
+                    chain_send_swap,
+                    context,
+                    is_local_within_grace_period,
+                )
+                .map(|_| true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl ChainSendSwapHandler {
+    /// Check if chain send swap recovery should be skipped
+    pub fn should_skip_recovery(
+        chain_swap: &ChainSwap,
+        recovered_data: &RecoveredOnchainDataChainSend,
+        is_local_within_grace_period: bool,
+    ) -> bool {
+        let swap_id = &chain_swap.id;
+
+        let lockup_is_cleared = chain_swap.user_lockup_tx_id.is_some()
+            && recovered_data.lbtc_user_lockup_tx_id.is_none();
+        let refund_is_cleared =
+            chain_swap.refund_tx_id.is_some() && recovered_data.lbtc_refund_tx_id.is_none();
+
+        if is_local_within_grace_period && (lockup_is_cleared || refund_is_cleared) {
+            warn!(
+                "Local outgoing chain swap {swap_id} was updated recently - skipping recovery \
+                as it would clear a tx that may have been broadcasted by us. Lockup clear: \
+                {lockup_is_cleared} - Refund clear: {refund_is_cleared}"
+            );
+            return true;
+        }
+
+        false
+    }
+
+    /// Recover and update a chain send swap with data from the chain
+    pub fn recover_and_update_swap(
+        chain_swap: &mut ChainSwap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        let swap_id = &chain_swap.id.clone();
+        debug!("[Recover Chain Send] Recovering data for swap {swap_id}");
+
+        // Extract claim script from swap
+        let claim_script = chain_swap
+            .get_claim_swap_script()
+            .ok()
+            .and_then(|script| script.as_bitcoin_script().ok())
+            .and_then(|script| script.funding_addrs.map(|addr| addr.script_pubkey()))
+            .ok_or_else(|| {
+                anyhow::anyhow!("BTC claim script not found for Onchain Send Swap {swap_id}")
+            })?;
+
+        let lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .ok()
+            .and_then(|script| script.as_liquid_script().ok())
+            .and_then(|script| script.funding_addrs.map(|addr| addr.script_pubkey()))
+            .ok_or_else(|| {
+                anyhow::anyhow!("LBTC lockup script not found for Onchain Send Swap {swap_id}")
+            })?;
+
+        let history = &SendChainSwapHistory {
+            lbtc_lockup_script_history: context
+                .lbtc_script_to_history_map
+                .get(&lockup_script)
+                .cloned()
+                .unwrap_or_default(),
+            btc_claim_script_history: context
+                .btc_script_to_history_map
+                .get(&claim_script)
+                .cloned()
+                .unwrap_or_default(),
+            btc_claim_script_txs: context
+                .btc_script_to_txs_map
+                .get(&claim_script)
+                .cloned()
+                .unwrap_or_default(),
+        };
+
+        // First obtain transaction IDs from the history
+        let recovered_data =
+            Self::recover_onchain_data(&context.tx_map, swap_id, history, &claim_script)?;
+
+        // Update the swap with recovered data
+        Self::update_swap(
+            chain_swap,
+            swap_id,
+            &recovered_data,
+            context.liquid_tip_height,
+            is_local_within_grace_period,
+        )
+    }
+
+    /// Update a chain send swap with recovered data
+    pub fn update_swap(
+        chain_swap: &mut ChainSwap,
+        _: &str,
+        recovered_data: &RecoveredOnchainDataChainSend,
+        current_block_height: u32,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        // Skip updating if within grace period and would clear transactions
+        if Self::should_skip_recovery(chain_swap, recovered_data, is_local_within_grace_period) {
+            return Ok(());
+        }
+
+        // Update state based on chain tip
+        let is_expired = current_block_height >= chain_swap.timeout_block_height;
+        if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
+            chain_swap.state = new_state;
+        }
+
+        // Update transaction IDs
+        chain_swap.user_lockup_tx_id = recovered_data
+            .lbtc_user_lockup_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.refund_tx_id = recovered_data
+            .lbtc_refund_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.server_lockup_tx_id = recovered_data
+            .btc_server_lockup_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        chain_swap.claim_tx_id = recovered_data
+            .btc_claim_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+
+        Ok(())
+    }
+
+    /// Reconstruct Chain Send Swap tx IDs from the onchain data
+    ///
+    /// The implementation tolerates a `tx_map` that is older than the history in the sense that
+    /// no incorrect data is recovered. Transactions that are missing from `tx_map` are simply not recovered.
+    fn recover_onchain_data(
+        tx_map: &TxMap,
+        swap_id: &str,
+        history: &SendChainSwapHistory,
+        claim_script: &BtcScript,
+    ) -> Result<RecoveredOnchainDataChainSend> {
+        // If a history tx is one of our outgoing txs, it's a lockup tx
+        let lbtc_user_lockup_tx_id = history
+            .lbtc_lockup_script_history
+            .iter()
+            .find(|&tx| tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
+            .cloned();
+
+        if lbtc_user_lockup_tx_id.is_none() {
+            error!("No lockup tx found when recovering data for Chain Send Swap {swap_id}");
+        }
+
+        // If a history tx is one of our incoming txs, it's a refund tx
+        let lbtc_refund_tx_id = history
+            .lbtc_lockup_script_history
+            .iter()
+            .find(|&tx| tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
+            .cloned();
+
+        let (btc_server_lockup_tx_id, btc_claim_tx_id) = match history
+            .btc_claim_script_history
+            .len()
+        {
+            // Only lockup tx available
+            1 => (Some(history.btc_claim_script_history[0].clone()), None),
+
+            2 => {
+                let first_tx = history.btc_claim_script_txs[0].clone();
+                let first_tx_id = history.btc_claim_script_history[0].clone();
+                let second_tx_id = history.btc_claim_script_history[1].clone();
+
+                // We check the full tx, to determine if this is the BTC lockup tx
+                let is_first_tx_lockup_tx = first_tx
+                    .output
+                    .iter()
+                    .any(|out| matches!(&out.script_pubkey, x if x == claim_script));
+
+                match is_first_tx_lockup_tx {
+                    true => (Some(first_tx_id), Some(second_tx_id)),
+                    false => (Some(second_tx_id), Some(first_tx_id)),
+                }
+            }
+            n => {
+                warn!("BTC script history with length {n} found while recovering data for Chain Send Swap {swap_id}");
+                (None, None)
+            }
+        };
+
+        Ok(RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id,
+            lbtc_refund_tx_id,
+            btc_server_lockup_tx_id,
+            btc_claim_tx_id,
+        })
+    }
+}
+
+pub(crate) struct RecoveredOnchainDataChainSend {
+    /// LBTC tx initiated by the SDK (the "user" as per Boltz), sending funds to the swap funding address.
+    pub(crate) lbtc_user_lockup_tx_id: Option<HistoryTxId>,
+    /// LBTC tx initiated by the SDK to itself, in case the initial funds have to be refunded.
+    pub(crate) lbtc_refund_tx_id: Option<HistoryTxId>,
+    /// BTC tx locking up funds by the swapper
+    pub(crate) btc_server_lockup_tx_id: Option<HistoryTxId>,
+    /// BTC tx that claims to the final BTC destination address. The final step in a successful swap.
+    pub(crate) btc_claim_tx_id: Option<HistoryTxId>,
+}
+
+// TODO: We have to be careful around overwriting the RefundPending state, as this swap monitored
+// after the expiration of the swap and if new funds are detected on the lockup script they are refunded.
+// Perhaps we should check in the recovery the lockup balance and set accordingly.
+impl RecoveredOnchainDataChainSend {
+    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
+        match &self.lbtc_user_lockup_tx_id {
+            Some(_) => match (&self.btc_claim_tx_id, &self.lbtc_refund_tx_id) {
+                (Some(btc_claim_tx_id), None) => match btc_claim_tx_id.confirmed() {
+                    true => Some(PaymentState::Complete),
+                    false => Some(PaymentState::Pending),
+                },
+                (None, Some(lbtc_refund_tx_id)) => match lbtc_refund_tx_id.confirmed() {
+                    true => Some(PaymentState::Failed),
+                    false => Some(PaymentState::RefundPending),
+                },
+                (Some(btc_claim_tx_id), Some(lbtc_refund_tx_id)) => {
+                    match btc_claim_tx_id.confirmed() {
+                        true => match lbtc_refund_tx_id.confirmed() {
+                            true => Some(PaymentState::Complete),
+                            false => Some(PaymentState::RefundPending),
+                        },
+                        false => Some(PaymentState::Pending),
+                    }
+                }
+                (None, None) => match is_expired {
+                    true => Some(PaymentState::RefundPending),
+                    false => Some(PaymentState::Pending),
+                },
+            },
+            None => match is_expired {
+                true => Some(PaymentState::Failed),
+                // We have no onchain data to support deriving the state as the swap could
+                // potentially be Created or TimedOut. In this case we return None.
+                false => None,
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SendChainSwapHistory {
+    pub(crate) lbtc_lockup_script_history: Vec<HistoryTxId>,
+    pub(crate) btc_claim_script_history: Vec<HistoryTxId>,
+    pub(crate) btc_claim_script_txs: Vec<boltz_client::bitcoin::Transaction>,
+}

--- a/lib/core/src/recover/handlers/handle_chain_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_send_swap.rs
@@ -1,35 +1,12 @@
 use anyhow::Result;
 use log::{debug, error, warn};
 use lwk_wollet::elements::Txid;
-use tonic::async_trait;
 
 use crate::prelude::*;
 use crate::recover::model::*;
 
 /// Handler for updating chain send swaps with recovered data
 pub(crate) struct ChainSendSwapHandler;
-
-#[async_trait]
-impl SwapRecoverHandler for ChainSendSwapHandler {
-    async fn recover_swap(
-        &self,
-        swap: &mut Swap,
-        context: &SwapsHistories,
-        is_local_within_grace_period: bool,
-    ) -> Result<bool> {
-        if let Swap::Chain(chain_send_swap) = swap {
-            if chain_send_swap.direction == Direction::Outgoing {
-                return Self::recover_and_update_swap(
-                    chain_send_swap,
-                    context,
-                    is_local_within_grace_period,
-                )
-                .map(|_| true);
-            }
-        }
-        Ok(false)
-    }
-}
 
 impl ChainSendSwapHandler {
     /// Check if chain send swap recovery should be skipped
@@ -58,9 +35,9 @@ impl ChainSendSwapHandler {
     }
 
     /// Recover and update a chain send swap with data from the chain
-    pub fn recover_and_update_swap(
+    pub async fn recover_swap(
         chain_swap: &mut ChainSwap,
-        context: &SwapsHistories,
+        context: &RecoveryContext,
         is_local_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = &chain_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_chain_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_send_swap.rs
@@ -21,8 +21,12 @@ impl ChainSendSwapHandler {
             && recovered_data.lbtc_user_lockup_tx_id.is_none();
         let refund_is_cleared =
             chain_swap.refund_tx_id.is_some() && recovered_data.lbtc_refund_tx_id.is_none();
+        let claim_is_cleared =
+            chain_swap.claim_tx_id.is_some() && recovered_data.btc_claim_tx_id.is_none();
 
-        if is_local_within_grace_period && (lockup_is_cleared || refund_is_cleared) {
+        if is_local_within_grace_period
+            && (lockup_is_cleared || refund_is_cleared || claim_is_cleared)
+        {
             warn!(
                 "Local outgoing chain swap {swap_id} was updated recently - skipping recovery \
                 as it would clear a tx that may have been broadcasted by us. Lockup clear: \
@@ -87,7 +91,6 @@ impl ChainSendSwapHandler {
         // Update the swap with recovered data
         Self::update_swap(
             chain_swap,
-            swap_id,
             &recovered_data,
             context.liquid_tip_height,
             is_local_within_grace_period,
@@ -97,7 +100,6 @@ impl ChainSendSwapHandler {
     /// Update a chain send swap with recovered data
     pub fn update_swap(
         chain_swap: &mut ChainSwap,
-        _: &str,
         recovered_data: &RecoveredOnchainDataChainSend,
         current_block_height: u32,
         is_local_within_grace_period: bool,

--- a/lib/core/src/recover/handlers/handle_receive_swap.rs
+++ b/lib/core/src/recover/handlers/handle_receive_swap.rs
@@ -5,30 +5,12 @@ use lwk_wollet::elements::Txid;
 use lwk_wollet::WalletTx;
 use std::collections::HashMap;
 use std::str::FromStr;
-use tonic::async_trait;
 
 use crate::prelude::*;
 use crate::recover::model::*;
 
 /// Handler for updating receive swaps with recovered data
 pub(crate) struct ReceiveSwapHandler;
-
-#[async_trait]
-impl SwapRecoverHandler for ReceiveSwapHandler {
-    async fn recover_swap(
-        &self,
-        swap: &mut Swap,
-        context: &SwapsHistories,
-        is_local_within_grace_period: bool,
-    ) -> Result<bool> {
-        if let Swap::Receive(receive_swap) = swap {
-            Self::recover_and_update_swap(receive_swap, context, is_local_within_grace_period)
-                .map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-}
 
 impl ReceiveSwapHandler {
     /// Check if receive swap recovery should be skipped
@@ -53,9 +35,9 @@ impl ReceiveSwapHandler {
     }
 
     /// Recover and update a receive swap with data from the chain
-    pub fn recover_and_update_swap(
+    pub(crate) async fn recover_swap(
         receive_swap: &mut ReceiveSwap,
-        context: &SwapsHistories,
+        context: &RecoveryContext,
         is_local_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = &receive_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_receive_swap.rs
+++ b/lib/core/src/recover/handlers/handle_receive_swap.rs
@@ -1,0 +1,304 @@
+use anyhow::Result;
+use boltz_client::ElementsAddress;
+use log::{debug, warn};
+use lwk_wollet::elements::Txid;
+use lwk_wollet::WalletTx;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tonic::async_trait;
+
+use crate::prelude::*;
+use crate::recover::model::*;
+
+/// Handler for updating receive swaps with recovered data
+pub(crate) struct ReceiveSwapHandler;
+
+#[async_trait]
+impl SwapRecoverHandler for ReceiveSwapHandler {
+    async fn recover_swap(
+        &self,
+        swap: &mut Swap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<bool> {
+        if let Swap::Receive(receive_swap) = swap {
+            Self::recover_and_update_swap(receive_swap, context, is_local_within_grace_period)
+                .map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl ReceiveSwapHandler {
+    /// Check if receive swap recovery should be skipped
+    pub fn should_skip_recovery(
+        receive_swap: &ReceiveSwap,
+        recovered_data: &RecoveredOnchainDataReceive,
+        is_local_within_grace_period: bool,
+    ) -> bool {
+        let swap_id = &receive_swap.id;
+        let claim_is_cleared =
+            receive_swap.claim_tx_id.is_some() && recovered_data.claim_tx_id.is_none();
+
+        if is_local_within_grace_period && claim_is_cleared {
+            warn!(
+                "Local receive swap {swap_id} was updated recently - skipping recovery \
+                as it would clear a tx that may have been broadcasted by us (claim)"
+            );
+            return true;
+        }
+
+        false
+    }
+
+    /// Recover and update a receive swap with data from the chain
+    pub fn recover_and_update_swap(
+        receive_swap: &mut ReceiveSwap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        let swap_id = &receive_swap.id.clone();
+        debug!("[Recover Receive] Recovering data for swap {swap_id}");
+
+        let mrh_script = ElementsAddress::from_str(&receive_swap.mrh_address)
+            .map_err(|_| anyhow::anyhow!("Invalid MRH address for swap {swap_id}"))?
+            .script_pubkey();
+        let claim_script = receive_swap.claim_script()?;
+        let history = ReceiveSwapHistory {
+            lbtc_mrh_script_history: context
+                .lbtc_script_to_history_map
+                .get(&mrh_script)
+                .cloned()
+                .unwrap_or_default()
+                .iter()
+                .filter(|&tx_history| tx_history.height < receive_swap.timeout_block_height as i32)
+                .cloned()
+                .collect(),
+
+            lbtc_claim_script_history: context
+                .lbtc_script_to_history_map
+                .get(&claim_script)
+                .cloned()
+                .unwrap_or_default()
+                .iter()
+                .filter(|&tx_history| tx_history.height < receive_swap.timeout_block_height as i32)
+                .cloned()
+                .collect(),
+        };
+
+        // First obtain recovered data from the history
+        let recovered_data = Self::recover_onchain_data(
+            &context.tx_map,
+            swap_id,
+            &history,
+            receive_swap.created_at,
+        )?;
+
+        // Update the swap with recovered data
+        Self::update_swap(
+            receive_swap,
+            swap_id,
+            &recovered_data,
+            context.liquid_tip_height,
+            is_local_within_grace_period,
+        )
+    }
+
+    /// Update a receive swap with recovered data
+    pub fn update_swap(
+        receive_swap: &mut ReceiveSwap,
+        _: &str,
+        recovered_data: &RecoveredOnchainDataReceive,
+        current_block_height: u32,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        // Skip updating if within grace period and would clear transactions
+        if Self::should_skip_recovery(receive_swap, recovered_data, is_local_within_grace_period) {
+            return Ok(());
+        }
+
+        // Update state based on chain tip
+        let timeout_block_height = receive_swap.timeout_block_height;
+        let is_expired = current_block_height >= timeout_block_height;
+        if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
+            receive_swap.state = new_state;
+        }
+
+        // Update transaction IDs
+        receive_swap.claim_tx_id = recovered_data
+            .claim_tx_id
+            .clone()
+            .map(|history_tx_id| history_tx_id.txid.to_string());
+        receive_swap.mrh_tx_id = recovered_data
+            .mrh_tx_id
+            .clone()
+            .map(|history_tx_id| history_tx_id.txid.to_string());
+        receive_swap.lockup_tx_id = recovered_data
+            .lockup_tx_id
+            .clone()
+            .map(|history_tx_id| history_tx_id.txid.to_string());
+
+        // Update amounts if we have MRH data
+        if let Some(mrh_amount_sat) = recovered_data.mrh_amount_sat {
+            receive_swap.payer_amount_sat = mrh_amount_sat;
+            receive_swap.receiver_amount_sat = mrh_amount_sat;
+        }
+
+        Ok(())
+    }
+
+    /// Reconstruct Receive Swap tx IDs from the onchain data
+    ///
+    /// The implementation tolerates a `tx_map` that is older than the history in the sense that
+    /// no incorrect data is recovered. Transactions that are missing from `tx_map` are simply not recovered.
+    fn recover_onchain_data(
+        tx_map: &TxMap,
+        swap_id: &str,
+        history: &ReceiveSwapHistory,
+        swap_timestamp: u32,
+    ) -> Result<RecoveredOnchainDataReceive> {
+        // The MRH script history txs filtered by the swap timestamp
+        let mrh_txs: HashMap<Txid, WalletTx> = history
+            .lbtc_mrh_script_history
+            .iter()
+            .filter_map(|h| tx_map.incoming_tx_map.get(&h.txid))
+            .filter(|tx| tx.timestamp.map(|t| t > swap_timestamp).unwrap_or(true))
+            .map(|tx| (tx.txid, tx.clone()))
+            .collect();
+
+        let mrh_tx_id = history
+            .lbtc_mrh_script_history
+            .iter()
+            .find(|&tx| mrh_txs.contains_key::<Txid>(&tx.txid))
+            .cloned();
+
+        let mrh_amount_sat = mrh_tx_id
+            .clone()
+            .and_then(|h| mrh_txs.get(&h.txid))
+            .map(|tx| tx.balance.values().sum::<i64>().unsigned_abs());
+
+        let (lockup_tx_id, claim_tx_id) = determine_incoming_lockup_and_claim_txs(
+            &history.lbtc_claim_script_history,
+            tx_map,
+            swap_id,
+        );
+
+        // Take only the lockup_tx_id and claim_tx_id if either are set,
+        // otherwise take the mrh_tx_id and mrh_amount_sat
+        let recovered_onchain_data = match (lockup_tx_id.as_ref(), claim_tx_id.as_ref()) {
+            (Some(_), None) | (Some(_), Some(_)) => RecoveredOnchainDataReceive {
+                lockup_tx_id,
+                claim_tx_id,
+                mrh_tx_id: None,
+                mrh_amount_sat: None,
+            },
+            _ => RecoveredOnchainDataReceive {
+                lockup_tx_id: None,
+                claim_tx_id: None,
+                mrh_tx_id,
+                mrh_amount_sat,
+            },
+        };
+
+        Ok(recovered_onchain_data)
+    }
+}
+
+/// Helper function for determining lockup and claim transactions in incoming swaps
+fn determine_incoming_lockup_and_claim_txs(
+    history: &[HistoryTxId],
+    tx_map: &TxMap,
+    swap_id: &str,
+) -> (Option<HistoryTxId>, Option<HistoryTxId>) {
+    match history.len() {
+        // Only lockup tx available
+        1 => (Some(history[0].clone()), None),
+        2 => {
+            let first = history[0].clone();
+            let second = history[1].clone();
+
+            if tx_map.incoming_tx_map.contains_key::<Txid>(&first.txid) {
+                // If the first tx is a known incoming tx, it's the claim tx and the second is the lockup
+                (Some(second), Some(first))
+            } else if tx_map.incoming_tx_map.contains_key::<Txid>(&second.txid) {
+                // If the second tx is a known incoming tx, it's the claim tx and the first is the lockup
+                (Some(first), Some(second))
+            } else {
+                // If none of the 2 txs is the claim tx, then the txs are lockup and swapper refund
+                // If so, we expect them to be confirmed at different heights
+                let first_conf_height = first.height;
+                let second_conf_height = second.height;
+                match (first.confirmed(), second.confirmed()) {
+                    // If they're both confirmed, the one with the lowest confirmation height is the lockup
+                    (true, true) => match first_conf_height < second_conf_height {
+                        true => (Some(first), None),
+                        false => (Some(second), None),
+                    },
+
+                    // If only one tx is confirmed, then that is the lockup
+                    (true, false) => (Some(first), None),
+                    (false, true) => (Some(second), None),
+
+                    // If neither is confirmed, this is an edge-case, and the most likely cause is an
+                    // out of date wallet tx_map that doesn't yet include one of the txs.
+                    (false, false) => {
+                        log::warn!(
+                            "Found 2 unconfirmed txs in the claim script history of Swap {swap_id}. \
+                            Unable to determine if they include a swapper refund or a user claim"
+                        );
+                        (None, None)
+                    }
+                }
+            }
+        }
+        n => {
+            log::warn!(
+                "Unexpected script history length {n} while recovering data for Swap {swap_id}"
+            );
+            (None, None)
+        }
+    }
+}
+
+pub(crate) struct RecoveredOnchainDataReceive {
+    pub(crate) lockup_tx_id: Option<HistoryTxId>,
+    pub(crate) claim_tx_id: Option<HistoryTxId>,
+    pub(crate) mrh_tx_id: Option<HistoryTxId>,
+    pub(crate) mrh_amount_sat: Option<u64>,
+}
+
+impl RecoveredOnchainDataReceive {
+    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
+        match &self.lockup_tx_id {
+            Some(_) => match &self.claim_tx_id {
+                Some(claim_tx_id) => match claim_tx_id.confirmed() {
+                    true => Some(PaymentState::Complete),
+                    false => Some(PaymentState::Pending),
+                },
+                None => match is_expired {
+                    true => Some(PaymentState::Failed),
+                    false => Some(PaymentState::Pending),
+                },
+            },
+            None => match &self.mrh_tx_id {
+                Some(mrh_tx_id) => match mrh_tx_id.confirmed() {
+                    true => Some(PaymentState::Complete),
+                    false => Some(PaymentState::Pending),
+                },
+                // We have no onchain data to support deriving the state as the swap could
+                // potentially be Created. In this case we return None.
+                None => match is_expired {
+                    true => Some(PaymentState::Failed),
+                    false => None,
+                },
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ReceiveSwapHistory {
+    pub(crate) lbtc_claim_script_history: Vec<HistoryTxId>,
+    pub(crate) lbtc_mrh_script_history: Vec<HistoryTxId>,
+}

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use boltz_client::ToHex;
 use log::{debug, error, warn};
 use lwk_wollet::elements::Txid;
-use tonic::async_trait;
 
 use crate::prelude::*;
 use crate::recover::model::*;
@@ -13,24 +12,6 @@ use crate::utils;
 
 /// Handler for updating send swaps with recovered data
 pub(crate) struct SendSwapHandler;
-
-#[async_trait]
-impl SwapRecoverHandler for SendSwapHandler {
-    async fn recover_swap(
-        &self,
-        swap: &mut Swap,
-        context: &SwapsHistories,
-        is_local_within_grace_period: bool,
-    ) -> Result<bool> {
-        if let Swap::Send(send_swap) = swap {
-            Self::recover_and_update_swap(send_swap, context, is_local_within_grace_period)
-                .await
-                .map(|_| true)
-        } else {
-            Ok(false)
-        }
-    }
-}
 
 impl SendSwapHandler {
     /// Check if send swap recovery should be skipped
@@ -58,9 +39,9 @@ impl SendSwapHandler {
     }
 
     /// Recover and update a send swap with data from the chain
-    pub async fn recover_and_update_swap(
+    pub async fn recover_swap(
         send_swap: &mut SendSwap,
-        context: &SwapsHistories,
+        context: &RecoveryContext,
         is_local_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = send_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -1,0 +1,282 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use boltz_client::ToHex;
+use log::{debug, error, warn};
+use lwk_wollet::elements::Txid;
+use tonic::async_trait;
+
+use crate::prelude::*;
+use crate::recover::model::*;
+use crate::swapper::Swapper;
+use crate::utils;
+
+/// Handler for updating send swaps with recovered data
+pub(crate) struct SendSwapHandler;
+
+#[async_trait]
+impl SwapRecoverHandler for SendSwapHandler {
+    async fn recover_swap(
+        &self,
+        swap: &mut Swap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<bool> {
+        if let Swap::Send(send_swap) = swap {
+            Self::recover_and_update_swap(send_swap, context, is_local_within_grace_period)
+                .await
+                .map(|_| true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl SendSwapHandler {
+    /// Check if send swap recovery should be skipped
+    pub fn should_skip_recovery(
+        send_swap: &SendSwap,
+        recovered_data: &RecoveredOnchainDataSend,
+        is_local_within_grace_period: bool,
+    ) -> bool {
+        let swap_id = &send_swap.id;
+        let lockup_is_cleared =
+            send_swap.lockup_tx_id.is_some() && recovered_data.lockup_tx_id.is_none();
+        let refund_is_cleared =
+            send_swap.refund_tx_id.is_some() && recovered_data.refund_tx_id.is_none();
+
+        if is_local_within_grace_period && (lockup_is_cleared || refund_is_cleared) {
+            warn!(
+                "Local send swap {swap_id} was updated recently - skipping recovery \
+                as it would clear a tx that may have been broadcasted by us. Lockup clear: \
+                {lockup_is_cleared} - Refund clear: {refund_is_cleared}"
+            );
+            return true;
+        }
+
+        false
+    }
+
+    /// Recover and update a send swap with data from the chain
+    pub async fn recover_and_update_swap(
+        send_swap: &mut SendSwap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        let swap_id = send_swap.id.clone();
+        debug!("[Recover Send] Recovering data for swap {swap_id}");
+        let swap_script = send_swap.get_swap_script()?;
+        let lockup_script = swap_script
+            .funding_addrs
+            .ok_or(anyhow::anyhow!("err"))?
+            .script_pubkey();
+
+        let empty_history = Vec::<HistoryTxId>::new();
+        let history = context
+            .lbtc_script_to_history_map
+            .get(&lockup_script)
+            .unwrap_or(&empty_history);
+
+        // First obtain transaction IDs from the history
+        let mut recovered_data = Self::recover_onchain_data(&context.tx_map, &swap_id, history)?;
+
+        // Recover preimage if needed
+        if let Some(claim_tx_id) = &recovered_data.claim_tx_id {
+            if let Ok(claim_txs) = context
+                .liquid_chain_service
+                .get_transactions(&[claim_tx_id.txid])
+                .await
+            {
+                if !claim_txs.is_empty() {
+                    let preimage =
+                        Self::recover_preimage(&claim_txs[0], &swap_id, context.swapper.clone())
+                            .await?;
+                    recovered_data.preimage = preimage;
+                }
+            }
+        }
+
+        // Update the swap with recovered data
+        Self::update_swap(
+            send_swap,
+            &swap_id,
+            &recovered_data,
+            context.liquid_tip_height,
+            is_local_within_grace_period,
+        )
+    }
+
+    /// Update a send swap with recovered data
+    pub fn update_swap(
+        send_swap: &mut SendSwap,
+        swap_id: &str,
+        recovered_data: &RecoveredOnchainDataSend,
+        current_block_height: u32,
+        is_local_within_grace_period: bool,
+    ) -> Result<()> {
+        // Skip updating if within grace period and would clear transactions
+        if Self::should_skip_recovery(send_swap, recovered_data, is_local_within_grace_period) {
+            return Ok(());
+        }
+
+        // Update transaction IDs
+        send_swap.lockup_tx_id = recovered_data
+            .lockup_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+        send_swap.refund_tx_id = recovered_data
+            .refund_tx_id
+            .clone()
+            .map(|h| h.txid.to_string());
+
+        // Update preimage if valid
+        if let Some(preimage) = &recovered_data.preimage {
+            if send_swap.preimage.is_none() {
+                match utils::verify_payment_hash(preimage, &send_swap.invoice) {
+                    Ok(_) => send_swap.preimage = Some(preimage.clone()),
+                    Err(e) => {
+                        error!("Failed to verify recovered preimage for swap {swap_id}: {e}");
+                    }
+                }
+            }
+        }
+
+        // Update state based on recovered data
+        let timeout_block_height = send_swap.timeout_block_height as u32;
+        let is_expired = current_block_height >= timeout_block_height;
+        if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
+            send_swap.state = new_state;
+        }
+
+        Ok(())
+    }
+
+    /// Reconstruct Send Swap tx IDs from the onchain data
+    ///
+    /// The implementation tolerates a `tx_map` that is older than the history in the sense that
+    /// no incorrect data is recovered. Transactions that are missing from `tx_map` are simply not recovered.
+    fn recover_onchain_data(
+        tx_map: &TxMap,
+        swap_id: &str,
+        history: &[HistoryTxId],
+    ) -> Result<RecoveredOnchainDataSend> {
+        // If a history tx is one of our outgoing txs, it's a lockup tx
+        let lockup_tx_id = history
+            .iter()
+            .find(|&tx| tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
+            .cloned();
+
+        let claim_tx_id = if lockup_tx_id.is_some() {
+            // A history tx that is neither a known incoming or outgoing tx is a claim tx.
+            //
+            // Only find the claim_tx from the history if we find a lockup_tx. Not doing so will select
+            // the first tx as the claim, whereas we should check that the claim is not the lockup.
+            history
+                .iter()
+                .filter(|&tx| !tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
+                .find(|&tx| !tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
+                .cloned()
+        } else {
+            error!("No lockup tx found when recovering data for Send Swap {swap_id}");
+            None
+        };
+
+        // If a history tx is one of our incoming txs, it's a refund tx
+        let refund_tx_id = history
+            .iter()
+            .find(|&tx| tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
+            .cloned();
+
+        Ok(RecoveredOnchainDataSend {
+            lockup_tx_id,
+            claim_tx_id,
+            refund_tx_id,
+            preimage: None,
+        })
+    }
+
+    /// Tries to recover the preimage for a send swap from its claim tx
+    async fn recover_preimage(
+        claim_tx: &lwk_wollet::elements::Transaction,
+        swap_id: &str,
+        swapper: Arc<dyn Swapper>,
+    ) -> Result<Option<String>> {
+        // Try cooperative first
+        if let Ok(preimage) = swapper.get_submarine_preimage(swap_id).await {
+            println!("Found Send Swap {swap_id} preimage cooperatively: {preimage}");
+            return Ok(Some(preimage));
+        }
+        warn!("Could not recover Send swap {swap_id} preimage cooperatively");
+        match Self::extract_preimage_from_claim_tx(claim_tx, swap_id) {
+            Ok(preimage) => Ok(Some(preimage)),
+            Err(e) => {
+                error!(
+                    "Couldn't get swap preimage from claim tx {} for swap {swap_id}: {e}",
+                    claim_tx.txid()
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Extracts the preimage from a claim tx
+    pub fn extract_preimage_from_claim_tx(
+        claim_tx: &lwk_wollet::elements::Transaction,
+        swap_id: &str,
+    ) -> Result<String> {
+        use lwk_wollet::bitcoin::Witness;
+        use lwk_wollet::hashes::{sha256, Hash as _};
+
+        let input = claim_tx
+            .input
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("Found no input for claim tx"))?;
+
+        let script_witness_bytes = input.clone().witness.script_witness;
+        log::debug!("Found Send Swap {swap_id} claim tx witness: {script_witness_bytes:?}");
+        let script_witness = Witness::from(script_witness_bytes);
+
+        let preimage_bytes = script_witness
+            .nth(1)
+            .ok_or_else(|| anyhow::anyhow!("Claim tx witness has no preimage"))?;
+        let preimage = sha256::Hash::from_slice(preimage_bytes)
+            .map_err(|e| anyhow::anyhow!("Claim tx witness has invalid preimage: {e}"))?;
+        let preimage_hex = preimage.to_hex();
+        log::debug!("Found Send Swap {swap_id} claim tx preimage: {preimage_hex}");
+
+        Ok(preimage_hex)
+    }
+}
+
+pub(crate) struct RecoveredOnchainDataSend {
+    pub(crate) lockup_tx_id: Option<HistoryTxId>,
+    pub(crate) claim_tx_id: Option<HistoryTxId>,
+    pub(crate) refund_tx_id: Option<HistoryTxId>,
+    pub(crate) preimage: Option<String>,
+}
+
+impl RecoveredOnchainDataSend {
+    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
+        match &self.lockup_tx_id {
+            Some(_) => match &self.claim_tx_id {
+                Some(_) => Some(PaymentState::Complete),
+                None => match &self.refund_tx_id {
+                    Some(refund_tx_id) => match refund_tx_id.confirmed() {
+                        true => Some(PaymentState::Failed),
+                        false => Some(PaymentState::RefundPending),
+                    },
+                    None => match is_expired {
+                        true => Some(PaymentState::RefundPending),
+                        false => Some(PaymentState::Pending),
+                    },
+                },
+            },
+            None => match is_expired {
+                true => Some(PaymentState::Failed),
+                // We have no onchain data to support deriving the state as the swap could
+                // potentially be Created or TimedOut. In this case we return None.
+                false => None,
+            },
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/mod.rs
+++ b/lib/core/src/recover/handlers/mod.rs
@@ -2,6 +2,7 @@ mod handle_chain_receive_swap;
 mod handle_chain_send_swap;
 mod handle_receive_swap;
 mod handle_send_swap;
+mod tests;
 
 pub(crate) use self::handle_chain_receive_swap::ChainReceiveSwapHandler;
 pub(crate) use self::handle_chain_send_swap::ChainSendSwapHandler;

--- a/lib/core/src/recover/handlers/mod.rs
+++ b/lib/core/src/recover/handlers/mod.rs
@@ -4,7 +4,64 @@ mod handle_receive_swap;
 mod handle_send_swap;
 mod tests;
 
+use lwk_wollet::elements::Txid;
+
 pub(crate) use self::handle_chain_receive_swap::ChainReceiveSwapHandler;
 pub(crate) use self::handle_chain_send_swap::ChainSendSwapHandler;
 pub(crate) use self::handle_receive_swap::ReceiveSwapHandler;
 pub(crate) use self::handle_send_swap::SendSwapHandler;
+
+use super::model::{HistoryTxId, TxMap};
+
+/// Helper function for determining lockup and claim transactions in incoming swaps
+pub(crate) fn determine_incoming_lockup_and_claim_txs(
+    history: &[HistoryTxId],
+    tx_map: &TxMap,
+) -> (Option<HistoryTxId>, Option<HistoryTxId>) {
+    match history.len() {
+        // Only lockup tx available
+        1 => (Some(history[0].clone()), None),
+        2 => {
+            let first = history[0].clone();
+            let second = history[1].clone();
+
+            if tx_map.incoming_tx_map.contains_key::<Txid>(&first.txid) {
+                // If the first tx is a known incoming tx, it's the claim tx and the second is the lockup
+                (Some(second), Some(first))
+            } else if tx_map.incoming_tx_map.contains_key::<Txid>(&second.txid) {
+                // If the second tx is a known incoming tx, it's the claim tx and the first is the lockup
+                (Some(first), Some(second))
+            } else {
+                // If none of the 2 txs is the claim tx, then the txs are lockup and swapper refund
+                // If so, we expect them to be confirmed at different heights
+                let first_conf_height = first.height;
+                let second_conf_height = second.height;
+                match (first.confirmed(), second.confirmed()) {
+                    // If they're both confirmed, the one with the lowest confirmation height is the lockup
+                    (true, true) => match first_conf_height < second_conf_height {
+                        true => (Some(first), None),
+                        false => (Some(second), None),
+                    },
+
+                    // If only one tx is confirmed, then that is the lockup
+                    (true, false) => (Some(first), None),
+                    (false, true) => (Some(second), None),
+
+                    // If neither is confirmed, this is an edge-case, and the most likely cause is an
+                    // out of date wallet tx_map that doesn't yet include one of the txs.
+                    (false, false) => {
+                        log::warn!(
+                            "Found 2 unconfirmed txs in the claim script history. \
+                          Unable to determine if they include a swapper refund or a user claim"
+                        );
+                        (None, None)
+                    }
+                }
+            }
+        }
+        n => {
+            log::warn!("Unexpected script history length {n} while recovering data for swap");
+            (None, None)
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/mod.rs
+++ b/lib/core/src/recover/handlers/mod.rs
@@ -1,0 +1,9 @@
+mod handle_chain_receive_swap;
+mod handle_chain_send_swap;
+mod handle_receive_swap;
+mod handle_send_swap;
+
+pub(crate) use self::handle_chain_receive_swap::ChainReceiveSwapHandler;
+pub(crate) use self::handle_chain_send_swap::ChainSendSwapHandler;
+pub(crate) use self::handle_receive_swap::ReceiveSwapHandler;
+pub(crate) use self::handle_send_swap::SendSwapHandler;

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
@@ -9,7 +9,10 @@ mod test {
     };
     use boltz_client::boltz::PairLimits;
 
-    #[test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_btc_lockup_and_lbtc_claim() {
         let recovered_data = RecoveredOnchainDataChainReceive {
             lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -53,7 +56,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_btc_lockup_and_btc_refund() {
         // Test with confirmed refund
         let recovered_data = RecoveredOnchainDataChainReceive {
@@ -98,7 +101,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_btc_lockup_only() {
         // Test with correct lockup amount
         let recovered_data = RecoveredOnchainDataChainReceive {
@@ -145,7 +148,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_incorrect_lockup_amount() {
         let limits = PairLimits {
             minimal: 10000,
@@ -205,7 +208,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_no_txs() {
         let recovered_data = RecoveredOnchainDataChainReceive {
             lbtc_server_lockup_tx_id: None,
@@ -230,7 +233,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_claim_refund() {
         // This is an edge case where both claim and refund txs exist
         let recovered_data = RecoveredOnchainDataChainReceive {

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
@@ -1,0 +1,270 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        model::PaymentState,
+        recover::{
+            handlers::handle_chain_receive_swap::RecoveredOnchainDataChainReceive,
+            model::HistoryTxId,
+        },
+    };
+    use boltz_client::boltz::PairLimits;
+    use lwk_wollet::elements::Txid;
+    use lwk_wollet::hashes::Hash;
+
+    #[test]
+    fn test_derive_partial_state_with_btc_lockup_and_lbtc_claim() {
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_claim_tx_id: Some(create_history_txid("2222", 101)),
+            lbtc_claim_address: Some("lq1qqvynd50t4tajashdguell7nu9gycuqqd869w8vqww9ys9dsz7szdfeu7pwe4yzzme28qsluyfyrtqmq9scl5ydw4lesx3c5qu".to_string()),
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: None,
+        };
+
+        // When there's a lockup and confirmed claim tx, it should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Complete)
+        );
+
+        // Test with unconfirmed claim
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_claim_tx_id: Some(create_history_txid("2222", 0)), // Unconfirmed claim
+            lbtc_claim_address: Some("lq1qqvynd50t4tajashdguell7nu9gycuqqd869w8vqww9ys9dsz7szdfeu7pwe4yzzme28qsluyfyrtqmq9scl5ydw4lesx3c5qu".to_string()),
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: None,
+        };
+
+        // When there's a lockup and unconfirmed claim tx, it should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Pending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Pending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_btc_lockup_and_btc_refund() {
+        // Test with confirmed refund
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: Some(create_history_txid("4444", 103)), // Confirmed refund
+        };
+
+        // When there's a lockup and confirmed refund tx, it should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Failed)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Failed)
+        );
+
+        // Test with unconfirmed refund
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: Some(create_history_txid("4444", 0)), // Unconfirmed refund
+        };
+
+        // When there's a lockup and unconfirmed refund tx, it should be RefundPending
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::RefundPending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::RefundPending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_btc_lockup_only() {
+        // Test with correct lockup amount
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: None,
+        };
+
+        // Not expired yet - should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Pending)
+        );
+        // Not expired, waiting for fee acceptance
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, true),
+            Some(PaymentState::WaitingFeeAcceptance)
+        );
+        // Expired - should be Refundable
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Pending)
+        );
+
+        // Test with funds still in the address
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 100000, // Funds still in address
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: None,
+        };
+
+        // Expired with funds still in address - should be Refundable
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Refundable)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_incorrect_lockup_amount() {
+        let limits = PairLimits {
+            minimal: 10000,
+            maximal: 2000000,
+            maximal_zero_conf: 0,
+        };
+
+        // Test with amount below minimum
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 5000,
+            btc_user_lockup_amount_sat: 5000, // Below minimum
+            btc_refund_tx_id: None,
+        };
+
+        // Should be Refundable due to amount below minimum
+        assert_eq!(
+            recovered_data.derive_partial_state(None, Some(limits.clone()), false, false),
+            Some(PaymentState::Refundable)
+        );
+
+        // Test with amount above maximum
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 3000000,
+            btc_user_lockup_amount_sat: 3000000, // Above maximum
+            btc_refund_tx_id: None,
+        };
+
+        // Should be Refundable due to amount above maximum
+        assert_eq!(
+            recovered_data.derive_partial_state(None, Some(limits), false, false),
+            Some(PaymentState::Refundable)
+        );
+
+        // Test with unexpected amount
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 150000,
+            btc_user_lockup_amount_sat: 150000, // Different from expected
+            btc_refund_tx_id: None,
+        };
+
+        // Should be Refundable due to unexpected amount
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Refundable)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_no_txs() {
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: None,
+            lbtc_claim_tx_id: None,
+            lbtc_claim_address: None,
+            btc_user_lockup_tx_id: None,
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 0,
+            btc_refund_tx_id: None,
+        };
+
+        // Not expired yet - should return None because we can't determine the state
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            None
+        );
+
+        // Expired - should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Failed)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_claim_refund() {
+        // This is an edge case where both claim and refund txs exist
+        let recovered_data = RecoveredOnchainDataChainReceive {
+            lbtc_server_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_claim_tx_id: Some(create_history_txid("2222", 101)),
+            lbtc_claim_address: Some("lq1qqvynd50t4tajashdguell7nu9gycuqqd869w8vqww9ys9dsz7szdfeu7pwe4yzzme28qsluyfyrtqmq9scl5ydw4lesx3c5qu".to_string()),
+            btc_user_lockup_tx_id: Some(create_history_txid("3333", 102)),
+            btc_user_lockup_address_balance_sat: 0,
+            btc_user_lockup_amount_sat: 100000,
+            btc_refund_tx_id: Some(create_history_txid("4444", 103)),
+        };
+
+        // Complete state should take precedence over refund
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, false, false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(Some(100000), None, true, false),
+            Some(PaymentState::Complete)
+        );
+    }
+
+    // Helper function to create a HistoryTxId for testing
+    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
+        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
+        let mut txid_array = [0u8; 32];
+        txid_array.copy_from_slice(&txid_bytes);
+
+        HistoryTxId {
+            txid: Txid::from_slice(&txid_array).unwrap(),
+            height,
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
@@ -2,14 +2,12 @@
 mod test {
     use crate::{
         model::PaymentState,
-        recover::{
-            handlers::handle_chain_receive_swap::RecoveredOnchainDataChainReceive,
-            model::HistoryTxId,
+        recover::handlers::{
+            handle_chain_receive_swap::RecoveredOnchainDataChainReceive,
+            tests::test::create_history_txid,
         },
     };
     use boltz_client::boltz::PairLimits;
-    use lwk_wollet::elements::Txid;
-    use lwk_wollet::hashes::Hash;
 
     #[test]
     fn test_derive_partial_state_with_btc_lockup_and_lbtc_claim() {
@@ -254,17 +252,5 @@ mod test {
             recovered_data.derive_partial_state(Some(100000), None, true, false),
             Some(PaymentState::Complete)
         );
-    }
-
-    // Helper function to create a HistoryTxId for testing
-    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
-        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
-        let mut txid_array = [0u8; 32];
-        txid_array.copy_from_slice(&txid_bytes);
-
-        HistoryTxId {
-            txid: Txid::from_slice(&txid_array).unwrap(),
-            height,
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
@@ -124,7 +124,7 @@ mod test {
             recovered_data.derive_partial_state(Some(100000), None, false, true),
             Some(PaymentState::WaitingFeeAcceptance)
         );
-        // Expired - should be Refundable
+        // Expired without balance - should be Pending
         assert_eq!(
             recovered_data.derive_partial_state(Some(100000), None, true, false),
             Some(PaymentState::Pending)

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
@@ -20,7 +20,10 @@ mod test {
     };
     use std::{collections::HashMap, str::FromStr, sync::Arc};
 
-    #[tokio::test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_btc_lockup_and_lbtc_claim() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -87,7 +90,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_btc_lockup_only() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -129,7 +132,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_btc_lockup_and_refund() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -173,7 +176,7 @@ mod test {
         assert_eq!(chain_swap.claim_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_expired_swap() {
         // Setup mock data
         let (mut chain_swap, mut recovery_context) = setup_test_data();
@@ -225,7 +228,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_incorrect_amount() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -268,7 +271,7 @@ mod test {
         assert_eq!(chain_swap.actual_payer_amount_sat, Some(50000));
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_no_transactions() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -290,7 +293,7 @@ mod test {
         assert_eq!(chain_swap.claim_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recovery_within_grace_period() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
@@ -1,0 +1,601 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        chain::liquid::MockLiquidChainService,
+        model::{ChainSwap, PaymentState, SwapMetadata},
+        recover::{
+            handlers::ChainReceiveSwapHandler,
+            model::{HistoryTxId, RecoveryContext, TxMap},
+        },
+        swapper::MockSwapper,
+    };
+    use boltz_client::{
+        bitcoin::{self, transaction::Version, Sequence},
+        Amount, LockTime,
+    };
+    use electrum_client::GetBalanceRes;
+    use lwk_wollet::{
+        elements::{self, AssetId, Transaction, TxIn, TxInWitness, Txid},
+        elements_miniscript::slip77::MasterBlindingKey,
+        WalletTx,
+    };
+    use std::{
+        collections::{BTreeMap, HashMap},
+        str::FromStr,
+        sync::Arc,
+    };
+
+    #[tokio::test]
+    async fn test_recover_with_btc_lockup_and_lbtc_claim() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add BTC lockup tx to history
+        let btc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let (recovery_context, btc_lockup_tx_id) = add_btc_lockup_to_context(
+            recovery_context,
+            &btc_lockup_script,
+            100, // Confirmed height
+            chain_swap.payer_amount_sat,
+        );
+
+        // Add LBTC claim tx to history
+        let lbtc_claim_script = chain_swap
+            .get_claim_swap_script()
+            .unwrap()
+            .as_liquid_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let lbtc_server_lockup_tx_id =
+            "2222222222222222222222222222222222222222222222222222222222222222";
+        let lbtc_claim_tx_id = "3333333333333333333333333333333333333333333333333333333333333333";
+
+        let recovery_context = add_lbtc_history_to_context(
+            recovery_context,
+            &lbtc_claim_script,
+            &[(lbtc_server_lockup_tx_id, 101), (lbtc_claim_tx_id, 102)],
+            lbtc_claim_tx_id,
+            chain_swap.receiver_amount_sat,
+        );
+
+        // Test recover swap
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Complete);
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
+        assert_eq!(
+            chain_swap.server_lockup_tx_id,
+            Some(lbtc_server_lockup_tx_id.to_string())
+        );
+        assert_eq!(chain_swap.claim_tx_id, Some(lbtc_claim_tx_id.to_string()));
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_btc_lockup_only() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add BTC lockup tx to history
+        let btc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let (recovery_context, btc_lockup_tx_id) = add_btc_lockup_to_context(
+            recovery_context,
+            &btc_lockup_script,
+            100, // Confirmed height
+            chain_swap.payer_amount_sat,
+        );
+
+        // Test recover swap
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Pending); // Not expired -> Pending
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_btc_lockup_and_refund() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add BTC lockup tx to history
+        let btc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let (recovery_context, btc_lockup_tx_id, btc_refund_tx_id) =
+            add_btc_lockup_and_refund_to_context(
+                recovery_context,
+                &btc_lockup_script,
+                102, // Confirmed height
+                100, // Confirmed height
+                chain_swap.payer_amount_sat,
+            );
+
+        // Test recover swap
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Failed);
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
+        assert_eq!(chain_swap.refund_tx_id, Some(btc_refund_tx_id.to_string()));
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_expired_swap() {
+        // Setup mock data
+        let (mut chain_swap, mut recovery_context) = setup_test_data();
+
+        // Make the swap expired
+        recovery_context.bitcoin_tip_height = chain_swap.timeout_block_height + 10;
+
+        // Add BTC lockup tx to history
+        let btc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let (mut recovery_context, btc_lockup_tx_id) = add_btc_lockup_to_context(
+            recovery_context,
+            &btc_lockup_script,
+            100, // Confirmed height
+            chain_swap.payer_amount_sat,
+        );
+
+        // Add balance to the lockup address to simulate funds still there
+        recovery_context.btc_script_to_balance_map.insert(
+            btc_lockup_script.clone(),
+            GetBalanceRes {
+                confirmed: chain_swap.payer_amount_sat,
+                unconfirmed: 0,
+            },
+        );
+
+        // Test recover swap
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Refundable); // Expired with funds -> Refundable
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_incorrect_amount() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Expected amount
+        chain_swap.payer_amount_sat = 100000;
+
+        // Add BTC lockup tx to history with wrong amount
+        let btc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let (recovery_context, btc_lockup_tx_id) = add_btc_lockup_to_context(
+            recovery_context,
+            &btc_lockup_script,
+            100,   // Confirmed height
+            50000, // Less than expected
+        );
+
+        // Test recover swap
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Refundable); // Wrong amount -> Refundable
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
+        assert_eq!(chain_swap.actual_payer_amount_sat, Some(50000));
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_no_transactions() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Test recover swap (no transactions in history)
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Created); // No change since no tx info
+        assert_eq!(chain_swap.user_lockup_tx_id, None);
+        assert_eq!(chain_swap.refund_tx_id, None);
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_within_grace_period() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Set existing tx IDs
+        chain_swap.user_lockup_tx_id = Some("existing-lockup-tx-id".to_string());
+        chain_swap.refund_tx_id = Some("existing-refund-tx-id".to_string());
+        chain_swap.server_lockup_tx_id = Some("existing-server-lockup-tx-id".to_string());
+        chain_swap.claim_tx_id = Some("existing-claim-tx-id".to_string());
+        chain_swap.claim_address = Some("existing-claim-address".to_string());
+
+        // Test recover swap (with grace period, but empty transaction history)
+        let result = ChainReceiveSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            true, // Within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        // Original txids should be preserved due to grace period
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some("existing-lockup-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.refund_tx_id,
+            Some("existing-refund-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.server_lockup_tx_id,
+            Some("existing-server-lockup-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.claim_tx_id,
+            Some("existing-claim-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.claim_address,
+            Some("existing-claim-address".to_string())
+        );
+    }
+
+    // Helper function to setup test data
+    fn setup_test_data() -> (ChainSwap, RecoveryContext) {
+        // Create a test chain swap
+        let chain_swap = ChainSwap {
+            id: "80MALuoKqcX".to_string(),
+            description: Some("Test swap".to_string()),
+            payer_amount_sat: 100000,
+            receiver_amount_sat: 95000,
+            actual_payer_amount_sat: None,
+            pair_fees_json: r#"{"id":"BTC/L-BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            create_response_json: r#"{"claim_details":{"swapTree":{"claimLeaf":{"output":"82012088a914afc2dd75ff1251e5142f0d2b4c484ae515bea2d88820daa822253d2de1da7728d41a5cdcf429d63e75096a10a03ecf777b26cd5f9bebac","version":196},"refundLeaf":{"output":"208401dec9e0a804f6297a6e0d3a683fdb927ce888a3997c824556504ef74c36c2ad03683d31b1","version":196}},"lockupAddress":"lq1pqg078dfv0880qtxs04mnz85fmj00x0va09y0cfkg2mn764w9pxd5d850e6sy86t6nzdsumuq970d0592f5r4kjjgkt04a3dmy8jr3p04cm993udvn8x9","serverPublicKey":"038401dec9e0a804f6297a6e0d3a683fdb927ce888a3997c824556504ef74c36c2","timeoutBlockHeight":3226984,"amount":98968,"blindingKey":"9dd5dd64cd82c46564d5c361dd632c24d8c0a6c6b86ce62ba0a0d05d1ae158f7"},"lockup_details":{"swapTree":{"claimLeaf":{"output":"82012088a914afc2dd75ff1251e5142f0d2b4c484ae515bea2d88820c460e9ddee0f9762362183457a98ae32fb1f4e7fd5e4f400cd43def3cc40c701ac","version":192},"refundLeaf":{"output":"20d945dfc41ed339ae02aefa0576aea34a4fa2b3adfb990b9f910a93e3163877b7ad035c720db1","version":192}},"lockupAddress":"bc1p7kaqml56kyzw6gwczgmswdnuk3e5dazvjv9arajdndyj76aaafrs5qgzxa","serverPublicKey":"03c460e9ddee0f9762362183457a98ae32fb1f4e7fd5e4f400cd43def3cc40c701","timeoutBlockHeight":881244,"amount":100000,"bip21":"bitcoin:bc1p7kaqml56kyzw6gwczgmswdnuk3e5dazvjv9arajdndyj76aaafrs5qgzxa?amount=0.001&label=Send%20to%20L-BTC%20address"}}"#.to_string(),
+            claim_private_key: "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
+            refund_private_key: "0000000000000000000000000000000000000000000000000000000000000002".to_string(),
+            user_lockup_tx_id: None,
+            server_lockup_tx_id: None,
+            claim_tx_id: None,
+            refund_tx_id: None,
+            claim_address: None,
+            created_at: 1000,
+            timeout_block_height: 1000,
+            state: PaymentState::Created,
+            metadata: SwapMetadata {
+                version: 1,
+                last_updated_at: 1000,
+                is_local: true,
+            },
+            direction: crate::model::Direction::Incoming,
+            lockup_address: "bc1p7kaqml56kyzw6gwczgmswdnuk3e5dazvjv9arajdndyj76aaafrs5qgzxa".to_string(),
+            preimage: "ce28697547391404b544ab8a108c6767fb7ad6c8e0cf133cdbab5c4e23403a62".to_string(),
+            accepted_receiver_amount_sat: Some(95000),
+            claim_fees_sat: 1000,
+            accept_zero_conf: true,
+            auto_accepted_fees: true,
+        };
+
+        // Create empty recovery context
+        let recovery_context = RecoveryContext {
+            lbtc_script_to_history_map: HashMap::new(),
+            btc_script_to_history_map: HashMap::new(),
+            btc_script_to_txs_map: HashMap::new(),
+            btc_script_to_balance_map: HashMap::new(),
+            tx_map: TxMap {
+                outgoing_tx_map: HashMap::new(),
+                incoming_tx_map: HashMap::new(),
+            },
+            liquid_tip_height: 900, // Below timeout height
+            bitcoin_tip_height: 900,
+            master_blinding_key: MasterBlindingKey::from_seed(&[]),
+            swapper: Arc::new(MockSwapper::new()),
+            liquid_chain_service: Arc::new(MockLiquidChainService::new()),
+        };
+
+        (chain_swap, recovery_context)
+    }
+
+    // Helper to add a BTC lockup transaction to the recovery context
+    fn add_btc_lockup_to_context(
+        mut context: RecoveryContext,
+        lockup_script: &bitcoin::ScriptBuf,
+        height: u32,
+        amount: u64,
+    ) -> (RecoveryContext, String) {
+        // Create a BTC transaction for the lockup
+        let tx = bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![],
+            output: vec![bitcoin::TxOut {
+                value: Amount::from_sat(amount),
+                script_pubkey: lockup_script.clone(),
+            }],
+        };
+
+        // Compute the actual txid from the transaction
+        let computed_txid = tx.compute_txid();
+        let computed_txid_str = computed_txid.to_string();
+
+        // Create history tx with the computed txid
+        let history_tx = HistoryTxId {
+            txid: computed_txid.to_string().parse().unwrap(),
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .btc_script_to_history_map
+            .get(lockup_script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx);
+        context
+            .btc_script_to_history_map
+            .insert(lockup_script.clone(), script_history);
+
+        // Add transaction to txs map
+        let mut txs = context
+            .btc_script_to_txs_map
+            .get(lockup_script)
+            .cloned()
+            .unwrap_or_default();
+        txs.push(tx);
+        context
+            .btc_script_to_txs_map
+            .insert(lockup_script.clone(), txs);
+
+        // Set balance to 0 (funds have been used)
+        context.btc_script_to_balance_map.insert(
+            lockup_script.clone(),
+            GetBalanceRes {
+                confirmed: 0,
+                unconfirmed: 0,
+            },
+        );
+
+        (context, computed_txid_str)
+    }
+
+    // Helper to add BTC lockup and refund transactions to the context
+    fn add_btc_lockup_and_refund_to_context(
+        context: RecoveryContext,
+        lockup_script: &bitcoin::ScriptBuf,
+        lockup_height: u32,
+        refund_height: u32,
+        amount: u64,
+    ) -> (RecoveryContext, String, String) {
+        // First add the lockup tx
+        let (mut context, lockup_tx_id) =
+            add_btc_lockup_to_context(context, lockup_script, lockup_height, amount);
+
+        // Create a BTC transaction for the refund
+        let lockup_bitcon_tx_id = bitcoin::Txid::from_str(&lockup_tx_id).unwrap();
+        let refund_tx = bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: lockup_bitcon_tx_id,
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::default(),
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: Amount::from_sat(amount - 1000),   // Subtract fee
+                script_pubkey: bitcoin::ScriptBuf::new(), // Destination address
+            }],
+        };
+
+        // Create history tx for refund
+        let refund_bitcoin_txid: Txid = refund_tx
+            .clone()
+            .compute_txid()
+            .to_string()
+            .parse()
+            .unwrap();
+        let refund_history_tx = HistoryTxId {
+            txid: refund_bitcoin_txid,
+            height: refund_height as i32,
+        };
+        // Add refund tx to script history
+        let mut script_history = context
+            .btc_script_to_history_map
+            .get(lockup_script)
+            .cloned()
+            .unwrap_or_default();
+
+        script_history.push(refund_history_tx);
+        context
+            .btc_script_to_history_map
+            .insert(lockup_script.clone(), script_history);
+
+        // Add refund tx to txs map
+        let mut txs = context
+            .btc_script_to_txs_map
+            .get(lockup_script)
+            .cloned()
+            .unwrap_or_default();
+        txs.push(refund_tx.clone());
+        context
+            .btc_script_to_txs_map
+            .insert(lockup_script.clone(), txs);
+
+        (context, lockup_tx_id, refund_tx.compute_txid().to_string())
+    }
+
+    // Helper to add LBTC transactions to the history
+    fn add_lbtc_history_to_context(
+        mut context: RecoveryContext,
+        claim_script: &elements::Script,
+        tx_ids: &[(/*tx_id*/ &str, /*height*/ u32)],
+        claim_tx_id_hex: &str,
+        amount: u64,
+    ) -> RecoveryContext {
+        // Add history txs
+        let mut history = Vec::new();
+        for (tx_id_hex, height) in tx_ids {
+            let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
+            history.push(HistoryTxId {
+                txid: tx_id,
+                height: *height as i32,
+            });
+
+            // If this is the claim tx, add it to the incoming tx map
+            if *tx_id_hex == claim_tx_id_hex {
+                let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, *height, amount as i64);
+                context.tx_map.incoming_tx_map.insert(tx_id, wallet_tx);
+            }
+        }
+
+        // Add to history map
+        context
+            .lbtc_script_to_history_map
+            .insert(claim_script.clone(), history);
+
+        context
+    }
+
+    // Create a mock LBTC wallet transaction
+    fn create_mock_lbtc_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
+        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
+
+        WalletTx {
+            txid: tx_id,
+            tx: create_empty_lbtc_transaction(),
+            height: Some(height),
+            fee: 1000,
+            timestamp: Some(1001), // Just after swap creation time
+            balance: {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
+                    amount,
+                );
+                map
+            },
+            outputs: vec![],
+            inputs: Vec::new(),
+            type_: "".to_string(),
+        }
+    }
+
+    // Create an empty LBTC transaction
+    fn create_empty_lbtc_transaction() -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: elements::LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                is_pegin: false,
+                script_sig: elements::Script::new(),
+                sequence: elements::Sequence::default(),
+                asset_issuance: Default::default(),
+                witness: TxInWitness::empty(),
+            }],
+            output: vec![],
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
@@ -4,7 +4,7 @@ mod test {
         chain::liquid::MockLiquidChainService,
         model::{ChainSwap, PaymentState, SwapMetadata},
         recover::{
-            handlers::ChainReceiveSwapHandler,
+            handlers::{tests::test::create_mock_lbtc_wallet_tx, ChainReceiveSwapHandler},
             model::{HistoryTxId, RecoveryContext, TxMap},
         },
         swapper::MockSwapper,
@@ -15,15 +15,10 @@ mod test {
     };
     use electrum_client::GetBalanceRes;
     use lwk_wollet::{
-        elements::{self, AssetId, Transaction, TxIn, TxInWitness, Txid},
+        elements::{self, Txid},
         elements_miniscript::slip77::MasterBlindingKey,
-        WalletTx,
     };
-    use std::{
-        collections::{BTreeMap, HashMap},
-        str::FromStr,
-        sync::Arc,
-    };
+    use std::{collections::HashMap, str::FromStr, sync::Arc};
 
     #[tokio::test]
     async fn test_recover_with_btc_lockup_and_lbtc_claim() {
@@ -556,46 +551,5 @@ mod test {
             .insert(claim_script.clone(), history);
 
         context
-    }
-
-    // Create a mock LBTC wallet transaction
-    fn create_mock_lbtc_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
-        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
-
-        WalletTx {
-            txid: tx_id,
-            tx: create_empty_lbtc_transaction(),
-            height: Some(height),
-            fee: 1000,
-            timestamp: Some(1001), // Just after swap creation time
-            balance: {
-                let mut map = BTreeMap::new();
-                map.insert(
-                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
-                    amount,
-                );
-                map
-            },
-            outputs: vec![],
-            inputs: Vec::new(),
-            type_: "".to_string(),
-        }
-    }
-
-    // Create an empty LBTC transaction
-    fn create_empty_lbtc_transaction() -> Transaction {
-        Transaction {
-            version: 2,
-            lock_time: elements::LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: Default::default(),
-                is_pegin: false,
-                script_sig: elements::Script::new(),
-                sequence: elements::Sequence::default(),
-                asset_issuance: Default::default(),
-                witness: TxInWitness::empty(),
-            }],
-            output: vec![],
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
@@ -2,11 +2,10 @@
 mod test {
     use crate::{
         model::PaymentState,
-        recover::{
-            handlers::handle_chain_send_swap::RecoveredOnchainDataChainSend, model::HistoryTxId,
+        recover::handlers::{
+            handle_chain_send_swap::RecoveredOnchainDataChainSend, tests::test::create_history_txid,
         },
     };
-    use lwk_wollet::hashes::Hash;
 
     #[test]
     fn test_derive_partial_state_with_lbtc_lockup_and_btc_claim() {
@@ -145,17 +144,5 @@ mod test {
             recovered_data.derive_partial_state(true),
             Some(PaymentState::Complete)
         );
-    }
-
-    // Helper function to create a HistoryTxId for testing
-    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
-        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
-        let mut txid_array = [0u8; 32];
-        txid_array.copy_from_slice(&txid_bytes);
-
-        HistoryTxId {
-            txid: lwk_wollet::elements::Txid::from_slice(&txid_array).unwrap(),
-            height,
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
@@ -1,0 +1,161 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        model::PaymentState,
+        recover::{
+            handlers::handle_chain_send_swap::RecoveredOnchainDataChainSend, model::HistoryTxId,
+        },
+    };
+    use lwk_wollet::hashes::Hash;
+
+    #[test]
+    fn test_derive_partial_state_with_lbtc_lockup_and_btc_claim() {
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: None,
+            btc_server_lockup_tx_id: Some(create_history_txid("2222", 101)),
+            btc_claim_tx_id: Some(create_history_txid("3333", 102)),
+        };
+
+        // When there's a lockup and confirmed claim tx, it should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+
+        // Test with unconfirmed claim
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: None,
+            btc_server_lockup_tx_id: Some(create_history_txid("2222", 101)),
+            btc_claim_tx_id: Some(create_history_txid("3333", 0)), // Unconfirmed claim
+        };
+
+        // When there's a lockup and unconfirmed claim tx, it should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Pending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_and_refund() {
+        // Test with confirmed refund
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: Some(create_history_txid("4444", 102)),
+            btc_server_lockup_tx_id: Some(create_history_txid("2222", 101)),
+            btc_claim_tx_id: None,
+        };
+
+        // When there's a lockup and confirmed refund tx, it should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Failed)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+
+        // Test with unconfirmed refund
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: Some(create_history_txid("4444", 0)), // Unconfirmed refund
+            btc_server_lockup_tx_id: Some(create_history_txid("2222", 101)),
+            btc_claim_tx_id: None,
+        };
+
+        // When there's a lockup and unconfirmed refund tx, it should be RefundPending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::RefundPending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::RefundPending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_only() {
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: None,
+            btc_server_lockup_tx_id: None,
+            btc_claim_tx_id: None,
+        };
+
+        // Not expired yet - should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+
+        // Expired - should be RefundPending
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::RefundPending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_no_txs() {
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: None,
+            lbtc_refund_tx_id: None,
+            btc_server_lockup_tx_id: None,
+            btc_claim_tx_id: None,
+        };
+
+        // Not expired yet - should return None because we can't determine the state
+        assert_eq!(recovered_data.derive_partial_state(false), None);
+
+        // Expired - should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_claim_refund() {
+        // This is an edge case where both claim and refund txs exist
+        let recovered_data = RecoveredOnchainDataChainSend {
+            lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
+            lbtc_refund_tx_id: Some(create_history_txid("4444", 102)),
+            btc_server_lockup_tx_id: Some(create_history_txid("2222", 101)),
+            btc_claim_tx_id: Some(create_history_txid("3333", 103)),
+        };
+
+        // Complete state should take precedence over refund
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+    }
+
+    // Helper function to create a HistoryTxId for testing
+    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
+        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
+        let mut txid_array = [0u8; 32];
+        txid_array.copy_from_slice(&txid_bytes);
+
+        HistoryTxId {
+            txid: lwk_wollet::elements::Txid::from_slice(&txid_array).unwrap(),
+            height,
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
@@ -7,7 +7,10 @@ mod test {
         },
     };
 
-    #[test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lbtc_lockup_and_btc_claim() {
         let recovered_data = RecoveredOnchainDataChainSend {
             lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -45,7 +48,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_refund() {
         // Test with confirmed refund
         let recovered_data = RecoveredOnchainDataChainSend {
@@ -84,7 +87,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_only() {
         let recovered_data = RecoveredOnchainDataChainSend {
             lbtc_user_lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -106,7 +109,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_no_txs() {
         let recovered_data = RecoveredOnchainDataChainSend {
             lbtc_user_lockup_tx_id: None,
@@ -125,7 +128,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_claim_refund() {
         // This is an edge case where both claim and refund txs exist
         let recovered_data = RecoveredOnchainDataChainSend {

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -4,7 +4,7 @@ mod test {
         chain::liquid::MockLiquidChainService,
         model::{ChainSwap, PaymentState, SwapMetadata},
         recover::{
-            handlers::ChainSendSwapHandler,
+            handlers::{tests::test::create_mock_lbtc_wallet_tx, ChainSendSwapHandler},
             model::{HistoryTxId, RecoveryContext, TxMap},
         },
         swapper::MockSwapper,
@@ -15,16 +15,11 @@ mod test {
     };
     use lwk_wollet::{
         bitcoin::{transaction::Version, ScriptBuf, Sequence},
-        elements::{self, AssetId, Transaction, TxIn, TxInWitness},
+        elements::{self},
         elements_miniscript::slip77::MasterBlindingKey,
-        WalletTx,
     };
 
-    use std::{
-        collections::{BTreeMap, HashMap},
-        str::FromStr,
-        sync::Arc,
-    };
+    use std::{collections::HashMap, str::FromStr, sync::Arc};
 
     #[tokio::test]
     async fn test_recover_with_lbtc_lockup_and_btc_claim() {
@@ -455,47 +450,6 @@ mod test {
             .insert(script.clone(), txs.to_vec());
 
         context
-    }
-
-    // Create a mock LBTC wallet transaction
-    fn create_mock_lbtc_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
-        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
-
-        WalletTx {
-            txid: tx_id,
-            tx: create_empty_lbtc_transaction(),
-            height: Some(height),
-            fee: 1000,
-            timestamp: Some(1001), // Just after swap creation time
-            balance: {
-                let mut map = BTreeMap::new();
-                map.insert(
-                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
-                    amount,
-                );
-                map
-            },
-            outputs: Vec::new(),
-            inputs: Vec::new(),
-            type_: "".to_string(),
-        }
-    }
-
-    // Create an empty LBTC transaction
-    fn create_empty_lbtc_transaction() -> Transaction {
-        Transaction {
-            version: 2,
-            lock_time: elements::LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: Default::default(),
-                is_pegin: false,
-                script_sig: elements::Script::new(),
-                sequence: elements::Sequence::default(),
-                asset_issuance: Default::default(),
-                witness: TxInWitness::empty(),
-            }],
-            output: vec![],
-        }
     }
 
     // Create a simple BTC transaction

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -2,7 +2,7 @@
 mod test {
     use crate::{
         chain::liquid::MockLiquidChainService,
-        model::{ChainSwap,  PaymentState, SwapMetadata},
+        model::{ChainSwap, PaymentState, SwapMetadata},
         recover::{
             handlers::ChainSendSwapHandler,
             model::{HistoryTxId, RecoveryContext, TxMap},
@@ -10,12 +10,16 @@ mod test {
         swapper::MockSwapper,
     };
     use boltz_client::{
-        bitcoin::{self, OutPoint}, Amount, LockTime
+        bitcoin::{self, OutPoint},
+        Amount, LockTime,
     };
     use lwk_wollet::{
-        bitcoin::{transaction::Version, ScriptBuf, Sequence}, elements::{self, AssetId, Transaction, TxIn, TxInWitness}, elements_miniscript::slip77::MasterBlindingKey, WalletTx
+        bitcoin::{transaction::Version, ScriptBuf, Sequence},
+        elements::{self, AssetId, Transaction, TxIn, TxInWitness},
+        elements_miniscript::slip77::MasterBlindingKey,
+        WalletTx,
     };
-  
+
     use std::{
         collections::{BTreeMap, HashMap},
         str::FromStr,
@@ -63,9 +67,13 @@ mod test {
             &btc_claim_script,
             &[
                 (btc_lockup_tx_id, 102), // Server lockup tx
-                (btc_claim_tx_id, 101),   // Claim tx
+                (btc_claim_tx_id, 101),  // Claim tx
             ],
-            &[create_btc_transaction(btc_lockup_tx_id, &btc_claim_script, 100000)],
+            &[create_btc_transaction(
+                btc_lockup_tx_id,
+                &btc_claim_script,
+                100000,
+            )],
         );
 
         // Test recover swap
@@ -79,8 +87,14 @@ mod test {
         // Verify results
         assert!(result.is_ok());
         assert_eq!(chain_swap.state, PaymentState::Complete);
-        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
-        assert_eq!(chain_swap.server_lockup_tx_id, Some(btc_lockup_tx_id.to_string()));
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(lbtc_lockup_tx_id.to_string())
+        );
+        assert_eq!(
+            chain_swap.server_lockup_tx_id,
+            Some(btc_lockup_tx_id.to_string())
+        );
         assert_eq!(chain_swap.claim_tx_id, Some(btc_claim_tx_id.to_string()));
         assert_eq!(chain_swap.refund_tx_id, None);
     }
@@ -119,7 +133,10 @@ mod test {
         // Verify results
         assert!(result.is_ok());
         assert_eq!(chain_swap.state, PaymentState::Pending); // Not expired -> Pending
-        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(lbtc_lockup_tx_id.to_string())
+        );
         assert_eq!(chain_swap.server_lockup_tx_id, None);
         assert_eq!(chain_swap.claim_tx_id, None);
         assert_eq!(chain_swap.refund_tx_id, None);
@@ -169,7 +186,10 @@ mod test {
         // Verify results
         assert!(result.is_ok());
         assert_eq!(chain_swap.state, PaymentState::Failed);
-        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(lbtc_lockup_tx_id.to_string())
+        );
         assert_eq!(chain_swap.refund_tx_id, Some(lbtc_refund_tx_id.to_string()));
         assert_eq!(chain_swap.server_lockup_tx_id, None);
         assert_eq!(chain_swap.claim_tx_id, None);
@@ -212,7 +232,10 @@ mod test {
         // Verify results
         assert!(result.is_ok());
         assert_eq!(chain_swap.state, PaymentState::RefundPending); // Expired -> RefundPending
-        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some(lbtc_lockup_tx_id.to_string())
+        );
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
@@ -260,10 +283,22 @@ mod test {
         // Verify results
         assert!(result.is_ok());
         // Original txids should be preserved due to grace period
-        assert_eq!(chain_swap.user_lockup_tx_id, Some("existing-lockup-tx-id".to_string()));
-        assert_eq!(chain_swap.refund_tx_id, Some("existing-refund-tx-id".to_string()));
-        assert_eq!(chain_swap.server_lockup_tx_id, Some("existing-server-lockup-tx-id".to_string()));
-        assert_eq!(chain_swap.claim_tx_id, Some("existing-claim-tx-id".to_string()));
+        assert_eq!(
+            chain_swap.user_lockup_tx_id,
+            Some("existing-lockup-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.refund_tx_id,
+            Some("existing-refund-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.server_lockup_tx_id,
+            Some("existing-server-lockup-tx-id".to_string())
+        );
+        assert_eq!(
+            chain_swap.claim_tx_id,
+            Some("existing-claim-tx-id".to_string())
+        );
     }
 
     // Helper function to setup test data
@@ -282,7 +317,7 @@ mod test {
             user_lockup_tx_id: None,
             server_lockup_tx_id: None,
             claim_tx_id: None,
-            refund_tx_id: None, 
+            refund_tx_id: None,
             claim_address: None,
             created_at: 1000,
             timeout_block_height: 1000,
@@ -290,7 +325,7 @@ mod test {
             metadata: SwapMetadata {
                 version: 1,
                 last_updated_at: 1000,
-                is_local: true,                
+                is_local: true,
             },
             direction: crate::model::Direction::Outgoing,
             lockup_address: "lq1pqgpec4sq2mav432r8ukrr80d59rfpjv6qlqc5jrmwl5u5l2qazsh0astupq4jfr7r58sxp4kfvxy3nm49e9x4ecs9jurmwp45xmmavhejmcdcajegnpt".to_string(),
@@ -408,12 +443,16 @@ mod test {
                 height: *height as i32,
             });
         }
-                
+
         // Add to history map
-        context.btc_script_to_history_map.insert(script.clone(), history);
+        context
+            .btc_script_to_history_map
+            .insert(script.clone(), history);
 
         // Add to txs map
-        context.btc_script_to_txs_map.insert(script.clone(), txs.to_vec());
+        context
+            .btc_script_to_txs_map
+            .insert(script.clone(), txs.to_vec());
 
         context
     }
@@ -446,7 +485,7 @@ mod test {
     fn create_empty_lbtc_transaction() -> Transaction {
         Transaction {
             version: 2,
-            lock_time:elements::LockTime::from_height(0).unwrap(),
+            lock_time: elements::LockTime::from_height(0).unwrap(),
             input: vec![TxIn {
                 previous_output: Default::default(),
                 is_pegin: false,
@@ -460,7 +499,11 @@ mod test {
     }
 
     // Create a simple BTC transaction
-    fn create_btc_transaction(tx_id_hex: &str, claim_script: &bitcoin::ScriptBuf, amount: u64) -> bitcoin::Transaction {
+    fn create_btc_transaction(
+        tx_id_hex: &str,
+        claim_script: &bitcoin::ScriptBuf,
+        amount: u64,
+    ) -> bitcoin::Transaction {
         let prev_tx_id = bitcoin::Txid::from_str(tx_id_hex).unwrap();
         bitcoin::Transaction {
             version: Version::TWO,
@@ -475,7 +518,7 @@ mod test {
                 witness: bitcoin::Witness::new(),
             }],
             output: vec![bitcoin::TxOut {
-                value:  Amount::from_sat(amount),
+                value: Amount::from_sat(amount),
                 script_pubkey: claim_script.clone(),
             }],
         }

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -21,7 +21,10 @@ mod test {
 
     use std::{collections::HashMap, str::FromStr, sync::Arc};
 
-    #[tokio::test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lbtc_lockup_and_btc_claim() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -94,7 +97,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lbtc_lockup_only() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -137,7 +140,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lbtc_lockup_and_refund() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -190,7 +193,7 @@ mod test {
         assert_eq!(chain_swap.claim_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_expired_swap() {
         // Setup mock data
         let (mut chain_swap, mut recovery_context) = setup_test_data();
@@ -234,7 +237,7 @@ mod test {
         assert_eq!(chain_swap.refund_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_no_transactions() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();
@@ -256,7 +259,7 @@ mod test {
         assert_eq!(chain_swap.claim_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recovery_within_grace_period() {
         // Setup mock data
         let (mut chain_swap, recovery_context) = setup_test_data();

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -1,0 +1,483 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        chain::liquid::MockLiquidChainService,
+        model::{ChainSwap,  PaymentState, SwapMetadata},
+        recover::{
+            handlers::ChainSendSwapHandler,
+            model::{HistoryTxId, RecoveryContext, TxMap},
+        },
+        swapper::MockSwapper,
+    };
+    use boltz_client::{
+        bitcoin::{self, OutPoint}, Amount, LockTime
+    };
+    use lwk_wollet::{
+        bitcoin::{transaction::Version, ScriptBuf, Sequence}, elements::{self, AssetId, Transaction, TxIn, TxInWitness}, elements_miniscript::slip77::MasterBlindingKey, WalletTx
+    };
+  
+    use std::{
+        collections::{BTreeMap, HashMap},
+        str::FromStr,
+        sync::Arc,
+    };
+
+    #[tokio::test]
+    async fn test_recover_with_lbtc_lockup_and_btc_claim() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add LBTC lockup tx to history
+        let lbtc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_liquid_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let lbtc_lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lbtc_outgoing_tx_to_context(
+            recovery_context,
+            &lbtc_lockup_script,
+            lbtc_lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Add BTC claim tx to history
+        let btc_claim_script = chain_swap
+            .get_claim_swap_script()
+            .unwrap()
+            .as_bitcoin_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let btc_lockup_tx_id = "2222222222222222222222222222222222222222222222222222222222222222";
+        let btc_claim_tx_id = "3333333333333333333333333333333333333333333333333333333333333333";
+
+        let recovery_context = add_btc_history_to_context(
+            recovery_context,
+            &btc_claim_script,
+            &[
+                (btc_lockup_tx_id, 102), // Server lockup tx
+                (btc_claim_tx_id, 101),   // Claim tx
+            ],
+            &[create_btc_transaction(btc_lockup_tx_id, &btc_claim_script, 100000)],
+        );
+
+        // Test recover swap
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Complete);
+        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(chain_swap.server_lockup_tx_id, Some(btc_lockup_tx_id.to_string()));
+        assert_eq!(chain_swap.claim_tx_id, Some(btc_claim_tx_id.to_string()));
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_lbtc_lockup_only() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add LBTC lockup tx to history
+        let lbtc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_liquid_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let lbtc_lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lbtc_outgoing_tx_to_context(
+            recovery_context,
+            &lbtc_lockup_script,
+            lbtc_lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Test recover swap
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Pending); // Not expired -> Pending
+        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_lbtc_lockup_and_refund() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Add LBTC lockup tx to history
+        let lbtc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_liquid_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let lbtc_lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lbtc_outgoing_tx_to_context(
+            recovery_context,
+            &lbtc_lockup_script,
+            lbtc_lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Add refund tx to history
+        let lbtc_refund_tx_id = "4444444444444444444444444444444444444444444444444444444444444444";
+        let recovery_context = add_lbtc_incoming_tx_to_context(
+            recovery_context,
+            &lbtc_lockup_script,
+            lbtc_refund_tx_id,
+            102, // Confirmed
+            50000,
+        );
+
+        // Test recover swap
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Failed);
+        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(chain_swap.refund_tx_id, Some(lbtc_refund_tx_id.to_string()));
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_expired_swap() {
+        // Setup mock data
+        let (mut chain_swap, mut recovery_context) = setup_test_data();
+
+        // Make the swap expired
+        recovery_context.liquid_tip_height = chain_swap.timeout_block_height + 10;
+
+        // Add LBTC lockup tx to history
+        let lbtc_lockup_script = chain_swap
+            .get_lockup_swap_script()
+            .unwrap()
+            .as_liquid_script()
+            .unwrap()
+            .funding_addrs
+            .unwrap()
+            .script_pubkey();
+
+        let lbtc_lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lbtc_outgoing_tx_to_context(
+            recovery_context,
+            &lbtc_lockup_script,
+            lbtc_lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Test recover swap
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::RefundPending); // Expired -> RefundPending
+        assert_eq!(chain_swap.user_lockup_tx_id, Some(lbtc_lockup_tx_id.to_string()));
+        assert_eq!(chain_swap.refund_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_no_transactions() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Test recover swap (no transactions in history)
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(chain_swap.state, PaymentState::Created); // No change since no tx info
+        assert_eq!(chain_swap.user_lockup_tx_id, None);
+        assert_eq!(chain_swap.refund_tx_id, None);
+        assert_eq!(chain_swap.server_lockup_tx_id, None);
+        assert_eq!(chain_swap.claim_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_within_grace_period() {
+        // Setup mock data
+        let (mut chain_swap, recovery_context) = setup_test_data();
+
+        // Set existing tx IDs
+        chain_swap.user_lockup_tx_id = Some("existing-lockup-tx-id".to_string());
+        chain_swap.refund_tx_id = Some("existing-refund-tx-id".to_string());
+        chain_swap.server_lockup_tx_id = Some("existing-server-lockup-tx-id".to_string());
+        chain_swap.claim_tx_id = Some("existing-claim-tx-id".to_string());
+
+        // Test recover swap (with grace period, but empty transaction history)
+        let result = ChainSendSwapHandler::recover_swap(
+            &mut chain_swap,
+            &recovery_context,
+            true, // Within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        // Original txids should be preserved due to grace period
+        assert_eq!(chain_swap.user_lockup_tx_id, Some("existing-lockup-tx-id".to_string()));
+        assert_eq!(chain_swap.refund_tx_id, Some("existing-refund-tx-id".to_string()));
+        assert_eq!(chain_swap.server_lockup_tx_id, Some("existing-server-lockup-tx-id".to_string()));
+        assert_eq!(chain_swap.claim_tx_id, Some("existing-claim-tx-id".to_string()));
+    }
+
+    // Helper function to setup test data
+    fn setup_test_data() -> (ChainSwap, RecoveryContext) {
+        // Create a test chain swap
+        let chain_swap = ChainSwap {
+            id: "7aSRLEvFAJX3".to_string(),                     
+            description: Some("Test swap".to_string()),
+            payer_amount_sat: 100000,
+            receiver_amount_sat: 95000,
+            actual_payer_amount_sat: None,
+            pair_fees_json: r#"{"id":"L-BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            create_response_json: r#"{"claim_details":{"swapTree":{"claimLeaf":{"output":"82012088a9149667195b60a10b31c967bddb5e27018ae8b6a0cc882003638ddfdc02e0fef1af18a484a0488c1b36270edc95fe90546cb149c16d97f8ac","version":192},"refundLeaf":{"output":"209c1c861c296fc94eea3ba76e225d7d38755874a9ba3b2d74869512c5736852d5ad033c5b0db1","version":192}},"lockupAddress":"bc1p545knq6m5p5xuqswuux9kvf37vzpalr2xjp738zlp6cd23yjuz9sf5a6d3","serverPublicKey":"039c1c861c296fc94eea3ba76e225d7d38755874a9ba3b2d74869512c5736852d5","timeoutBlockHeight":875324,"amount":52221},"lockup_details":{"swapTree":{"claimLeaf":{"output":"82012088a9149667195b60a10b31c967bddb5e27018ae8b6a0cc88204ad74f69865a09bcff4699deb0b35c6784fb59ded212eedb9c520cb6e6c6d3d1ac","version":196},"refundLeaf":{"output":"20016278e04cfd8721ad8a87cf7ffa255ebdd22b3bb21a160dd8470a2aea44de81ad03a05a30b1","version":196}},"lockupAddress":"lq1pqgpec4sq2mav432r8ukrr80d59rfpjv6qlqc5jrmwl5u5l2qazsh0astupq4jfr7r58sxp4kfvxy3nm49e9x4ecs9jurmwp45xmmavhejmcdcajegnpt","serverPublicKey":"034ad74f69865a09bcff4699deb0b35c6784fb59ded212eedb9c520cb6e6c6d3d1","timeoutBlockHeight":3168928,"amount":54292,"blindingKey":"bbbfd86767009007a58862706f32f709bcd060422ed47dc375ef76afa8e0e478","bip21":"liquidnetwork:lq1pqgpec4sq2mav432r8ukrr80d59rfpjv6qlqc5jrmwl5u5l2qazsh0astupq4jfr7r58sxp4kfvxy3nm49e9x4ecs9jurmwp45xmmavhejmcdcajegnpt?amount=0.00054292&label=Send%20to%20BTC%20address&assetid=6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"}}"#.to_string(),
+            claim_private_key: "ba2e8fc169022b9eb11ff9312b8bc6a6187af70c83a86afc780211a222fca194".to_string(),
+            refund_private_key: "3efcaa05843a536cc028360c98af8fa57b8703a824cf0973213bec0f033c499a".to_string(),
+            user_lockup_tx_id: None,
+            server_lockup_tx_id: None,
+            claim_tx_id: None,
+            refund_tx_id: None, 
+            claim_address: None,
+            created_at: 1000,
+            timeout_block_height: 1000,
+            state: PaymentState::Created,
+            metadata: SwapMetadata {
+                version: 1,
+                last_updated_at: 1000,
+                is_local: true,                
+            },
+            direction: crate::model::Direction::Outgoing,
+            lockup_address: "lq1pqgpec4sq2mav432r8ukrr80d59rfpjv6qlqc5jrmwl5u5l2qazsh0astupq4jfr7r58sxp4kfvxy3nm49e9x4ecs9jurmwp45xmmavhejmcdcajegnpt".to_string(),
+            preimage: "72a639c5c09e0c68a15e7765f8eaa0efb0cb064c7c1e753bb9d5da907edbc427".to_string(),
+            accepted_receiver_amount_sat: None,
+            claim_fees_sat: 1221,
+            accept_zero_conf: true,
+            auto_accepted_fees: true,
+        };
+
+        // Create empty recovery context
+        let recovery_context = RecoveryContext {
+            lbtc_script_to_history_map: HashMap::new(),
+            btc_script_to_history_map: HashMap::new(),
+            btc_script_to_txs_map: HashMap::new(),
+            btc_script_to_balance_map: HashMap::new(),
+            tx_map: TxMap {
+                outgoing_tx_map: HashMap::new(),
+                incoming_tx_map: HashMap::new(),
+            },
+            liquid_tip_height: 900, // Below timeout height
+            bitcoin_tip_height: 900,
+            master_blinding_key: MasterBlindingKey::from_seed(&[]),
+            swapper: Arc::new(MockSwapper::new()),
+            liquid_chain_service: Arc::new(MockLiquidChainService::new()),
+        };
+
+        (chain_swap, recovery_context)
+    }
+
+    // Helper to add an LBTC outgoing transaction (lockup) to the recovery context
+    fn add_lbtc_outgoing_tx_to_context(
+        mut context: RecoveryContext,
+        script: &elements::Script,
+        tx_id_hex: &str,
+        height: u32,
+    ) -> RecoveryContext {
+        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx);
+        context
+            .lbtc_script_to_history_map
+            .insert(script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, -100000); // Negative amount for outgoing
+
+        // Add to outgoing tx map
+        context.tx_map.outgoing_tx_map.insert(tx_id, wallet_tx);
+
+        context
+    }
+
+    // Helper to add an LBTC incoming transaction (refund) to the recovery context
+    fn add_lbtc_incoming_tx_to_context(
+        mut context: RecoveryContext,
+        script: &elements::Script,
+        tx_id_hex: &str,
+        height: u32,
+        amount: u64,
+    ) -> RecoveryContext {
+        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx);
+        context
+            .lbtc_script_to_history_map
+            .insert(script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, amount as i64); // Positive for incoming
+
+        // Add to incoming tx map
+        context.tx_map.incoming_tx_map.insert(tx_id, wallet_tx);
+
+        context
+    }
+
+    // Helper to add BTC transactions and history to the recovery context
+    fn add_btc_history_to_context(
+        mut context: RecoveryContext,
+        script: &bitcoin::ScriptBuf,
+        tx_ids: &[(/*tx_id*/ &str, /*height*/ u32)],
+        txs: &[bitcoin::Transaction],
+    ) -> RecoveryContext {
+        // Add history txs
+        let mut history = Vec::new();
+        for (tx_id_hex, height) in tx_ids {
+            let tx_id = bitcoin::Txid::from_str(tx_id_hex).unwrap();
+            history.push(HistoryTxId {
+                txid: tx_id.to_string().parse().unwrap(),
+                height: *height as i32,
+            });
+        }
+                
+        // Add to history map
+        context.btc_script_to_history_map.insert(script.clone(), history);
+
+        // Add to txs map
+        context.btc_script_to_txs_map.insert(script.clone(), txs.to_vec());
+
+        context
+    }
+
+    // Create a mock LBTC wallet transaction
+    fn create_mock_lbtc_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
+        let tx_id = elements::Txid::from_str(tx_id_hex).unwrap();
+
+        WalletTx {
+            txid: tx_id,
+            tx: create_empty_lbtc_transaction(),
+            height: Some(height),
+            fee: 1000,
+            timestamp: Some(1001), // Just after swap creation time
+            balance: {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
+                    amount,
+                );
+                map
+            },
+            outputs: Vec::new(),
+            inputs: Vec::new(),
+            type_: "".to_string(),
+        }
+    }
+
+    // Create an empty LBTC transaction
+    fn create_empty_lbtc_transaction() -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time:elements::LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                is_pegin: false,
+                script_sig: elements::Script::new(),
+                sequence: elements::Sequence::default(),
+                asset_issuance: Default::default(),
+                witness: TxInWitness::empty(),
+            }],
+            output: vec![],
+        }
+    }
+
+    // Create a simple BTC transaction
+    fn create_btc_transaction(tx_id_hex: &str, claim_script: &bitcoin::ScriptBuf, amount: u64) -> bitcoin::Transaction {
+        let prev_tx_id = bitcoin::Txid::from_str(tx_id_hex).unwrap();
+        bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![bitcoin::TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx_id,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(1),
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value:  Amount::from_sat(amount),
+                script_pubkey: claim_script.clone(),
+            }],
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
@@ -2,10 +2,10 @@
 mod test {
     use crate::{
         model::PaymentState,
-        recover::{handlers::handle_receive_swap::RecoveredOnchainDataReceive, model::HistoryTxId},
+        recover::handlers::{
+            handle_receive_swap::RecoveredOnchainDataReceive, tests::test::create_history_txid,
+        },
     };
-    use lwk_wollet::elements::Txid;
-    use lwk_wollet::hashes::Hash;
 
     #[test]
     fn test_derive_partial_state_with_lockup_and_claim() {
@@ -124,17 +124,5 @@ mod test {
             recovered_data.derive_partial_state(true),
             Some(PaymentState::Failed)
         );
-    }
-
-    // Helper function to create a HistoryTxId for testing
-    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
-        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
-        let mut txid_array = [0u8; 32];
-        txid_array.copy_from_slice(&txid_bytes);
-
-        HistoryTxId {
-            txid: Txid::from_slice(&txid_array).unwrap(),
-            height,
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
@@ -7,7 +7,10 @@ mod test {
         },
     };
 
-    #[test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_claim() {
         // Test with confirmed claim
         let recovered_data = RecoveredOnchainDataReceive {
@@ -46,7 +49,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_only() {
         let recovered_data = RecoveredOnchainDataReceive {
             lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -68,7 +71,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_mrh_tx() {
         // Test with confirmed MRH tx
         let recovered_data = RecoveredOnchainDataReceive {
@@ -107,7 +110,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_no_txs() {
         let recovered_data = RecoveredOnchainDataReceive {
             lockup_tx_id: None,

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
@@ -1,0 +1,140 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        model::PaymentState,
+        recover::{handlers::handle_receive_swap::RecoveredOnchainDataReceive, model::HistoryTxId},
+    };
+    use lwk_wollet::elements::Txid;
+    use lwk_wollet::hashes::Hash;
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_and_claim() {
+        // Test with confirmed claim
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: Some(create_history_txid("2222", 101)), // Confirmed claim
+            mrh_tx_id: None,
+            mrh_amount_sat: None,
+        };
+
+        // When there's a lockup and confirmed claim tx, it should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+
+        // Test with unconfirmed claim
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: Some(create_history_txid("2222", 0)), // Unconfirmed claim
+            mrh_tx_id: None,
+            mrh_amount_sat: None,
+        };
+
+        // When there's a lockup and unconfirmed claim tx, it should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Pending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_only() {
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: None,
+            mrh_tx_id: None,
+            mrh_amount_sat: None,
+        };
+
+        // Not expired yet - should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+
+        // Expired - should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_mrh_tx() {
+        // Test with confirmed MRH tx
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: None,
+            claim_tx_id: None,
+            mrh_tx_id: Some(create_history_txid("3333", 103)),
+            mrh_amount_sat: Some(100000),
+        };
+
+        // When there's a confirmed MRH tx, it should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+
+        // Test with unconfirmed MRH tx
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: None,
+            claim_tx_id: None,
+            mrh_tx_id: Some(create_history_txid("3333", 0)), // Unconfirmed MRH tx
+            mrh_amount_sat: Some(100000),
+        };
+
+        // When there's an unconfirmed MRH tx, it should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Pending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_no_txs() {
+        let recovered_data = RecoveredOnchainDataReceive {
+            lockup_tx_id: None,
+            claim_tx_id: None,
+            mrh_tx_id: None,
+            mrh_amount_sat: None,
+        };
+
+        // Not expired yet - should return None because we can't determine the state
+        assert_eq!(recovered_data.derive_partial_state(false), None);
+
+        // Expired - should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+    }
+
+    // Helper function to create a HistoryTxId for testing
+    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
+        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
+        let mut txid_array = [0u8; 32];
+        txid_array.copy_from_slice(&txid_bytes);
+
+        HistoryTxId {
+            txid: Txid::from_slice(&txid_array).unwrap(),
+            height,
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -15,7 +15,10 @@ mod test {
     use lwk_wollet::WalletTx;
     use std::{collections::HashMap, str::FromStr, sync::Arc};
 
-    #[tokio::test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_claim_tx() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();
@@ -55,7 +58,7 @@ mod test {
         assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_mrh_tx() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();
@@ -87,7 +90,7 @@ mod test {
         assert_eq!(receive_swap.mrh_tx_id, Some(mrh_tx_id.to_string()));
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_expired_swap() {
         // Setup mock data
         let (mut receive_swap, mut recovery_context) = setup_test_data();
@@ -110,7 +113,7 @@ mod test {
         assert_eq!(receive_swap.mrh_tx_id, None);
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lockup_no_claim() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();
@@ -141,7 +144,7 @@ mod test {
         assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lockup_expired() {
         // Setup mock data
         let (mut receive_swap, mut recovery_context) = setup_test_data();
@@ -175,7 +178,7 @@ mod test {
         assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_no_transactions() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();
@@ -195,7 +198,7 @@ mod test {
         assert_eq!(receive_swap.lockup_tx_id, None); // No lockup tx
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recovery_within_grace_period_claim() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();
@@ -220,7 +223,7 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_unconfirmed_tx() {
         // Setup mock data
         let (mut receive_swap, recovery_context) = setup_test_data();

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -4,22 +4,16 @@ mod test {
         chain::liquid::MockLiquidChainService,
         model::{PaymentState, ReceiveSwap, SwapMetadata},
         recover::{
-            handlers::ReceiveSwapHandler,
+            handlers::{tests::test::create_mock_wallet_tx, ReceiveSwapHandler},
             model::{HistoryTxId, RecoveryContext, TxMap},
         },
         swapper::MockSwapper,
     };
     use boltz_client::ElementsAddress;
-    use lwk_wollet::elements::{
-        AssetId, LockTime, Script, Sequence, Transaction, TxIn, TxInWitness, Txid,
-    };
+    use lwk_wollet::elements::{Script, Txid};
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
     use lwk_wollet::WalletTx;
-    use std::{
-        collections::{BTreeMap, HashMap},
-        str::FromStr,
-        sync::Arc,
-    };
+    use std::{collections::HashMap, str::FromStr, sync::Arc};
 
     #[tokio::test]
     async fn test_recover_with_claim_tx() {
@@ -344,7 +338,7 @@ mod test {
             .insert(claim_script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount);
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64);
 
         // Add to incoming tx map
         context
@@ -411,7 +405,7 @@ mod test {
             .insert(mrh_script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount);
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64);
 
         // Add to incoming tx map
         context
@@ -420,42 +414,5 @@ mod test {
             .insert(tx_id, wallet_tx.clone());
 
         (context, wallet_tx)
-    }
-
-    // Create a mock wallet transaction
-    fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: u64) -> WalletTx {
-        let tx_id = Txid::from_str(tx_id_hex).unwrap();
-
-        // Create balance for the transaction
-        let mut balance = BTreeMap::new();
-        balance.insert(AssetId::default(), amount as i64);
-
-        WalletTx {
-            txid: tx_id,
-            tx: create_empty_transaction(),
-            height: Some(height),
-            fee: 1000,
-            timestamp: Some(1001), // Just after swap creation time
-            balance,
-            outputs: Vec::new(),
-            inputs: Vec::new(),
-            type_: "".to_string(),
-        }
-    }
-
-    fn create_empty_transaction() -> Transaction {
-        Transaction {
-            version: 2,
-            lock_time: LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: Default::default(),
-                is_pegin: false,
-                script_sig: Script::new(),
-                sequence: Sequence::default(),
-                asset_issuance: Default::default(),
-                witness: TxInWitness::empty(),
-            }],
-            output: vec![],
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -4,7 +4,7 @@ mod test {
         chain::liquid::MockLiquidChainService,
         model::{PaymentState, ReceiveSwap, SwapMetadata},
         recover::{
-            handlers::{tests::test::create_mock_wallet_tx, ReceiveSwapHandler},
+            handlers::{tests::test::create_mock_lbtc_wallet_tx, ReceiveSwapHandler},
             model::{HistoryTxId, RecoveryContext, TxMap},
         },
         swapper::MockSwapper,
@@ -341,7 +341,7 @@ mod test {
             .insert(claim_script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64);
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, amount as i64);
 
         // Add to incoming tx map
         context
@@ -408,7 +408,7 @@ mod test {
             .insert(mrh_script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64);
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, amount as i64);
 
         // Add to incoming tx map
         context

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -1,0 +1,461 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        chain::liquid::MockLiquidChainService,
+        model::{PaymentState, ReceiveSwap, SwapMetadata},
+        recover::{
+            handlers::ReceiveSwapHandler,
+            model::{HistoryTxId, RecoveryContext, TxMap},
+        },
+        swapper::MockSwapper,
+    };
+    use boltz_client::ElementsAddress;
+    use lwk_wollet::elements::{
+        AssetId, LockTime, Script, Sequence, Transaction, TxIn, TxInWitness, Txid,
+    };
+    use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
+    use lwk_wollet::WalletTx;
+    use std::{
+        collections::{BTreeMap, HashMap},
+        str::FromStr,
+        sync::Arc,
+    };
+
+    #[tokio::test]
+    async fn test_recover_with_claim_tx() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Setup a claim tx in the history
+        let claim_script = receive_swap.claim_script().unwrap();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lockup_tx_to_context(
+            recovery_context,
+            &claim_script,
+            lockup_tx_id,
+            100, // Confirmed
+        );
+
+        let claim_tx_id = "2222222222222222222222222222222222222222222222222222222222222222";
+        let (recovery_context, _) = add_claim_tx_to_context(
+            recovery_context,
+            &claim_script,
+            claim_tx_id,
+            101,    // Confirmed
+            100000, // Amount
+        );
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Complete);
+        assert_eq!(receive_swap.claim_tx_id, Some(claim_tx_id.to_string()));
+        assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_mrh_tx() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Setup an MRH tx in the history
+        let mrh_script = ElementsAddress::from_str(&receive_swap.mrh_address)
+            .unwrap()
+            .script_pubkey();
+        let mrh_tx_id = "3333333333333333333333333333333333333333333333333333333333333333";
+        let (recovery_context, _) = add_mrh_tx_to_context(
+            recovery_context,
+            &mrh_script,
+            mrh_tx_id,
+            102,    // Confirmed
+            150000, // Amount
+        );
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Complete);
+        assert_eq!(receive_swap.mrh_tx_id, Some(mrh_tx_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_recover_expired_swap() {
+        // Setup mock data
+        let (mut receive_swap, mut recovery_context) = setup_test_data();
+
+        // Set tip height to make swap expired
+        recovery_context.liquid_tip_height = receive_swap.timeout_block_height + 10;
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Failed);
+        assert_eq!(receive_swap.claim_tx_id, None);
+        assert_eq!(receive_swap.mrh_tx_id, None);
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_lockup_no_claim() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Setup only a lockup tx in the history
+        let claim_script = receive_swap.claim_script().unwrap();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lockup_tx_to_context(
+            recovery_context,
+            &claim_script,
+            lockup_tx_id,
+            100, // Confirmed
+        );
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Pending); // Should be pending
+        assert_eq!(receive_swap.claim_tx_id, None); // No claim tx
+        assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_lockup_expired() {
+        // Setup mock data
+        let (mut receive_swap, mut recovery_context) = setup_test_data();
+
+        // Make the swap expired
+        recovery_context.liquid_tip_height = receive_swap.timeout_block_height + 10;
+
+        // Setup only a lockup tx in the history
+        let claim_script = receive_swap.claim_script().unwrap();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lockup_tx_to_context(
+            recovery_context,
+            &claim_script,
+            lockup_tx_id,
+            100, // Confirmed
+        );
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Failed); // Should be failed since expired
+        assert_eq!(receive_swap.claim_tx_id, None); // No claim tx
+        assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_no_transactions() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Test recover swap (no transactions in history)
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Created); // Should remain as created
+        assert_eq!(receive_swap.claim_tx_id, None); // No claim tx
+        assert_eq!(receive_swap.lockup_tx_id, None); // No lockup tx
+    }
+
+    #[tokio::test]
+    async fn test_recovery_within_grace_period_claim() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Set existing claim tx ID in the swap
+        receive_swap.claim_tx_id = Some("existing-claim-tx-id".to_string());
+
+        // Test recover swap (with grace period, but no transactions in the chain)
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            true, // Within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        // Should still have the original claim_tx_id since we're in the grace period
+        assert_eq!(
+            receive_swap.claim_tx_id,
+            Some("existing-claim-tx-id".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_with_unconfirmed_tx() {
+        // Setup mock data
+        let (mut receive_swap, recovery_context) = setup_test_data();
+
+        // Setup an unconfirmed claim tx in the history
+        let claim_script = receive_swap.claim_script().unwrap();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_lockup_tx_to_context(
+            recovery_context,
+            &claim_script,
+            lockup_tx_id,
+            100, // Confirmed
+        );
+
+        let claim_tx_id = "2222222222222222222222222222222222222222222222222222222222222222";
+        let (recovery_context, _) = add_claim_tx_to_context(
+            recovery_context,
+            &claim_script,
+            claim_tx_id,
+            0,      // Unconfirmed (height = 0)
+            100000, // Amount
+        );
+
+        // Test recover swap
+        let result = ReceiveSwapHandler::recover_swap(
+            &mut receive_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(receive_swap.state, PaymentState::Pending); // Should be pending
+        assert_eq!(receive_swap.claim_tx_id, Some(claim_tx_id.to_string()));
+        assert_eq!(receive_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+    }
+
+    // Helper function to setup test data
+    fn setup_test_data() -> (ReceiveSwap, RecoveryContext) {
+        // Create a test receive swap
+        let receive_swap = ReceiveSwap {
+            id: "test-swap-id".to_string(),
+            preimage: "5747ef5affdf79f693ea56e6e65bb68718f57f160a92197bcac2fd456cb06edd".to_string(),
+            create_response_json: r#"{"swap_tree":{"claim_leaf":{"output":"82012088a91460bac83421a184c3cf912ae231df8e3f0ce6ac5488204c9f9e348b27b1257c51f3ad2a05589ac8f3af72246ff3094950441cdf826b47ac","version":196},"refund_leaf":{"output":"209916729fe59068c8544b8070a32f653ed9cb550e76a5caaeda557aadf9e2cc2fad03e48c31b1","version":196}},"lockup_address":"lq1pqw632yu95t23pa7jr4s746g68nwl0ukkfvncs3q7t66f9gjqj7ccj2nwx8verw57l2zn029vlnwjuvrpm4yxnz3tccfks9e8rdy2r9tu586g8fya887j","refund_public_key":"029916729fe59068c8544b8070a32f653ed9cb550e76a5caaeda557aadf9e2cc2f","timeout_block_height":3247332,"onchain_amount":1071,"blinding_key":"605f50d0c0516c800594e1d44b9ceaeb7fa7a4258d6357043cc2daaa13e48895"}"#.to_string(),
+            claim_private_key: "2f23dbb3c13e30ac8df594369b62ef1eb34a50197d7acc15db413961d90810e5".to_string(),
+            invoice: "lnbc11u1pn65lr9sp5xfmwgmaddn2acwc7rr4xhj3k5dy4tyfhma57tpfp0z7eyp90fdjspp5a48w03jc5dtzqnyyqw727naffpcdvhj7s9hen45zh9m3auhfmx2qdpz2djkuepqw3hjqnpdgf2yxgrpv3j8yetnwvxqyp2xqcqz95rzjqfxfl8353vnmzftu28e662s9tzdv3ua0wgjxlucff9gyg8xlsf45wzzxeyqq28qqqqqqqqqqqqqqq9gq2y9qyysgq37h36xnz7khazpus03846hml4q8y8qekrzwh5ql36fy6l7dmgyuq3d9jyvnmm3h8tmxn7ae20wgte2elq4akpu3mqnyj626zy69drmqq95tqch".to_string(),
+            payment_hash: Some("ed4ee7c658a356204c8403bcaf4fa94870d65e5e816f99d682b9771ef2e9d994".to_string()),
+            destination_pubkey: Some("03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f".to_string()),
+            description: Some("Test payment".to_string()),
+            payer_amount_sat: 100000,
+            receiver_amount_sat: 95000,
+            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            claim_fees_sat: 500,
+            claim_tx_id: None,
+            lockup_tx_id: None,
+            mrh_address: "lq1qqvynd50t4tajashdguell7nu9gycuqqd869w8vqww9ys9dsz7szdfeu7pwe4yzzme28qsluyfyrtqmq9scl5ydw4lesx3c5qu".to_string(),
+            mrh_tx_id: None,
+            created_at: 1000,
+            timeout_block_height: 1000,
+            state: PaymentState::Created,
+            metadata: SwapMetadata {
+                version: 1,
+                last_updated_at: 1000,
+                is_local: true,
+            },
+        };
+
+        // Create empty recovery context
+        let recovery_context = RecoveryContext {
+            lbtc_script_to_history_map: HashMap::new(),
+            btc_script_to_history_map: HashMap::new(),
+            btc_script_to_txs_map: HashMap::new(),
+            btc_script_to_balance_map: HashMap::new(),
+            tx_map: TxMap {
+                outgoing_tx_map: HashMap::new(),
+                incoming_tx_map: HashMap::new(),
+            },
+            liquid_tip_height: 900, // Below timeout height
+            bitcoin_tip_height: 900,
+            master_blinding_key: MasterBlindingKey::from_seed(&[]),
+            swapper: Arc::new(MockSwapper::new()),
+            liquid_chain_service: Arc::new(MockLiquidChainService::new()),
+        };
+
+        (receive_swap, recovery_context)
+    }
+
+    // Helper to add a claim transaction to the recovery context
+    fn add_claim_tx_to_context(
+        mut context: RecoveryContext,
+        claim_script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+        amount: u64,
+    ) -> (RecoveryContext, WalletTx) {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(claim_script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(claim_script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount);
+
+        // Add to incoming tx map
+        context
+            .tx_map
+            .incoming_tx_map
+            .insert(tx_id, wallet_tx.clone());
+
+        (context, wallet_tx)
+    }
+
+    fn add_lockup_tx_to_context(
+        mut context: RecoveryContext,
+        lockup_script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+    ) -> RecoveryContext {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(lockup_script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(lockup_script.clone(), script_history);
+
+        context
+    }
+
+    // Helper to add an MRH transaction to the recovery context
+    fn add_mrh_tx_to_context(
+        mut context: RecoveryContext,
+        mrh_script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+        amount: u64,
+    ) -> (RecoveryContext, WalletTx) {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(mrh_script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(mrh_script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount);
+
+        // Add to incoming tx map
+        context
+            .tx_map
+            .incoming_tx_map
+            .insert(tx_id, wallet_tx.clone());
+
+        (context, wallet_tx)
+    }
+
+    // Create a mock wallet transaction
+    fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: u64) -> WalletTx {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create balance for the transaction
+        let mut balance = BTreeMap::new();
+        balance.insert(AssetId::default(), amount as i64);
+
+        WalletTx {
+            txid: tx_id,
+            tx: create_empty_transaction(),
+            height: Some(height),
+            fee: 1000,
+            timestamp: Some(1001), // Just after swap creation time
+            balance,
+            outputs: Vec::new(),
+            inputs: Vec::new(),
+            type_: "".to_string(),
+        }
+    }
+
+    fn create_empty_transaction() -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                is_pegin: false,
+                script_sig: Script::new(),
+                sequence: Sequence::default(),
+                asset_issuance: Default::default(),
+                witness: TxInWitness::empty(),
+            }],
+            output: vec![],
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
@@ -7,7 +7,10 @@ mod test {
         },
     };
 
-    #[test]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_claim() {
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -27,7 +30,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_refund() {
         // Test with confirmed refund
         let recovered_data = RecoveredOnchainDataSend {
@@ -66,7 +69,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_only() {
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_history_txid("1111", 100)),
@@ -88,7 +91,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_no_txs() {
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: None,
@@ -107,7 +110,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_claim_refund() {
         // This is an edge case where both claim and refund txs exist
         let recovered_data = RecoveredOnchainDataSend {

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
@@ -2,9 +2,10 @@
 mod test {
     use crate::{
         model::PaymentState,
-        recover::{handlers::handle_send_swap::RecoveredOnchainDataSend, model::HistoryTxId},
+        recover::handlers::{
+            handle_send_swap::RecoveredOnchainDataSend, tests::test::create_history_txid,
+        },
     };
-    use lwk_wollet::{elements::Txid, hashes::Hash};
 
     #[test]
     fn test_derive_partial_state_with_lockup_and_claim() {
@@ -125,17 +126,5 @@ mod test {
             recovered_data.derive_partial_state(true),
             Some(PaymentState::Complete)
         );
-    }
-
-    // Helper function to create a HistoryTxId for testing
-    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
-        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
-        let mut txid_array = [0u8; 32];
-        txid_array.copy_from_slice(&txid_bytes);
-
-        HistoryTxId {
-            txid: Txid::from_slice(&txid_array).unwrap(),
-            height,
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
@@ -1,0 +1,141 @@
+#[cfg(test)]
+mod test {
+    use crate::{
+        model::PaymentState,
+        recover::{handlers::handle_send_swap::RecoveredOnchainDataSend, model::HistoryTxId},
+    };
+    use lwk_wollet::{elements::Txid, hashes::Hash};
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_and_claim() {
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: Some(create_history_txid("2222", 101)),
+            refund_tx_id: None,
+            preimage: None,
+        };
+
+        // When there's a lockup and claim tx, it should always be Complete, regardless of timeout
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_and_refund() {
+        // Test with confirmed refund
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: None,
+            refund_tx_id: Some(create_history_txid("3333", 102)),
+            preimage: None,
+        };
+
+        // When there's a lockup and confirmed refund tx, it should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Failed)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+
+        // Test with unconfirmed refund
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: None,
+            refund_tx_id: Some(create_history_txid("3333", 0)), // Unconfirmed tx
+            preimage: None,
+        };
+
+        // When there's a lockup and unconfirmed refund tx, it should be RefundPending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::RefundPending)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::RefundPending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_only() {
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: None,
+            refund_tx_id: None,
+            preimage: None,
+        };
+
+        // Not expired yet - should be Pending
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Pending)
+        );
+
+        // Expired - should be RefundPending
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::RefundPending)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_no_txs() {
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: None,
+            claim_tx_id: None,
+            refund_tx_id: None,
+            preimage: None,
+        };
+
+        // Not expired yet - should return None because we can't determine the state
+        assert_eq!(recovered_data.derive_partial_state(false), None);
+
+        // Expired - should be Failed
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Failed)
+        );
+    }
+
+    #[test]
+    fn test_derive_partial_state_with_lockup_claim_refund() {
+        // This is an edge case where both claim and refund txs exist
+        let recovered_data = RecoveredOnchainDataSend {
+            lockup_tx_id: Some(create_history_txid("1111", 100)),
+            claim_tx_id: Some(create_history_txid("2222", 101)),
+            refund_tx_id: Some(create_history_txid("3333", 102)),
+            preimage: None,
+        };
+
+        // Complete state should take precedence over refund
+        assert_eq!(
+            recovered_data.derive_partial_state(false),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(true),
+            Some(PaymentState::Complete)
+        );
+    }
+
+    // Helper function to create a HistoryTxId for testing
+    fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
+        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
+        let mut txid_array = [0u8; 32];
+        txid_array.copy_from_slice(&txid_bytes);
+
+        HistoryTxId {
+            txid: Txid::from_slice(&txid_array).unwrap(),
+            height,
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -2,12 +2,14 @@
 mod test {
     use crate::chain::liquid::MockLiquidChainService;
     use crate::prelude::*;
-    use crate::recover::handlers::tests::test::create_mock_lbtc_wallet_tx;
+    use crate::recover::handlers::tests::test::{
+        create_empty_lbtc_transaction, create_mock_lbtc_wallet_tx,
+    };
     use crate::recover::handlers::SendSwapHandler;
     use crate::recover::model::*;
     use crate::swapper::MockSwapper;
     use lwk_wollet::elements::script::Script;
-    use lwk_wollet::elements::{LockTime, Transaction, TxIn, TxInWitness, Txid};
+    use lwk_wollet::elements::Txid;
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
     use lwk_wollet::WalletTx;
     use mockall::predicate::*;
@@ -39,7 +41,7 @@ mod test {
         // Setup claim tx with preimage
         let claim_tx_id = "2222222222222222222222222222222222222222222222222222222222222222";
         let preimage = "49666c97f6cea07fa5780c22ece1f0c9957caf1e3c37b9037b4f64dc6d09be7f"; // base64 of "somepreimage1234567890"
-        let claim_tx = create_empty_transaction();
+        let claim_tx = create_empty_lbtc_transaction();
 
         // Setup the mock chain service to return our claim tx
         let mut mock_liquid_chain_service = MockLiquidChainService::new();
@@ -434,21 +436,5 @@ mod test {
             .insert(tx_id, wallet_tx.clone());
 
         (context, wallet_tx)
-    }
-
-    fn create_empty_transaction() -> Transaction {
-        Transaction {
-            version: 2,
-            lock_time: LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: Default::default(),
-                is_pegin: false,
-                script_sig: Script::new(),
-                sequence: lwk_wollet::elements::Sequence::default(),
-                asset_issuance: Default::default(),
-                witness: TxInWitness::empty(),
-            }],
-            output: vec![],
-        }
     }
 }

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -2,15 +2,16 @@
 mod test {
     use crate::chain::liquid::MockLiquidChainService;
     use crate::prelude::*;
+    use crate::recover::handlers::tests::test::create_mock_wallet_tx;
     use crate::recover::handlers::SendSwapHandler;
     use crate::recover::model::*;
     use crate::swapper::MockSwapper;
     use lwk_wollet::elements::script::Script;
-    use lwk_wollet::elements::{AssetId, LockTime, Transaction, TxIn, TxInWitness, Txid};
+    use lwk_wollet::elements::{LockTime, Transaction, TxIn, TxInWitness, Txid};
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
     use lwk_wollet::WalletTx;
     use mockall::predicate::*;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -430,30 +431,6 @@ mod test {
             .insert(tx_id, wallet_tx.clone());
 
         (context, wallet_tx)
-    }
-
-    // Create a mock wallet transaction
-    fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
-        let tx_id = Txid::from_str(tx_id_hex).unwrap();
-
-        WalletTx {
-            txid: tx_id,
-            tx: create_empty_transaction(),
-            height: Some(height),
-            fee: 1000,
-            timestamp: Some(1001), // Just after swap creation time
-            balance: {
-                let mut map = BTreeMap::new();
-                map.insert(
-                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
-                    amount,
-                );
-                map
-            },
-            outputs: Vec::new(),
-            inputs: Vec::new(),
-            type_: "".to_string(),
-        }
     }
 
     fn create_empty_transaction() -> Transaction {

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -1,0 +1,474 @@
+#[cfg(test)]
+mod test {
+    use crate::chain::liquid::MockLiquidChainService;
+    use crate::prelude::*;
+    use crate::recover::handlers::SendSwapHandler;
+    use crate::recover::model::*;
+    use crate::swapper::MockSwapper;
+    use lwk_wollet::elements::script::Script;
+    use lwk_wollet::elements::{AssetId, LockTime, Transaction, TxIn, TxInWitness, Txid};
+    use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
+    use lwk_wollet::WalletTx;
+    use mockall::predicate::*;
+    use std::collections::{BTreeMap, HashMap};
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    /// Test recovery with a claim transaction and preimage
+    #[tokio::test]
+    async fn test_recover_with_claim_tx_and_preimage() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Create a lockup tx
+        let swap_script = send_swap.get_swap_script().unwrap();
+        let lockup_script = swap_script.funding_addrs.unwrap().script_pubkey();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let mut recovery_context = add_outgoing_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Setup claim tx with preimage
+        let claim_tx_id = "2222222222222222222222222222222222222222222222222222222222222222";
+        let preimage = "49666c97f6cea07fa5780c22ece1f0c9957caf1e3c37b9037b4f64dc6d09be7f"; // base64 of "somepreimage1234567890"
+        let claim_tx = create_empty_transaction();
+
+        // Setup the mock chain service to return our claim tx
+        let mut mock_liquid_chain_service = MockLiquidChainService::new();
+        mock_liquid_chain_service
+            .expect_get_transactions()
+            .returning(move |_| Ok(vec![claim_tx.clone()]));
+
+        recovery_context.liquid_chain_service = Arc::new(mock_liquid_chain_service);
+
+        let mut swapper = MockSwapper::new();
+        swapper
+            .expect_get_submarine_preimage()
+            .returning(move |_| Ok(preimage.to_string()));
+        recovery_context.swapper = Arc::new(swapper);
+
+        // Add the claim tx to history
+        let recovery_context = add_claim_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            claim_tx_id,
+            101, // Confirmed
+        );
+
+        // Test recover swap
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::Complete);
+        assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+        assert_eq!(send_swap.preimage, Some(preimage.to_string()));
+    }
+
+    /// Test recovery with a lockup and refund transaction
+    #[tokio::test]
+    async fn test_recover_with_refund_tx() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Create a lockup tx
+        let swap_script = send_swap.get_swap_script().unwrap();
+        let lockup_script = swap_script.funding_addrs.unwrap().script_pubkey();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_outgoing_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Add a refund tx to history
+        let refund_tx_id = "3333333333333333333333333333333333333333333333333333333333333333";
+        let (recovery_context, _) = add_incoming_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            refund_tx_id,
+            102,   // Confirmed
+            50000, // Refund amount
+        );
+
+        // Test recover swap
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::Failed); // Confirmed refund -> Failed
+        assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+        assert_eq!(send_swap.refund_tx_id, Some(refund_tx_id.to_string()));
+    }
+
+    /// Test recovery with only a lockup tx (not expired)
+    #[tokio::test]
+    async fn test_recover_with_lockup_only() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Create a lockup tx
+        let swap_script = send_swap.get_swap_script().unwrap();
+        let lockup_script = swap_script.funding_addrs.unwrap().script_pubkey();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_outgoing_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Test recover swap
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::Pending); // Not expired -> Pending
+        assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+        assert_eq!(send_swap.refund_tx_id, None);
+    }
+
+    /// Test recovery with only a lockup tx (expired)
+    #[tokio::test]
+    async fn test_recover_with_lockup_expired() {
+        // Setup mock data
+        let (mut send_swap, mut recovery_context) = setup_test_data();
+
+        // Set tip height to make swap expired
+        recovery_context.liquid_tip_height = send_swap.timeout_block_height as u32 + 10;
+
+        // Create a lockup tx
+        let swap_script = send_swap.get_swap_script().unwrap();
+        let lockup_script = swap_script.funding_addrs.unwrap().script_pubkey();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_outgoing_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Test recover swap
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::RefundPending); // Expired -> RefundPending
+        assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+        assert_eq!(send_swap.refund_tx_id, None);
+    }
+
+    /// Test recovery with unconfirmed refund tx
+    #[tokio::test]
+    async fn test_recover_with_unconfirmed_refund() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Create a lockup tx
+        let swap_script = send_swap.get_swap_script().unwrap();
+        let lockup_script = swap_script.funding_addrs.unwrap().script_pubkey();
+
+        let lockup_tx_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let recovery_context = add_outgoing_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            lockup_tx_id,
+            100, // Confirmed height
+        );
+
+        // Add an unconfirmed refund tx
+        let refund_tx_id = "3333333333333333333333333333333333333333333333333333333333333333";
+        let (recovery_context, _) = add_incoming_tx_to_context(
+            recovery_context,
+            &lockup_script,
+            refund_tx_id,
+            0,     // Unconfirmed
+            50000, // Refund amount
+        );
+
+        // Test recover swap
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::RefundPending); // Unconfirmed refund -> RefundPending
+        assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
+        assert_eq!(send_swap.refund_tx_id, Some(refund_tx_id.to_string()));
+    }
+
+    /// Test recovery with no transactions
+    #[tokio::test]
+    async fn test_recover_with_no_transactions() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Test recover swap (no transactions in history)
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            false, // Not within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        assert_eq!(send_swap.state, PaymentState::Created); // No change since no tx info
+        assert_eq!(send_swap.lockup_tx_id, None);
+        assert_eq!(send_swap.refund_tx_id, None);
+    }
+
+    /// Test recovery when swap is within grace period
+    #[tokio::test]
+    async fn test_recovery_within_grace_period() {
+        // Setup mock data
+        let (mut send_swap, recovery_context) = setup_test_data();
+
+        // Set existing lockup and refund tx IDs
+        send_swap.lockup_tx_id = Some("existing-lockup-tx-id".to_string());
+        send_swap.refund_tx_id = Some("existing-refund-tx-id".to_string());
+
+        // Test recover swap (with grace period, but empty transaction history)
+        let result = SendSwapHandler::recover_swap(
+            &mut send_swap,
+            &recovery_context,
+            true, // Within grace period
+        )
+        .await;
+
+        // Verify results
+        assert!(result.is_ok());
+        // Original txids should be preserved due to grace period
+        assert_eq!(
+            send_swap.lockup_tx_id,
+            Some("existing-lockup-tx-id".to_string())
+        );
+        assert_eq!(
+            send_swap.refund_tx_id,
+            Some("existing-refund-tx-id".to_string())
+        );
+    }
+
+    // Helper function to setup test data
+    fn setup_test_data() -> (SendSwap, RecoveryContext) {
+        // Create a test send swap
+        let send_swap = SendSwap {
+            id: "test-swap-id".to_string(),
+            invoice: "lnbc10u1pnuv29epp5gzznge42jmaypq98xalte29hg8mddq7577uxvlv7alqtus2xgzjqhp52q6dyyex57klg3xhvl8tme05uwd5vghuuhm4av0gwgalx8vglr3qcqzzsxqyz5vqsp5l9r3lccpc258wq783c97n58wkk0ft5kqhdpp63ds75t93e7zu3ps9qxpqysgqmg2t6ry7mpr35jx6pq2ha960y2vwnl7050w87022g5qm00nyw83j47f8f6npr2yjmw2hennl8ewe87dj6nvg750zhcr3e94ypcxchdcp8q95j7".to_string(),
+            bolt12_offer: None,
+            payment_hash: Some("40853466aa96fa4080a7377ebca8b741f6d683d4f7b8667d9eefc0be414640a4".to_string()),
+            destination_pubkey: Some("03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f".to_string()),
+            description: Some("Test payment".to_string()),
+            preimage: None,
+            payer_amount_sat: 100000,
+            receiver_amount_sat: 95000,
+            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            create_response_json: r#"{"accept_zero_conf":true,"address":"lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv","bip21":"liquidnetwork:lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv?amount=0.00001015&label=Send%20to%20BTC%20lightning&assetid=6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d","claim_public_key":"0381b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123","expected_amount":1015,"referral_id":"breez-sdk","swap_tree":{"claim_leaf":{"output":"a914cea2d1aa5af00fb688727b0054de58ecf45e948f882081b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123ac","version":196},"refund_leaf":{"output":"20a668381222ff9076ca6d5f5b098b501331f07d5065f1dc0e0f217cc493359e69ad03b12432b1","version":196}},"timeout_block_height":3286193,"blinding_key":"73332603e5d438ddb3b12c16c7271c9f98658c77257cbb06639d05773aa1fec3"}"#.to_string(),
+            lockup_tx_id: None,
+            refund_tx_id: None,
+            created_at: 1000,
+            timeout_block_height: 1000,
+            state: PaymentState::Created,
+            refund_private_key: "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
+            metadata: SwapMetadata {
+                version: 1,
+                last_updated_at: 1000,
+                is_local: true,
+            },
+        };
+
+        // Create empty recovery context
+        let recovery_context = RecoveryContext {
+            lbtc_script_to_history_map: HashMap::new(),
+            btc_script_to_history_map: HashMap::new(),
+            btc_script_to_txs_map: HashMap::new(),
+            btc_script_to_balance_map: HashMap::new(),
+            tx_map: TxMap {
+                outgoing_tx_map: HashMap::new(),
+                incoming_tx_map: HashMap::new(),
+            },
+            liquid_tip_height: 900, // Below timeout height
+            bitcoin_tip_height: 900,
+            master_blinding_key: MasterBlindingKey::from_seed(&[]),
+            swapper: Arc::new(MockSwapper::new()),
+            liquid_chain_service: Arc::new(MockLiquidChainService::new()),
+        };
+
+        (send_swap, recovery_context)
+    }
+
+    // Helper to add an outgoing transaction (lockup) to the recovery context
+    fn add_outgoing_tx_to_context(
+        mut context: RecoveryContext,
+        script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+    ) -> RecoveryContext {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, -100000); // Negative amount for outgoing
+
+        // Add to outgoing tx map
+        context.tx_map.outgoing_tx_map.insert(tx_id, wallet_tx);
+
+        context
+    }
+
+    // Helper to add a claim tx to the history without adding it to the wallet tx map
+    fn add_claim_tx_to_context(
+        mut context: RecoveryContext,
+        script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+    ) -> RecoveryContext {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(script.clone(), script_history);
+
+        context
+    }
+
+    // Helper to add an incoming transaction (refund) to the recovery context
+    fn add_incoming_tx_to_context(
+        mut context: RecoveryContext,
+        script: &Script,
+        tx_id_hex: &str,
+        height: u32,
+        amount: u64,
+    ) -> (RecoveryContext, WalletTx) {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // Create history tx
+        let history_tx = HistoryTxId {
+            txid: tx_id,
+            height: height as i32,
+        };
+
+        // Add to script history map
+        let mut script_history = context
+            .lbtc_script_to_history_map
+            .get(script)
+            .cloned()
+            .unwrap_or_default();
+        script_history.push(history_tx.clone());
+        context
+            .lbtc_script_to_history_map
+            .insert(script.clone(), script_history);
+
+        // Create wallet tx
+        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64); // Positive amount for incoming
+
+        // Add to incoming tx map
+        context
+            .tx_map
+            .incoming_tx_map
+            .insert(tx_id, wallet_tx.clone());
+
+        (context, wallet_tx)
+    }
+
+    // Create a mock wallet transaction
+    fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        WalletTx {
+            txid: tx_id,
+            tx: create_empty_transaction(),
+            height: Some(height),
+            fee: 1000,
+            timestamp: Some(1001), // Just after swap creation time
+            balance: {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
+                    amount,
+                );
+                map
+            },
+            outputs: Vec::new(),
+            inputs: Vec::new(),
+            type_: "".to_string(),
+        }
+    }
+
+    fn create_empty_transaction() -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                is_pegin: false,
+                script_sig: Script::new(),
+                sequence: lwk_wollet::elements::Sequence::default(),
+                asset_issuance: Default::default(),
+                witness: TxInWitness::empty(),
+            }],
+            output: vec![],
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -15,8 +15,11 @@ mod test {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
     /// Test recovery with a claim transaction and preimage
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_claim_tx_and_preimage() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();
@@ -76,7 +79,7 @@ mod test {
     }
 
     /// Test recovery with a lockup and refund transaction
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_refund_tx() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();
@@ -119,7 +122,7 @@ mod test {
     }
 
     /// Test recovery with only a lockup tx (not expired)
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lockup_only() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();
@@ -152,7 +155,7 @@ mod test {
     }
 
     /// Test recovery with only a lockup tx (expired)
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_lockup_expired() {
         // Setup mock data
         let (mut send_swap, mut recovery_context) = setup_test_data();
@@ -188,7 +191,7 @@ mod test {
     }
 
     /// Test recovery with unconfirmed refund tx
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_unconfirmed_refund() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();
@@ -231,7 +234,7 @@ mod test {
     }
 
     /// Test recovery with no transactions
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recover_with_no_transactions() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();
@@ -252,7 +255,7 @@ mod test {
     }
 
     /// Test recovery when swap is within grace period
-    #[tokio::test]
+    #[sdk_macros::async_test_all]
     async fn test_recovery_within_grace_period() {
         // Setup mock data
         let (mut send_swap, recovery_context) = setup_test_data();

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -2,7 +2,7 @@
 mod test {
     use crate::chain::liquid::MockLiquidChainService;
     use crate::prelude::*;
-    use crate::recover::handlers::tests::test::create_mock_wallet_tx;
+    use crate::recover::handlers::tests::test::create_mock_lbtc_wallet_tx;
     use crate::recover::handlers::SendSwapHandler;
     use crate::recover::model::*;
     use crate::swapper::MockSwapper;
@@ -360,7 +360,7 @@ mod test {
             .insert(script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, -100000); // Negative amount for outgoing
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, -100000); // Negative amount for outgoing
 
         // Add to outgoing tx map
         context.tx_map.outgoing_tx_map.insert(tx_id, wallet_tx);
@@ -425,7 +425,7 @@ mod test {
             .insert(script.clone(), script_history);
 
         // Create wallet tx
-        let wallet_tx = create_mock_wallet_tx(tx_id_hex, height, amount as i64); // Positive amount for incoming
+        let wallet_tx = create_mock_lbtc_wallet_tx(tx_id_hex, height, amount as i64); // Positive amount for incoming
 
         // Add to incoming tx map
         context

--- a/lib/core/src/recover/handlers/tests/mod.rs
+++ b/lib/core/src/recover/handlers/tests/mod.rs
@@ -32,7 +32,7 @@ mod test {
     }
 
     // Create an empty LBTC transaction
-    fn create_empty_lbtc_transaction() -> Transaction {
+    pub(crate) fn create_empty_lbtc_transaction() -> Transaction {
         Transaction {
             version: 2,
             lock_time: elements::LockTime::from_height(0).unwrap(),

--- a/lib/core/src/recover/handlers/tests/mod.rs
+++ b/lib/core/src/recover/handlers/tests/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 // Module declaration for test files
 pub mod handle_chain_receive_swap_tests;
 pub mod handle_chain_receive_swap_tests_integration;
@@ -7,3 +8,93 @@ pub mod handle_receive_swap_tests;
 pub mod handle_receive_swap_tests_integration;
 pub mod handle_send_swap_tests;
 pub mod handle_send_swap_tests_integration;
+
+// Helper function to create a HistoryTxId for testing
+mod test {
+    use std::{collections::BTreeMap, str::FromStr};
+
+    use crate::recover::model::HistoryTxId;
+    use lwk_wollet::{
+        elements::{self, AssetId, Transaction, TxIn, TxInWitness, Txid},
+        hashes::Hash,
+        WalletTx,
+    };
+
+    pub(crate) fn create_history_txid(hex_id: &str, height: i32) -> HistoryTxId {
+        let txid_bytes = hex::decode(format!("{:0>64}", hex_id)).unwrap();
+        let mut txid_array = [0u8; 32];
+        txid_array.copy_from_slice(&txid_bytes);
+
+        HistoryTxId {
+            txid: Txid::from_slice(&txid_array).unwrap(),
+            height,
+        }
+    }
+
+    // Create an empty LBTC transaction
+    fn create_empty_lbtc_transaction() -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: elements::LockTime::from_height(0).unwrap(),
+            input: vec![TxIn {
+                previous_output: Default::default(),
+                is_pegin: false,
+                script_sig: elements::Script::new(),
+                sequence: elements::Sequence::default(),
+                asset_issuance: Default::default(),
+                witness: TxInWitness::empty(),
+            }],
+            output: vec![],
+        }
+    }
+
+    // Create a mock wallet transaction
+    pub(crate) fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
+        create_mock_lbtc_wallet_tx(tx_id_hex, height, amount)
+        // let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        // // Create balance for the transaction
+        // let mut balance = BTreeMap::new();
+        // balance.insert(AssetId::default(), amount as i64);
+
+        // WalletTx {
+        //     txid: tx_id,
+        //     tx: create_empty_transaction(),
+        //     height: Some(height),
+        //     fee: 1000,
+        //     timestamp: Some(1001), // Just after swap creation time
+        //     balance,
+        //     outputs: Vec::new(),
+        //     inputs: Vec::new(),
+        //     type_: "".to_string(),
+        // }
+    }
+
+    // Create a mock LBTC wallet transaction
+    pub(crate) fn create_mock_lbtc_wallet_tx(
+        tx_id_hex: &str,
+        height: u32,
+        amount: i64,
+    ) -> WalletTx {
+        let tx_id = Txid::from_str(tx_id_hex).unwrap();
+
+        WalletTx {
+            txid: tx_id,
+            tx: create_empty_lbtc_transaction(),
+            height: Some(height),
+            fee: 1000,
+            timestamp: Some(1001), // Just after swap creation time
+            balance: {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    AssetId::from_slice(&[0; 32]).unwrap(), // Default asset ID
+                    amount,
+                );
+                map
+            },
+            outputs: vec![],
+            inputs: Vec::new(),
+            type_: "".to_string(),
+        }
+    }
+}

--- a/lib/core/src/recover/handlers/tests/mod.rs
+++ b/lib/core/src/recover/handlers/tests/mod.rs
@@ -1,0 +1,9 @@
+// Module declaration for test files
+pub mod handle_chain_receive_swap_tests;
+pub mod handle_chain_receive_swap_tests_integration;
+pub mod handle_chain_send_swap_tests;
+pub mod handle_chain_send_swap_tests_integration;
+pub mod handle_receive_swap_tests;
+pub mod handle_receive_swap_tests_integration;
+pub mod handle_send_swap_tests;
+pub mod handle_send_swap_tests_integration;

--- a/lib/core/src/recover/handlers/tests/mod.rs
+++ b/lib/core/src/recover/handlers/tests/mod.rs
@@ -48,28 +48,6 @@ mod test {
         }
     }
 
-    // Create a mock wallet transaction
-    pub(crate) fn create_mock_wallet_tx(tx_id_hex: &str, height: u32, amount: i64) -> WalletTx {
-        create_mock_lbtc_wallet_tx(tx_id_hex, height, amount)
-        // let tx_id = Txid::from_str(tx_id_hex).unwrap();
-
-        // // Create balance for the transaction
-        // let mut balance = BTreeMap::new();
-        // balance.insert(AssetId::default(), amount as i64);
-
-        // WalletTx {
-        //     txid: tx_id,
-        //     tx: create_empty_transaction(),
-        //     height: Some(height),
-        //     fee: 1000,
-        //     timestamp: Some(1001), // Just after swap creation time
-        //     balance,
-        //     outputs: Vec::new(),
-        //     inputs: Vec::new(),
-        //     type_: "".to_string(),
-        // }
-    }
-
     // Create a mock LBTC wallet transaction
     pub(crate) fn create_mock_lbtc_wallet_tx(
         tx_id_hex: &str,

--- a/lib/core/src/recover/mod.rs
+++ b/lib/core/src/recover/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod handlers;
 pub(crate) mod model;
 pub(crate) mod recoverer;

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -1,19 +1,32 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 
-use anyhow::anyhow;
-use boltz_client::boltz::PairLimits;
 use boltz_client::ElementsAddress;
 use electrum_client::GetBalanceRes;
 use lwk_wollet::elements::Txid;
+use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
 use lwk_wollet::History;
 use lwk_wollet::WalletTx;
+use tonic::async_trait;
 
+use crate::chain::liquid::LiquidChainService;
 use crate::prelude::*;
+use crate::swapper::Swapper;
+use anyhow::Result;
 
 pub(crate) type BtcScript = lwk_wollet::bitcoin::ScriptBuf;
 pub(crate) type LBtcScript = lwk_wollet::elements::Script;
-pub(crate) type SendSwapHistory = Vec<HistoryTxId>;
+
+#[async_trait]
+pub(crate) trait SwapRecoverHandler: Send + Sync {
+    async fn recover_swap(
+        &self,
+        swap: &mut Swap,
+        context: &SwapsHistories,
+        is_local_within_grace_period: bool,
+    ) -> Result<bool>;
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct HistoryTxId {
@@ -62,373 +75,11 @@ impl TxMap {
     }
 }
 
-pub(crate) struct RecoveredOnchainDataSend {
-    pub(crate) lockup_tx_id: Option<HistoryTxId>,
-    pub(crate) claim_tx_id: Option<HistoryTxId>,
-    pub(crate) refund_tx_id: Option<HistoryTxId>,
-    pub(crate) preimage: Option<String>,
-}
-
-impl RecoveredOnchainDataSend {
-    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
-        match &self.lockup_tx_id {
-            Some(_) => match &self.claim_tx_id {
-                Some(_) => Some(PaymentState::Complete),
-                None => match &self.refund_tx_id {
-                    Some(refund_tx_id) => match refund_tx_id.confirmed() {
-                        true => Some(PaymentState::Failed),
-                        false => Some(PaymentState::RefundPending),
-                    },
-                    None => match is_expired {
-                        true => Some(PaymentState::RefundPending),
-                        false => Some(PaymentState::Pending),
-                    },
-                },
-            },
-            None => match is_expired {
-                true => Some(PaymentState::Failed),
-                // We have no onchain data to support deriving the state as the swap could
-                // potentially be Created or TimedOut. In this case we return None.
-                false => None,
-            },
-        }
-    }
-}
-
-pub(crate) struct RecoveredOnchainDataReceive {
-    pub(crate) lockup_tx_id: Option<HistoryTxId>,
-    pub(crate) claim_tx_id: Option<HistoryTxId>,
-    pub(crate) mrh_tx_id: Option<HistoryTxId>,
-    pub(crate) mrh_amount_sat: Option<u64>,
-}
-
-impl RecoveredOnchainDataReceive {
-    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
-        match &self.lockup_tx_id {
-            Some(_) => match &self.claim_tx_id {
-                Some(claim_tx_id) => match claim_tx_id.confirmed() {
-                    true => Some(PaymentState::Complete),
-                    false => Some(PaymentState::Pending),
-                },
-                None => match is_expired {
-                    true => Some(PaymentState::Failed),
-                    false => Some(PaymentState::Pending),
-                },
-            },
-            None => match &self.mrh_tx_id {
-                Some(mrh_tx_id) => match mrh_tx_id.confirmed() {
-                    true => Some(PaymentState::Complete),
-                    false => Some(PaymentState::Pending),
-                },
-                // We have no onchain data to support deriving the state as the swap could
-                // potentially be Created. In this case we return None.
-                None => match is_expired {
-                    true => Some(PaymentState::Failed),
-                    false => None,
-                },
-            },
-        }
-    }
-}
-
-pub(crate) struct RecoveredOnchainDataChainSend {
-    /// LBTC tx initiated by the SDK (the "user" as per Boltz), sending funds to the swap funding address.
-    pub(crate) lbtc_user_lockup_tx_id: Option<HistoryTxId>,
-    /// LBTC tx initiated by the SDK to itself, in case the initial funds have to be refunded.
-    pub(crate) lbtc_refund_tx_id: Option<HistoryTxId>,
-    /// BTC tx locking up funds by the swapper
-    pub(crate) btc_server_lockup_tx_id: Option<HistoryTxId>,
-    /// BTC tx that claims to the final BTC destination address. The final step in a successful swap.
-    pub(crate) btc_claim_tx_id: Option<HistoryTxId>,
-}
-
-// TODO: We have to be careful around overwriting the RefundPending state, as this swap monitored
-// after the expiration of the swap and if new funds are detected on the lockup script they are refunded.
-// Perhaps we should check in the recovery the lockup balance and set accordingly.
-impl RecoveredOnchainDataChainSend {
-    pub(crate) fn derive_partial_state(&self, is_expired: bool) -> Option<PaymentState> {
-        match &self.lbtc_user_lockup_tx_id {
-            Some(_) => match (&self.btc_claim_tx_id, &self.lbtc_refund_tx_id) {
-                (Some(btc_claim_tx_id), None) => match btc_claim_tx_id.confirmed() {
-                    true => Some(PaymentState::Complete),
-                    false => Some(PaymentState::Pending),
-                },
-                (None, Some(lbtc_refund_tx_id)) => match lbtc_refund_tx_id.confirmed() {
-                    true => Some(PaymentState::Failed),
-                    false => Some(PaymentState::RefundPending),
-                },
-                (Some(btc_claim_tx_id), Some(lbtc_refund_tx_id)) => {
-                    match btc_claim_tx_id.confirmed() {
-                        true => match lbtc_refund_tx_id.confirmed() {
-                            true => Some(PaymentState::Complete),
-                            false => Some(PaymentState::RefundPending),
-                        },
-                        false => Some(PaymentState::Pending),
-                    }
-                }
-                (None, None) => match is_expired {
-                    true => Some(PaymentState::RefundPending),
-                    false => Some(PaymentState::Pending),
-                },
-            },
-            None => match is_expired {
-                true => Some(PaymentState::Failed),
-                // We have no onchain data to support deriving the state as the swap could
-                // potentially be Created or TimedOut. In this case we return None.
-                false => None,
-            },
-        }
-    }
-}
-
-pub(crate) struct RecoveredOnchainDataChainReceive {
-    /// LBTC tx locking up funds by the swapper
-    pub(crate) lbtc_server_lockup_tx_id: Option<HistoryTxId>,
-    /// LBTC tx that claims to our wallet. The final step in a successful swap.
-    pub(crate) lbtc_claim_tx_id: Option<HistoryTxId>,
-    /// LBTC tx out address for the claim tx.
-    pub(crate) lbtc_claim_address: Option<String>,
-    /// BTC tx initiated by the payer (the "user" as per Boltz), sending funds to the swap funding address.
-    pub(crate) btc_user_lockup_tx_id: Option<HistoryTxId>,
-    /// BTC total funds currently available at the swap funding address.
-    pub(crate) btc_user_lockup_address_balance_sat: u64,
-    /// BTC sent to lockup address as part of lockup tx.
-    pub(crate) btc_user_lockup_amount_sat: u64,
-    /// BTC tx initiated by the SDK to a user-chosen address, in case the initial funds have to be refunded.
-    pub(crate) btc_refund_tx_id: Option<HistoryTxId>,
-}
-
-impl RecoveredOnchainDataChainReceive {
-    pub(crate) fn derive_partial_state(
-        &self,
-        expected_user_lockup_amount_sat: Option<u64>,
-        swap_limits: Option<PairLimits>,
-        is_expired: bool,
-        is_waiting_fee_acceptance: bool,
-    ) -> Option<PaymentState> {
-        let unexpected_amount =
-            expected_user_lockup_amount_sat.is_some_and(|expected_lockup_amount_sat| {
-                expected_lockup_amount_sat != self.btc_user_lockup_amount_sat
-            });
-        let amount_out_of_bounds = swap_limits.is_some_and(|limits| {
-            self.btc_user_lockup_amount_sat < limits.minimal
-                || self.btc_user_lockup_amount_sat > limits.maximal
-        });
-        let is_expired_refundable = is_expired && self.btc_user_lockup_address_balance_sat > 0;
-        let is_refundable = is_expired_refundable || unexpected_amount || amount_out_of_bounds;
-        match &self.btc_user_lockup_tx_id {
-            Some(_) => match (&self.lbtc_claim_tx_id, &self.btc_refund_tx_id) {
-                (Some(lbtc_claim_tx_id), None) => match lbtc_claim_tx_id.confirmed() {
-                    true => match is_expired_refundable {
-                        true => Some(PaymentState::Refundable),
-                        false => Some(PaymentState::Complete),
-                    },
-                    false => Some(PaymentState::Pending),
-                },
-                (None, Some(btc_refund_tx_id)) => match btc_refund_tx_id.confirmed() {
-                    true => match is_expired_refundable {
-                        true => Some(PaymentState::Refundable),
-                        false => Some(PaymentState::Failed),
-                    },
-                    false => Some(PaymentState::RefundPending),
-                },
-                (Some(lbtc_claim_tx_id), Some(btc_refund_tx_id)) => {
-                    match lbtc_claim_tx_id.confirmed() {
-                        true => match btc_refund_tx_id.confirmed() {
-                            true => match is_expired_refundable {
-                                true => Some(PaymentState::Refundable),
-                                false => Some(PaymentState::Complete),
-                            },
-                            false => Some(PaymentState::RefundPending),
-                        },
-                        false => Some(PaymentState::Pending),
-                    }
-                }
-                (None, None) => match is_refundable {
-                    true => Some(PaymentState::Refundable),
-                    false => match is_waiting_fee_acceptance {
-                        true => Some(PaymentState::WaitingFeeAcceptance),
-                        false => Some(PaymentState::Pending),
-                    },
-                },
-            },
-            None => match is_expired {
-                true => Some(PaymentState::Failed),
-                // We have no onchain data to support deriving the state as the swap could
-                // potentially be Created. In this case we return None.
-                false => None,
-            },
-        }
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct SendSwapImmutableData {
-    pub(crate) swap_id: String,
-    pub(crate) lockup_script: LBtcScript,
-}
-
-impl TryFrom<SendSwap> for SendSwapImmutableData {
-    type Error = anyhow::Error;
-
-    fn try_from(swap: SendSwap) -> std::result::Result<Self, Self::Error> {
-        let swap_script = swap.get_swap_script()?;
-
-        let funding_address = swap_script.funding_addrs.ok_or(anyhow!(
-            "No funding address found for Send Swap {}",
-            swap.id
-        ))?;
-
-        let swap_id = swap.id;
-        Ok(SendSwapImmutableData {
-            swap_id,
-            lockup_script: funding_address.script_pubkey(),
-        })
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct ReceiveSwapImmutableData {
-    pub(crate) swap_id: String,
-    pub(crate) swap_timestamp: u32,
-    pub(crate) timeout_block_height: u32,
-    pub(crate) claim_script: LBtcScript,
-    pub(crate) mrh_script: Option<LBtcScript>,
-}
-
-impl TryFrom<ReceiveSwap> for ReceiveSwapImmutableData {
-    type Error = anyhow::Error;
-
-    fn try_from(swap: ReceiveSwap) -> std::result::Result<Self, Self::Error> {
-        let swap_script = swap.get_swap_script()?;
-        let create_response = swap.get_boltz_create_response()?;
-        let mrh_address = ElementsAddress::from_str(&swap.mrh_address).ok();
-
-        let funding_address = swap_script.funding_addrs.ok_or(anyhow!(
-            "No funding address found for Receive Swap {}",
-            swap.id
-        ))?;
-
-        let swap_id = swap.id;
-        Ok(ReceiveSwapImmutableData {
-            swap_id,
-            swap_timestamp: swap.created_at,
-            timeout_block_height: create_response.timeout_block_height,
-            claim_script: funding_address.script_pubkey(),
-            mrh_script: mrh_address.map(|s| s.script_pubkey()),
-        })
-    }
-}
-
-pub(crate) struct ReceiveSwapHistory {
-    pub(crate) lbtc_claim_script_history: Vec<HistoryTxId>,
-    pub(crate) lbtc_mrh_script_history: Vec<HistoryTxId>,
-}
-
-#[derive(Clone)]
-pub(crate) struct SendChainSwapImmutableData {
-    swap_id: String,
-    lockup_script: LBtcScript,
-    pub(crate) claim_script: BtcScript,
-}
-
-impl TryFrom<ChainSwap> for SendChainSwapImmutableData {
-    type Error = anyhow::Error;
-
-    fn try_from(swap: ChainSwap) -> std::result::Result<Self, Self::Error> {
-        if swap.direction == Direction::Incoming {
-            return Err(anyhow!(
-                "Cannot convert incoming chain swap to `SendChainSwapImmutableData`"
-            ));
-        }
-
-        let lockup_swap_script = swap.get_lockup_swap_script()?.as_liquid_script()?;
-        let claim_swap_script = swap.get_claim_swap_script()?.as_bitcoin_script()?;
-
-        let maybe_lockup_script = lockup_swap_script
-            .clone()
-            .funding_addrs
-            .map(|addr| addr.script_pubkey());
-        let maybe_claim_script = claim_swap_script
-            .clone()
-            .funding_addrs
-            .map(|addr| addr.script_pubkey());
-
-        let swap_id = swap.id;
-        match (maybe_lockup_script, maybe_claim_script) {
-            (Some(lockup_script), Some(claim_script)) => Ok(SendChainSwapImmutableData {
-                swap_id,
-                lockup_script,
-                claim_script,
-            }),
-            (lockup_script, claim_script) => Err(anyhow!("Failed to get lockup or claim script for swap {swap_id}. Lockup script: {lockup_script:?}. Claim script: {claim_script:?}")),
-        }
-    }
-}
-
-pub(crate) struct SendChainSwapHistory {
-    pub(crate) lbtc_lockup_script_history: Vec<HistoryTxId>,
-    pub(crate) btc_claim_script_history: Vec<HistoryTxId>,
-    pub(crate) btc_claim_script_txs: Vec<boltz_client::bitcoin::Transaction>,
-}
-
-#[derive(Clone)]
-pub(crate) struct ReceiveChainSwapImmutableData {
-    swap_id: String,
-    pub(crate) lockup_script: BtcScript,
-    claim_script: LBtcScript,
-}
-
-impl TryFrom<ChainSwap> for ReceiveChainSwapImmutableData {
-    type Error = anyhow::Error;
-
-    fn try_from(swap: ChainSwap) -> std::result::Result<Self, Self::Error> {
-        if swap.direction == Direction::Outgoing {
-            return Err(anyhow!(
-                "Cannot convert outgoing chain swap to `ReceiveChainSwapImmutableData`"
-            ));
-        }
-
-        let lockup_swap_script = swap.get_lockup_swap_script()?.as_bitcoin_script()?;
-        let claim_swap_script = swap.get_claim_swap_script()?.as_liquid_script()?;
-
-        let maybe_lockup_script = lockup_swap_script
-            .clone()
-            .funding_addrs
-            .map(|addr| addr.script_pubkey());
-        let maybe_claim_script = claim_swap_script
-            .clone()
-            .funding_addrs
-            .map(|addr| addr.script_pubkey());
-
-        let swap_id = swap.id;
-        match (maybe_lockup_script, maybe_claim_script) {
-            (Some(lockup_script), Some(claim_script)) => Ok(ReceiveChainSwapImmutableData {
-                swap_id,
-                lockup_script,
-                claim_script,
-            }),
-            (lockup_script, claim_script) => Err(anyhow!("Failed to get lockup or claim script for swap {swap_id}. Lockup script: {lockup_script:?}. Claim script: {claim_script:?}")),
-        }
-    }
-}
-
-pub(crate) struct ReceiveChainSwapHistory {
-    pub(crate) lbtc_claim_script_history: Vec<HistoryTxId>,
-    pub(crate) btc_lockup_script_history: Vec<HistoryTxId>,
-    pub(crate) btc_lockup_script_txs: Vec<boltz_client::bitcoin::Transaction>,
-    pub(crate) btc_lockup_script_balance: Option<GetBalanceRes>,
-}
-
-/// Swap immutable data
+/// Swap list containing all swap data indexed by swap ID
 #[derive(Default)]
 pub(crate) struct SwapsList {
-    pub(crate) send_swap_immutable_data_by_swap_id: HashMap<String, SendSwapImmutableData>,
-    pub(crate) receive_swap_immutable_data_by_swap_id: HashMap<String, ReceiveSwapImmutableData>,
-    pub(crate) send_chain_swap_immutable_data_by_swap_id:
-        HashMap<String, SendChainSwapImmutableData>,
-    pub(crate) receive_chain_swap_immutable_data_by_swap_id:
-        HashMap<String, ReceiveChainSwapImmutableData>,
+    // Single map for all swap types indexed by swap ID
+    pub(crate) swaps_by_id: HashMap<String, Swap>,
 }
 
 impl TryFrom<Vec<Swap>> for SwapsList {
@@ -439,58 +90,7 @@ impl TryFrom<Vec<Swap>> for SwapsList {
 
         for swap in swaps.into_iter() {
             let swap_id = swap.id();
-            match swap {
-                Swap::Send(send_swap) => match send_swap.try_into() {
-                    Ok(send_swap_immutable_data) => {
-                        swaps_list
-                            .send_swap_immutable_data_by_swap_id
-                            .insert(swap_id, send_swap_immutable_data);
-                    }
-                    Err(e) => {
-                        log::error!("Could not retrieve send swap immutable data: {e:?}");
-                        continue;
-                    }
-                },
-                Swap::Receive(receive_swap) => match receive_swap.try_into() {
-                    Ok(receive_swap_immutable_data) => {
-                        swaps_list
-                            .receive_swap_immutable_data_by_swap_id
-                            .insert(swap_id, receive_swap_immutable_data);
-                    }
-                    Err(e) => {
-                        log::error!("Could not retrieve receive swap immutable data: {e:?}");
-                        continue;
-                    }
-                },
-                Swap::Chain(chain_swap) => match chain_swap.direction {
-                    Direction::Incoming => match chain_swap.try_into() {
-                        Ok(receive_chain_swap_immutable_data) => {
-                            swaps_list
-                                .receive_chain_swap_immutable_data_by_swap_id
-                                .insert(swap_id, receive_chain_swap_immutable_data);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Could not retrieve incoming chain swap immutable data: {e:?}"
-                            );
-                            continue;
-                        }
-                    },
-                    Direction::Outgoing => match chain_swap.try_into() {
-                        Ok(send_chain_swap_immutable_data) => {
-                            swaps_list
-                                .send_chain_swap_immutable_data_by_swap_id
-                                .insert(swap_id, send_chain_swap_immutable_data);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Could not retrieve outgoing chain swap immutable data: {e:?}"
-                            );
-                            continue;
-                        }
-                    },
-                },
-            }
+            swaps_list.swaps_by_id.insert(swap_id, swap);
         }
 
         Ok(swaps_list)
@@ -498,261 +98,104 @@ impl TryFrom<Vec<Swap>> for SwapsList {
 }
 
 impl SwapsList {
-    fn send_swaps_by_script(&self) -> HashMap<LBtcScript, SendSwapImmutableData> {
-        self.send_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| (imm.lockup_script.clone(), imm))
-            .collect()
-    }
-
-    pub(crate) fn send_histories_by_swap_id(
-        &self,
-        lbtc_script_to_history_map: &HashMap<LBtcScript, Vec<HistoryTxId>>,
-    ) -> HashMap<String, SendSwapHistory> {
-        let send_swaps_by_script = self.send_swaps_by_script();
-
-        let mut data: HashMap<String, SendSwapHistory> = HashMap::new();
-        lbtc_script_to_history_map
-            .iter()
-            .for_each(|(lbtc_script, lbtc_script_history)| {
-                if let Some(imm) = send_swaps_by_script.get(lbtc_script) {
-                    data.insert(imm.swap_id.clone(), lbtc_script_history.clone());
-                }
-            });
-        data
-    }
-
-    fn receive_swaps_by_claim_script(&self) -> HashMap<LBtcScript, ReceiveSwapImmutableData> {
-        self.receive_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| (imm.claim_script.clone(), imm))
-            .collect()
-    }
-
-    fn receive_swaps_by_mrh_script(&self) -> HashMap<LBtcScript, ReceiveSwapImmutableData> {
-        self.receive_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .filter_map(|imm| imm.mrh_script.clone().map(|mrh_script| (mrh_script, imm)))
-            .collect()
-    }
-
-    pub(crate) fn receive_histories_by_swap_id(
-        &self,
-        lbtc_script_to_history_map: &HashMap<LBtcScript, Vec<HistoryTxId>>,
-    ) -> HashMap<String, ReceiveSwapHistory> {
-        let receive_swaps_by_claim_script = self.receive_swaps_by_claim_script();
-        let receive_swaps_by_mrh_script = self.receive_swaps_by_mrh_script();
-
-        let mut data: HashMap<String, ReceiveSwapHistory> = HashMap::new();
-        lbtc_script_to_history_map
-            .iter()
-            .for_each(|(lbtc_script, lbtc_script_history)| {
-                if let Some(imm) = receive_swaps_by_claim_script.get(lbtc_script) {
-                    // The MRH script history filtered by the swap timeout block height
-                    let mrh_script_history = imm
-                        .mrh_script
-                        .clone()
-                        .and_then(|mrh_script| {
-                            lbtc_script_to_history_map.get(&mrh_script).map(|h| {
-                                h.iter()
-                                    .filter(|&tx_history| {
-                                        tx_history.height < imm.timeout_block_height as i32
-                                    })
-                                    .cloned()
-                                    .collect::<Vec<HistoryTxId>>()
-                            })
-                        })
-                        .unwrap_or_default();
-                    data.insert(
-                        imm.swap_id.clone(),
-                        ReceiveSwapHistory {
-                            lbtc_claim_script_history: lbtc_script_history.clone(),
-                            lbtc_mrh_script_history: mrh_script_history,
-                        },
-                    );
-                }
-                if let Some(imm) = receive_swaps_by_mrh_script.get(lbtc_script) {
-                    let claim_script_history = lbtc_script_to_history_map
-                        .get(&imm.claim_script)
-                        .cloned()
-                        .unwrap_or_default();
-                    // The MRH script history filtered by the swap timeout block height
-                    let mrh_script_history = lbtc_script_history
-                        .iter()
-                        .filter(|&tx_history| tx_history.height < imm.timeout_block_height as i32)
-                        .cloned()
-                        .collect::<Vec<HistoryTxId>>();
-                    data.insert(
-                        imm.swap_id.clone(),
-                        ReceiveSwapHistory {
-                            lbtc_claim_script_history: claim_script_history,
-                            lbtc_mrh_script_history: mrh_script_history,
-                        },
-                    );
-                }
-            });
-        data
-    }
-
-    fn send_chain_swaps_by_lbtc_lockup_script(
-        &self,
-    ) -> HashMap<LBtcScript, SendChainSwapImmutableData> {
-        self.send_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| (imm.lockup_script.clone(), imm))
-            .collect()
-    }
-
-    pub(crate) fn send_chain_histories_by_swap_id(
-        &self,
-        lbtc_script_to_history_map: &HashMap<LBtcScript, Vec<HistoryTxId>>,
-        btc_script_to_history_map: &HashMap<BtcScript, Vec<HistoryTxId>>,
-        btc_script_to_txs_map: &HashMap<BtcScript, Vec<boltz_client::bitcoin::Transaction>>,
-    ) -> HashMap<String, SendChainSwapHistory> {
-        let send_chain_swaps_by_lbtc_script = self.send_chain_swaps_by_lbtc_lockup_script();
-
-        let mut data: HashMap<String, SendChainSwapHistory> = HashMap::new();
-        lbtc_script_to_history_map
-            .iter()
-            .for_each(|(lbtc_lockup_script, lbtc_script_history)| {
-                if let Some(imm) = send_chain_swaps_by_lbtc_script.get(lbtc_lockup_script) {
-                    let btc_script_history = btc_script_to_history_map
-                        .get(&imm.claim_script)
-                        .cloned()
-                        .unwrap_or_default();
-                    let btc_script_txs = btc_script_to_txs_map
-                        .get(&imm.claim_script)
-                        .cloned()
-                        .unwrap_or_default();
-
-                    data.insert(
-                        imm.swap_id.clone(),
-                        SendChainSwapHistory {
-                            lbtc_lockup_script_history: lbtc_script_history.clone(),
-                            btc_claim_script_history: btc_script_history,
-                            btc_claim_script_txs: btc_script_txs,
-                        },
-                    );
-                }
-            });
-        data
-    }
-
-    fn receive_chain_swaps_by_lbtc_claim_script(
-        &self,
-    ) -> HashMap<LBtcScript, ReceiveChainSwapImmutableData> {
-        self.receive_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| (imm.claim_script.clone(), imm))
-            .collect()
-    }
-
-    pub(super) fn receive_chain_histories_by_swap_id(
-        &self,
-        lbtc_script_to_history_map: &HashMap<LBtcScript, Vec<HistoryTxId>>,
-        btc_script_to_history_map: &HashMap<BtcScript, Vec<HistoryTxId>>,
-        btc_script_to_txs_map: &HashMap<BtcScript, Vec<boltz_client::bitcoin::Transaction>>,
-        btc_script_to_balance_map: &HashMap<BtcScript, GetBalanceRes>,
-    ) -> HashMap<String, ReceiveChainSwapHistory> {
-        let receive_chain_swaps_by_lbtc_script = self.receive_chain_swaps_by_lbtc_claim_script();
-
-        let mut data: HashMap<String, ReceiveChainSwapHistory> = HashMap::new();
-        lbtc_script_to_history_map
-            .iter()
-            .for_each(|(lbtc_script_pk, lbtc_script_history)| {
-                if let Some(imm) = receive_chain_swaps_by_lbtc_script.get(lbtc_script_pk) {
-                    let btc_script_history = btc_script_to_history_map
-                        .get(&imm.lockup_script)
-                        .cloned()
-                        .unwrap_or_default();
-                    let btc_script_txs = btc_script_to_txs_map
-                        .get(&imm.lockup_script)
-                        .cloned()
-                        .unwrap_or_default();
-                    let btc_script_balance =
-                        btc_script_to_balance_map.get(&imm.lockup_script).cloned();
-
-                    data.insert(
-                        imm.swap_id.clone(),
-                        ReceiveChainSwapHistory {
-                            lbtc_claim_script_history: lbtc_script_history.clone(),
-                            btc_lockup_script_history: btc_script_history,
-                            btc_lockup_script_txs: btc_script_txs,
-                            btc_lockup_script_balance: btc_script_balance,
-                        },
-                    );
-                }
-            });
-        data
-    }
-
     pub(crate) fn get_swap_lbtc_scripts(&self) -> Vec<LBtcScript> {
-        let receive_swap_lbtc_mrh_scripts: Vec<LBtcScript> = self
-            .receive_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .filter_map(|imm| imm.mrh_script)
-            .collect();
-        let receive_swap_lbtc_claim_scripts: Vec<LBtcScript> = self
-            .receive_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.claim_script)
-            .collect();
-        let send_swap_scripts: Vec<LBtcScript> = self
-            .send_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.lockup_script)
-            .collect();
-        let send_chain_swap_lbtc_lockup_scripts: Vec<LBtcScript> = self
-            .send_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.lockup_script)
-            .collect();
-        let receive_chain_swap_lbtc_claim_scripts: Vec<LBtcScript> = self
-            .receive_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.claim_script)
-            .collect();
-        let mut swap_scripts = receive_swap_lbtc_mrh_scripts.clone();
-        swap_scripts.extend(receive_swap_lbtc_claim_scripts.clone());
-        swap_scripts.extend(send_swap_scripts.clone());
-        swap_scripts.extend(send_chain_swap_lbtc_lockup_scripts.clone());
-        swap_scripts.extend(receive_chain_swap_lbtc_claim_scripts.clone());
+        let mut swap_scripts = Vec::new();
+
+        for swap in self.swaps_by_id.values() {
+            match swap {
+                Swap::Send(send_swap) => {
+                    if let Ok(script) = send_swap.get_swap_script() {
+                        if let Some(funding_addr) = script.funding_addrs {
+                            swap_scripts.push(funding_addr.script_pubkey());
+                        }
+                    }
+                }
+                Swap::Receive(receive_swap) => {
+                    // Add claim script
+                    if let Ok(script) = receive_swap.get_swap_script() {
+                        if let Some(funding_addr) = script.funding_addrs {
+                            swap_scripts.push(funding_addr.script_pubkey());
+                        }
+                    }
+
+                    // Add MRH script if available
+                    if let Ok(mrh_address) = ElementsAddress::from_str(&receive_swap.mrh_address) {
+                        swap_scripts.push(mrh_address.script_pubkey());
+                    }
+                }
+                Swap::Chain(chain_swap) => {
+                    match chain_swap.direction {
+                        Direction::Outgoing => {
+                            // For outgoing chain swaps, add lockup script
+                            if let Ok(lockup_script) = chain_swap.get_lockup_swap_script() {
+                                if let Ok(liquid_script) = lockup_script.as_liquid_script() {
+                                    if let Some(funding_addr) = liquid_script.funding_addrs {
+                                        swap_scripts.push(funding_addr.script_pubkey());
+                                    }
+                                }
+                            }
+                        }
+                        Direction::Incoming => {
+                            // For incoming chain swaps, add claim script
+                            if let Ok(claim_script) = chain_swap.get_claim_swap_script() {
+                                if let Ok(liquid_script) = claim_script.as_liquid_script() {
+                                    if let Some(funding_addr) = liquid_script.funding_addrs {
+                                        swap_scripts.push(funding_addr.script_pubkey());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         swap_scripts
     }
 
     pub(crate) fn get_swap_btc_scripts(&self) -> Vec<BtcScript> {
-        let mut swap_scripts = vec![];
-        let send_chain_swap_btc_claim_scripts: Vec<BtcScript> = self
-            .send_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.claim_script)
-            .collect();
-        let receive_chain_swap_btc_lockup_scripts: Vec<BtcScript> = self
-            .receive_chain_swap_immutable_data_by_swap_id
-            .clone()
-            .into_values()
-            .map(|imm| imm.lockup_script)
-            .collect();
-        swap_scripts.extend(send_chain_swap_btc_claim_scripts.clone());
-        swap_scripts.extend(receive_chain_swap_btc_lockup_scripts.clone());
+        let mut swap_scripts = Vec::new();
+
+        for swap in self.swaps_by_id.values() {
+            if let Swap::Chain(chain_swap) = swap {
+                match chain_swap.direction {
+                    Direction::Outgoing => {
+                        // For outgoing chain swaps, add claim script (BTC)
+                        if let Ok(claim_script) = chain_swap.get_claim_swap_script() {
+                            if let Ok(bitcoin_script) = claim_script.as_bitcoin_script() {
+                                if let Some(funding_addr) = bitcoin_script.funding_addrs {
+                                    swap_scripts.push(funding_addr.script_pubkey());
+                                }
+                            }
+                        }
+                    }
+                    Direction::Incoming => {
+                        // For incoming chain swaps, add lockup script (BTC)
+                        if let Ok(lockup_script) = chain_swap.get_lockup_swap_script() {
+                            if let Ok(bitcoin_script) = lockup_script.as_bitcoin_script() {
+                                if let Some(funding_addr) = bitcoin_script.funding_addrs {
+                                    swap_scripts.push(funding_addr.script_pubkey());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         swap_scripts
     }
 }
 
 pub(crate) struct SwapsHistories {
-    pub(crate) send: HashMap<String, SendSwapHistory>,
-    pub(crate) receive: HashMap<String, ReceiveSwapHistory>,
-    pub(crate) send_chain: HashMap<String, SendChainSwapHistory>,
-    pub(crate) receive_chain: HashMap<String, ReceiveChainSwapHistory>,
+    pub(crate) lbtc_script_to_history_map: HashMap<LBtcScript, Vec<HistoryTxId>>,
+    pub(crate) btc_script_to_history_map: HashMap<BtcScript, Vec<HistoryTxId>>,
+    pub(crate) btc_script_to_txs_map: HashMap<BtcScript, Vec<boltz_client::bitcoin::Transaction>>,
+    pub(crate) btc_script_to_balance_map: HashMap<BtcScript, GetBalanceRes>,
+    pub(crate) liquid_chain_service: Arc<dyn LiquidChainService>,
+    pub(crate) swapper: Arc<dyn Swapper>,
+    pub(crate) tx_map: TxMap,
+    pub(crate) master_blinding_key: MasterBlindingKey,
+    pub(crate) liquid_tip_height: u32,
+    pub(crate) bitcoin_tip_height: u32,
 }

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -8,25 +8,13 @@ use lwk_wollet::elements::Txid;
 use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
 use lwk_wollet::History;
 use lwk_wollet::WalletTx;
-use tonic::async_trait;
 
 use crate::chain::liquid::LiquidChainService;
 use crate::prelude::*;
 use crate::swapper::Swapper;
-use anyhow::Result;
 
 pub(crate) type BtcScript = lwk_wollet::bitcoin::ScriptBuf;
 pub(crate) type LBtcScript = lwk_wollet::elements::Script;
-
-#[async_trait]
-pub(crate) trait SwapRecoverHandler: Send + Sync {
-    async fn recover_swap(
-        &self,
-        swap: &mut Swap,
-        context: &SwapsHistories,
-        is_local_within_grace_period: bool,
-    ) -> Result<bool>;
-}
 
 #[derive(Clone, Debug)]
 pub(crate) struct HistoryTxId {
@@ -187,7 +175,7 @@ impl SwapsList {
     }
 }
 
-pub(crate) struct SwapsHistories {
+pub(crate) struct RecoveryContext {
     pub(crate) lbtc_script_to_history_map: HashMap<LBtcScript, Vec<HistoryTxId>>,
     pub(crate) btc_script_to_history_map: HashMap<BtcScript, Vec<HistoryTxId>>,
     pub(crate) btc_script_to_txs_map: HashMap<BtcScript, Vec<boltz_client::bitcoin::Transaction>>,

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -115,23 +115,23 @@ impl SwapsList {
                     match chain_swap.direction {
                         Direction::Outgoing => {
                             // For outgoing chain swaps, add lockup script
-                            if let Ok(lockup_script) = chain_swap.get_lockup_swap_script() {
-                                if let Ok(liquid_script) = lockup_script.as_liquid_script() {
-                                    if let Some(funding_addr) = liquid_script.funding_addrs {
-                                        swap_scripts.push(funding_addr.script_pubkey());
-                                    }
-                                }
-                            }
+                            _ = chain_swap
+                                .get_lockup_swap_script()
+                                .and_then(|lockup_script| {
+                                    Ok(lockup_script.as_liquid_script()?.funding_addrs.map(
+                                        |funding_addr| {
+                                            swap_scripts.push(funding_addr.script_pubkey())
+                                        },
+                                    ))
+                                })
                         }
                         Direction::Incoming => {
                             // For incoming chain swaps, add claim script
-                            if let Ok(claim_script) = chain_swap.get_claim_swap_script() {
-                                if let Ok(liquid_script) = claim_script.as_liquid_script() {
-                                    if let Some(funding_addr) = liquid_script.funding_addrs {
-                                        swap_scripts.push(funding_addr.script_pubkey());
-                                    }
-                                }
-                            }
+                            _ = chain_swap.get_claim_swap_script().and_then(|claim_script| {
+                                Ok(claim_script.as_liquid_script()?.funding_addrs.map(
+                                    |funding_addr| swap_scripts.push(funding_addr.script_pubkey()),
+                                ))
+                            })
                         }
                     }
                 }
@@ -149,23 +149,21 @@ impl SwapsList {
                 match chain_swap.direction {
                     Direction::Outgoing => {
                         // For outgoing chain swaps, add claim script (BTC)
-                        if let Ok(claim_script) = chain_swap.get_claim_swap_script() {
-                            if let Ok(bitcoin_script) = claim_script.as_bitcoin_script() {
-                                if let Some(funding_addr) = bitcoin_script.funding_addrs {
-                                    swap_scripts.push(funding_addr.script_pubkey());
-                                }
-                            }
-                        }
+                        _ = chain_swap.get_claim_swap_script().and_then(|claim_script| {
+                            Ok(claim_script.as_bitcoin_script()?.funding_addrs.map(
+                                |funding_addr| swap_scripts.push(funding_addr.script_pubkey()),
+                            ))
+                        })
                     }
                     Direction::Incoming => {
                         // For incoming chain swaps, add lockup script (BTC)
-                        if let Ok(lockup_script) = chain_swap.get_lockup_swap_script() {
-                            if let Ok(bitcoin_script) = lockup_script.as_bitcoin_script() {
-                                if let Some(funding_addr) = bitcoin_script.funding_addrs {
-                                    swap_scripts.push(funding_addr.script_pubkey());
-                                }
-                            }
-                        }
+                        _ = chain_swap
+                            .get_lockup_swap_script()
+                            .and_then(|lockup_script| {
+                                Ok(lockup_script.as_bitcoin_script()?.funding_addrs.map(
+                                    |funding_addr| swap_scripts.push(funding_addr.script_pubkey()),
+                                ))
+                            })
                     }
                 }
             }

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -1,19 +1,20 @@
+use std::vec;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, ensure, Result};
-use boltz_client::{ElementsAddress, ToHex as _};
 use electrum_client::GetBalanceRes;
-use log::{debug, error, info, warn};
-use lwk_wollet::bitcoin::Witness;
-use lwk_wollet::elements::{secp256k1_zkp, AddressParams, Txid};
+use log::{info, warn};
+use lwk_wollet::elements::Txid;
 use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
 use lwk_wollet::hashes::hex::{DisplayHex, FromHex};
-use lwk_wollet::hashes::{sha256, Hash as _};
 use lwk_wollet::WalletTx;
 
+use super::handlers::{
+    ChainReceiveSwapHandler, ChainSendSwapHandler, ReceiveSwapHandler, SendSwapHandler,
+};
 use super::model::*;
 
-use crate::prelude::{Direction, Swap};
+use crate::prelude::Swap;
 use crate::sdk::NETWORK_PROPAGATION_GRACE_PERIOD;
 use crate::swapper::Swapper;
 use crate::wallet::OnchainWallet;
@@ -31,6 +32,7 @@ pub(crate) struct Recoverer {
     onchain_wallet: Arc<dyn OnchainWallet>,
     liquid_chain_service: Arc<dyn LiquidChainService>,
     bitcoin_chain_service: Arc<dyn BitcoinChainService>,
+    recover_handlers: Vec<Box<dyn SwapRecoverHandler>>,
 }
 
 impl Recoverer {
@@ -49,111 +51,13 @@ impl Recoverer {
             onchain_wallet,
             liquid_chain_service,
             bitcoin_chain_service,
+            recover_handlers: vec![
+                Box::new(SendSwapHandler),
+                Box::new(ReceiveSwapHandler),
+                Box::new(ChainSendSwapHandler),
+                Box::new(ChainReceiveSwapHandler),
+            ],
         })
-    }
-
-    async fn recover_cooperative_preimages(
-        &self,
-        recovered_send_data: &mut HashMap<String, &mut RecoveredOnchainDataSend>,
-    ) -> HashMap<String, Txid> {
-        let mut failed = HashMap::new();
-        for (swap_id, recovered_data) in recovered_send_data {
-            let Some(claim_tx_id) = &recovered_data.claim_tx_id else {
-                continue;
-            };
-
-            match self.swapper.get_submarine_preimage(swap_id).await {
-                Ok(preimage) => recovered_data.preimage = Some(preimage),
-                Err(err) => {
-                    warn!("Could not recover Send swap {swap_id} preimage cooperatively: {err:?}");
-                    failed.insert(swap_id.clone(), claim_tx_id.txid);
-                }
-            }
-        }
-        failed
-    }
-
-    async fn recover_non_cooperative_preimages(
-        &self,
-        recovered_send_data: &mut HashMap<String, &mut RecoveredOnchainDataSend>,
-        failed_cooperative: HashMap<String, Txid>,
-    ) -> Result<()> {
-        let claim_tx_ids: Vec<Txid> = failed_cooperative.values().cloned().collect();
-        let claim_txs = self
-            .liquid_chain_service
-            .get_transactions(claim_tx_ids.as_slice())
-            .await
-            .map_err(|e| anyhow!("Failed to fetch claim txs from recovery: {e}"))?;
-
-        let claim_tx_ids_len = claim_tx_ids.len();
-        let claim_txs_len = claim_txs.len();
-        ensure!(
-            claim_tx_ids_len == claim_txs_len,
-            anyhow!("Got {claim_txs_len} send claim transactions, expected {claim_tx_ids_len}")
-        );
-
-        let claim_txs_by_swap_id: HashMap<String, lwk_wollet::elements::Transaction> =
-            failed_cooperative.into_keys().zip(claim_txs).collect();
-
-        for (swap_id, claim_tx) in claim_txs_by_swap_id {
-            let Some(recovered_data) = recovered_send_data.get_mut(&swap_id) else {
-                continue;
-            };
-
-            match Self::get_send_swap_preimage_from_claim_tx(&swap_id, &claim_tx) {
-                Ok(preimage) => recovered_data.preimage = Some(preimage),
-                Err(e) => {
-                    error!(
-                        "Couldn't get non-cooperative swap preimage from claim tx {} for swap {swap_id}: {e}",
-                        claim_tx.txid()
-                    );
-                    // Keep only claim tx for which there is a recovered or synced preimage
-                    recovered_data.claim_tx_id = None;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn recover_preimages(
-        &self,
-        mut recovered_send_data: HashMap<String, &mut RecoveredOnchainDataSend>,
-    ) -> Result<()> {
-        // Recover the preimages by querying the swapper, only if there is a claim_tx_id
-        let failed_cooperative = self
-            .recover_cooperative_preimages(&mut recovered_send_data)
-            .await;
-
-        // For those which failed, recover the preimages by querying onchain (non-cooperative case)
-        self.recover_non_cooperative_preimages(&mut recovered_send_data, failed_cooperative)
-            .await
-    }
-
-    pub(crate) fn get_send_swap_preimage_from_claim_tx(
-        swap_id: &str,
-        claim_tx: &lwk_wollet::elements::Transaction,
-    ) -> Result<String, anyhow::Error> {
-        debug!("Send Swap {swap_id} has claim tx {}", claim_tx.txid());
-
-        let input = claim_tx
-            .input
-            .first()
-            .ok_or_else(|| anyhow!("Found no input for claim tx"))?;
-
-        let script_witness_bytes = input.clone().witness.script_witness;
-        log::info!("Found Send Swap {swap_id} claim tx witness: {script_witness_bytes:?}");
-        let script_witness = Witness::from(script_witness_bytes);
-
-        let preimage_bytes = script_witness
-            .nth(1)
-            .ok_or_else(|| anyhow!("Claim tx witness has no preimage"))?;
-        let preimage = sha256::Hash::from_slice(preimage_bytes)
-            .map_err(|e| anyhow!("Claim tx witness has invalid preimage: {e}"))?;
-        let preimage_hex = preimage.to_hex();
-        debug!("Found Send Swap {swap_id} claim tx preimage: {preimage_hex}");
-
-        Ok(preimage_hex)
     }
 
     /// For each swap, recovers data from chain services.
@@ -165,8 +69,7 @@ impl Recoverer {
     ///
     /// ### Arguments
     ///
-    /// - `tx_map`: all known onchain txs of this wallet at this time, essentially our own LWK cache.
-    /// - `swaps`: immutable data of the swaps for which we want to recover onchain data.
+    /// - `swaps`: The swaps for which we want to recover onchain data.
     ///
     /// Returns the raw onchain tx map used for recovery.
     pub(crate) async fn recover_from_onchain(
@@ -182,247 +85,38 @@ impl Recoverer {
 
         let recovery_started_at = utils::now();
 
+        // Fetch raw transaction map and convert to our internal format
         let raw_tx_map = self.onchain_wallet.transactions_by_tx_id().await?;
-        let tx_map = TxMap::from_raw_tx_map(raw_tx_map.clone());
 
-        let swaps_list = swaps.to_vec().try_into()?;
-        let histories = self.fetch_swaps_histories(&swaps_list).await?;
-
-        let mut recovered_send_data = self.recover_send_swap_tx_ids(&tx_map, histories.send)?;
-        let recovered_send_data_without_preimage = recovered_send_data
-            .iter_mut()
-            .filter_map(|(swap_id, recovered_data)| {
-                if let Some(Swap::Send(send_swap)) = swaps.iter().find(|s| s.id() == *swap_id) {
-                    if send_swap.preimage.is_none() {
-                        return Some((swap_id.clone(), recovered_data));
-                    }
-                }
-                None
-            })
-            .collect::<HashMap<String, &mut RecoveredOnchainDataSend>>();
-        self.recover_preimages(recovered_send_data_without_preimage)
-            .await?;
-
-        let recovered_receive_data = self.recover_receive_swap_tx_ids(
-            &tx_map,
-            histories.receive,
-            &swaps_list.receive_swap_immutable_data_by_swap_id,
-        )?;
-        let recovered_chain_send_data = self.recover_send_chain_swap_tx_ids(
-            &tx_map,
-            histories.send_chain,
-            &swaps_list.send_chain_swap_immutable_data_by_swap_id,
-        )?;
-        let recovered_chain_receive_data = self.recover_receive_chain_swap_tx_ids(
-            &tx_map,
-            histories.receive_chain,
-            &swaps_list.receive_chain_swap_immutable_data_by_swap_id,
-        )?;
-
+        // Fetch chain tips for expiration checks
         let bitcoin_tip = self.bitcoin_chain_service.tip()?;
         let liquid_tip = self.liquid_chain_service.tip().await?;
 
+        // Convert swaps to SwapsList and fetch history data
+        let swaps_list = swaps.to_vec().try_into()?;
+        let histories = self
+            .fetch_swaps_histories(
+                &swaps_list,
+                TxMap::from_raw_tx_map(raw_tx_map.clone()),
+                liquid_tip,
+                bitcoin_tip.height as u32,
+                self.master_blinding_key,
+            )
+            .await?;
+
+        // Apply recovered data to the swaps
         for swap in swaps.iter_mut() {
             let swap_id = &swap.id();
-
             let is_local_within_grace_period = swap.is_local()
                 && recovery_started_at.saturating_sub(swap.last_updated_at())
                     < NETWORK_PROPAGATION_GRACE_PERIOD.as_secs() as u32;
-
-            match swap {
-                Swap::Send(send_swap) => {
-                    let Some(recovered_data) = recovered_send_data.get_mut(swap_id) else {
-                        warn!("Could not apply recovered data for Send swap {swap_id}: recovery data not found");
-                        continue;
-                    };
-
-                    let lockup_is_cleared =
-                        send_swap.lockup_tx_id.is_some() && recovered_data.lockup_tx_id.is_none();
-                    let refund_is_cleared =
-                        send_swap.refund_tx_id.is_some() && recovered_data.refund_tx_id.is_none();
-                    if is_local_within_grace_period && (lockup_is_cleared || refund_is_cleared) {
-                        warn!(
-                            "Local send swap {swap_id} was updated recently - skipping recovery \
-                        as it would clear a tx that may have been broadcasted by us. Lockup clear: \
-                        {lockup_is_cleared} - Refund clear: {refund_is_cleared}"
-                        );
-                        continue;
-                    }
-
-                    send_swap.lockup_tx_id = recovered_data
-                        .lockup_tx_id
-                        .clone()
-                        .map(|h| h.txid.to_string());
-                    send_swap.refund_tx_id = recovered_data
-                        .refund_tx_id
-                        .clone()
-                        .map(|h| h.txid.to_string());
-                    match (&send_swap.preimage, &recovered_data.preimage) {
-                        // Update the preimage only if we don't have one already (e.g. from
-                        // real-time sync)
-                        (Some(_), _) | (None, None) => {}
-
-                        // Keep only verified preimages
-                        (None, Some(recovered_preimage)) => {
-                            match utils::verify_payment_hash(recovered_preimage, &send_swap.invoice)
-                            {
-                                Ok(_) => send_swap.preimage = Some(recovered_preimage.clone()),
-                                Err(e) => {
-                                    error!("Failed to verify recovered preimage for swap {swap_id}: {e}");
-                                    recovered_data.claim_tx_id = None;
-                                }
-                            }
-                        }
-                    }
-                    // Set the state only AFTER the preimage and claim_tx_id have been verified
-                    let timeout_block_height = send_swap.timeout_block_height as u32;
-                    let is_expired = liquid_tip >= timeout_block_height;
-                    if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
-                        send_swap.state = new_state;
-                    }
+            for handler in self.recover_handlers.iter() {
+                if let Err(err) = handler
+                    .recover_swap(swap, &histories, is_local_within_grace_period)
+                    .await
+                {
+                    warn!("Error recovering data for swap {swap_id}: {err}");
                 }
-                Swap::Receive(receive_swap) => {
-                    let Some(recovered_data) = recovered_receive_data.get(swap_id) else {
-                        warn!("Could not apply recovered data for Receive swap {swap_id}: recovery data not found");
-                        continue;
-                    };
-
-                    let claim_is_cleared =
-                        receive_swap.claim_tx_id.is_some() && recovered_data.claim_tx_id.is_none();
-                    if is_local_within_grace_period && claim_is_cleared {
-                        warn!(
-                            "Local receive swap {swap_id} was updated recently - skipping recovery \
-                        as it would clear a tx that may have been broadcasted by us (claim)"
-                        );
-                        continue;
-                    }
-
-                    let timeout_block_height = receive_swap.timeout_block_height;
-                    let is_expired = liquid_tip >= timeout_block_height;
-                    if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
-                        receive_swap.state = new_state;
-                    }
-                    receive_swap.claim_tx_id = recovered_data
-                        .claim_tx_id
-                        .clone()
-                        .map(|history_tx_id| history_tx_id.txid.to_string());
-                    receive_swap.mrh_tx_id = recovered_data
-                        .mrh_tx_id
-                        .clone()
-                        .map(|history_tx_id| history_tx_id.txid.to_string());
-                    receive_swap.lockup_tx_id = recovered_data
-                        .lockup_tx_id
-                        .clone()
-                        .map(|history_tx_id| history_tx_id.txid.to_string());
-                    if let Some(mrh_amount_sat) = recovered_data.mrh_amount_sat {
-                        receive_swap.payer_amount_sat = mrh_amount_sat;
-                        receive_swap.receiver_amount_sat = mrh_amount_sat;
-                    }
-                }
-                Swap::Chain(chain_swap) => match chain_swap.direction {
-                    Direction::Incoming => {
-                        let Some(recovered_data) = recovered_chain_receive_data.get(swap_id) else {
-                            warn!("Could not apply recovered data for incoming Chain swap {swap_id}: recovery data not found");
-                            continue;
-                        };
-
-                        let claim_is_cleared = chain_swap.claim_tx_id.is_some()
-                            && recovered_data.lbtc_claim_tx_id.is_none();
-                        let refund_is_cleared = chain_swap.refund_tx_id.is_some()
-                            && recovered_data.btc_refund_tx_id.is_none();
-                        if is_local_within_grace_period && (claim_is_cleared || refund_is_cleared) {
-                            warn!(
-                            "Local incoming chain swap {swap_id} was updated recently - skipping recovery \
-                        as it would clear a tx that may have been broadcasted by us. Claim clear: \
-                        {claim_is_cleared} - Refund clear: {refund_is_cleared}"
-                        );
-                            continue;
-                        }
-
-                        if recovered_data.btc_user_lockup_amount_sat > 0 {
-                            chain_swap.actual_payer_amount_sat =
-                                Some(recovered_data.btc_user_lockup_amount_sat);
-                        }
-                        let is_expired =
-                            bitcoin_tip.height as u32 >= chain_swap.timeout_block_height;
-                        let (expected_user_lockup_amount_sat, swap_limits) =
-                            match chain_swap.payer_amount_sat {
-                                0 => (None, Some(chain_swap.get_boltz_pair()?.limits)),
-                                expected => (Some(expected), None),
-                            };
-                        if let Some(new_state) = recovered_data.derive_partial_state(
-                            expected_user_lockup_amount_sat,
-                            swap_limits,
-                            is_expired,
-                            chain_swap.is_waiting_fee_acceptance(),
-                        ) {
-                            chain_swap.state = new_state;
-                        }
-                        chain_swap.server_lockup_tx_id = recovered_data
-                            .lbtc_server_lockup_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap
-                            .claim_address
-                            .clone_from(&recovered_data.lbtc_claim_address);
-                        chain_swap.user_lockup_tx_id = recovered_data
-                            .btc_user_lockup_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap.claim_tx_id = recovered_data
-                            .lbtc_claim_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap.refund_tx_id = recovered_data
-                            .btc_refund_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                    }
-                    Direction::Outgoing => {
-                        let Some(recovered_data) = recovered_chain_send_data.get(swap_id) else {
-                            warn!("Could not apply recovered data for outgoing Chain swap {swap_id}: recovery data not found");
-                            continue;
-                        };
-
-                        let lockup_is_cleared = chain_swap.user_lockup_tx_id.is_some()
-                            && recovered_data.lbtc_user_lockup_tx_id.is_none();
-                        let refund_is_cleared = chain_swap.refund_tx_id.is_some()
-                            && recovered_data.lbtc_refund_tx_id.is_none();
-                        let claim_is_cleared = chain_swap.claim_tx_id.is_some()
-                            && recovered_data.btc_claim_tx_id.is_none();
-                        if is_local_within_grace_period
-                            && (lockup_is_cleared || refund_is_cleared || claim_is_cleared)
-                        {
-                            warn!(
-                            "Local outgoing chain swap {swap_id} was updated recently - skipping recovery \
-                        as it would clear a tx that may have been broadcasted by us. Lockup clear: \
-                        {lockup_is_cleared} - Refund clear: {refund_is_cleared} - Claim clear: {claim_is_cleared}"
-                        );
-                            continue;
-                        }
-
-                        let is_expired = liquid_tip >= chain_swap.timeout_block_height;
-                        if let Some(new_state) = recovered_data.derive_partial_state(is_expired) {
-                            chain_swap.state = new_state;
-                        }
-                        chain_swap.server_lockup_tx_id = recovered_data
-                            .btc_server_lockup_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap.user_lockup_tx_id = recovered_data
-                            .lbtc_user_lockup_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap.claim_tx_id = recovered_data
-                            .btc_claim_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                        chain_swap.refund_tx_id = recovered_data
-                            .lbtc_refund_tx_id
-                            .clone()
-                            .map(|h| h.txid.to_string());
-                    }
-                },
             }
         }
 
@@ -430,7 +124,14 @@ impl Recoverer {
     }
 
     /// For a given [SwapList], this fetches the script histories from the chain services
-    async fn fetch_swaps_histories(&self, swaps_list: &SwapsList) -> Result<SwapsHistories> {
+    async fn fetch_swaps_histories(
+        &self,
+        swaps_list: &SwapsList,
+        tx_map: TxMap,
+        liquid_tip_height: u32,
+        bitcoin_tip_height: u32,
+        master_blinding_key: MasterBlindingKey,
+    ) -> Result<SwapsHistories> {
         let swap_lbtc_scripts = swaps_list.get_swap_lbtc_scripts();
 
         let t0 = std::time::Instant::now();
@@ -537,411 +238,16 @@ impl Recoverer {
             .collect();
 
         Ok(SwapsHistories {
-            send: swaps_list.send_histories_by_swap_id(&lbtc_script_to_history_map),
-            receive: swaps_list.receive_histories_by_swap_id(&lbtc_script_to_history_map),
-            send_chain: swaps_list.send_chain_histories_by_swap_id(
-                &lbtc_script_to_history_map,
-                &btc_script_to_history_map,
-                &btc_script_to_txs_map,
-            ),
-            receive_chain: swaps_list.receive_chain_histories_by_swap_id(
-                &lbtc_script_to_history_map,
-                &btc_script_to_history_map,
-                &btc_script_to_txs_map,
-                &btc_script_to_balance_map,
-            ),
+            lbtc_script_to_history_map,
+            btc_script_to_history_map,
+            btc_script_to_txs_map,
+            btc_script_to_balance_map,
+            tx_map,
+            liquid_tip_height,
+            bitcoin_tip_height,
+            master_blinding_key,
+            liquid_chain_service: self.liquid_chain_service.clone(),
+            swapper: self.swapper.clone(),
         })
-    }
-
-    /// Reconstruct Send Swap tx IDs from the onchain data and the immutable data
-    ///
-    /// The implementation tolerates a `tx_map` that is older than the `send_histories_by_swap_id`
-    /// in the sense that no incorrect data is recovered. Transactions that are missing from `tx_map`
-    /// are simply not recovered.
-    fn recover_send_swap_tx_ids(
-        &self,
-        tx_map: &TxMap,
-        send_histories_by_swap_id: HashMap<String, SendSwapHistory>,
-    ) -> Result<HashMap<String, RecoveredOnchainDataSend>> {
-        let mut res: HashMap<String, RecoveredOnchainDataSend> = HashMap::new();
-        for (swap_id, history) in send_histories_by_swap_id {
-            debug!("[Recover Send] Checking swap {swap_id}");
-
-            // If a history tx is one of our outgoing txs, it's a lockup tx
-            let lockup_tx_id = history
-                .iter()
-                .find(|&tx| tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
-                .cloned();
-            let claim_tx_id = if lockup_tx_id.is_some() {
-                // A history tx that is neither a known incoming or outgoing tx is a claim tx.
-                //
-                // Only find the claim_tx from the history if we find a lockup_tx. Not doing so will select
-                // the first tx as the claim, whereas we should check that the claim is not the lockup.
-                history
-                    .iter()
-                    .filter(|&tx| !tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
-                    .find(|&tx| !tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
-                    .cloned()
-            } else {
-                error!("No lockup tx found when recovering data for Send Swap {swap_id}");
-                None
-            };
-
-            // If a history tx is one of our incoming txs, it's a refund tx
-            let refund_tx_id = history
-                .iter()
-                .find(|&tx| tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
-                .cloned();
-
-            res.insert(
-                swap_id,
-                RecoveredOnchainDataSend {
-                    lockup_tx_id,
-                    claim_tx_id,
-                    refund_tx_id,
-                    preimage: None,
-                },
-            );
-        }
-
-        Ok(res)
-    }
-
-    /// Reconstruct Receive Swap tx IDs from the onchain data and the immutable data
-    ///
-    /// The implementation tolerates a `tx_map` that is older than the `receive_histories_by_swap_id`
-    /// in the sense that no incorrect data is recovered. Transactions that are missing from `tx_map`
-    /// are simply not recovered.
-    fn recover_receive_swap_tx_ids(
-        &self,
-        tx_map: &TxMap,
-        receive_histories_by_swap_id: HashMap<String, ReceiveSwapHistory>,
-        receive_swap_immutable_data_by_swap_id: &HashMap<String, ReceiveSwapImmutableData>,
-    ) -> Result<HashMap<String, RecoveredOnchainDataReceive>> {
-        let mut res: HashMap<String, RecoveredOnchainDataReceive> = HashMap::new();
-        for (swap_id, history) in receive_histories_by_swap_id {
-            debug!("[Recover Receive] Checking swap {swap_id}");
-
-            // The MRH script history txs filtered by the swap timestamp
-            let swap_timestamp = receive_swap_immutable_data_by_swap_id
-                .get(&swap_id)
-                .map(|imm: &ReceiveSwapImmutableData| imm.swap_timestamp)
-                .ok_or_else(|| anyhow!("Swap timestamp not found for Receive Swap {swap_id}"))?;
-            let mrh_txs: HashMap<Txid, WalletTx> = history
-                .lbtc_mrh_script_history
-                .iter()
-                .filter_map(|h| tx_map.incoming_tx_map.get(&h.txid))
-                .filter(|tx| tx.timestamp.map(|t| t > swap_timestamp).unwrap_or(true))
-                .map(|tx| (tx.txid, tx.clone()))
-                .collect();
-            let mrh_tx_id = history
-                .lbtc_mrh_script_history
-                .iter()
-                .find(|&tx| mrh_txs.contains_key::<Txid>(&tx.txid))
-                .cloned();
-            let mrh_amount_sat = mrh_tx_id
-                .clone()
-                .and_then(|h| mrh_txs.get(&h.txid))
-                .map(|tx| tx.balance.values().sum::<i64>().unsigned_abs());
-
-            let (lockup_tx_id, claim_tx_id) = determine_incoming_lockup_and_claim_txs(
-                &history.lbtc_claim_script_history,
-                tx_map,
-                &swap_id,
-            );
-
-            // Take only the lockup_tx_id and claim_tx_id if either are set,
-            // otherwise take the mrh_tx_id and mrh_amount_sat
-            let recovered_onchain_data = match (lockup_tx_id.as_ref(), claim_tx_id.as_ref()) {
-                (Some(_), None) | (Some(_), Some(_)) => RecoveredOnchainDataReceive {
-                    lockup_tx_id,
-                    claim_tx_id,
-                    mrh_tx_id: None,
-                    mrh_amount_sat: None,
-                },
-                _ => RecoveredOnchainDataReceive {
-                    lockup_tx_id: None,
-                    claim_tx_id: None,
-                    mrh_tx_id,
-                    mrh_amount_sat,
-                },
-            };
-
-            res.insert(swap_id, recovered_onchain_data);
-        }
-
-        Ok(res)
-    }
-
-    /// Reconstruct Chain Send Swap tx IDs from the onchain data and the immutable data
-    ///
-    /// The implementation tolerates a `tx_map` that is older than the `chain_send_histories_by_swap_id`
-    /// in the sense that no incorrect data is recovered. Transactions that are missing from `tx_map`
-    /// are simply not recovered.
-    fn recover_send_chain_swap_tx_ids(
-        &self,
-        tx_map: &TxMap,
-        chain_send_histories_by_swap_id: HashMap<String, SendChainSwapHistory>,
-        send_chain_swap_immutable_data_by_swap_id: &HashMap<String, SendChainSwapImmutableData>,
-    ) -> Result<HashMap<String, RecoveredOnchainDataChainSend>> {
-        let mut res: HashMap<String, RecoveredOnchainDataChainSend> = HashMap::new();
-        for (swap_id, history) in chain_send_histories_by_swap_id {
-            debug!("[Recover Chain Send] Checking swap {swap_id}");
-
-            // If a history tx is one of our outgoing txs, it's a lockup tx
-            let lbtc_user_lockup_tx_id = history
-                .lbtc_lockup_script_history
-                .iter()
-                .find(|&tx| tx_map.outgoing_tx_map.contains_key::<Txid>(&tx.txid))
-                .cloned();
-            if lbtc_user_lockup_tx_id.is_none() {
-                error!("No lockup tx found when recovering data for Chain Send Swap {swap_id}");
-            }
-
-            // If a history tx is one of our incoming txs, it's a refund tx
-            let lbtc_refund_tx_id = history
-                .lbtc_lockup_script_history
-                .iter()
-                .find(|&tx| tx_map.incoming_tx_map.contains_key::<Txid>(&tx.txid))
-                .cloned();
-
-            let (btc_server_lockup_tx_id, btc_claim_tx_id) = match history
-                .btc_claim_script_history
-                .len()
-            {
-                // Only lockup tx available
-                1 => (Some(history.btc_claim_script_history[0].clone()), None),
-
-                2 => {
-                    let first_tx = history.btc_claim_script_txs[0].clone();
-                    let first_tx_id = history.btc_claim_script_history[0].clone();
-                    let second_tx_id = history.btc_claim_script_history[1].clone();
-
-                    let btc_lockup_script = send_chain_swap_immutable_data_by_swap_id
-                        .get(&swap_id)
-                        .map(|imm| imm.claim_script.clone())
-                        .ok_or_else(|| {
-                            anyhow!("BTC claim script not found for Onchain Send Swap {swap_id}")
-                        })?;
-
-                    // We check the full tx, to determine if this is the BTC lockup tx
-                    let is_first_tx_lockup_tx = first_tx
-                        .output
-                        .iter()
-                        .any(|out| matches!(&out.script_pubkey, x if x == &btc_lockup_script));
-
-                    match is_first_tx_lockup_tx {
-                        true => (Some(first_tx_id), Some(second_tx_id)),
-                        false => (Some(second_tx_id), Some(first_tx_id)),
-                    }
-                }
-                n => {
-                    warn!("BTC script history with length {n} found while recovering data for Chain Send Swap {swap_id}");
-                    (None, None)
-                }
-            };
-
-            res.insert(
-                swap_id,
-                RecoveredOnchainDataChainSend {
-                    lbtc_user_lockup_tx_id,
-                    lbtc_refund_tx_id,
-                    btc_server_lockup_tx_id,
-                    btc_claim_tx_id,
-                },
-            );
-        }
-
-        Ok(res)
-    }
-
-    /// Reconstruct Chain Receive Swap tx IDs from the onchain data and the immutable data
-    ///
-    /// The implementation tolerates a `tx_map` that is older than the `chain_receive_histories_by_swap_id`
-    /// in the sense that no incorrect data is recovered. Transactions that are missing from `tx_map`
-    /// are simply not recovered.
-    fn recover_receive_chain_swap_tx_ids(
-        &self,
-        tx_map: &TxMap,
-        chain_receive_histories_by_swap_id: HashMap<String, ReceiveChainSwapHistory>,
-        receive_chain_swap_immutable_data_by_swap_id: &HashMap<
-            String,
-            ReceiveChainSwapImmutableData,
-        >,
-    ) -> Result<HashMap<String, RecoveredOnchainDataChainReceive>> {
-        let secp = secp256k1_zkp::Secp256k1::new();
-
-        let mut res: HashMap<String, RecoveredOnchainDataChainReceive> = HashMap::new();
-        for (swap_id, history) in chain_receive_histories_by_swap_id {
-            debug!("[Recover Chain Receive] Checking swap {swap_id}");
-
-            let (lbtc_server_lockup_tx_id, lbtc_claim_tx_id) =
-                determine_incoming_lockup_and_claim_txs(
-                    &history.lbtc_claim_script_history,
-                    tx_map,
-                    &swap_id,
-                );
-
-            let lbtc_claim_address = if let Some(claim_tx_id) = &lbtc_claim_tx_id {
-                tx_map
-                    .incoming_tx_map
-                    .get(&claim_tx_id.txid)
-                    .and_then(|tx| {
-                        tx.outputs
-                            .iter()
-                            .find(|output| output.is_some())
-                            .and_then(|output| output.clone().map(|o| o.script_pubkey))
-                    })
-                    .and_then(|script| {
-                        ElementsAddress::from_script(
-                            &script,
-                            Some(self.master_blinding_key.blinding_key(&secp, &script)),
-                            &AddressParams::LIQUID,
-                        )
-                        .map(|addr| addr.to_string())
-                    })
-            } else {
-                None
-            };
-
-            // Get the current confirmed amount available for the lockup script
-            let btc_user_lockup_address_balance_sat = history
-                .btc_lockup_script_balance
-                .map(|balance| balance.confirmed)
-                .unwrap_or_default();
-
-            // The btc_lockup_script_history can contain 3 kinds of txs, of which only 2 are expected:
-            // - 1) btc_user_lockup_tx_id (initial BTC funds sent by the sender)
-            // - 2A) btc_server_claim_tx_id (the swapper tx that claims the BTC funds, in success case)
-            // - 2B) btc_refund_tx_id (refund tx we initiate, in failure case or with lockup address reuse)
-            // The exact type of the second is found in the next step.
-            let btc_lockup_script = receive_chain_swap_immutable_data_by_swap_id
-                .get(&swap_id)
-                .map(|imm| imm.lockup_script.clone())
-                .ok_or_else(|| {
-                    anyhow!("BTC lockup script not found for Onchain Receive Swap {swap_id}")
-                })?;
-            let (btc_lockup_incoming_txs, btc_lockup_outgoing_txs): (Vec<_>, Vec<_>) =
-                history.btc_lockup_script_txs.iter().partition(|tx| {
-                    tx.output
-                        .iter()
-                        .any(|out| matches!(&out.script_pubkey, x if x == &btc_lockup_script))
-                });
-            // Get the user lockup tx from the first incoming txs
-            let btc_user_lockup_tx_id = btc_lockup_incoming_txs
-                .first()
-                .and_then(|tx| {
-                    history
-                        .btc_lockup_script_history
-                        .iter()
-                        .find(|h| h.txid.as_raw_hash() == tx.compute_txid().as_raw_hash())
-                })
-                .cloned();
-            let btc_user_lockup_amount_sat = btc_lockup_incoming_txs
-                .first()
-                .and_then(|tx| {
-                    tx.output
-                        .iter()
-                        .find(|out| out.script_pubkey == btc_lockup_script)
-                        .map(|out| out.value)
-                })
-                .unwrap_or_default()
-                .to_sat();
-            let btc_outgoing_tx_ids: Vec<HistoryTxId> = btc_lockup_outgoing_txs
-                .iter()
-                .filter_map(|tx| {
-                    history
-                        .btc_lockup_script_history
-                        .iter()
-                        .find(|h| h.txid.as_raw_hash() == tx.compute_txid().as_raw_hash())
-                })
-                .cloned()
-                .collect();
-            // Get the last unconfirmed tx from the outgoing txs, else take the last outgoing tx
-            let btc_last_outgoing_tx_id = btc_outgoing_tx_ids
-                .iter()
-                .rev()
-                .find(|h| h.height == 0)
-                .or(btc_outgoing_tx_ids.last())
-                .cloned();
-
-            // The first outgoing BTC tx is only a refund in case we didn't claim.
-            // If we claimed, then the first tx was the swapper BTC claim tx.
-            // If there are more than 1 outgoing txs then this is a refund from lockup address re-use,
-            // so take the last unconfirmed tx else take the last confirmed tx.
-            let btc_refund_tx_id = match lbtc_claim_tx_id.is_some() {
-                true => match btc_lockup_outgoing_txs.len() > 1 {
-                    true => btc_last_outgoing_tx_id,
-                    false => None,
-                },
-                false => btc_last_outgoing_tx_id,
-            };
-
-            res.insert(
-                swap_id,
-                RecoveredOnchainDataChainReceive {
-                    lbtc_server_lockup_tx_id,
-                    lbtc_claim_tx_id,
-                    lbtc_claim_address,
-                    btc_user_lockup_tx_id,
-                    btc_user_lockup_address_balance_sat,
-                    btc_user_lockup_amount_sat,
-                    btc_refund_tx_id,
-                },
-            );
-        }
-
-        Ok(res)
-    }
-}
-
-fn determine_incoming_lockup_and_claim_txs(
-    history: &[HistoryTxId],
-    tx_map: &TxMap,
-    swap_id: &str,
-) -> (Option<HistoryTxId>, Option<HistoryTxId>) {
-    match history.len() {
-        // Only lockup tx available
-        1 => (Some(history[0].clone()), None),
-        2 => {
-            let first = history[0].clone();
-            let second = history[1].clone();
-
-            if tx_map.incoming_tx_map.contains_key::<Txid>(&first.txid) {
-                // If the first tx is a known incoming tx, it's the claim tx and the second is the lockup
-                (Some(second), Some(first))
-            } else if tx_map.incoming_tx_map.contains_key::<Txid>(&second.txid) {
-                // If the second tx is a known incoming tx, it's the claim tx and the first is the lockup
-                (Some(first), Some(second))
-            } else {
-                // If none of the 2 txs is the claim tx, then the txs are lockup and swapper refund
-                // If so, we expect them to be confirmed at different heights
-                let first_conf_height = first.height;
-                let second_conf_height = second.height;
-                match (first.confirmed(), second.confirmed()) {
-                    // If they're both confirmed, the one with the lowest confirmation height is the lockup
-                    (true, true) => match first_conf_height < second_conf_height {
-                        true => (Some(first), None),
-                        false => (Some(second), None),
-                    },
-
-                    // If only one tx is confirmed, then that is the lockup
-                    (true, false) => (Some(first), None),
-                    (false, true) => (Some(second), None),
-
-                    // If neither is confirmed, this is an edge-case, and the most likely cause is an
-                    // out of date wallet tx_map that doesn't yet include one of the txs.
-                    (false, false) => {
-                        warn!("Found 2 unconfirmed txs in the claim script history of Swap {swap_id}. \
-                        Unable to determine if they include a swapper refund or a user claim");
-                        (None, None)
-                    }
-                }
-            }
-        }
-        n => {
-            warn!("Unexpected script history length {n} while recovering data for Swap {swap_id}");
-            (None, None)
-        }
     }
 }

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -78,7 +78,7 @@ impl Recoverer {
 
         let recovery_started_at = utils::now();
 
-        // Fetch raw transaction map and convert to our internal format
+        // Create wallet transactions map
         let raw_tx_map = self.onchain_wallet.transactions_by_tx_id().await?;
 
         // Fetch chain tips for expiration checks
@@ -159,12 +159,12 @@ impl Recoverer {
     ) -> Result<RecoveryContext> {
         // Fetch history data for each lbtc swap script
         let lbtc_script_to_history_map = self
-            .create_lbtc_history_map(swaps_list.get_swap_lbtc_scripts())
+            .fetch_lbtc_history_map(swaps_list.get_swap_lbtc_scripts())
             .await?;
 
         // Fetch history data for each btc swap script
         let (btc_script_to_history_map, btc_script_to_txs_map, btc_script_to_balance_map) = self
-            .create_btc_history_maps(swaps_list.get_swap_btc_scripts())
+            .fetch_btc_script_maps(swaps_list.get_swap_btc_scripts())
             .await?;
 
         Ok(RecoveryContext {
@@ -181,7 +181,7 @@ impl Recoverer {
         })
     }
 
-    async fn create_lbtc_history_map(
+    async fn fetch_lbtc_history_map(
         &self,
         swap_lbtc_scripts: Vec<LBtcScript>,
     ) -> Result<HashMap<LBtcScript, Vec<HistoryTxId>>> {
@@ -211,7 +211,7 @@ impl Recoverer {
         Ok(lbtc_script_to_history_map)
     }
 
-    async fn create_btc_history_maps(
+    async fn fetch_btc_script_maps(
         &self,
         swap_btc_script_bufs: Vec<BtcScript>,
     ) -> Result<(

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -291,6 +291,7 @@ impl LiquidSdkBuilder {
             persister.clone(),
             swapper.clone(),
             liquid_chain_service.clone(),
+            recoverer.clone(),
         );
 
         let receive_swap_handler = ReceiveSwapHandler::new(

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -123,12 +123,6 @@ impl SendSwapHandler {
                             return Err(anyhow!("Expected a Send swap"));
                         };
                         self.update_swap(s)?;
-                        // let preimage = self
-                        //     .get_preimage_from_script_path_claim_spend(&swap)
-                        //     .await?;
-                        // self.validate_send_swap_preimage(id, &swap.invoice, &preimage)
-                        //     .await?;
-                        // self.update_swap_info(id, Complete, Some(&preimage), None, None)?;
                     }
                 }
 

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -62,8 +62,7 @@ pub trait Swapper: Send + Sync {
     /// Get a submarine pair information
     async fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError>;
 
-    /// Get a submarine swap's preimage
-    #[allow(dead_code)]
+    /// Get a submarine swap's preimage    
     async fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError>;
 
     /// Get send swap claim tx details which includes the preimage as a proof of payment.

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -61,6 +61,7 @@ pub trait Swapper: Send + Sync {
     async fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError>;
 
     /// Get a submarine swap's preimage
+    #[allow(dead_code)]
     async fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError>;
 
     /// Get send swap claim tx details which includes the preimage as a proof of payment.

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -10,6 +10,7 @@ use boltz_client::{
     network::Chain,
     Amount,
 };
+use mockall::automock;
 use tokio::sync::{broadcast, watch};
 
 use crate::{
@@ -22,6 +23,7 @@ pub(crate) use subscription_handler::*;
 pub(crate) mod boltz;
 pub(crate) mod subscription_handler;
 
+#[automock]
 #[sdk_macros::async_trait]
 pub trait Swapper: Send + Sync {
     /// Create a new chain swap

--- a/lib/core/src/test_utils/chain.rs
+++ b/lib/core/src/test_utils/chain.rs
@@ -108,7 +108,7 @@ impl LiquidChainService for MockLiquidChainService {
         Ok(self.get_history().into_iter().map(Into::into).collect())
     }
 
-    async fn get_scripts_history(&self, _scripts: &[&ElementsScript]) -> Result<Vec<Vec<History>>> {
+    async fn get_scripts_history(&self, _scripts: &[ElementsScript]) -> Result<Vec<Vec<History>>> {
         Ok(vec![])
     }
 

--- a/lib/core/src/test_utils/send_swap.rs
+++ b/lib/core/src/test_utils/send_swap.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use crate::{
     model::{Config, Signer},
     persist::Persister,
+    recover::recoverer::Recoverer,
     send_swap::SendSwapHandler,
 };
 use anyhow::Result;
 
 use super::{
-    chain::MockLiquidChainService,
+    chain::{MockBitcoinChainService, MockLiquidChainService},
     swapper::MockSwapper,
     wallet::{MockSigner, MockWallet},
 };
@@ -18,9 +19,18 @@ use super::{
 pub(crate) fn new_send_swap_handler(persister: Arc<Persister>) -> Result<SendSwapHandler> {
     let config = Config::testnet(None);
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
-    let onchain_wallet = Arc::new(MockWallet::new(signer)?);
+    let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
     let swapper = Arc::new(MockSwapper::default());
     let chain_service = Arc::new(MockLiquidChainService::new());
+    let liquid_chain_service = Arc::new(MockLiquidChainService::new());
+    let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
+    let recoverer = Arc::new(Recoverer::new(
+        signer.slip77_master_blinding_key()?,
+        swapper.clone(),
+        onchain_wallet.clone(),
+        liquid_chain_service.clone(),
+        bitcoin_chain_service.clone(),
+    )?);
 
     Ok(SendSwapHandler::new(
         config,
@@ -28,5 +38,6 @@ pub(crate) fn new_send_swap_handler(persister: Arc<Persister>) -> Result<SendSwa
         persister,
         swapper,
         chain_service,
+        recoverer,
     ))
 }


### PR DESCRIPTION
Work in progress.
Instead of letting the recoverer handle all kind of hash tables tailored maid for each swap, it is only responsible for fetching the script histories (and transactions) from the chain services, passing it as context to the specific swap recover handler and let it doing all the matching work at the low level.
Still need to do a lot of testing and changes before it is ready.
Pushing it to get feedback on the concept.