### PR TITLE
Update selected built packages to Uniffi 0.28

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -21,14 +21,35 @@ on:
         required: false
         type: boolean
         default: false
+      uniffi-25:
+        description: 'If true, builds additional bindings for Uniffi 0.25'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-matrix
+        run: |
+          if [ ${{ inputs.uniffi-25 }} == true ]; then
+            echo "::set-output name=matrix::['', '-uniffi-25']"
+          else
+            echo "::set-output name=matrix::['']"
+          fi
+    outputs:
+      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build ${{ matrix.target }}
+    name: build ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
           x86_64-linux-android,
@@ -55,12 +76,18 @@ jobs:
         
     - uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ matrix.uniffi }}
         workspaces: lib
 
     - name: Build bindings
+      if: matrix.uniffi != '-uniffi-25'
       working-directory: lib/bindings
-      run: |
-        cargo ndk -t ${{ matrix.target }} build --release
+      run: cargo ndk -t ${{ matrix.target }} build --release
+
+    - name: Build bindings Uniffi 0.25
+      if: matrix.uniffi == '-uniffi-25'
+      working-directory: lib/bindings
+      run: cargo ndk -t ${{ matrix.target }} build --no-default-features --features=uniffi-25 --release
 
     - name: Copy build output
       run: |
@@ -73,36 +100,43 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-${{ matrix.target }}
+        name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
         path: dist/*
   
   jnilibs:
-    needs: build
+    needs: 
+    - setup
+    - build
     runs-on: ubuntu-latest
-    name: build jniLibs
+    name: build jniLibs${{ matrix.uniffi }}
+    strategy:
+      matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-linux-android
+          name: bindings-aarch64-linux-android${{ matrix.uniffi }}
           path: arm64-v8a
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-linux-android
+          name: bindings-x86_64-linux-android${{ matrix.uniffi }}
           path: x86_64
       
       - name: Archive jniLibs
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-android-jniLibs
+          name: bindings-android-jniLibs${{ matrix.uniffi }}
           path: ./*
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build android dummies
+    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
           x86_64-linux-android,
@@ -116,26 +150,31 @@ jobs:
       - name: Upload dummy Android ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
           path: ./*
 
   jnilibs-dummy:
-    needs: build-dummies
+    needs: 
+    - setup
+    - build-dummies
     runs-on: ubuntu-latest
-    name: build jniLibs dummy
+    name: build jniLibs dummy ${{ matrix.target }}${{ matrix.uniffi }}
+    strategy:
+      matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-linux-android
+          name: bindings-aarch64-linux-android${{ matrix.uniffi }}
           path: arm64-v8a
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-linux-android
+          name: bindings-x86_64-linux-android${{ matrix.uniffi }}
           path: x86_64
       
       - name: Archive jniLibs
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-android-jniLibs
+          name: bindings-android-jniLibs${{ matrix.uniffi }}
           path: ./*

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -21,14 +21,35 @@ on:
         required: false
         type: boolean
         default: false
+      uniffi-25:
+        description: 'If true, builds additional bindings for Uniffi 0.25'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-matrix
+        run: |
+          if [ ${{ inputs.uniffi-25 }} == true ]; then
+            echo "::set-output name=matrix::['', '-uniffi-25']"
+          else
+            echo "::set-output name=matrix::['']"
+          fi
+    outputs:
+      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
-    name: build ${{ matrix.target }}
+    name: build ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-darwin,
           x86_64-apple-darwin,
@@ -55,33 +76,45 @@ jobs:
         
     - uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ matrix.uniffi }}
         workspaces: lib
 
     - name: Build bindings
+      if: matrix.uniffi != '-uniffi-25'
       working-directory: lib/bindings
       run: cargo lipo --release --targets ${{ matrix.target }}
+
+    - name: Build bindings Uniffi 0.25
+      if: matrix.uniffi == '-uniffi-25'
+      working-directory: lib/bindings
+      run: cargo lipo --no-default-features --features=uniffi-25 --release --targets ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-${{ matrix.target }}
+        name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
         path: |
           lib/target/${{ matrix.target }}/release/libbreez_sdk_liquid_bindings.dylib
           lib/target/${{ matrix.target }}/release/libbreez_sdk_liquid_bindings.a
   
   merge:
     runs-on: macOS-latest
-    needs: build
-    name: build darwin-universal
+    needs: 
+    - setup
+    - build
+    name: build darwin-universal${{ matrix.uniffi }}
+    strategy:
+      matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: bindings-aarch64-apple-darwin
+        name: bindings-aarch64-apple-darwin${{ matrix.uniffi }}
         path: aarch64-apple-darwin
 
     - uses: actions/download-artifact@v4
       with:
-        name: bindings-x86_64-apple-darwin
+        name: bindings-x86_64-apple-darwin${{ matrix.uniffi }}
         path: x86_64-apple-darwin
 
     - name: Build Darwin universal
@@ -93,7 +126,7 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-darwin-universal
+        name: bindings-darwin-universal${{ matrix.uniffi }}
         path: |
           darwin-universal/libbreez_sdk_liquid_bindings.dylib
           darwin-universal/libbreez_sdk_liquid_bindings.a
@@ -101,9 +134,12 @@ jobs:
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build darwin dummies
+    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: 
+    - setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-darwin,
           x86_64-apple-darwin,
@@ -118,5 +154,5 @@ jobs:
       - name: Upload dummy darwin ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
           path: ./*

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -21,14 +21,35 @@ on:
         required: false
         type: boolean
         default: false
+      uniffi-25:
+        description: 'If true, builds additional bindings for Uniffi 0.25'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-matrix
+        run: |
+          if [ ${{ inputs.uniffi-25 }} == true ]; then
+            echo "::set-output name=matrix::['', '-uniffi-25']"
+          else
+            echo "::set-output name=matrix::['']"
+          fi
+    outputs:
+      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
-    name: build ${{ matrix.target }}
+    name: build ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-ios,
           x86_64-apple-ios,
@@ -58,6 +79,7 @@ jobs:
         
     - uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ matrix.uniffi }}
         workspaces: lib
 
     - name: Install xcode
@@ -66,33 +88,44 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build bindings
+      if: matrix.uniffi != '-uniffi-25'
       working-directory: lib/bindings
       run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Build bindings Uniffi 0.25
+      if: matrix.uniffi == '-uniffi-25'
+      working-directory: lib/bindings
+      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-${{ matrix.target }}
+        name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
         path: lib/target/${{ matrix.target }}/release/libbreez_sdk_liquid_bindings.a
 
   merge:
     runs-on: macOS-latest
-    needs: build
-    name: build ios-universal
+    needs: 
+    - setup
+    - build
+    name: build ios-universal${{ matrix.uniffi }}
+    strategy:
+      matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: bindings-aarch64-apple-ios
+        name: bindings-aarch64-apple-ios${{ matrix.uniffi }}
         path: aarch64-apple-ios
 
     - uses: actions/download-artifact@v4
       with:
-        name: bindings-x86_64-apple-ios
+        name: bindings-x86_64-apple-ios${{ matrix.uniffi }}
         path: x86_64-apple-ios
 
     - uses: actions/download-artifact@v4
       with:
-        name: bindings-aarch64-apple-ios-sim
+        name: bindings-aarch64-apple-ios-sim${{ matrix.uniffi }}
         path: aarch64-apple-ios-sim
 
     - name: Build ios-universal
@@ -108,21 +141,23 @@ jobs:
     - name: Archive ios-universal
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-ios-universal
+        name: bindings-ios-universal${{ matrix.uniffi }}
         path: ios-universal/libbreez_sdk_liquid_bindings.a
 
     - name: Archive ios-universal-sim
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-ios-universal-sim
+        name: bindings-ios-universal-sim${{ matrix.uniffi }}
         path: ios-universal-sim/libbreez_sdk_liquid_bindings.a
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build ios dummies
+    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-ios,
           x86_64-apple-ios,
@@ -138,5 +173,5 @@ jobs:
       - name: Upload dummy ios ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}{{ matrix.uniffi }}
           path: ./*

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -21,14 +21,35 @@ on:
         required: false
         type: boolean
         default: false
+      uniffi-25:
+        description: 'If true, builds additional bindings for Uniffi 0.25'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-matrix
+        run: |
+          if [ ${{ inputs.uniffi-25 }} == true ]; then
+            echo "::set-output name=matrix::['', '-uniffi-25']"
+          else
+            echo "::set-output name=matrix::['']"
+          fi
+    outputs:
+      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-20.04
-    name: build ${{ matrix.target }}
+    name: build ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-unknown-linux-gnu,
           x86_64-unknown-linux-gnu,
@@ -66,27 +87,39 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ matrix.uniffi }}
         workspaces: lib
 
     - name: Build bindings
+      if: matrix.uniffi != '-uniffi-25'
       working-directory: lib/bindings
       env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
       run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Build bindings Uniffi 0.25
+      if: matrix.uniffi == '-uniffi-25'
+      working-directory: lib/bindings
+      env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
+      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-${{ matrix.target }}
+        name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
         path: lib/target/${{ matrix.target }}/release/libbreez_sdk_liquid_bindings.so
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build linux dummies
+    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-unknown-linux-gnu,
           x86_64-unknown-linux-gnu,
@@ -99,5 +132,5 @@ jobs:
       - name: Upload dummy linux ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
           path: ./*

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -21,14 +21,35 @@ on:
         required: false
         type: boolean
         default: false
+      uniffi-25:
+        description: 'If true, builds additional bindings for Uniffi 0.25'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-matrix
+        run: |
+          if [ ${{ inputs.uniffi-25 }} == true ]; then
+            echo "::set-output name=matrix::['', '-uniffi-25']"
+          else
+            echo "::set-output name=matrix::['']"
+          fi
+    outputs:
+      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: windows-latest
-    name: build ${{ matrix.target }}
+    name: build ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           x86_64-pc-windows-msvc,
         ]
@@ -53,24 +74,33 @@ jobs:
         
     - uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ matrix.uniffi }}
         workspaces: lib
 
     - name: Build bindings
+      if: matrix.uniffi != '-uniffi-25'
       working-directory: lib/bindings
       run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Build bindings Uniffi 0.25
+      if: matrix.uniffi == '-uniffi-25'
+      working-directory: lib/bindings
+      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
 
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: bindings-${{ matrix.target }}
+        name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
         path: lib/target/${{ matrix.target }}/release/breez_sdk_liquid_bindings.dll
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build windows dummies
+    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
+    needs: setup
     strategy:
       matrix:
+        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           x86_64-pc-windows-msvc,
         ]
@@ -82,5 +112,5 @@ jobs:
       - name: Upload dummy windows ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}${{ matrix.uniffi }}
           path: ./*

--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -60,6 +60,7 @@ on:
 jobs:
   build-language-bindings:
     runs-on: ubuntu-latest
+    if: ${{ inputs.kotlin || inputs.swift || inputs.python }}
     steps:
       - name: Checkout breez-sdk-liquid repo
         uses: actions/checkout@v4
@@ -77,12 +78,16 @@ jobs:
         with:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: lib
 
       - name: Build Kotlin binding
         if: ${{ inputs.kotlin }}
         working-directory: lib/bindings
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language kotlin -o ffi/kotlin
+          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language kotlin -o ffi/kotlin
   
       - name: Archive Kotlin binding
         if: ${{ inputs.kotlin }}
@@ -90,19 +95,12 @@ jobs:
         with:
           name: bindings-kotlin
           path: lib/bindings/ffi/kotlin/breez_sdk_liquid/breez_sdk_liquid.kt
-
-      - name: Archive Kotlin multiplatform binding
-        if: ${{ inputs.kotlin }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-kotlin-multiplatform
-          path: lib/bindings/ffi/kmp/*
       
       - name: Build Swift binding
         if: ${{ inputs.swift }}
         working-directory: lib/bindings
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift --out-dir langs/swift/Sources/BreezSDKLiquid
+          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift --out-dir langs/swift/Sources/BreezSDKLiquid
           mv langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquid.swift langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquid.swift
       
       - name: Archive Swift binding
@@ -116,7 +114,7 @@ jobs:
         if: ${{ inputs.python }}
         working-directory: lib/bindings
         run: |
-            cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language python -o ffi/python
+            cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language python -o ffi/python
     
       - name: Archive Python binding
         if: ${{ inputs.python }}
@@ -124,6 +122,45 @@ jobs:
         with:
           name: bindings-python
           path: lib/bindings/ffi/python/breez_sdk_liquid.py
+
+  build-language-bindings-uniffi-25:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.kotlin || inputs.csharp || inputs.golang }}
+    steps:
+      - name: Checkout breez-sdk-liquid repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Install rust
+        run: |
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile minimal
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: uniffi-25
+          workspaces: lib
+
+      - name: Build Kotlin binding
+        if: ${{ inputs.kotlin }}
+        working-directory: lib/bindings
+        run: |
+          cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language kotlin -o ffi/kotlin
+
+      - name: Archive Kotlin multiplatform binding
+        if: ${{ inputs.kotlin }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-kotlin-multiplatform
+          path: lib/bindings/ffi/kmp/*
 
       - name: Build C# binding
         if: ${{ inputs.csharp }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,15 +153,55 @@ jobs:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      
+      - name: Build bindings
+        working-directory: lib/bindings
+        run: cargo build
+
+      - name: Run bindings tests
+        run: |
+          curl -o jna-5.12.1.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
+          export CLASSPATH=$(pwd)/jna-5.12.1.jar;
+          cd lib/bindings
+          cargo test
+
+  build-bindings-uniffi-25:
+    name: Test bindings Uniffi 0.25
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: -uniffi-25
+          workspaces: |
+            lib -> target
+            cli -> target
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup dotnet
-        if: ${{ !inputs.skip-tests }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
 
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.9'
+
       - name: Build bindings
         working-directory: lib/bindings
-        run: cargo build
+        run: cargo build --no-default-features --features uniffi-25
 
       - name: Build C# bindings
         working-directory: lib/bindings       
@@ -178,22 +218,9 @@ jobs:
           cp ../target/debug/libbreez_sdk_liquid_bindings.so ffi/golang
           cp -r ffi/golang/breez_sdk_liquid tests/bindings/golang/
 
-      - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.19.9'
-
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
       - name: Run bindings tests
-        run: |
-          curl -o jna-5.12.1.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
-          export CLASSPATH=$(pwd)/jna-5.12.1.jar;
-          cd lib/bindings
-          cargo test
+        working-directory: lib/bindings       
+        run: cargo test --no-default-features --features uniffi-25
 
   build-wasm:
     name: Test WASM
@@ -255,7 +282,7 @@ jobs:
       - name: Build Android bindings
         working-directory: lib/bindings       
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o langs/android/lib/src/main/kotlin
+          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o langs/android/lib/src/main/kotlin
 
       - name: Run Android build
         working-directory: lib/bindings/langs/android  
@@ -265,7 +292,7 @@ jobs:
       - name: Build Swift bindings
         working-directory: lib/bindings       
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift -o langs/swift/Sources/BreezSDKLiquid
+          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift -o langs/swift/Sources/BreezSDKLiquid
           mv langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquid.swift langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquid.swift
           cp langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.h langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64/breez_sdk_liquidFFI.framework/Headers
           cp langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.h langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/Headers

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -121,6 +121,7 @@ jobs:
       swift-package-version: ${{ needs.pre-setup.outputs.swift-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
       use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
+      uniffi-25: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version }}
     steps:
       - run: echo "set setup output variables"
 
@@ -132,6 +133,7 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-darwin:
     needs: setup
@@ -141,6 +143,7 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-linux:
     needs: setup
@@ -150,6 +153,7 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-android:
     needs: setup
@@ -159,6 +163,7 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-ios:
     needs: setup
@@ -168,6 +173,7 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-language-bindings:
     needs: setup

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -46,27 +46,27 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-apple-darwin
+          name: bindings-aarch64-apple-darwin-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/osx-arm64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-apple-darwin
+          name: bindings-x86_64-apple-darwin-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/osx-x64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-unknown-linux-gnu
+          name: bindings-aarch64-unknown-linux-gnu-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/linux-arm64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-unknown-linux-gnu
+          name: bindings-x86_64-unknown-linux-gnu-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/linux-x64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-pc-windows-msvc
+          name: bindings-x86_64-pc-windows-msvc-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/win-x64/native
 
       - name: Update package version

--- a/.github/workflows/publish-golang.yml
+++ b/.github/workflows/publish-golang.yml
@@ -38,37 +38,37 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-linux-android
+          name: bindings-aarch64-linux-android-uniffi-25
           path: breez_sdk_liquid/lib/android-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-linux-android
+          name: bindings-x86_64-linux-android-uniffi-25
           path: breez_sdk_liquid/lib/android-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-apple-darwin
+          name: bindings-aarch64-apple-darwin-uniffi-25
           path: breez_sdk_liquid/lib/darwin-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-apple-darwin
+          name: bindings-x86_64-apple-darwin-uniffi-25
           path: breez_sdk_liquid/lib/darwin-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-unknown-linux-gnu
+          name: bindings-aarch64-unknown-linux-gnu-uniffi-25
           path: breez_sdk_liquid/lib/linux-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-unknown-linux-gnu
+          name: bindings-x86_64-unknown-linux-gnu-uniffi-25
           path: breez_sdk_liquid/lib/linux-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-pc-windows-msvc
+          name: bindings-x86_64-pc-windows-msvc-uniffi-25
           path: breez_sdk_liquid/lib/windows-amd64
 
       - name: Archive Go release

--- a/.github/workflows/publish-kotlin-multiplatform.yml
+++ b/.github/workflows/publish-kotlin-multiplatform.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-android-jniLibs
+          name: bindings-android-jniLibs-uniffi-25
           path: lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/androidMain/jniLibs
 
       - uses: actions/download-artifact@v4
@@ -59,17 +59,17 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-apple-ios
+          name: bindings-aarch64-apple-ios-uniffi-25
           path: lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/lib/ios-arm64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-aarch64-apple-ios-sim
+          name: bindings-aarch64-apple-ios-sim-uniffi-25
           path: lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/lib/ios-simulator-arm64
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-x86_64-apple-ios
+          name: bindings-x86_64-apple-ios-uniffi-25
           path: lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/lib/ios-simulator-x64
 
       - name: Build Kotlin Multiplatform project

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -5,3 +5,4 @@ target
 *.so
 *.a
 bindings/ffi
+bindings/testnet

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -856,7 +856,9 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "uniffi 0.25.3",
+ "uniffi 0.28.0",
  "uniffi_bindgen 0.25.3",
+ "uniffi_bindgen 0.28.0",
  "uniffi_bindgen_kotlin_multiplatform",
 ]
 
@@ -1869,7 +1871,18 @@ checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
 dependencies = [
  "log",
  "plain",
- "scroll",
+ "scroll 0.11.0",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.12.0",
 ]
 
 [[package]]
@@ -4130,7 +4143,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 dependencies = [
- "scroll_derive",
+ "scroll_derive 0.11.1",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive 0.12.0",
 ]
 
 [[package]]
@@ -4138,6 +4160,17 @@ name = "scroll_derive"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4450,6 +4483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4683,9 @@ name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+]
 
 [[package]]
 name = "thiserror"
@@ -5223,6 +5265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31bff6daf87277a9014bcdefbc2842b0553392919d1096843c5aad899ca4588"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap 4.5.17",
+ "uniffi_bindgen 0.28.0",
+ "uniffi_build 0.28.0",
+ "uniffi_core 0.28.0",
+ "uniffi_macros 0.28.0",
+]
+
+[[package]]
 name = "uniffi_bindgen"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,7 +5291,7 @@ dependencies = [
  "camino",
  "fs-err",
  "glob",
- "goblin",
+ "goblin 0.6.1",
  "heck 0.4.1",
  "once_cell",
  "paste",
@@ -5243,7 +5300,7 @@ dependencies = [
  "toml",
  "uniffi_meta 0.23.0",
  "uniffi_testing 0.23.0",
- "weedle2",
+ "weedle2 4.0.0",
 ]
 
 [[package]]
@@ -5259,7 +5316,7 @@ dependencies = [
  "clap 4.5.17",
  "fs-err",
  "glob",
- "goblin",
+ "goblin 0.6.1",
  "heck 0.4.1",
  "once_cell",
  "paste",
@@ -5267,7 +5324,31 @@ dependencies = [
  "toml",
  "uniffi_meta 0.25.3",
  "uniffi_testing 0.25.3",
- "uniffi_udl",
+ "uniffi_udl 0.25.3",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96061d7e01b185aa405f7c9b134741ab3e50cc6796a47d6fd8ab9a5364b5feed"
+dependencies = [
+ "anyhow",
+ "askama 0.12.1",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin 0.8.2",
+ "heck 0.5.0",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml",
+ "uniffi_meta 0.28.0",
+ "uniffi_testing 0.28.0",
+ "uniffi_udl 0.28.0",
 ]
 
 [[package]]
@@ -5310,6 +5391,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_build"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b86f9b221046af0c533eafe09ece04e2f1ded04ccdc9bba0ec09aec1c52bd"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen 0.28.0",
+]
+
+[[package]]
 name = "uniffi_checksum_derive"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5324,6 +5416,16 @@ name = "uniffi_checksum_derive"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
+dependencies = [
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -5357,6 +5459,21 @@ dependencies = [
  "log",
  "once_cell",
  "oneshot-uniffi",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3210d57d6ab6065ab47a2898dacdb7c606fd6a4156196831fa3bf82e34ac58a6"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "log",
+ "once_cell",
  "paste",
  "static_assertions",
 ]
@@ -5400,6 +5517,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58691741080935437dc862122e68d7414432a11824ac1137868de46181a0bd2"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.98",
+ "toml",
+ "uniffi_meta 0.28.0",
+]
+
+[[package]]
 name = "uniffi_meta"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5420,6 +5555,18 @@ dependencies = [
  "bytes",
  "siphasher",
  "uniffi_checksum_derive 0.25.3",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive 0.28.3",
 ]
 
 [[package]]
@@ -5451,6 +5598,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_testing"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f922465f7566f25f8fe766920205fdfa9a3fcdc209c6bfb7557f0b5bf45b04dd"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
 name = "uniffi_udl"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5459,7 +5619,20 @@ dependencies = [
  "anyhow",
  "uniffi_meta 0.25.3",
  "uniffi_testing 0.25.3",
- "weedle2",
+ "weedle2 4.0.0",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef408229a3a407fafa4c36dc4f6ece78a6fb258ab28d2b64bddd49c8cb680f6"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta 0.28.0",
+ "uniffi_testing 0.28.0",
+ "weedle2 5.0.0",
 ]
 
 [[package]]
@@ -5748,6 +5921,15 @@ name = "weedle2"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -40,8 +40,6 @@ serde = { version = "1.0", features = ["derive"] }
 sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "0017f7d3f76a1f0094ad9ff25422b72c31acc60e", features = ["liquid"] }
 sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "0017f7d3f76a1f0094ad9ff25422b72c31acc60e" }
 thiserror = "1.0"
-# Version must match that used by uniffi-bindgen-go
-uniffi = "0.25.0"
 
 [patch.crates-io]
 # https://github.com/BlockstreamResearch/rust-secp256k1-zkp/pull/48/commits and rebased on secp256k1-zkp 0.11.0

--- a/lib/bindings/Cargo.toml
+++ b/lib/bindings/Cargo.toml
@@ -11,6 +11,11 @@ path = "uniffi-bindgen.rs"
 name = "breez_sdk_liquid_bindings"
 crate-type = ["staticlib", "cdylib", "lib"]
 
+[features]
+default = ["uniffi-28"]
+uniffi-25 = ["uniffi_25", "uniffi_bindgen_25", "uniffi_bindgen_kotlin_multiplatform"]
+uniffi-28 = ["uniffi_28", "uniffi_bindgen_28"]
+
 [lints]
 workspace = true
 
@@ -18,15 +23,17 @@ workspace = true
 anyhow = { workspace = true }
 breez-sdk-liquid = { path = "../core" }
 log = { workspace = true }
-uniffi = { workspace = true, features = [ "bindgen-tests", "cli" ] }
-# Bindgen used by KMP, version has to match the one supported by KMP
-uniffi_bindgen = "0.25.2"
-uniffi_bindgen_kotlin_multiplatform = { git = "https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings", rev = "e8e3a88df5b657787c1198425c16008232b26548" }
+uniffi_25 = { package = "uniffi", version = "0.25.2", features = [ "bindgen-tests", "cli" ], optional = true }
+uniffi_28 = { package = "uniffi", version = "0.28.0", features = [ "bindgen-tests", "cli" ], optional = true }
+uniffi_bindgen_25 = { package = "uniffi_bindgen", version = "0.25.2", optional = true }
+uniffi_bindgen_28 = { package = "uniffi_bindgen", version = "0.28.0", optional = true }
+uniffi_bindgen_kotlin_multiplatform = { git = "https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings", rev = "e8e3a88df5b657787c1198425c16008232b26548", optional = true }
 camino = "1.1.1"
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt"] }
 once_cell = { workspace = true }
 
 [build-dependencies]
-uniffi = { workspace = true, features = [ "build" ] }
+uniffi_25 = { package = "uniffi", version = "0.25.2", features = [ "build" ], optional = true }
+uniffi_28 = { package = "uniffi", version = "0.28.0", features = [ "build" ], optional = true }
 glob = "0.3.1"

--- a/lib/bindings/build.rs
+++ b/lib/bindings/build.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "uniffi-25")]
+extern crate uniffi_25 as uniffi;
+#[cfg(feature = "uniffi-28")]
+extern crate uniffi_28 as uniffi;
+
 use glob::glob;
 use std::env;
 

--- a/lib/bindings/langs/android/lib/build.gradle.kts
+++ b/lib/bindings/langs/android/lib/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 33
         consumerProguardFiles("consumer-rules.pro")
     }
     

--- a/lib/bindings/langs/flutter/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h
@@ -24,24 +24,10 @@
 
 typedef struct RustBuffer
 {
-    int32_t capacity;
-    int32_t len;
+    uint64_t capacity;
+    uint64_t len;
     uint8_t *_Nullable data;
 } RustBuffer;
-
-typedef int32_t (*ForeignCallback)(uint64_t, int32_t, const uint8_t *_Nonnull, int32_t, RustBuffer *_Nonnull);
-
-// Task defined in Rust that Swift executes
-typedef void (*UniFfiRustTaskCallback)(const void * _Nullable, int8_t);
-
-// Callback to execute Rust tasks using a Swift Task
-//
-// Args:
-//   executor: ForeignExecutor lowered into a size_t value
-//   delay: Delay in MS
-//   task: UniFfiRustTaskCallback to call
-//   task_data: data to pass the task callback
-typedef int8_t (*UniFfiForeignExecutorCallback)(size_t, uint32_t, UniFfiRustTaskCallback _Nullable, const void * _Nullable);
 
 typedef struct ForeignBytes
 {
@@ -58,374 +44,1145 @@ typedef struct RustCallStatus {
 // ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) you *must* ⚠️
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
+#ifndef UNIFFI_FFIDEF_RUST_FUTURE_CONTINUATION_CALLBACK
+#define UNIFFI_FFIDEF_RUST_FUTURE_CONTINUATION_CALLBACK
+typedef void (*UniffiRustFutureContinuationCallback)(uint64_t, int8_t
+    );
 
-// Continuation callback for UniFFI Futures
-typedef void (*UniFfiRustFutureContinuation)(void * _Nonnull, int8_t);
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
+typedef void (*UniffiForeignFutureFree)(uint64_t
+    );
 
-// Scaffolding functions
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_FREE
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_FREE
+typedef void (*UniffiCallbackInterfaceFree)(uint64_t
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE
+typedef struct UniffiForeignFuture {
+    uint64_t handle;
+    UniffiForeignFutureFree _Nonnull free;
+} UniffiForeignFuture;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
+typedef struct UniffiForeignFutureStructU8 {
+    uint8_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructU8;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
+typedef void (*UniffiForeignFutureCompleteU8)(uint64_t, UniffiForeignFutureStructU8
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
+typedef struct UniffiForeignFutureStructI8 {
+    int8_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructI8;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
+typedef void (*UniffiForeignFutureCompleteI8)(uint64_t, UniffiForeignFutureStructI8
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
+typedef struct UniffiForeignFutureStructU16 {
+    uint16_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructU16;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
+typedef void (*UniffiForeignFutureCompleteU16)(uint64_t, UniffiForeignFutureStructU16
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
+typedef struct UniffiForeignFutureStructI16 {
+    int16_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructI16;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
+typedef void (*UniffiForeignFutureCompleteI16)(uint64_t, UniffiForeignFutureStructI16
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
+typedef struct UniffiForeignFutureStructU32 {
+    uint32_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructU32;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
+typedef void (*UniffiForeignFutureCompleteU32)(uint64_t, UniffiForeignFutureStructU32
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
+typedef struct UniffiForeignFutureStructI32 {
+    int32_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructI32;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
+typedef void (*UniffiForeignFutureCompleteI32)(uint64_t, UniffiForeignFutureStructI32
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
+typedef struct UniffiForeignFutureStructU64 {
+    uint64_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructU64;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
+typedef void (*UniffiForeignFutureCompleteU64)(uint64_t, UniffiForeignFutureStructU64
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
+typedef struct UniffiForeignFutureStructI64 {
+    int64_t returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructI64;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
+typedef void (*UniffiForeignFutureCompleteI64)(uint64_t, UniffiForeignFutureStructI64
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
+typedef struct UniffiForeignFutureStructF32 {
+    float returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructF32;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
+typedef void (*UniffiForeignFutureCompleteF32)(uint64_t, UniffiForeignFutureStructF32
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
+typedef struct UniffiForeignFutureStructF64 {
+    double returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructF64;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
+typedef void (*UniffiForeignFutureCompleteF64)(uint64_t, UniffiForeignFutureStructF64
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
+typedef struct UniffiForeignFutureStructPointer {
+    void*_Nonnull returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructPointer;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
+typedef void (*UniffiForeignFutureCompletePointer)(uint64_t, UniffiForeignFutureStructPointer
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
+typedef struct UniffiForeignFutureStructRustBuffer {
+    RustBuffer returnValue;
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructRustBuffer;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
+typedef void (*UniffiForeignFutureCompleteRustBuffer)(uint64_t, UniffiForeignFutureStructRustBuffer
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
+typedef struct UniffiForeignFutureStructVoid {
+    RustCallStatus callStatus;
+} UniffiForeignFutureStructVoid;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
+typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t, UniffiForeignFutureStructVoid
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EVENT_LISTENER_METHOD0
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EVENT_LISTENER_METHOD0
+typedef void (*UniffiCallbackInterfaceEventListenerMethod0)(uint64_t, RustBuffer, void* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_LOGGER_METHOD0
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_LOGGER_METHOD0
+typedef void (*UniffiCallbackInterfaceLoggerMethod0)(uint64_t, RustBuffer, void* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD0
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD0
+typedef void (*UniffiCallbackInterfaceSignerMethod0)(uint64_t, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD1
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD1
+typedef void (*UniffiCallbackInterfaceSignerMethod1)(uint64_t, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD2
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD2
+typedef void (*UniffiCallbackInterfaceSignerMethod2)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD3
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD3
+typedef void (*UniffiCallbackInterfaceSignerMethod3)(uint64_t, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD4
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD4
+typedef void (*UniffiCallbackInterfaceSignerMethod4)(uint64_t, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD5
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD5
+typedef void (*UniffiCallbackInterfaceSignerMethod5)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD6
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD6
+typedef void (*UniffiCallbackInterfaceSignerMethod6)(uint64_t, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD7
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_SIGNER_METHOD7
+typedef void (*UniffiCallbackInterfaceSignerMethod7)(uint64_t, RustBuffer, RustBuffer* _Nonnull, 
+        RustCallStatus *_Nonnull uniffiCallStatus
+    );
+
+#endif
+#ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_EVENT_LISTENER
+#define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_EVENT_LISTENER
+typedef struct UniffiVTableCallbackInterfaceEventListener {
+    UniffiCallbackInterfaceEventListenerMethod0 _Nonnull onEvent;
+    UniffiCallbackInterfaceFree _Nonnull uniffiFree;
+} UniffiVTableCallbackInterfaceEventListener;
+
+#endif
+#ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_LOGGER
+#define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_LOGGER
+typedef struct UniffiVTableCallbackInterfaceLogger {
+    UniffiCallbackInterfaceLoggerMethod0 _Nonnull log;
+    UniffiCallbackInterfaceFree _Nonnull uniffiFree;
+} UniffiVTableCallbackInterfaceLogger;
+
+#endif
+#ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_SIGNER
+#define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_SIGNER
+typedef struct UniffiVTableCallbackInterfaceSigner {
+    UniffiCallbackInterfaceSignerMethod0 _Nonnull xpub;
+    UniffiCallbackInterfaceSignerMethod1 _Nonnull deriveXpub;
+    UniffiCallbackInterfaceSignerMethod2 _Nonnull signEcdsa;
+    UniffiCallbackInterfaceSignerMethod3 _Nonnull signEcdsaRecoverable;
+    UniffiCallbackInterfaceSignerMethod4 _Nonnull slip77MasterBlindingKey;
+    UniffiCallbackInterfaceSignerMethod5 _Nonnull hmacSha256;
+    UniffiCallbackInterfaceSignerMethod6 _Nonnull eciesEncrypt;
+    UniffiCallbackInterfaceSignerMethod7 _Nonnull eciesDecrypt;
+    UniffiCallbackInterfaceFree _Nonnull uniffiFree;
+} UniffiVTableCallbackInterfaceSigner;
+
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_CLONE_BINDINGLIQUIDSDK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_CLONE_BINDINGLIQUIDSDK
+void*_Nonnull uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdk(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FREE_BINDINGLIQUIDSDK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FREE_BINDINGLIQUIDSDK
 void uniffi_breez_sdk_liquid_bindings_fn_free_bindingliquidsdk(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_ACCEPT_PAYMENT_PROPOSED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_ACCEPT_PAYMENT_PROPOSED_FEES
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_accept_payment_proposed_fees(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_ADD_EVENT_LISTENER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_ADD_EVENT_LISTENER
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_add_event_listener(void*_Nonnull ptr, uint64_t listener, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_BACKUP
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_BACKUP
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_backup(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_BUY_BITCOIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_BUY_BITCOIN
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_buy_bitcoin(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_CHECK_MESSAGE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_CHECK_MESSAGE
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_check_message(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_DISCONNECT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_DISCONNECT
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_disconnect(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_FIAT_RATES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_FIAT_RATES
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_fetch_fiat_rates(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_LIGHTNING_LIMITS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_LIGHTNING_LIMITS
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_fetch_lightning_limits(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_ONCHAIN_LIMITS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_ONCHAIN_LIMITS
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_fetch_onchain_limits(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_PAYMENT_PROPOSED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_FETCH_PAYMENT_PROPOSED_FEES
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_fetch_payment_proposed_fees(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_GET_INFO
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_GET_INFO
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_get_info(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_GET_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_GET_PAYMENT
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_get_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_FIAT_CURRENCIES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_FIAT_CURRENCIES
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_list_fiat_currencies(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_PAYMENTS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_PAYMENTS
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_list_payments(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_REFUNDABLES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LIST_REFUNDABLES
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_list_refundables(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_AUTH
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_AUTH
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_lnurl_auth(void*_Nonnull ptr, RustBuffer req_data, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_PAY
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_PAY
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_lnurl_pay(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_WITHDRAW
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_LNURL_WITHDRAW
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_lnurl_withdraw(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PARSE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PARSE
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_parse(void*_Nonnull ptr, RustBuffer input, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PAY_ONCHAIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PAY_ONCHAIN
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_pay_onchain(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_BUY_BITCOIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_BUY_BITCOIN
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_buy_bitcoin(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_LNURL_PAY
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_LNURL_PAY
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_lnurl_pay(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_PAY_ONCHAIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_PAY_ONCHAIN
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_pay_onchain(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_RECEIVE_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_RECEIVE_PAYMENT
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_receive_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_REFUND
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_REFUND
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_refund(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_SEND_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_PREPARE_SEND_PAYMENT
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_prepare_send_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RECEIVE_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RECEIVE_PAYMENT
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_receive_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RECOMMENDED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RECOMMENDED_FEES
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_recommended_fees(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REFUND
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REFUND
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_refund(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REGISTER_WEBHOOK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REGISTER_WEBHOOK
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_register_webhook(void*_Nonnull ptr, RustBuffer webhook_url, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REMOVE_EVENT_LISTENER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_REMOVE_EVENT_LISTENER
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_remove_event_listener(void*_Nonnull ptr, RustBuffer id, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RESCAN_ONCHAIN_SWAPS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RESCAN_ONCHAIN_SWAPS
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_rescan_onchain_swaps(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RESTORE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_RESTORE
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_restore(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SEND_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SEND_PAYMENT
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_send_payment(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SIGN_MESSAGE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SIGN_MESSAGE
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_sign_message(void*_Nonnull ptr, RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SYNC
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_SYNC
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_sync(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_UNREGISTER_WEBHOOK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_METHOD_BINDINGLIQUIDSDK_UNREGISTER_WEBHOOK
 void uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_unregister_webhook(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
-void uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistener(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_EVENTLISTENER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_EVENTLISTENER
+void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistener(UniffiVTableCallbackInterfaceEventListener* _Nonnull vtable
 );
-void uniffi_breez_sdk_liquid_bindings_fn_init_callback_logger(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_LOGGER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_LOGGER
+void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_logger(UniffiVTableCallbackInterfaceLogger* _Nonnull vtable
 );
-void uniffi_breez_sdk_liquid_bindings_fn_init_callback_signer(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_SIGNER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_INIT_CALLBACK_VTABLE_SIGNER
+void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signer(UniffiVTableCallbackInterfaceSigner* _Nonnull vtable
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_CONNECT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_CONNECT
 void*_Nonnull uniffi_breez_sdk_liquid_bindings_fn_func_connect(RustBuffer req, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_CONNECT_WITH_SIGNER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_CONNECT_WITH_SIGNER
 void*_Nonnull uniffi_breez_sdk_liquid_bindings_fn_func_connect_with_signer(RustBuffer req, uint64_t signer, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_DEFAULT_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_DEFAULT_CONFIG
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_func_default_config(RustBuffer network, RustBuffer breez_api_key, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_PARSE_INVOICE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_PARSE_INVOICE
 RustBuffer uniffi_breez_sdk_liquid_bindings_fn_func_parse_invoice(RustBuffer input, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_SET_LOGGER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_FN_FUNC_SET_LOGGER
 void uniffi_breez_sdk_liquid_bindings_fn_func_set_logger(uint64_t logger, RustCallStatus *_Nonnull out_status
 );
-RustBuffer ffi_breez_sdk_liquid_bindings_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_ALLOC
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_ALLOC
+RustBuffer ffi_breez_sdk_liquid_bindings_rustbuffer_alloc(uint64_t size, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_FROM_BYTES
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_FROM_BYTES
 RustBuffer ffi_breez_sdk_liquid_bindings_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_Nonnull out_status
 );
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_FREE
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_FREE
 void ffi_breez_sdk_liquid_bindings_rustbuffer_free(RustBuffer buf, RustCallStatus *_Nonnull out_status
 );
-RustBuffer ffi_breez_sdk_liquid_bindings_rustbuffer_reserve(RustBuffer buf, int32_t additional, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_RESERVE
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUSTBUFFER_RESERVE
+RustBuffer ffi_breez_sdk_liquid_bindings_rustbuffer_reserve(RustBuffer buf, uint64_t additional, RustCallStatus *_Nonnull out_status
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_set(UniFfiRustFutureContinuation _Nonnull callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U8
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_u8(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_u8(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U8
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U8
+void ffi_breez_sdk_liquid_bindings_rust_future_free_u8(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_u8(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U8
+uint8_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u8(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-uint8_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u8(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I8
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_i8(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_i8(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I8
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I8
+void ffi_breez_sdk_liquid_bindings_rust_future_free_i8(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_i8(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I8
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I8
+int8_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i8(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-int8_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i8(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U16
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_u16(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_u16(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U16
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U16
+void ffi_breez_sdk_liquid_bindings_rust_future_free_u16(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_u16(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U16
+uint16_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u16(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-uint16_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u16(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I16
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_i16(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_i16(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I16
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I16
+void ffi_breez_sdk_liquid_bindings_rust_future_free_i16(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_i16(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I16
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I16
+int16_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i16(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-int16_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i16(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U32
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_u32(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_u32(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U32
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U32
+void ffi_breez_sdk_liquid_bindings_rust_future_free_u32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_u32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U32
+uint32_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u32(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-uint32_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u32(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I32
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_i32(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_i32(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I32
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I32
+void ffi_breez_sdk_liquid_bindings_rust_future_free_i32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_i32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I32
+int32_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i32(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-int32_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i32(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_U64
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_u64(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_u64(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_U64
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_U64
+void ffi_breez_sdk_liquid_bindings_rust_future_free_u64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_u64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_U64
+uint64_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u64(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-uint64_t ffi_breez_sdk_liquid_bindings_rust_future_complete_u64(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_I64
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_i64(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_i64(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_I64
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_I64
+void ffi_breez_sdk_liquid_bindings_rust_future_free_i64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_i64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_I64
+int64_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i64(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-int64_t ffi_breez_sdk_liquid_bindings_rust_future_complete_i64(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_F32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_F32
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_f32(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_f32(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_F32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_F32
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_F32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_F32
+void ffi_breez_sdk_liquid_bindings_rust_future_free_f32(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_f32(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_F32
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_F32
+float ffi_breez_sdk_liquid_bindings_rust_future_complete_f32(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-float ffi_breez_sdk_liquid_bindings_rust_future_complete_f32(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_F64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_F64
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_f64(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_f64(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_F64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_F64
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_F64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_F64
+void ffi_breez_sdk_liquid_bindings_rust_future_free_f64(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_f64(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_F64
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_F64
+double ffi_breez_sdk_liquid_bindings_rust_future_complete_f64(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-double ffi_breez_sdk_liquid_bindings_rust_future_complete_f64(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_POINTER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_POINTER
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_POINTER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_POINTER
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_POINTER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_POINTER
+void ffi_breez_sdk_liquid_bindings_rust_future_free_pointer(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_pointer(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_POINTER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_POINTER
+void*_Nonnull ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_RUST_BUFFER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_RUST_BUFFER
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_RUST_BUFFER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_RUST_BUFFER
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_RUST_BUFFER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_RUST_BUFFER
+void ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_RUST_BUFFER
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_RUST_BUFFER
+RustBuffer ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-RustBuffer ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_VOID
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_POLL_VOID
+void ffi_breez_sdk_liquid_bindings_rust_future_poll_void(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_poll_void(void* _Nonnull handle, void* _Nonnull uniffi_callback
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_VOID
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_CANCEL_VOID
+void ffi_breez_sdk_liquid_bindings_rust_future_cancel_void(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_cancel_void(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_VOID
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_FREE_VOID
+void ffi_breez_sdk_liquid_bindings_rust_future_free_void(uint64_t handle
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_free_void(void* _Nonnull handle
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_VOID
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_RUST_FUTURE_COMPLETE_VOID
+void ffi_breez_sdk_liquid_bindings_rust_future_complete_void(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
-void ffi_breez_sdk_liquid_bindings_rust_future_complete_void(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
-);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_CONNECT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_CONNECT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_func_connect(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_CONNECT_WITH_SIGNER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_CONNECT_WITH_SIGNER
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_func_connect_with_signer(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_DEFAULT_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_DEFAULT_CONFIG
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_func_default_config(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_PARSE_INVOICE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_PARSE_INVOICE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_func_parse_invoice(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_SET_LOGGER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_FUNC_SET_LOGGER
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_func_set_logger(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_ACCEPT_PAYMENT_PROPOSED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_ACCEPT_PAYMENT_PROPOSED_FEES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_accept_payment_proposed_fees(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_ADD_EVENT_LISTENER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_ADD_EVENT_LISTENER
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_add_event_listener(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_BACKUP
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_BACKUP
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_backup(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_BUY_BITCOIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_BUY_BITCOIN
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_buy_bitcoin(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_CHECK_MESSAGE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_CHECK_MESSAGE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_check_message(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_DISCONNECT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_DISCONNECT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_disconnect(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_FIAT_RATES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_FIAT_RATES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_fetch_fiat_rates(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_LIGHTNING_LIMITS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_LIGHTNING_LIMITS
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_fetch_lightning_limits(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_ONCHAIN_LIMITS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_ONCHAIN_LIMITS
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_fetch_onchain_limits(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_PAYMENT_PROPOSED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_FETCH_PAYMENT_PROPOSED_FEES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_fetch_payment_proposed_fees(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_GET_INFO
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_GET_INFO
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_get_info(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_GET_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_GET_PAYMENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_get_payment(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_FIAT_CURRENCIES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_FIAT_CURRENCIES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_list_fiat_currencies(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_PAYMENTS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_PAYMENTS
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_list_payments(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_REFUNDABLES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LIST_REFUNDABLES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_list_refundables(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_AUTH
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_AUTH
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_lnurl_auth(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_PAY
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_PAY
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_lnurl_pay(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_WITHDRAW
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_LNURL_WITHDRAW
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_lnurl_withdraw(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PARSE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PARSE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_parse(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PAY_ONCHAIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PAY_ONCHAIN
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_pay_onchain(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_BUY_BITCOIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_BUY_BITCOIN
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_buy_bitcoin(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_LNURL_PAY
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_LNURL_PAY
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_lnurl_pay(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_PAY_ONCHAIN
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_PAY_ONCHAIN
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_pay_onchain(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_RECEIVE_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_RECEIVE_PAYMENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_receive_payment(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_REFUND
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_REFUND
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_refund(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_SEND_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_PREPARE_SEND_PAYMENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_prepare_send_payment(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RECEIVE_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RECEIVE_PAYMENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_receive_payment(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RECOMMENDED_FEES
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RECOMMENDED_FEES
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_recommended_fees(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REFUND
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REFUND
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_refund(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REGISTER_WEBHOOK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REGISTER_WEBHOOK
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_register_webhook(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REMOVE_EVENT_LISTENER
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_REMOVE_EVENT_LISTENER
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_remove_event_listener(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RESCAN_ONCHAIN_SWAPS
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RESCAN_ONCHAIN_SWAPS
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_rescan_onchain_swaps(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RESTORE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_RESTORE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_restore(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SEND_PAYMENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SEND_PAYMENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_send_payment(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SIGN_MESSAGE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SIGN_MESSAGE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_sign_message(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SYNC
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_SYNC
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_sync(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_UNREGISTER_WEBHOOK
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_BINDINGLIQUIDSDK_UNREGISTER_WEBHOOK
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_bindingliquidsdk_unregister_webhook(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_EVENTLISTENER_ON_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_EVENTLISTENER_ON_EVENT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_eventlistener_on_event(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_LOGGER_LOG
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_LOGGER_LOG
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_logger_log(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_XPUB
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_XPUB
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_xpub(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_DERIVE_XPUB
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_DERIVE_XPUB
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_derive_xpub(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SIGN_ECDSA
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SIGN_ECDSA
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_sign_ecdsa(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SIGN_ECDSA_RECOVERABLE
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SIGN_ECDSA_RECOVERABLE
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_sign_ecdsa_recoverable(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SLIP77_MASTER_BLINDING_KEY
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_SLIP77_MASTER_BLINDING_KEY
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_slip77_master_blinding_key(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_HMAC_SHA256
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_HMAC_SHA256
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_hmac_sha256(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_ECIES_ENCRYPT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_ECIES_ENCRYPT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_ecies_encrypt(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_ECIES_DECRYPT
+#define UNIFFI_FFIDEF_UNIFFI_BREEZ_SDK_LIQUID_BINDINGS_CHECKSUM_METHOD_SIGNER_ECIES_DECRYPT
 uint16_t uniffi_breez_sdk_liquid_bindings_checksum_method_signer_ecies_decrypt(void
     
 );
+#endif
+#ifndef UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_UNIFFI_CONTRACT_VERSION
+#define UNIFFI_FFIDEF_FFI_BREEZ_SDK_LIQUID_BINDINGS_UNIFFI_CONTRACT_VERSION
 uint32_t ffi_breez_sdk_liquid_bindings_uniffi_contract_version(void
     
 );
+#endif
 

--- a/lib/bindings/makefile
+++ b/lib/bindings/makefile
@@ -37,14 +37,25 @@ all: bindings-swift bindings-android python-darwin react-native
 ## Android 
 .PHONY: android
 android: aarch64-linux-android x86_64-linux-android
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
+
+android-uniffi-25: aarch64-linux-android-uniffi-25 x86_64-linux-android-uniffi-25
+	cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
 
 aarch64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --release	
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
 
+aarch64-linux-android-uniffi-25: $(SOURCES) ndk-home
+	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release	
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
+
 x86_64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --release
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
+
+x86_64-linux-android-uniffi-25: $(SOURCES) ndk-home
+	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
 
 bindings-android: android
@@ -58,9 +69,9 @@ bindings-android: android
 .PHONY: kotlin
 kotlin: $(SOURCES)
 	cargo build --release --target $(TARGET)
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
 
-bindings-kotlin-multiplatform: ios-universal android
+bindings-kotlin-multiplatform: ios-universal-uniffi-25 android-uniffi-25
 	mkdir -p langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/androidMain
 	cp -r ffi/kotlin/jniLibs/ langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/androidMain/jniLibs/
 	cp -r ffi/kmp/* langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/
@@ -88,6 +99,17 @@ ios-universal: $(SOURCES)
 	# build universal lib for arm sim and x86 sim
 	lipo -create -output ../target/ios-universal-sim/release/libbreez_sdk_liquid_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_liquid_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_liquid_bindings.a
 
+ios-universal-uniffi-25: $(SOURCES)		
+	mkdir -p ../target/ios-universal/release
+	mkdir -p ../target/ios-universal-sim/release
+	cargo build --no-default-features --features uniffi-25 --release --target aarch64-apple-ios ;\
+	cargo build --no-default-features --features uniffi-25 --release --target x86_64-apple-ios ;\
+	cargo build --no-default-features --features uniffi-25 --release --target aarch64-apple-ios-sim ;\
+	# build universal lib for arm device and x86 sim
+	lipo -create -output ../target/ios-universal/release/libbreez_sdk_liquid_bindings.a ../target/aarch64-apple-ios/release/libbreez_sdk_liquid_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_liquid_bindings.a
+	# build universal lib for arm sim and x86 sim
+	lipo -create -output ../target/ios-universal-sim/release/libbreez_sdk_liquid_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_liquid_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_liquid_bindings.a
+
 darwin-universal: $(SOURCES)
 	mkdir -p ../target/darwin-universal/release
 	cargo lipo --release --targets aarch64-apple-darwin
@@ -95,14 +117,21 @@ darwin-universal: $(SOURCES)
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_liquid_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_liquid_bindings.dylib
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_liquid_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_liquid_bindings.a
 
+darwin-universal-uniffi-25: $(SOURCES)
+	mkdir -p ../target/darwin-universal/release
+	cargo lipo --no-default-features --features uniffi-25 --release --targets aarch64-apple-darwin
+	cargo lipo --no-default-features --features uniffi-25 --release --targets x86_64-apple-darwin
+	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_liquid_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_liquid_bindings.dylib
+	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_liquid_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_liquid_bindings.a
+
 ## Swift
 swift-ios: ios-universal
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl -l swift -o ffi/swift-ios
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl -l swift -o ffi/swift-ios
 	cp ../target/ios-universal/release/libbreez_sdk_liquid_bindings.a ffi/swift-ios
 	cd ffi/swift-ios && "swiftc" "-emit-module" "-module-name" "breez_sdk_liquid_bindings" "-Xcc" "-fmodule-map-file=$(CURRENT_DIR)/ffi/swift-ios/breez_sdk_liquidFFI.modulemap" "-I" "."  "-L" "." "-lbreez_sdk_liquid_bindings" breez_sdk_liquid.swift
 
 swift-darwin: darwin-universal
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl -l swift -o ffi/swift-darwin
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl -l swift -o ffi/swift-darwin
 	cp ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ffi/swift-darwin
 	cd ffi/swift-darwin && "swiftc" "-emit-module" "-module-name" "breez_sdk_liquid_bindings" "-Xcc" "-fmodule-map-file=$(CURRENT_DIR)/ffi/swift-darwin/breez_sdk_liquidFFI.modulemap" "-I" "."  "-L" "." "-lbreez_sdk_liquid_bindings" breez_sdk_liquid.swift
 
@@ -110,7 +139,7 @@ bindings-swift: ios-universal darwin-universal build-ios-framework
 
 build-ios-framework:
 	mkdir -p langs/swift/Sources/BreezSDKLiquid
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift -o langs/swift/Sources/BreezSDKLiquid
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language swift -o langs/swift/Sources/BreezSDKLiquid
 	mv langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquid.swift langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquid.swift
 	cp langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.h langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64/breez_sdk_liquidFFI.framework/Headers
 	cp langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.h langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/Headers
@@ -122,19 +151,19 @@ build-ios-framework:
 	rm langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.h
 	rm langs/swift/Sources/BreezSDKLiquid/breez_sdk_liquidFFI.modulemap
 
-csharp-darwin: darwin-universal
+csharp-darwin: darwin-universal-uniffi-25
 	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
 	uniffi-bindgen-cs src/breez_sdk_liquid.udl -o ffi/csharp -c ./uniffi.toml
 	cp ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ffi/csharp
 
 csharp-linux: $(SOURCES)
 	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
-	cargo build --release --target $(TARGET)
+	cargo build --no-default-features --features uniffi-25 --release --target $(TARGET)
 	uniffi-bindgen-cs src/breez_sdk_liquid.udl -o ffi/csharp -c ./uniffi.toml
 	cp ../target/$(TARGET)/release/libbreez_sdk_liquid_bindings.so ffi/csharp
 
 ## Go
-golang-darwin: darwin-universal
+golang-darwin: darwin-universal-uniffi-25
 	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
 	uniffi-bindgen-go src/breez_sdk_liquid.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ffi/golang
@@ -142,7 +171,7 @@ golang-darwin: darwin-universal
 
 golang-linux: $(SOURCES)
 	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
-	cargo build --release --target $(TARGET)
+	cargo build --no-default-features --features uniffi-25 --release --target $(TARGET)
 	uniffi-bindgen-go src/breez_sdk_liquid.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/$(TARGET)/release/libbreez_sdk_liquid_bindings.so ffi/golang
 	cp -r ffi/golang/breez_sdk_liquid tests/bindings/golang/
@@ -150,11 +179,11 @@ golang-linux: $(SOURCES)
 ## Python
 python-linux: $(SOURCES)
 	cargo build --release --target $(TARGET)
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language python -o ffi/python
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language python -o ffi/python
 	cp ../target/$(TARGET)/release/libbreez_sdk_liquid_bindings.so ffi/python
 
 python-darwin: darwin-universal
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language python -o ffi/python
+	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language python -o ffi/python
 	cp ../target/darwin-universal/release/libbreez_sdk_liquid_bindings.dylib ffi/python
 
 ## React Native

--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -1,4 +1,8 @@
 //! Uniffi bindings
+#[cfg(feature = "uniffi-25")]
+extern crate uniffi_25 as uniffi;
+#[cfg(feature = "uniffi-28")]
+extern crate uniffi_28 as uniffi;
 
 use std::sync::Arc;
 

--- a/lib/bindings/tests/test_generated_bindings.rs
+++ b/lib/bindings/tests/test_generated_bindings.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "uniffi-28")]
+extern crate uniffi_28 as uniffi;
+
+#[cfg(feature = "uniffi-25")]
 use std::process::Command;
 
+#[cfg(feature = "uniffi-28")]
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_breez_sdk_liquid.swift",
     "tests/bindings/test_breez_sdk_liquid.kts",
@@ -7,6 +12,7 @@ uniffi::build_foreign_language_testcases!(
 );
 
 #[test]
+#[cfg(feature = "uniffi-25")]
 fn test_csharp() {
     let output = Command::new("dotnet")
         .arg("run")
@@ -21,6 +27,7 @@ fn test_csharp() {
 }
 
 #[test]
+#[cfg(feature = "uniffi-25")]
 fn test_golang() {
     let output = Command::new("go")
         .env(

--- a/lib/bindings/uniffi-bindgen.rs
+++ b/lib/bindings/uniffi-bindgen.rs
@@ -1,14 +1,26 @@
+#[cfg(feature = "uniffi-25")]
+extern crate uniffi_25 as uniffi;
+#[cfg(feature = "uniffi-28")]
+extern crate uniffi_28 as uniffi;
+#[cfg(feature = "uniffi-25")]
+extern crate uniffi_bindgen_25 as uniffi_bindgen;
+
+#[cfg(feature = "uniffi-25")]
 use camino::Utf8Path;
-use uniffi_bindgen_kotlin_multiplatform::KotlinBindingGenerator;
 
 fn main() {
     uniffi::uniffi_bindgen_main();
+    #[cfg(feature = "uniffi-25")]
+    build_kmp()
+}
 
+#[cfg(feature = "uniffi-25")]
+fn build_kmp() {
     let udl_file = "./src/breez_sdk_liquid.udl";
     let out_dir = Utf8Path::new("ffi/kmp");
     let config = Utf8Path::new("uniffi.toml");
     uniffi_bindgen::generate_external_bindings(
-        KotlinBindingGenerator {},
+        uniffi_bindgen_kotlin_multiplatform::KotlinBindingGenerator {},
         udl_file,
         Some(config),
         Some(out_dir),

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [features]
 default = ["frb"]
 frb = ["dep:flutter_rust_bridge"]
+# Uniffi features required to build using cargo-lipo
+uniffi-25 = []
+uniffi-28 = []
 
 [lints]
 workspace = true

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -577,8 +577,6 @@ pub mod duplicates {
     use serde::{Deserialize, Serialize};
     use thiserror::Error;
 
-    use crate::error::PaymentError;
-
     #[derive(Clone, Debug, Error)]
     pub enum LnUrlPayError {
         /// This error is raised when attempting to pay an invoice that has already being paid.
@@ -669,14 +667,6 @@ pub mod duplicates {
         }
     }
 
-    impl From<PaymentError> for sdk_common::prelude::LnUrlPayError {
-        fn from(value: PaymentError) -> Self {
-            Self::Generic {
-                err: format!("{value}"),
-            }
-        }
-    }
-
     #[derive(Debug, Error)]
     pub enum LnUrlWithdrawError {
         /// This error is raised when a general error occurs not specific to other error variants
@@ -726,14 +716,6 @@ pub mod duplicates {
                 sdk_common::prelude::LnUrlWithdrawError::ServiceConnectivity { err } => {
                     Self::ServiceConnectivity { err }
                 }
-            }
-        }
-    }
-
-    impl From<PaymentError> for sdk_common::prelude::LnUrlWithdrawError {
-        fn from(value: PaymentError) -> Self {
-            Self::Generic {
-                err: format!("{value}"),
             }
         }
     }

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 use lwk_wollet::secp256k1;
-use sdk_common::prelude::LnUrlAuthError;
+use sdk_common::prelude::{LnUrlAuthError, LnUrlPayError, LnUrlWithdrawError};
 
 pub type SdkResult<T, E = SdkError> = Result<T, E>;
 
@@ -249,9 +249,25 @@ impl From<secp256k1::Error> for PaymentError {
 }
 
 impl From<PaymentError> for LnUrlAuthError {
-    fn from(value: PaymentError) -> Self {
+    fn from(err: PaymentError) -> Self {
         Self::Generic {
-            err: format!("Failed to perform LNURL-auth: {value:?}"),
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<PaymentError> for LnUrlPayError {
+    fn from(err: PaymentError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<PaymentError> for LnUrlWithdrawError {
+    fn from(err: PaymentError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
         }
     }
 }

--- a/packages/dart/lib/src/bindings/duplicates.dart
+++ b/packages/dart/lib/src/bindings/duplicates.dart
@@ -9,7 +9,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'duplicates.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 @freezed
 sealed class LnUrlAuthError with _$LnUrlAuthError implements FrbException {

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 33
     }
 }
 

--- a/packages/flutter/android/build.gradle.production
+++ b/packages/flutter/android/build.gradle.production
@@ -51,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 33
     }
 }
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1746,7 +1746,24 @@ class FlutterBreezLiquidBindings {
   late final _dummy_method_to_enforce_bundling =
       _dummy_method_to_enforce_bundlingPtr.asFunction<int Function()>();
 
-  /// Scaffolding functions
+  ffi.Pointer<ffi.Void> uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdk(
+    ffi.Pointer<ffi.Void> ptr,
+    ffi.Pointer<RustCallStatus> out_status,
+  ) {
+    return _uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdk(
+      ptr,
+      out_status,
+    );
+  }
+
+  late final _uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdkPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>,
+              ffi.Pointer<RustCallStatus>)>>('uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdk');
+  late final _uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdk =
+      _uniffi_breez_sdk_liquid_bindings_fn_clone_bindingliquidsdkPtr
+          .asFunction<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+
   void uniffi_breez_sdk_liquid_bindings_fn_free_bindingliquidsdk(
     ffi.Pointer<ffi.Void> ptr,
     ffi.Pointer<RustCallStatus> out_status,
@@ -2474,56 +2491,50 @@ class FlutterBreezLiquidBindings {
       _uniffi_breez_sdk_liquid_bindings_fn_method_bindingliquidsdk_unregister_webhookPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
 
-  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistener(
-    ForeignCallback callback_stub,
-    ffi.Pointer<RustCallStatus> out_status,
+  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistener(
+    ffi.Pointer<UniffiVTableCallbackInterfaceEventListener> vtable,
   ) {
-    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistener(
-      callback_stub,
-      out_status,
+    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistener(
+      vtable,
     );
   }
 
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>>(
-          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistener');
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistener =
-      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_eventlistenerPtr
-          .asFunction<void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>();
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistenerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<UniffiVTableCallbackInterfaceEventListener>)>>(
+          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistener');
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistener =
+      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_eventlistenerPtr
+          .asFunction<void Function(ffi.Pointer<UniffiVTableCallbackInterfaceEventListener>)>();
 
-  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_logger(
-    ForeignCallback callback_stub,
-    ffi.Pointer<RustCallStatus> out_status,
+  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_logger(
+    ffi.Pointer<UniffiVTableCallbackInterfaceLogger> vtable,
   ) {
-    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_logger(
-      callback_stub,
-      out_status,
+    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_logger(
+      vtable,
     );
   }
 
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_loggerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>>(
-          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_logger');
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_logger =
-      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_loggerPtr
-          .asFunction<void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>();
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_loggerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<UniffiVTableCallbackInterfaceLogger>)>>(
+          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_logger');
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_logger =
+      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_loggerPtr
+          .asFunction<void Function(ffi.Pointer<UniffiVTableCallbackInterfaceLogger>)>();
 
-  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_signer(
-    ForeignCallback callback_stub,
-    ffi.Pointer<RustCallStatus> out_status,
+  void uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signer(
+    ffi.Pointer<UniffiVTableCallbackInterfaceSigner> vtable,
   ) {
-    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_signer(
-      callback_stub,
-      out_status,
+    return _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signer(
+      vtable,
     );
   }
 
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_signerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>>(
-          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_signer');
-  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_signer =
-      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_signerPtr
-          .asFunction<void Function(ForeignCallback, ffi.Pointer<RustCallStatus>)>();
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<UniffiVTableCallbackInterfaceSigner>)>>(
+          'uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signer');
+  late final _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signer =
+      _uniffi_breez_sdk_liquid_bindings_fn_init_callback_vtable_signerPtr
+          .asFunction<void Function(ffi.Pointer<UniffiVTableCallbackInterfaceSigner>)>();
 
   ffi.Pointer<ffi.Void> uniffi_breez_sdk_liquid_bindings_fn_func_connect(
     RustBuffer req,
@@ -2626,7 +2637,7 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rustbuffer_allocPtr =
-      _lookup<ffi.NativeFunction<RustBuffer Function(ffi.Int32, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<RustBuffer Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rustbuffer_alloc');
   late final _ffi_breez_sdk_liquid_bindings_rustbuffer_alloc =
       _ffi_breez_sdk_liquid_bindings_rustbuffer_allocPtr
@@ -2679,46 +2690,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rustbuffer_reservePtr =
-      _lookup<ffi.NativeFunction<RustBuffer Function(RustBuffer, ffi.Int32, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<RustBuffer Function(RustBuffer, ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rustbuffer_reserve');
   late final _ffi_breez_sdk_liquid_bindings_rustbuffer_reserve =
       _ffi_breez_sdk_liquid_bindings_rustbuffer_reservePtr
           .asFunction<RustBuffer Function(RustBuffer, int, ffi.Pointer<RustCallStatus>)>();
 
-  void ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_set(
-    UniFfiRustFutureContinuation callback,
-  ) {
-    return _ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_set(
-      callback,
-    );
-  }
-
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_setPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(UniFfiRustFutureContinuation)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_set');
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_set =
-      _ffi_breez_sdk_liquid_bindings_rust_future_continuation_callback_setPtr
-          .asFunction<void Function(UniFfiRustFutureContinuation)>();
-
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_u8(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_u8(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_u8');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u8Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_u8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u8 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_u8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8(
       handle,
@@ -2726,14 +2725,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u8Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_u8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_u8(
       handle,
@@ -2741,14 +2739,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_u8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u8 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_u8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_u8Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_u8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_u8(
@@ -2758,31 +2755,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Uint8 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Uint8 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_u8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u8 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_u8Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_i8(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_i8(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_i8');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i8Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_i8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i8 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_i8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8(
       handle,
@@ -2790,14 +2790,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i8Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_i8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_i8(
       handle,
@@ -2805,14 +2804,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_i8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i8 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_i8Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_i8Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_i8(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_i8(
@@ -2822,31 +2820,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int8 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Int8 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_i8');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i8 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_i8Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_u16(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_u16(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_u16');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u16Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_u16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u16 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_u16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16(
       handle,
@@ -2854,14 +2855,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u16Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_u16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_u16(
       handle,
@@ -2869,14 +2869,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_u16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u16 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_u16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_u16Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_u16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_u16(
@@ -2886,31 +2885,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Uint16 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Uint16 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_u16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u16 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_u16Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_i16(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_i16(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_i16');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i16Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_i16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i16 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_i16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16(
       handle,
@@ -2918,14 +2920,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i16Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_i16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_i16(
       handle,
@@ -2933,14 +2934,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_i16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i16 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_i16Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_i16Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_i16(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_i16(
@@ -2950,31 +2950,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i16Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int16 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Int16 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_i16');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i16 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_i16Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_u32(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_u32(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_u32');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u32Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_u32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_u32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32(
       handle,
@@ -2982,14 +2985,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u32Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_u32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_u32(
       handle,
@@ -2997,14 +2999,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_u32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_u32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_u32Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_u32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_u32(
@@ -3014,31 +3015,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Uint32 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_u32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_u32Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_i32(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_i32(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_i32');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i32Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_i32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_i32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32(
       handle,
@@ -3046,14 +3050,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i32Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_i32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_i32(
       handle,
@@ -3061,14 +3064,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_i32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_i32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_i32Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_i32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_i32(
@@ -3078,31 +3080,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int32 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Int32 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_i32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_i32Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_u64(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_u64(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_u64');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u64Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_u64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_u64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_u64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64(
       handle,
@@ -3110,14 +3115,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_u64Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_u64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_u64(
       handle,
@@ -3125,14 +3129,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_u64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_u64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_u64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_u64Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_u64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_u64(
@@ -3142,31 +3145,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Uint64 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Uint64 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_u64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_u64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_u64Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_i64(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_i64(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_i64');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i64Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_i64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_i64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_i64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64(
       handle,
@@ -3174,14 +3180,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_i64Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_i64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_i64(
       handle,
@@ -3189,14 +3194,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_i64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_i64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_i64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_i64Ptr.asFunction<void Function(int)>();
 
   int ffi_breez_sdk_liquid_bindings_rust_future_complete_i64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_i64(
@@ -3206,31 +3210,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_i64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_i64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_i64Ptr
-          .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<int Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_f32(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_f32(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_f32');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f32Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_f32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_f32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32(
       handle,
@@ -3238,14 +3245,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f32Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_f32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_f32(
       handle,
@@ -3253,14 +3259,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_f32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_f32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_f32 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_f32Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_f32Ptr.asFunction<void Function(int)>();
 
   double ffi_breez_sdk_liquid_bindings_rust_future_complete_f32(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_f32(
@@ -3270,31 +3275,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_f32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Float Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Float Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_f32');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_f32 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_f32Ptr
-          .asFunction<double Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<double Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_f64(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_f64(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_f64');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f64Ptr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_f64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_f64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_f64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64(
       handle,
@@ -3302,14 +3310,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_f64Ptr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_f64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_f64(
       handle,
@@ -3317,14 +3324,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_f64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_f64 =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_f64Ptr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_f64Ptr.asFunction<void Function(int)>();
 
   double ffi_breez_sdk_liquid_bindings_rust_future_complete_f64(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_f64(
@@ -3334,31 +3340,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Double Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Double Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_f64');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_f64 =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_f64Ptr
-          .asFunction<double Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<double Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_pointerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_pointerPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_pointer =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_pointerPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer(
       handle,
@@ -3366,14 +3375,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointer =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointerPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_pointerPtr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_pointer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_pointer(
       handle,
@@ -3381,14 +3389,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_pointerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_pointer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_pointer =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_pointerPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_pointerPtr.asFunction<void Function(int)>();
 
   ffi.Pointer<ffi.Void> ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer(
@@ -3397,33 +3404,35 @@ class FlutterBreezLiquidBindings {
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_pointerPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>,
-              ffi.Pointer<RustCallStatus>)>>('ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_pointerPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
+          'ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_pointer =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_pointerPtr
-          .asFunction<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<ffi.Pointer<ffi.Void> Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_bufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_bufferPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_buffer =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_rust_bufferPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer(
       handle,
@@ -3431,14 +3440,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_bufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_buffer =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_bufferPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_rust_bufferPtr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer(
       handle,
@@ -3446,14 +3454,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_rust_bufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_rust_buffer =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_rust_bufferPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_rust_bufferPtr.asFunction<void Function(int)>();
 
   RustBuffer ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer(
@@ -3463,31 +3470,34 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_bufferPtr =
-      _lookup<ffi.NativeFunction<RustBuffer Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<RustBuffer Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_buffer =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_rust_bufferPtr
-          .asFunction<RustBuffer Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<RustBuffer Function(int, ffi.Pointer<RustCallStatus>)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_poll_void(
-    ffi.Pointer<ffi.Void> handle,
-    ffi.Pointer<ffi.Void> uniffi_callback,
+    int handle,
+    UniffiRustFutureContinuationCallback callback,
+    int callback_data,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_poll_void(
       handle,
-      uniffi_callback,
+      callback,
+      callback_data,
     );
   }
 
-  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_voidPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
-          'ffi_breez_sdk_liquid_bindings_rust_future_poll_void');
+  late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_voidPtr = _lookup<
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Uint64, UniffiRustFutureContinuationCallback, ffi.Uint64)>>(
+      'ffi_breez_sdk_liquid_bindings_rust_future_poll_void');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_poll_void =
       _ffi_breez_sdk_liquid_bindings_rust_future_poll_voidPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          .asFunction<void Function(int, UniffiRustFutureContinuationCallback, int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_cancel_void(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_cancel_void(
       handle,
@@ -3495,14 +3505,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_voidPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_cancel_void');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_cancel_void =
-      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_voidPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_cancel_voidPtr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_free_void(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_free_void(
       handle,
@@ -3510,14 +3519,13 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_voidPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_free_void');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_free_void =
-      _ffi_breez_sdk_liquid_bindings_rust_future_free_voidPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+      _ffi_breez_sdk_liquid_bindings_rust_future_free_voidPtr.asFunction<void Function(int)>();
 
   void ffi_breez_sdk_liquid_bindings_rust_future_complete_void(
-    ffi.Pointer<ffi.Void> handle,
+    int handle,
     ffi.Pointer<RustCallStatus> out_status,
   ) {
     return _ffi_breez_sdk_liquid_bindings_rust_future_complete_void(
@@ -3527,11 +3535,11 @@ class FlutterBreezLiquidBindings {
   }
 
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_voidPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Uint64, ffi.Pointer<RustCallStatus>)>>(
           'ffi_breez_sdk_liquid_bindings_rust_future_complete_void');
   late final _ffi_breez_sdk_liquid_bindings_rust_future_complete_void =
       _ffi_breez_sdk_liquid_bindings_rust_future_complete_voidPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>)>();
+          .asFunction<void Function(int, ffi.Pointer<RustCallStatus>)>();
 
   int uniffi_breez_sdk_liquid_bindings_checksum_func_connect() {
     return _uniffi_breez_sdk_liquid_bindings_checksum_func_connect();
@@ -5693,10 +5701,10 @@ typedef WireSyncRust2DartDco = ffi.Pointer<DartCObject>;
 /// ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) you *must* ⚠️
 /// ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 final class RustBuffer extends ffi.Struct {
-  @ffi.Int32()
+  @ffi.Uint64()
   external int capacity;
 
-  @ffi.Int32()
+  @ffi.Uint64()
   external int len;
 
   external ffi.Pointer<ffi.Uint8> data;
@@ -5717,16 +5725,204 @@ final class RustCallStatus extends ffi.Struct {
   external RustBuffer errorBuf;
 }
 
-typedef ForeignCallback = ffi.Pointer<ffi.NativeFunction<ForeignCallbackFunction>>;
-typedef ForeignCallbackFunction = ffi.Int32 Function(
-    ffi.Uint64, ffi.Int32, ffi.Pointer<ffi.Uint8>, ffi.Int32, ffi.Pointer<RustBuffer>);
-typedef DartForeignCallbackFunction = int Function(
-    int, int, ffi.Pointer<ffi.Uint8>, int, ffi.Pointer<RustBuffer>);
+final class UniffiForeignFuture extends ffi.Struct {
+  @ffi.Uint64()
+  external int handle;
 
-/// Continuation callback for UniFFI Futures
-typedef UniFfiRustFutureContinuation = ffi.Pointer<ffi.NativeFunction<UniFfiRustFutureContinuationFunction>>;
-typedef UniFfiRustFutureContinuationFunction = ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Int8);
-typedef DartUniFfiRustFutureContinuationFunction = void Function(ffi.Pointer<ffi.Void>, int);
+  external UniffiForeignFutureFree free;
+}
+
+typedef UniffiForeignFutureFree = ffi.Pointer<ffi.NativeFunction<UniffiForeignFutureFreeFunction>>;
+typedef UniffiForeignFutureFreeFunction = ffi.Void Function(ffi.Uint64);
+typedef DartUniffiForeignFutureFreeFunction = void Function(int);
+
+final class UniffiForeignFutureStructU8 extends ffi.Struct {
+  @ffi.Uint8()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructI8 extends ffi.Struct {
+  @ffi.Int8()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructU16 extends ffi.Struct {
+  @ffi.Uint16()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructI16 extends ffi.Struct {
+  @ffi.Int16()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructU32 extends ffi.Struct {
+  @ffi.Uint32()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructI32 extends ffi.Struct {
+  @ffi.Int32()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructU64 extends ffi.Struct {
+  @ffi.Uint64()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructI64 extends ffi.Struct {
+  @ffi.Int64()
+  external int returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructF32 extends ffi.Struct {
+  @ffi.Float()
+  external double returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructF64 extends ffi.Struct {
+  @ffi.Double()
+  external double returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructPointer extends ffi.Struct {
+  external ffi.Pointer<ffi.Void> returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructRustBuffer extends ffi.Struct {
+  external RustBuffer returnValue;
+
+  external RustCallStatus callStatus;
+}
+
+final class UniffiForeignFutureStructVoid extends ffi.Struct {
+  external RustCallStatus callStatus;
+}
+
+final class UniffiVTableCallbackInterfaceEventListener extends ffi.Struct {
+  external UniffiCallbackInterfaceEventListenerMethod0 onEvent;
+
+  external UniffiCallbackInterfaceFree uniffiFree;
+}
+
+typedef UniffiCallbackInterfaceEventListenerMethod0
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceEventListenerMethod0Function>>;
+typedef UniffiCallbackInterfaceEventListenerMethod0Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceEventListenerMethod0Function = void Function(
+    int, RustBuffer, ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceFree = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceFreeFunction>>;
+typedef UniffiCallbackInterfaceFreeFunction = ffi.Void Function(ffi.Uint64);
+typedef DartUniffiCallbackInterfaceFreeFunction = void Function(int);
+
+final class UniffiVTableCallbackInterfaceLogger extends ffi.Struct {
+  external UniffiCallbackInterfaceLoggerMethod0 log;
+
+  external UniffiCallbackInterfaceFree uniffiFree;
+}
+
+typedef UniffiCallbackInterfaceLoggerMethod0
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceLoggerMethod0Function>>;
+typedef UniffiCallbackInterfaceLoggerMethod0Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceLoggerMethod0Function = void Function(
+    int, RustBuffer, ffi.Pointer<ffi.Void>, ffi.Pointer<RustCallStatus>);
+
+final class UniffiVTableCallbackInterfaceSigner extends ffi.Struct {
+  external UniffiCallbackInterfaceSignerMethod0 xpub;
+
+  external UniffiCallbackInterfaceSignerMethod1 deriveXpub;
+
+  external UniffiCallbackInterfaceSignerMethod2 signEcdsa;
+
+  external UniffiCallbackInterfaceSignerMethod3 signEcdsaRecoverable;
+
+  external UniffiCallbackInterfaceSignerMethod4 slip77MasterBlindingKey;
+
+  external UniffiCallbackInterfaceSignerMethod5 hmacSha256;
+
+  external UniffiCallbackInterfaceSignerMethod6 eciesEncrypt;
+
+  external UniffiCallbackInterfaceSignerMethod7 eciesDecrypt;
+
+  external UniffiCallbackInterfaceFree uniffiFree;
+}
+
+typedef UniffiCallbackInterfaceSignerMethod0
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod0Function>>;
+typedef UniffiCallbackInterfaceSignerMethod0Function = ffi.Void Function(
+    ffi.Uint64, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod0Function = void Function(
+    int, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod1
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod1Function>>;
+typedef UniffiCallbackInterfaceSignerMethod1Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod1Function = void Function(
+    int, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod2
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod2Function>>;
+typedef UniffiCallbackInterfaceSignerMethod2Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod2Function = void Function(
+    int, RustBuffer, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod3
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod3Function>>;
+typedef UniffiCallbackInterfaceSignerMethod3Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod3Function = void Function(
+    int, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod4
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod4Function>>;
+typedef UniffiCallbackInterfaceSignerMethod4Function = ffi.Void Function(
+    ffi.Uint64, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod4Function = void Function(
+    int, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod5
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod5Function>>;
+typedef UniffiCallbackInterfaceSignerMethod5Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod5Function = void Function(
+    int, RustBuffer, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod6
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod6Function>>;
+typedef UniffiCallbackInterfaceSignerMethod6Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod6Function = void Function(
+    int, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiCallbackInterfaceSignerMethod7
+    = ffi.Pointer<ffi.NativeFunction<UniffiCallbackInterfaceSignerMethod7Function>>;
+typedef UniffiCallbackInterfaceSignerMethod7Function = ffi.Void Function(
+    ffi.Uint64, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef DartUniffiCallbackInterfaceSignerMethod7Function = void Function(
+    int, RustBuffer, ffi.Pointer<RustBuffer>, ffi.Pointer<RustCallStatus>);
+typedef UniffiRustFutureContinuationCallback
+    = ffi.Pointer<ffi.NativeFunction<UniffiRustFutureContinuationCallbackFunction>>;
+typedef UniffiRustFutureContinuationCallbackFunction = ffi.Void Function(ffi.Uint64, ffi.Int8);
+typedef DartUniffiRustFutureContinuationCallbackFunction = void Function(int, int);
 
 const int ESTIMATED_BTC_CLAIM_TX_VSIZE = 111;
 

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 34
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 33
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/packages/react-native/example/android/build.gradle
+++ b/packages/react-native/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 24
+        minSdkVersion = 33
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlin_version = "1.8.0"


### PR DESCRIPTION
This PR updates compatible packages in the CI build/publish workflow to build using Uniffi 0.28. This works by selectively building 2 versions (Uniffi 0.25 & Uniffi 0.28) of the target binaries depending on if they are required for the package.

Uniffi 0.28 compatible packages are: 
- maven (android)
- flutter (android, ios, darwin)
- react-native (android, ios, darwin)
- python (darwin, linux, windows)
- swift (ios, darwin)

Uniffi 0.25 compatible packages are:
- csharp (windows, darwin, linux): Restricted to 0.25 by the [uniffi-bindgen-cs](https://github.com/NordSecurity/uniffi-bindgen-cs) bindgen
- golang (android, windows, darwin, linux): Restricted to 0.25 by the [uniffi-bindgen-go](https://github.com/NordSecurity/uniffi-bindgen-go) bindgen
- kotlin-multiplatform (android, ios): 0.28 is available in the [uniffi-kotlin-multiplatform-bindings](https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings) bindgen, but fails to build

CI run to test build: https://github.com/breez/breez-sdk-liquid/actions/runs/13725146740