### PR TITLE
Wallet: Switch clients on full sync failure

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -461,6 +461,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -725,6 +731,7 @@ dependencies = [
  "ecies",
  "electrum-client",
  "env_logger 0.11.6",
+ "esplora-client",
  "flutter_rust_bridge",
  "futures-util",
  "glob",
@@ -1315,6 +1322,21 @@ name = "error-code"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
+name = "esplora-client"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0da3c186d286e046253ccdc4bb71aa87ef872e4eff2045947c0c4fe3d2b2efc"
+dependencies = [
+ "bitcoin 0.32.5",
+ "hex-conservative 0.2.1",
+ "log",
+ "minreq",
+ "reqwest 0.11.20",
+ "serde",
+ "tokio",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -2656,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.8.0"
-source = "git+https://github.com/breez/lwk?branch=breez-sdk-liquid-0.6.3#a14f83a41b671d66769458893c9ba0fd2b9c4268"
+source = "git+https://github.com/breez/lwk?rev=9e256839c26e47378c21c373d1376aa87802663a#9e256839c26e47378c21c373d1376aa87802663a"
 dependencies = [
  "aes-gcm-siv",
  "age",
@@ -2749,6 +2771,7 @@ version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0c420feb01b9fb5061f8c8f452534361dd783756dcf38ec45191ce55e7a161"
 dependencies = [
+ "base64 0.12.3",
  "log",
  "serde",
  "serde_json",
@@ -3472,6 +3495,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4440,6 +4464,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.23",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -540,6 +540,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -803,6 +809,7 @@ dependencies = [
  "ecies",
  "electrum-client",
  "env_logger 0.11.5",
+ "esplora-client",
  "flutter_rust_bridge",
  "futures-util",
  "glob",
@@ -1464,6 +1471,20 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "esplora-client"
+version = "0.11.0"
+source = "git+https://github.com/hydra-yse/rust-esplora-client?branch=scripthash-utxo#0c99761f352f495dff5fe5bc0b664cbf8b273db0"
+dependencies = [
+ "bitcoin 0.32.4",
+ "hex-conservative",
+ "log",
+ "minreq",
+ "reqwest 0.11.20",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -2156,6 +2177,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
@@ -2817,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.8.0"
-source = "git+https://github.com/breez/lwk?branch=breez-sdk-liquid-0.6.3#a14f83a41b671d66769458893c9ba0fd2b9c4268"
+source = "git+https://github.com/breez/lwk?rev=9e256839c26e47378c21c373d1376aa87802663a#9e256839c26e47378c21c373d1376aa87802663a"
 dependencies = [
  "aes-gcm-siv",
  "age",
@@ -2920,6 +2955,7 @@ version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a8e50e917e18a37d500d27d40b7bc7d127e71c0c94fb2d83f43b4afd308390"
 dependencies = [
+ "base64 0.12.3",
  "log",
  "serde",
  "serde_json",
@@ -3668,6 +3704,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -3677,16 +3714,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.1",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3707,7 +3749,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -4704,12 +4746,34 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls 0.23.12",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.63",
  "tokio",
 ]
 

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -627,6 +627,30 @@ typedef struct wire_cst_sdk_event {
   union SdkEventKind kind;
 } wire_cst_sdk_event;
 
+typedef struct wire_cst_BlockchainExplorer_Electrum {
+  struct wire_cst_list_prim_u_8_strict *url;
+} wire_cst_BlockchainExplorer_Electrum;
+
+typedef struct wire_cst_BlockchainExplorer_Esplora {
+  struct wire_cst_list_prim_u_8_strict *url;
+  bool use_waterfalls;
+} wire_cst_BlockchainExplorer_Esplora;
+
+typedef union BlockchainExplorerKind {
+  struct wire_cst_BlockchainExplorer_Electrum Electrum;
+  struct wire_cst_BlockchainExplorer_Esplora Esplora;
+} BlockchainExplorerKind;
+
+typedef struct wire_cst_blockchain_explorer {
+  int32_t tag;
+  union BlockchainExplorerKind kind;
+} wire_cst_blockchain_explorer;
+
+typedef struct wire_cst_list_blockchain_explorer {
+  struct wire_cst_blockchain_explorer *ptr;
+  int32_t len;
+} wire_cst_list_blockchain_explorer;
+
 typedef struct wire_cst_external_input_parser {
   struct wire_cst_list_prim_u_8_strict *provider_id;
   struct wire_cst_list_prim_u_8_strict *input_regex;
@@ -651,9 +675,8 @@ typedef struct wire_cst_list_asset_metadata {
 } wire_cst_list_asset_metadata;
 
 typedef struct wire_cst_config {
-  struct wire_cst_list_prim_u_8_strict *liquid_electrum_url;
-  struct wire_cst_list_prim_u_8_strict *bitcoin_electrum_url;
-  struct wire_cst_list_prim_u_8_strict *mempoolspace_url;
+  struct wire_cst_list_blockchain_explorer *liquid_explorers;
+  struct wire_cst_list_blockchain_explorer *bitcoin_explorers;
   struct wire_cst_list_prim_u_8_strict *working_dir;
   struct wire_cst_list_prim_u_8_strict *cache_dir;
   int32_t network;
@@ -1448,6 +1471,8 @@ struct wire_cst_list_asset_balance *frbgen_breez_liquid_cst_new_list_asset_balan
 
 struct wire_cst_list_asset_metadata *frbgen_breez_liquid_cst_new_list_asset_metadata(int32_t len);
 
+struct wire_cst_list_blockchain_explorer *frbgen_breez_liquid_cst_new_list_blockchain_explorer(int32_t len);
+
 struct wire_cst_list_external_input_parser *frbgen_breez_liquid_cst_new_list_external_input_parser(int32_t len);
 
 struct wire_cst_list_fiat_currency *frbgen_breez_liquid_cst_new_list_fiat_currency(int32_t len);
@@ -1533,6 +1558,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_String);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_asset_balance);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_asset_metadata);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_blockchain_explorer);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_external_input_parser);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_fiat_currency);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_cst_new_list_ln_offer_blinded_path);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -325,10 +325,15 @@ enum PaymentError {
     "SignerError",
 };
 
+[Enum]
+interface BlockchainExplorer {
+    Electrum(string url);
+    Esplora(string url, boolean use_waterfalls);
+};
+
 dictionary Config {
-    string liquid_electrum_url;
-    string bitcoin_electrum_url;
-    string mempoolspace_url;
+    sequence<BlockchainExplorer> liquid_explorers;
+    sequence<BlockchainExplorer> bitcoin_explorers;
     string working_dir;
     LiquidNetwork network;
     u64 payment_timeout_sec;

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -51,6 +51,9 @@ prost = "0.13.3"
 ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
 semver = "1.0.23"
 lazy_static = "1.5.0"
+esplora-client = { git = "https://github.com/hydra-yse/rust-esplora-client", branch = "scripthash-utxo", features = [
+    "async-https-rustls"
+] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 electrum-client = { version = "0.21.0", default-features = false, features = [
@@ -62,10 +65,10 @@ tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls-vendored"] }
 tonic = { version = "0.12.3", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-lwk_wollet = { git = "https://github.com/breez/lwk", branch = "breez-sdk-liquid-0.6.3" }
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "9e256839c26e47378c21c373d1376aa87802663a" }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-lwk_wollet = { git = "https://github.com/breez/lwk", branch = "breez-sdk-liquid-0.6.3", default-features = false, features = [ "esplora" ] }
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "9e256839c26e47378c21c373d1376aa87802663a", default-features = false, features = [ "esplora" ] }
 
 [dev-dependencies]
 paste = "1.0.15"

--- a/lib/core/src/chain/bitcoin/client.rs
+++ b/lib/core/src/chain/bitcoin/client.rs
@@ -1,0 +1,195 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, Context, Result};
+
+use crate::prelude::*;
+use bitcoin::{Script, Transaction, Txid};
+use {electrum_client::ElectrumApi as _, lwk_wollet::ElectrumOptions};
+
+use crate::model::{BlockchainExplorer, LiquidNetwork, RecommendedFees};
+
+pub(crate) enum BitcoinClient {
+    Electrum { inner: Box<electrum_client::Client> },
+    Esplora {
+        inner: Box<esplora_client::AsyncClient>,
+    },
+}
+
+impl BitcoinClient {
+    pub(crate) fn is_available(&self) -> bool {
+        match self {
+            BitcoinClient::Electrum { inner } => inner.ping().is_ok(),
+            BitcoinClient::Esplora { .. } => true,
+        }
+    }
+
+    pub(crate) fn try_from_explorer(
+        exp: &BlockchainExplorer,
+        network: LiquidNetwork,
+    ) -> Result<Self> {
+        match exp {
+            BlockchainExplorer::Electrum { url } => {
+                let (tls, validate_domain) = match network {
+                    LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
+                    LiquidNetwork::Regtest => (false, false),
+                };
+                let url = lwk_wollet::ElectrumUrl::new(url, tls, validate_domain)?;
+                let client = url.build_client(&ElectrumOptions { timeout: Some(3) })?;
+                // Ensure we ping so we know the client is working
+                client.ping()?;
+                Ok(BitcoinClient::Electrum {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::Esplora { url, .. } => {
+                let client = esplora_client::Builder::new(url)
+                    .timeout(3)
+                    .max_retries(5)
+                    .build_async()?;
+                Ok(BitcoinClient::Esplora {
+                    inner: Box::new(client),
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn tip(&mut self) -> Result<u32> {
+        match self {
+            BitcoinClient::Electrum { inner } => {
+                let mut maybe_popped_header = None;
+                while let Some(header) = inner.block_headers_pop_raw()? {
+                    maybe_popped_header = Some(header)
+                }
+
+                match maybe_popped_header {
+                    Some(popped_header) => Ok(popped_header.height as u32),
+                    None => {
+                        // https://github.com/bitcoindevkit/rust-electrum-client/issues/124
+                        // It might be that the client has reconnected and subscriptions don't persist
+                        // across connections. Calling `client.ping()` won't help here because the
+                        // successful retry will prevent us knowing about the reconnect.
+                        if let Ok(header) = inner.block_headers_subscribe_raw() {
+                            return Ok(header.height as u32);
+                        }
+
+                        bail!("No new tip found")
+                    }
+                }
+            }
+            BitcoinClient::Esplora { inner } => Ok(inner.get_height().await?),
+        }
+    }
+
+    pub(crate) async fn broadcast(&self, tx: &Transaction) -> Result<Txid> {
+        Ok(match self {
+            BitcoinClient::Electrum { inner } => inner.transaction_broadcast(tx)?,
+            BitcoinClient::Esplora { inner } => {
+                inner.broadcast(tx).await?;
+                tx.compute_txid()
+            }
+        })
+    }
+
+    pub(crate) async fn get_transactions(&self, txids: &[Txid]) -> Result<Vec<Transaction>> {
+        Ok(match self {
+            BitcoinClient::Electrum { inner } => inner.batch_transaction_get(txids)?,
+            BitcoinClient::Esplora { inner } => {
+                // TODO Add support for batch search
+                let mut result = vec![];
+                for txid in txids {
+                    result.push(inner.get_tx(txid).await?.context("Transaction not found")?);
+                }
+                result
+            }
+        })
+    }
+
+    pub(crate) async fn get_scripts_history(
+        &self,
+        scripts: &[&Script],
+    ) -> Result<Vec<Vec<History<Txid>>>> {
+        Ok(match self {
+            BitcoinClient::Electrum { inner } => inner
+                .batch_script_get_history(scripts)?
+                .into_iter()
+                .map(|histories| histories.into_iter().map(Into::into).collect())
+                .collect(),
+            BitcoinClient::Esplora { inner } => {
+                // TODO Add support for batch search
+                let mut histories = vec![];
+                for script in scripts {
+                    let txs = inner.scripthash_txs(script, None).await?;
+                    let history = txs
+                        .into_iter()
+                        .map(|tx| History::<Txid> {
+                            height: match tx.vin.iter().any(|input| input.prevout.is_none()) {
+                                true => -1,
+                                false => 0,
+                            },
+                            txid: tx.txid,
+                        })
+                        .collect();
+                    histories.push(history);
+                }
+                histories
+            }
+        })
+    }
+
+    pub(crate) async fn get_scripts_balance(
+        &self,
+        scripts: &[&Script],
+    ) -> Result<Vec<BtcScriptBalance>> {
+        Ok(match self {
+            BitcoinClient::Electrum { inner } => inner
+                .batch_script_get_balance(scripts)?
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            BitcoinClient::Esplora { inner } => {
+                let mut result = vec![];
+                for script in scripts {
+                    let mut balance = BtcScriptBalance {
+                        confirmed: 0,
+                        unconfirmed: 0,
+                    };
+                    for utxo in inner.scripthash_outputs(script).await? {
+                        if utxo.status.confirmed {
+                            balance.confirmed += utxo.value;
+                        } else {
+                            balance.unconfirmed += utxo.value as i64;
+                        }
+                    }
+                    result.push(balance);
+                }
+                result
+            }
+        })
+    }
+
+    pub(crate) async fn get_recommended_fees(&self) -> Result<RecommendedFees> {
+        Ok(match self {
+            BitcoinClient::Electrum { .. } => unreachable!(),
+            BitcoinClient::Esplora { inner } => {
+                let fee_estimates: HashMap<u16, u64> = inner
+                    .get_fee_estimates()
+                    .await?
+                    .into_iter()
+                    .map(|(k, v)| (k, v as u64))
+                    .collect();
+
+                let get_fee_estimate =
+                    |block: &u16| fee_estimates.get(block).cloned().unwrap_or_default();
+
+                // See https://github.com/Blockstream/esplora/blob/master/API.md#fee-estimates
+                RecommendedFees {
+                    fastest_fee: get_fee_estimate(&1),
+                    half_hour_fee: get_fee_estimate(&3),
+                    hour_fee: get_fee_estimate(&6),
+                    economy_fee: get_fee_estimate(&144),
+                    minimum_fee: get_fee_estimate(&1008),
+                }
+            }
+        })
+    }
+}

--- a/lib/core/src/chain/bitcoin/mod.rs
+++ b/lib/core/src/chain/bitcoin/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod client;
+pub(crate) mod service;

--- a/lib/core/src/chain/client.rs
+++ b/lib/core/src/chain/client.rs
@@ -1,0 +1,227 @@
+use anyhow::{bail, Result};
+use electrum_client::ElectrumApi as _;
+use lwk_wollet::{
+    asyncr::EsploraClient, blocking::BlockchainBackend, ElectrumOptions, ElectrumUrl,
+};
+
+use crate::model::{BlockchainExplorer, LiquidNetwork};
+
+#[macro_export]
+macro_rules! get_client {
+    ($chain_service:ident,$client:ident) => {
+        $chain_service.set_client()?;
+        let lock = $chain_service
+            .client
+            .read()
+            .map_err(|err| anyhow!("Could not read client lock: {err:?}"))
+            .await?;
+        let Some($client) = lock.as_ref() else {
+            bail!("Client not set"); // unreachable
+        };
+    };
+}
+
+pub(crate) enum BlockchainClient<ElectrumClient, EsploraClient> {
+    Electrum { inner: Box<ElectrumClient> },
+    Esplora { inner: Box<EsploraClient> },
+}
+
+/// The impl below is used for all Liquid-related instances, using [lwk_wollet::ElectrumClient] and
+/// [lwk_wollet::blocking::EsploraClient]
+impl BlockchainClient<lwk_wollet::ElectrumClient, lwk_wollet::blocking::EsploraClient> {
+    pub(crate) fn is_available(&self) -> bool {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.ping().is_ok(),
+            BlockchainClient::Esplora { .. } => true,
+        }
+    }
+
+    pub(crate) fn try_from_explorer(
+        exp: &BlockchainExplorer,
+        network: LiquidNetwork,
+    ) -> Result<Self> {
+        match exp {
+            BlockchainExplorer::Electrum { url } => {
+                let (tls, validate_domain) = match network {
+                    LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
+                    LiquidNetwork::Regtest => (false, false),
+                };
+                let url = ElectrumUrl::new(url, tls, validate_domain)?;
+                let client = lwk_wollet::ElectrumClient::with_options(
+                    &url,
+                    ElectrumOptions { timeout: Some(3) },
+                )?;
+                // Ensure we ping so we know the client is working
+                client.ping()?;
+                Ok(BlockchainClient::Electrum {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::Esplora {
+                url,
+                use_waterfalls,
+            } => {
+                let client = match *use_waterfalls {
+                    true => lwk_wollet::blocking::EsploraClient::new(url, network.into()),
+                    false => {
+                        lwk_wollet::blocking::EsploraClient::new_waterfalls(url, network.into())
+                    }
+                }?;
+                Ok(BlockchainClient::Esplora {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::MempoolSpace { .. } => {
+                bail!("Cannot create client from MempoolSpace url")
+            }
+        }
+    }
+
+    pub(crate) fn update_wallet(
+        &mut self,
+        wollet: &mut lwk_wollet::Wollet,
+        index: u32,
+    ) -> Result<(), lwk_wollet::Error> {
+        let state = wollet.state();
+        let update = match self {
+            Self::Electrum { inner, .. } => inner.full_scan_to_index(&state, index)?,
+            Self::Esplora { inner, .. } => inner.full_scan_to_index(&state, index)?,
+        };
+        if let Some(update) = update {
+            wollet.apply_update(update)?;
+        }
+        Ok(())
+    }
+}
+
+impl<C: BlockchainBackend> BlockchainBackend for BlockchainClient<C> {
+    fn tip(&mut self) -> std::result::Result<lwk_wollet::elements::BlockHeader, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.tip(),
+            BlockchainClient::Esplora { inner } => inner.tip(),
+        }
+    }
+
+    fn broadcast(
+        &self,
+        tx: &lwk_wollet::elements::Transaction,
+    ) -> Result<lwk_wollet::elements::Txid, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.broadcast(tx),
+            BlockchainClient::Esplora { inner } => inner.broadcast(tx),
+        }
+    }
+
+    fn get_transactions(
+        &self,
+        txids: &[lwk_wollet::elements::Txid],
+    ) -> std::result::Result<Vec<lwk_wollet::elements::Transaction>, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.get_transactions(txids),
+            BlockchainClient::Esplora { inner } => inner.get_transactions(txids),
+        }
+    }
+
+    fn get_headers(
+        &self,
+        heights: &[u32],
+        height_blockhash: &std::collections::HashMap<u32, lwk_wollet::elements::BlockHash>,
+    ) -> std::result::Result<Vec<lwk_wollet::elements::BlockHeader>, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.get_headers(heights, height_blockhash),
+            BlockchainClient::Esplora { inner } => inner.get_headers(heights, height_blockhash),
+        }
+    }
+
+    fn get_scripts_history(
+        &self,
+        scripts: &[&lwk_wollet::elements::Script],
+    ) -> std::result::Result<Vec<Vec<lwk_wollet::History>>, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.get_scripts_history(scripts),
+            BlockchainClient::Esplora { inner } => inner.get_scripts_history(scripts),
+        }
+    }
+}
+
+/// The impl below is used for all Bitcoin-related instances, using [electrum_client::Client]
+impl BlockchainClient<electrum_client::Client> {
+    pub(crate) fn is_available(&self) -> bool {
+        match self {
+            BlockchainClient::Electrum { inner } => inner.ping().is_ok(),
+            BlockchainClient::Esplora { .. } => true,
+        }
+    }
+
+    pub(crate) fn try_from_explorer(
+        exp: &BlockchainExplorer,
+        network: LiquidNetwork,
+    ) -> Result<Self> {
+        match exp {
+            BlockchainExplorer::Electrum { url } => {
+                let (tls, validate_domain) = match network {
+                    LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
+                    LiquidNetwork::Regtest => (false, false),
+                };
+                let url = ElectrumUrl::new(url, tls, validate_domain)?;
+                let client = url.build_client(&ElectrumOptions { timeout: Some(3) })?;
+                // Ensure we ping so we know the client is working
+                client.ping()?;
+                Ok(BlockchainClient::Electrum {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::Esplora {
+                url,
+                use_waterfalls,
+            } => {
+                let client = match *use_waterfalls {
+                    true => EsploraClient::new(url, network.into()),
+                    false => EsploraClient::new_waterfalls(url, network.into()),
+                }?;
+                Ok(BlockchainClient::Esplora {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::MempoolSpace { .. } => {
+                bail!("Cannot create client from MempoolSpace url")
+            }
+        }
+    }
+
+    // fn tip(&mut self) -> Result<lwk_wollet::elements::BlockHeader, lwk_wollet::Error> {
+    //     todo!()
+    // }
+    //
+    fn broadcast(
+        &self,
+        tx: &electrum_client::bitcoin::blockdata::transaction::Transaction,
+    ) -> Result<lwk_wollet::elements::Txid, lwk_wollet::Error> {
+        match self {
+            BlockchainClient::Electrum { inner } => todo!(),
+            BlockchainClient::Esplora { inner } => inner.broadcast(tx),
+        }
+    }
+    //
+    // fn get_transactions(
+    //     &self,
+    //     txids: &[lwk_wollet::elements::Txid],
+    // ) -> Result<Vec<lwk_wollet::elements::Transaction>, lwk_wollet::Error> {
+    //     todo!()
+    // }
+    //
+    // fn get_headers(
+    //     &self,
+    //     heights: &[u32],
+    //     height_blockhash: &std::collections::HashMap<Height, lwk_wollet::elements::BlockHash>,
+    // ) -> Result<Vec<lwk_wollet::elements::BlockHeader>, lwk_wollet::Error> {
+    //     todo!()
+    // }
+
+    // fn get_scripts_history(
+    //     &self,
+    //     scripts: &[&lwk_wollet::elements::Script],
+    // ) -> Result<Vec<Vec<lwk_wollet::History>>, lwk_wollet::Error> {
+    //     todo!()
+    // }
+}

--- a/lib/core/src/chain/liquid/client.rs
+++ b/lib/core/src/chain/liquid/client.rs
@@ -1,0 +1,111 @@
+use anyhow::Result;
+use lwk_wollet::{
+    asyncr::{EsploraClient, EsploraClientBuilder},
+    elements::{BlockHeader, Script, Transaction, Txid},
+    History,
+};
+use lwk_wollet::{blocking::BlockchainBackend, ElectrumClient, ElectrumOptions, ElectrumUrl};
+
+use crate::model::{BlockchainExplorer, LiquidNetwork};
+
+pub(crate) enum LiquidClient {
+    Electrum {
+        inner: Box<ElectrumClient>,
+    },
+    Esplora {
+        inner: Box<EsploraClient>,
+    },
+}
+
+impl LiquidClient {
+    pub(crate) fn is_available(&self) -> bool {
+        match self {
+            LiquidClient::Electrum { inner } => inner.ping().is_ok(),
+            LiquidClient::Esplora { .. } => true,
+        }
+    }
+
+    pub(crate) fn try_from_explorer(
+        exp: &BlockchainExplorer,
+        network: LiquidNetwork,
+    ) -> Result<Self> {
+        match exp {
+            BlockchainExplorer::Electrum { url } => {
+                let (tls, validate_domain) = match network {
+                    LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
+                    LiquidNetwork::Regtest => (false, false),
+                };
+                let url = ElectrumUrl::new(url, tls, validate_domain)?;
+                let client =
+                    ElectrumClient::with_options(&url, ElectrumOptions { timeout: Some(3) })?;
+                // Ensure we ping so we know the client is working
+                client.ping()?;
+                Ok(LiquidClient::Electrum {
+                    inner: Box::new(client),
+                })
+            }
+            BlockchainExplorer::Esplora {
+                url,
+                use_waterfalls,
+            } => {
+                let client = EsploraClientBuilder::new(url, network.into())
+                    .waterfalls(*use_waterfalls)
+                    .build();
+                Ok(LiquidClient::Esplora {
+                    inner: Box::new(client),
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn update_wallet(
+        &mut self,
+        wollet: &mut lwk_wollet::Wollet,
+        index: u32,
+    ) -> Result<(), lwk_wollet::Error> {
+        let update = match self {
+            Self::Electrum { inner, .. } => {
+                let state = wollet.state();
+                inner.full_scan_to_index(&state, index)?
+            }
+            Self::Esplora { inner, .. } => inner.full_scan_to_index(wollet, index).await?,
+        };
+        if let Some(update) = update {
+            wollet.apply_update(update)?;
+        }
+        Ok(())
+    }
+}
+
+impl LiquidClient {
+    pub(crate) async fn tip(&mut self) -> Result<BlockHeader> {
+        Ok(match self {
+            LiquidClient::Electrum { inner } => inner.tip()?,
+            LiquidClient::Esplora { inner } => inner.tip().await?,
+        })
+    }
+
+    pub(crate) async fn broadcast(&self, tx: &Transaction) -> Result<Txid> {
+        Ok(match self {
+            LiquidClient::Electrum { inner } => inner.broadcast(tx)?,
+            LiquidClient::Esplora { inner } => inner.broadcast(tx).await?,
+        })
+    }
+
+    pub(crate) async fn get_transactions(&self, txids: &[Txid]) -> Result<Vec<Transaction>> {
+        Ok(match self {
+            LiquidClient::Electrum { inner } => inner.get_transactions(txids)?,
+            LiquidClient::Esplora { inner } => inner.get_transactions(txids).await?,
+        })
+    }
+
+    pub(crate) async fn get_scripts_history(
+        &self,
+        scripts: &[&Script],
+    ) -> Result<Vec<Vec<History>>> {
+        Ok(match self {
+            LiquidClient::Electrum { inner } => inner.get_scripts_history(scripts)?,
+            LiquidClient::Esplora { inner } => inner.get_scripts_history(scripts).await?,
+        })
+    }
+}

--- a/lib/core/src/chain/liquid/client.rs
+++ b/lib/core/src/chain/liquid/client.rs
@@ -4,11 +4,13 @@ use lwk_wollet::{
     elements::{BlockHeader, Script, Transaction, Txid},
     History,
 };
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 use lwk_wollet::{blocking::BlockchainBackend, ElectrumClient, ElectrumOptions, ElectrumUrl};
 
 use crate::model::{BlockchainExplorer, LiquidNetwork};
 
 pub(crate) enum LiquidClient {
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     Electrum {
         inner: Box<ElectrumClient>,
     },
@@ -30,6 +32,7 @@ impl LiquidClient {
         network: LiquidNetwork,
     ) -> Result<Self> {
         match exp {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             BlockchainExplorer::Electrum { url } => {
                 let (tls, validate_domain) = match network {
                     LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
@@ -64,6 +67,7 @@ impl LiquidClient {
         index: u32,
     ) -> Result<(), lwk_wollet::Error> {
         let update = match self {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             Self::Electrum { inner, .. } => {
                 let state = wollet.state();
                 inner.full_scan_to_index(&state, index)?
@@ -80,6 +84,7 @@ impl LiquidClient {
 impl LiquidClient {
     pub(crate) async fn tip(&mut self) -> Result<BlockHeader> {
         Ok(match self {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             LiquidClient::Electrum { inner } => inner.tip()?,
             LiquidClient::Esplora { inner } => inner.tip().await?,
         })
@@ -87,6 +92,7 @@ impl LiquidClient {
 
     pub(crate) async fn broadcast(&self, tx: &Transaction) -> Result<Txid> {
         Ok(match self {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             LiquidClient::Electrum { inner } => inner.broadcast(tx)?,
             LiquidClient::Esplora { inner } => inner.broadcast(tx).await?,
         })
@@ -94,6 +100,7 @@ impl LiquidClient {
 
     pub(crate) async fn get_transactions(&self, txids: &[Txid]) -> Result<Vec<Transaction>> {
         Ok(match self {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             LiquidClient::Electrum { inner } => inner.get_transactions(txids)?,
             LiquidClient::Esplora { inner } => inner.get_transactions(txids).await?,
         })
@@ -104,6 +111,7 @@ impl LiquidClient {
         scripts: &[&Script],
     ) -> Result<Vec<Vec<History>>> {
         Ok(match self {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             LiquidClient::Electrum { inner } => inner.get_scripts_history(scripts)?,
             LiquidClient::Esplora { inner } => inner.get_scripts_history(scripts).await?,
         })

--- a/lib/core/src/chain/liquid/mod.rs
+++ b/lib/core/src/chain/liquid/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod client;
+pub(crate) mod service;

--- a/lib/core/src/chain/mod.rs
+++ b/lib/core/src/chain/mod.rs
@@ -1,2 +1,13 @@
 pub(crate) mod bitcoin;
 pub(crate) mod liquid;
+
+#[macro_export]
+macro_rules! get_client {
+    ($chain_service:ident,$client:ident) => {
+        $chain_service.set_client().await?;
+        let lock = $chain_service.client.read().await;
+        let Some($client) = lock.as_ref() else {
+            bail!("Client not set"); // unreachable
+        };
+    };
+}

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -7,18 +7,16 @@ use boltz_client::{
     swaps::boltz::{ChainSwapStates, CreateChainResponse, SwapUpdateTxDetails},
     ElementsLockTime, Secp256k1, Serialize, ToHex,
 };
+use elements::{hex::FromHex, Script, Transaction};
 use futures_util::TryFutureExt;
 use log::{debug, error, info, warn};
-use lwk_wollet::{
-    elements::{hex::FromHex, Script, Transaction},
-    hashes::hex::DisplayHex,
-    History,
-};
+use lwk_wollet::hashes::hex::DisplayHex;
 use tokio::sync::broadcast;
 
-use crate::model::{BlockListener, ChainSwapUpdate, LIQUID_FEE_RATE_MSAT_PER_VBYTE};
+use crate::model::{BlockListener, ChainSwapUpdate, History, LIQUID_FEE_RATE_MSAT_PER_VBYTE};
+use crate::{bitcoin, elements};
 use crate::{
-    chain::{bitcoin::BitcoinChainService, liquid::LiquidChainService},
+    chain::{bitcoin::service::BitcoinChainService, liquid::service::LiquidChainService},
     ensure_sdk,
     error::{PaymentError, SdkError, SdkResult},
     model::{
@@ -166,6 +164,24 @@ impl ChainSwapHandler {
         Ok(())
     }
 
+    async fn fetch_script_history(&self, swap_script: &SwapScriptV2) -> Result<Vec<(String, i32)>> {
+        let history = match swap_script {
+            SwapScriptV2::Liquid(_) => self
+                .fetch_liquid_script_history(swap_script)
+                .await?
+                .into_iter()
+                .map(|h| (h.txid.to_hex(), h.height))
+                .collect(),
+            SwapScriptV2::Bitcoin(_) => self
+                .fetch_bitcoin_script_history(swap_script)
+                .await?
+                .into_iter()
+                .map(|h| (h.txid.to_hex(), h.height))
+                .collect(),
+        };
+        Ok(history)
+    }
+
     async fn claim_confirmed_server_lockup(&self, swap: &ChainSwap) -> Result<()> {
         let Some(tx_id) = swap.server_lockup_tx_id.clone() else {
             // Skip the rescan if there is no server_lockup_tx_id yet
@@ -173,17 +189,15 @@ impl ChainSwapHandler {
         };
         let swap_id = &swap.id;
         let swap_script = swap.get_claim_swap_script()?;
-        let script_history = match swap.direction {
-            Direction::Incoming => self.fetch_liquid_script_history(&swap_script).await,
-            Direction::Outgoing => self.fetch_bitcoin_script_history(&swap_script).await,
-        }?;
-        let tx_history = script_history
-            .iter()
-            .find(|h| h.txid.to_hex().eq(&tx_id))
-            .ok_or(anyhow!(
-                "Server lockup tx for Chain Swap {swap_id} was not found, txid={tx_id}"
-            ))?;
-        if tx_history.height > 0 {
+        let script_history = self.fetch_script_history(&swap_script).await?;
+        let (_tx_history, tx_height) =
+            script_history
+                .iter()
+                .find(|h| h.0.eq(&tx_id))
+                .ok_or(anyhow!(
+                    "Server lockup tx for Chain Swap {swap_id} was not found, txid={tx_id}"
+                ))?;
+        if *tx_height > 0 {
             info!("Chain Swap {swap_id} server lockup tx is confirmed");
             self.claim(swap_id)
                 .await
@@ -862,6 +876,7 @@ impl ChainSwapHandler {
                     SdkTransaction::Bitcoin(tx) => self
                         .bitcoin_chain_service
                         .broadcast(&tx)
+                        .await
                         .map(|tx_id| tx_id.to_hex())
                         .map_err(|err| PaymentError::Generic {
                             err: err.to_string(),
@@ -989,7 +1004,10 @@ impl ChainSwapHandler {
             .to_address(self.config.network.as_bitcoin_chain())
             .map_err(|e| anyhow!("Could not retrieve address from swap script: {e:?}"))?
             .script_pubkey();
-        let utxos = self.bitcoin_chain_service.get_script_utxos(&script_pk)?;
+        let utxos = self
+            .bitcoin_chain_service
+            .get_script_utxos(&script_pk)
+            .await?;
 
         let SdkTransaction::Bitcoin(refund_tx) = self
             .swapper
@@ -1008,7 +1026,8 @@ impl ChainSwapHandler {
         };
         let refund_tx_id = self
             .bitcoin_chain_service
-            .broadcast(&refund_tx)?
+            .broadcast(&refund_tx)
+            .await?
             .to_string();
 
         info!("Successfully broadcast refund for incoming Chain Swap {id}, is_cooperative: {is_cooperative}");
@@ -1222,7 +1241,8 @@ impl ChainSwapHandler {
         // Get full transaction
         let txs = self
             .bitcoin_chain_service
-            .get_transactions(&[first_tx_id])?;
+            .get_transactions(&[first_tx_id])
+            .await?;
         let user_lockup_tx = txs.first().ok_or(anyhow!(
             "No transactions found for user lockup script for swap {}",
             chain_swap.id
@@ -1370,27 +1390,21 @@ impl ChainSwapHandler {
     }
 
     async fn user_lockup_tx_exists(&self, chain_swap: &ChainSwap) -> Result<bool> {
-        let swap_script = chain_swap.get_lockup_swap_script()?;
-        let script_history = match chain_swap.direction {
-            Direction::Incoming => self.fetch_bitcoin_script_history(&swap_script).await,
-            Direction::Outgoing => self.fetch_liquid_script_history(&swap_script).await,
-        }?;
+        let lockup_script = chain_swap.get_lockup_swap_script()?;
+        let script_history = self.fetch_script_history(&lockup_script).await?;
 
         match chain_swap.user_lockup_tx_id.clone() {
             Some(user_lockup_tx_id) => {
-                if !script_history
-                    .iter()
-                    .any(|h| h.txid.to_hex() == user_lockup_tx_id)
-                {
+                if !script_history.iter().any(|h| h.0 == user_lockup_tx_id) {
                     return Ok(false);
                 }
             }
             None => {
-                let txid = match script_history.first() {
+                let (txid, _tx_height) = match script_history.into_iter().nth(0) {
+                    Some(h) => h,
                     None => {
                         return Ok(false);
                     }
-                    Some(h) => h.txid.to_hex(),
                 };
                 self.update_swap_info(&ChainSwapUpdate {
                     swap_id: chain_swap.id.clone(),
@@ -1436,7 +1450,7 @@ impl ChainSwapHandler {
     async fn fetch_bitcoin_script_history(
         &self,
         swap_script: &SwapScriptV2,
-    ) -> Result<Vec<History>> {
+    ) -> Result<Vec<History<bitcoin::Txid>>> {
         let address = swap_script
             .as_bitcoin_script()?
             .to_address(self.config.network.as_bitcoin_chain())
@@ -1451,7 +1465,7 @@ impl ChainSwapHandler {
     async fn fetch_liquid_script_history(
         &self,
         swap_script: &SwapScriptV2,
-    ) -> Result<Vec<History>> {
+    ) -> Result<Vec<History<elements::Txid>>> {
         let address = swap_script
             .as_liquid_script()?
             .to_address(self.config.network.into())

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -232,8 +232,8 @@ impl From<SdkError> for PaymentError {
     }
 }
 
-impl From<crate::bitcoin::util::bip32::Error> for PaymentError {
-    fn from(err: crate::bitcoin::util::bip32::Error) -> Self {
+impl From<sdk_common::bitcoin::util::bip32::Error> for PaymentError {
+    fn from(err: sdk_common::bitcoin::util::bip32::Error) -> Self {
         Self::SignerError {
             err: err.to_string(),
         }

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2476,6 +2476,30 @@ impl SseDecode for crate::bindings::BitcoinAddressData {
     }
 }
 
+impl SseDecode for crate::model::BlockchainExplorer {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_url = <String>::sse_decode(deserializer);
+                return crate::model::BlockchainExplorer::Electrum { url: var_url };
+            }
+            1 => {
+                let mut var_url = <String>::sse_decode(deserializer);
+                let mut var_useWaterfalls = <bool>::sse_decode(deserializer);
+                return crate::model::BlockchainExplorer::Esplora {
+                    url: var_url,
+                    use_waterfalls: var_useWaterfalls,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::model::BlockchainInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2546,9 +2570,10 @@ impl SseDecode for crate::model::CheckMessageResponse {
 impl SseDecode for crate::model::Config {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_liquidElectrumUrl = <String>::sse_decode(deserializer);
-        let mut var_bitcoinElectrumUrl = <String>::sse_decode(deserializer);
-        let mut var_mempoolspaceUrl = <String>::sse_decode(deserializer);
+        let mut var_liquidExplorers =
+            <Vec<crate::model::BlockchainExplorer>>::sse_decode(deserializer);
+        let mut var_bitcoinExplorers =
+            <Vec<crate::model::BlockchainExplorer>>::sse_decode(deserializer);
         let mut var_workingDir = <String>::sse_decode(deserializer);
         let mut var_cacheDir = <Option<String>>::sse_decode(deserializer);
         let mut var_network = <crate::model::LiquidNetwork>::sse_decode(deserializer);
@@ -2563,9 +2588,8 @@ impl SseDecode for crate::model::Config {
         let mut var_assetMetadata =
             <Option<Vec<crate::model::AssetMetadata>>>::sse_decode(deserializer);
         return crate::model::Config {
-            liquid_electrum_url: var_liquidElectrumUrl,
-            bitcoin_electrum_url: var_bitcoinElectrumUrl,
-            mempoolspace_url: var_mempoolspaceUrl,
+            liquid_explorers: var_liquidExplorers,
+            bitcoin_explorers: var_bitcoinExplorers,
             working_dir: var_workingDir,
             cache_dir: var_cacheDir,
             network: var_network,
@@ -2893,6 +2917,18 @@ impl SseDecode for Vec<crate::model::AssetMetadata> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<crate::model::AssetMetadata>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::model::BlockchainExplorer> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::model::BlockchainExplorer>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -5043,6 +5079,39 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::bindings::BitcoinAddres
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::model::BlockchainExplorer {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::model::BlockchainExplorer::Electrum { url } => {
+                [0.into_dart(), url.into_into_dart().into_dart()].into_dart()
+            }
+            crate::model::BlockchainExplorer::Esplora {
+                url,
+                use_waterfalls,
+            } => [
+                1.into_dart(),
+                url.into_into_dart().into_dart(),
+                use_waterfalls.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::model::BlockchainExplorer
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::model::BlockchainExplorer>
+    for crate::model::BlockchainExplorer
+{
+    fn into_into_dart(self) -> crate::model::BlockchainExplorer {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::model::BlockchainInfo {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -5144,9 +5213,8 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::CheckMessageResponse>
 impl flutter_rust_bridge::IntoDart for crate::model::Config {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.liquid_electrum_url.into_into_dart().into_dart(),
-            self.bitcoin_electrum_url.into_into_dart().into_dart(),
-            self.mempoolspace_url.into_into_dart().into_dart(),
+            self.liquid_explorers.into_into_dart().into_dart(),
+            self.bitcoin_explorers.into_into_dart().into_dart(),
             self.working_dir.into_into_dart().into_dart(),
             self.cache_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
@@ -7407,6 +7475,29 @@ impl SseEncode for crate::bindings::BitcoinAddressData {
     }
 }
 
+impl SseEncode for crate::model::BlockchainExplorer {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::model::BlockchainExplorer::Electrum { url } => {
+                <i32>::sse_encode(0, serializer);
+                <String>::sse_encode(url, serializer);
+            }
+            crate::model::BlockchainExplorer::Esplora {
+                url,
+                use_waterfalls,
+            } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(url, serializer);
+                <bool>::sse_encode(use_waterfalls, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::model::BlockchainInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7464,9 +7555,8 @@ impl SseEncode for crate::model::CheckMessageResponse {
 impl SseEncode for crate::model::Config {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.liquid_electrum_url, serializer);
-        <String>::sse_encode(self.bitcoin_electrum_url, serializer);
-        <String>::sse_encode(self.mempoolspace_url, serializer);
+        <Vec<crate::model::BlockchainExplorer>>::sse_encode(self.liquid_explorers, serializer);
+        <Vec<crate::model::BlockchainExplorer>>::sse_encode(self.bitcoin_explorers, serializer);
         <String>::sse_encode(self.working_dir, serializer);
         <Option<String>>::sse_encode(self.cache_dir, serializer);
         <crate::model::LiquidNetwork>::sse_encode(self.network, serializer);
@@ -7721,6 +7811,16 @@ impl SseEncode for Vec<crate::model::AssetMetadata> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::model::AssetMetadata>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::model::BlockchainExplorer> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::model::BlockchainExplorer>::sse_encode(item, serializer);
         }
     }
 }
@@ -9448,6 +9548,27 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::model::BlockchainExplorer> for wire_cst_blockchain_explorer {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::model::BlockchainExplorer {
+            match self.tag {
+                0 => {
+                    let ans = unsafe { self.kind.Electrum };
+                    crate::model::BlockchainExplorer::Electrum {
+                        url: ans.url.cst_decode(),
+                    }
+                }
+                1 => {
+                    let ans = unsafe { self.kind.Esplora };
+                    crate::model::BlockchainExplorer::Esplora {
+                        url: ans.url.cst_decode(),
+                        use_waterfalls: ans.use_waterfalls.cst_decode(),
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<crate::model::BlockchainInfo> for wire_cst_blockchain_info {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::BlockchainInfo {
@@ -9887,9 +10008,8 @@ mod io {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::model::Config {
             crate::model::Config {
-                liquid_electrum_url: self.liquid_electrum_url.cst_decode(),
-                bitcoin_electrum_url: self.bitcoin_electrum_url.cst_decode(),
-                mempoolspace_url: self.mempoolspace_url.cst_decode(),
+                liquid_explorers: self.liquid_explorers.cst_decode(),
+                bitcoin_explorers: self.bitcoin_explorers.cst_decode(),
                 working_dir: self.working_dir.cst_decode(),
                 cache_dir: self.cache_dir.cst_decode(),
                 network: self.network.cst_decode(),
@@ -10132,6 +10252,16 @@ mod io {
     impl CstDecode<Vec<crate::model::AssetMetadata>> for *mut wire_cst_list_asset_metadata {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<crate::model::AssetMetadata> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
+    impl CstDecode<Vec<crate::model::BlockchainExplorer>> for *mut wire_cst_list_blockchain_explorer {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::model::BlockchainExplorer> {
             let vec = unsafe {
                 let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
                 flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
@@ -11523,6 +11653,19 @@ mod io {
             Self::new_with_null_ptr()
         }
     }
+    impl NewWithNullPtr for wire_cst_blockchain_explorer {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: BlockchainExplorerKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_blockchain_explorer {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
     impl NewWithNullPtr for wire_cst_blockchain_info {
         fn new_with_null_ptr() -> Self {
             Self {
@@ -11578,9 +11721,8 @@ mod io {
     impl NewWithNullPtr for wire_cst_config {
         fn new_with_null_ptr() -> Self {
             Self {
-                liquid_electrum_url: core::ptr::null_mut(),
-                bitcoin_electrum_url: core::ptr::null_mut(),
-                mempoolspace_url: core::ptr::null_mut(),
+                liquid_explorers: core::ptr::null_mut(),
+                bitcoin_explorers: core::ptr::null_mut(),
                 working_dir: core::ptr::null_mut(),
                 cache_dir: core::ptr::null_mut(),
                 network: Default::default(),
@@ -13527,6 +13669,20 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_breez_liquid_cst_new_list_blockchain_explorer(
+        len: i32,
+    ) -> *mut wire_cst_list_blockchain_explorer {
+        let wrap = wire_cst_list_blockchain_explorer {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_blockchain_explorer>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_breez_liquid_cst_new_list_external_input_parser(
         len: i32,
     ) -> *mut wire_cst_list_external_input_parser {
@@ -13807,6 +13963,30 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_blockchain_explorer {
+        tag: i32,
+        kind: BlockchainExplorerKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union BlockchainExplorerKind {
+        Electrum: wire_cst_BlockchainExplorer_Electrum,
+        Esplora: wire_cst_BlockchainExplorer_Esplora,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_BlockchainExplorer_Electrum {
+        url: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_BlockchainExplorer_Esplora {
+        url: *mut wire_cst_list_prim_u_8_strict,
+        use_waterfalls: bool,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_blockchain_info {
         liquid_tip: u32,
         bitcoin_tip: u32,
@@ -13832,9 +14012,8 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_config {
-        liquid_electrum_url: *mut wire_cst_list_prim_u_8_strict,
-        bitcoin_electrum_url: *mut wire_cst_list_prim_u_8_strict,
-        mempoolspace_url: *mut wire_cst_list_prim_u_8_strict,
+        liquid_explorers: *mut wire_cst_list_blockchain_explorer,
+        bitcoin_explorers: *mut wire_cst_list_blockchain_explorer,
         working_dir: *mut wire_cst_list_prim_u_8_strict,
         cache_dir: *mut wire_cst_list_prim_u_8_strict,
         network: i32,
@@ -14034,6 +14213,12 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_list_asset_metadata {
         ptr: *mut wire_cst_asset_metadata,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_blockchain_explorer {
+        ptr: *mut wire_cst_blockchain_explorer,
         len: i32,
     }
     #[repr(C)]

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -186,6 +186,8 @@ pub(crate) mod test_utils;
 pub(crate) mod utils;
 pub(crate) mod wallet;
 
+pub use lwk_wollet::bitcoin;
+pub use lwk_wollet::elements;
 pub use sdk_common::prelude::*;
 
 #[allow(ambiguous_glob_reexports)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -32,13 +32,23 @@ pub const LIQUID_FEE_RATE_SAT_PER_VBYTE: f64 = 0.1;
 pub const LIQUID_FEE_RATE_MSAT_PER_VBYTE: f32 = (LIQUID_FEE_RATE_SAT_PER_VBYTE * 1000.0) as f32;
 pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 
+#[derive(Clone, Debug, Serialize)]
+pub enum BlockchainExplorer {
+    Electrum {
+        url: String,
+    },
+    Esplora {
+        url: String,
+        /// Whether or not to use the "waterfalls" extension
+        use_waterfalls: bool,
+    },
+}
+
 /// Configuration for the Liquid SDK
 #[derive(Clone, Debug, Serialize)]
 pub struct Config {
-    pub liquid_electrum_url: String,
-    pub bitcoin_electrum_url: String,
-    /// The mempool.space API URL, has to be in the format: `https://mempool.space/api`
-    pub mempoolspace_url: String,
+    pub liquid_explorers: Vec<BlockchainExplorer>,
+    pub bitcoin_explorers: Vec<BlockchainExplorer>,
     /// Directory in which the DB and log files are stored.
     ///
     /// Prefix can be a relative or absolute path to this directory.
@@ -81,9 +91,18 @@ pub struct Config {
 impl Config {
     pub fn mainnet(breez_api_key: Option<String>) -> Self {
         Config {
-            liquid_electrum_url: "elements-mainnet.breez.technology:50002".to_string(),
-            bitcoin_electrum_url: "bitcoin-mainnet.blockstream.info:50002".to_string(),
-            mempoolspace_url: "https://mempool.space/api".to_string(),
+            liquid_explorers: vec![
+                BlockchainExplorer::Esplora {
+                    url: "https://waterfalls.liquidwebwallet.org/liquid/api".to_string(),
+                    use_waterfalls: true,
+                },
+                BlockchainExplorer::Electrum {
+                    url: "elements-mainnet.breez.technology:50002".to_string(),
+                },
+            ],
+            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
+                url: "bitcoin-mainnet.blockstream.info:50002".to_string(),
+            }],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Mainnet,
@@ -100,9 +119,18 @@ impl Config {
 
     pub fn testnet(breez_api_key: Option<String>) -> Self {
         Config {
-            liquid_electrum_url: "elements-testnet.blockstream.info:50002".to_string(),
-            bitcoin_electrum_url: "bitcoin-testnet.blockstream.info:50002".to_string(),
-            mempoolspace_url: "https://mempool.space/testnet/api".to_string(),
+            liquid_explorers: vec![
+                BlockchainExplorer::Esplora {
+                    url: "https://waterfalls.liquidwebwallet.org/liquidtestnet/api".to_string(),
+                    use_waterfalls: true,
+                },
+                BlockchainExplorer::Electrum {
+                    url: "elements-testnet.blockstream.info:50002".to_string(),
+                },
+            ],
+            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
+                url: "bitcoin-testnet.blockstream.info:50002".to_string(),
+            }],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Testnet,
@@ -119,9 +147,12 @@ impl Config {
 
     pub fn regtest() -> Self {
         Config {
-            liquid_electrum_url: "localhost:19002".to_string(),
-            bitcoin_electrum_url: "localhost:19001".to_string(),
-            mempoolspace_url: "http://localhost/api".to_string(),
+            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
+                url: "localhost:19001".to_string(),
+            }],
+            liquid_explorers: vec![BlockchainExplorer::Electrum {
+                url: "localhost:19002".to_string(),
+            }],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Regtest,
@@ -188,6 +219,42 @@ impl Config {
             LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
             LiquidNetwork::Regtest => BOLTZ_REGTEST,
         }
+    }
+
+    fn get_explorers(
+        v: &[BlockchainExplorer],
+        predicate: fn(&BlockchainExplorer) -> Option<&String>,
+    ) -> Vec<&String> {
+        v.iter().filter_map(predicate).collect()
+    }
+
+    pub(crate) fn liquid_electrum_explorers(&self) -> Vec<&String> {
+        Self::get_explorers(&self.liquid_explorers, |be| match be {
+            BlockchainExplorer::Electrum { url } => Some(url),
+            _ => None,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn liquid_esplora_explorers(&self) -> Vec<&String> {
+        Self::get_explorers(&self.liquid_explorers, |be| match be {
+            BlockchainExplorer::Esplora { url, .. } => Some(url),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn bitcoin_electrum_explorers(&self) -> Vec<&String> {
+        Self::get_explorers(&self.bitcoin_explorers, |be| match be {
+            BlockchainExplorer::Electrum { url } => Some(url),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn bitcoin_esplora_explorers(&self) -> Vec<&String> {
+        Self::get_explorers(&self.bitcoin_explorers, |be| match be {
+            BlockchainExplorer::Esplora { url, .. } => Some(url),
+            _ => None,
+        })
     }
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -33,9 +33,8 @@ pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 
 #[derive(Clone, Debug, Serialize)]
 pub enum BlockchainExplorer {
-    Electrum {
-        url: String,
-    },
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    Electrum { url: String },
     Esplora {
         url: String,
         /// Whether or not to use the "waterfalls" extension
@@ -95,13 +94,17 @@ impl Config {
                     url: "https://waterfalls.liquidwebwallet.org/liquid/api".to_string(),
                     use_waterfalls: true,
                 },
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
                 BlockchainExplorer::Electrum {
                     url: "elements-mainnet.breez.technology:50002".to_string(),
                 },
             ],
-            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
-                url: "bitcoin-mainnet.blockstream.info:50002".to_string(),
-            }],
+            bitcoin_explorers: vec![
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+                BlockchainExplorer::Electrum {
+                    url: "bitcoin-mainnet.blockstream.info:50002".to_string(),
+                },
+            ],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Mainnet,
@@ -123,13 +126,17 @@ impl Config {
                     url: "https://waterfalls.liquidwebwallet.org/liquidtestnet/api".to_string(),
                     use_waterfalls: true,
                 },
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
                 BlockchainExplorer::Electrum {
                     url: "elements-testnet.blockstream.info:50002".to_string(),
                 },
             ],
-            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
-                url: "bitcoin-testnet.blockstream.info:50002".to_string(),
-            }],
+            bitcoin_explorers: vec![
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+                BlockchainExplorer::Electrum {
+                    url: "bitcoin-testnet.blockstream.info:50002".to_string(),
+                },
+            ],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Testnet,
@@ -146,12 +153,18 @@ impl Config {
 
     pub fn regtest() -> Self {
         Config {
-            bitcoin_explorers: vec![BlockchainExplorer::Electrum {
-                url: "localhost:19001".to_string(),
-            }],
-            liquid_explorers: vec![BlockchainExplorer::Electrum {
-                url: "localhost:19002".to_string(),
-            }],
+            bitcoin_explorers: vec![
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+                BlockchainExplorer::Electrum {
+                    url: "localhost:19001".to_string(),
+                },
+            ],
+            liquid_explorers: vec![
+                #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+                BlockchainExplorer::Electrum {
+                    url: "localhost:19002".to_string(),
+                },
+            ],
             working_dir: ".".to_string(),
             cache_dir: None,
             network: LiquidNetwork::Regtest,
@@ -227,6 +240,7 @@ impl Config {
         v.iter().filter_map(predicate).collect()
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub(crate) fn liquid_electrum_explorers(&self) -> Vec<&String> {
         Self::get_explorers(&self.liquid_explorers, |be| match be {
             BlockchainExplorer::Electrum { url } => Some(url),
@@ -242,6 +256,7 @@ impl Config {
         })
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub(crate) fn bitcoin_electrum_explorers(&self) -> Vec<&String> {
         Self::get_explorers(&self.bitcoin_explorers, |be| match be {
             BlockchainExplorer::Electrum { url } => Some(url),

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -11,7 +11,7 @@ use lwk_wollet::hashes::hex::DisplayHex;
 use lwk_wollet::secp256k1::SecretKey;
 use tokio::sync::broadcast;
 
-use crate::chain::liquid::LiquidChainService;
+use crate::chain::liquid::service::LiquidChainService;
 use crate::model::{BlockListener, PaymentState::*};
 use crate::model::{Config, PaymentTxData, PaymentType, ReceiveSwap};
 use crate::prelude::Swap;

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -35,7 +35,7 @@ pub(crate) fn new_chain_swap_handler(persister: Arc<Persister>) -> Result<ChainS
     let swapper = Arc::new(BoltzSwapper::new(
         config.clone(),
         Arc::new(MockProxyUrlFetcher::new()),
-    ));
+    )?);
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
 

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -105,7 +105,7 @@ impl OnchainWallet for MockWallet {
         unimplemented!()
     }
 
-    async fn full_scan(&self) -> Result<(), PaymentError> {
+    async fn full_scan(&self) -> Result<()> {
         Ok(())
     }
 }

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -5,23 +5,23 @@ use std::path::PathBuf;
 use std::time::Instant;
 use std::{path::Path, str::FromStr, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use boltz_client::ElementsAddress;
 use log::{debug, info, warn};
 use lwk_common::Signer as LwkSigner;
 use lwk_common::{singlesig_desc, Singlesig};
 use lwk_wollet::elements::{AssetId, Txid};
-use lwk_wollet::ElectrumOptions;
 use lwk_wollet::{
     elements::{hex::ToHex, Address, Transaction},
-    ElectrumClient, ElectrumUrl, ElementsNetwork, FsPersister, WalletTx, Wollet, WolletDescriptor,
+    ElementsNetwork, FsPersister, WalletTx, Wollet, WolletDescriptor,
 };
 use sdk_common::bitcoin::hashes::{sha256, Hash};
 use sdk_common::bitcoin::secp256k1::PublicKey;
 use sdk_common::lightning::util::message_signing::verify;
 use tokio::sync::Mutex;
 
+use crate::chain::liquid::client::LiquidClient;
 use crate::model::Signer;
 use crate::persist::Persister;
 use crate::signer::SdkLwkSigner;
@@ -97,19 +97,43 @@ pub trait OnchainWallet: Send + Sync {
     fn check_message(&self, message: &str, pubkey: &str, signature: &str) -> Result<bool>;
 
     /// Perform a full scan of the wallet
-    async fn full_scan(&self) -> Result<(), PaymentError>;
+    async fn full_scan(&self) -> Result<()>;
 }
 
 pub(crate) struct LiquidOnchainWallet {
     config: Config,
     persister: Arc<Persister>,
     wallet: Arc<Mutex<Wollet>>,
-    electrum_client: Mutex<Option<ElectrumClient>>,
+    client: Mutex<(LiquidClient, usize)>,
     working_dir: String,
     pub(crate) signer: SdkLwkSigner,
 }
 
 impl LiquidOnchainWallet {
+    fn get_client(config: &Config, index: usize) -> Result<(LiquidClient, usize)> {
+        let explorer = config
+            .liquid_explorers
+            .get(index)
+            .context("Expected existing liquid explorer")?;
+        Ok((
+            LiquidClient::try_from_explorer(explorer, config.network)?,
+            index,
+        ))
+    }
+
+    fn get_next_available_client(
+        config: &Config,
+        start_index: usize,
+    ) -> Result<(LiquidClient, usize)> {
+        let total_explorers = config.liquid_explorers.len();
+        for index in start_index..start_index + total_explorers {
+            if let Ok(res) = Self::get_client(config, index % total_explorers) {
+                return Ok(res);
+            }
+        }
+        bail!("Could not find a working client")
+    }
+
     pub(crate) fn new(
         config: Config,
         working_dir: &String,
@@ -123,12 +147,13 @@ impl LiquidOnchainWallet {
         if !working_dir_buf.exists() {
             create_dir_all(&working_dir_buf)?;
         }
+        let client = Mutex::new(Self::get_next_available_client(&config, 0)?);
 
         Ok(Self {
             config,
             persister,
             wallet: Arc::new(Mutex::new(wollet)),
-            electrum_client: Mutex::new(None),
+            client,
             working_dir: working_dir.clone(),
             signer,
         })
@@ -180,6 +205,20 @@ impl LiquidOnchainWallet {
         )
         .map_err(|e| anyhow!("Invalid descriptor: {e}"))?;
         Ok(descriptor_str.parse()?)
+    }
+
+    async fn execute_scan(&self, client: &mut LiquidClient, index: u32) -> Result<()> {
+        let mut wallet = self.wallet.lock().await;
+        if let Err(lwk_wollet::Error::UpdateHeightTooOld { .. }) =
+            client.update_wallet(&mut wallet, index).await
+        {
+            warn!("Full scan failed with update height too old, wiping storage and retrying");
+            let mut new_wallet =
+                Self::create_wallet(&self.config, &self.working_dir, &self.signer)?;
+            client.update_wallet(&mut new_wallet, index).await?;
+            *wallet = new_wallet;
+        };
+        Ok(())
     }
 }
 
@@ -357,60 +396,37 @@ impl OnchainWallet for LiquidOnchainWallet {
     }
 
     /// Perform a full scan of the wallet
-    async fn full_scan(&self) -> Result<(), PaymentError> {
+    async fn full_scan(&self) -> Result<()> {
         let full_scan_started = Instant::now();
 
-        // create electrum client if doesn't already exist
-        let mut electrum_client = self.electrum_client.lock().await;
-        if electrum_client.is_none() {
-            let (tls, validate_domain) = match self.config.network {
-                LiquidNetwork::Mainnet | LiquidNetwork::Testnet => (true, true),
-                LiquidNetwork::Regtest => (false, false),
-            };
-
-            let electrum_url =
-                ElectrumUrl::new(&self.config.liquid_electrum_url, tls, validate_domain)?;
-            *electrum_client = Some(ElectrumClient::with_options(
-                &electrum_url,
-                ElectrumOptions { timeout: Some(3) },
-            )?);
-        }
-        let client = electrum_client
-            .as_mut()
-            .ok_or_else(|| PaymentError::Generic {
-                err: "Electrum client not initialized".to_string(),
-            })?;
-
         // Use the cached derivation index with a buffer of 5 to perform the scan
-        let index = self
+        let derivation_index = self
             .persister
             .get_last_derivation_index()?
             .map(|i| i + 5)
             .unwrap_or_default();
-        let mut wallet = self.wallet.lock().await;
 
-        let res =
-            match lwk_wollet::full_scan_to_index_with_electrum_client(&mut wallet, index, client) {
-                Ok(()) => Ok(()),
-                Err(lwk_wollet::Error::UpdateHeightTooOld { .. }) => {
-                    warn!(
-                        "Full scan failed with update height too old, wiping storage and retrying"
-                    );
-                    let mut new_wallet =
-                        Self::create_wallet(&self.config, &self.working_dir, &self.signer)?;
-                    lwk_wollet::full_scan_to_index_with_electrum_client(
-                        &mut new_wallet,
-                        index,
-                        client,
-                    )?;
-                    *wallet = new_wallet;
-                    Ok(())
-                }
-                Err(e) => Err(e.into()),
-            };
+        let mut attempts = 0;
+        let mut lock = self.client.lock().await;
+        while attempts < self.config.liquid_explorers.len() {
+            if self
+                .execute_scan(&mut lock.0, derivation_index)
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            *lock = Self::get_next_available_client(&self.config, lock.1 + 1)?;
+            attempts += 1;
+        }
+
+        if attempts >= self.config.liquid_explorers.len() {
+            bail!("Could not run full scan: request failed on all provided clients");
+        }
+
         let duration_ms = Instant::now().duration_since(full_scan_started).as_millis();
         info!("lwk wallet full_scan duration: ({duration_ms} ms)");
-        res
+        Ok(())
     }
 
     fn sign_message(&self, message: &str) -> Result<String> {

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1528,6 +1528,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  BlockchainExplorer dco_decode_blockchain_explorer(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return BlockchainExplorer_Electrum(url: dco_decode_String(raw[1]));
+      case 1:
+        return BlockchainExplorer_Esplora(
+          url: dco_decode_String(raw[1]),
+          useWaterfalls: dco_decode_bool(raw[2]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   BlockchainInfo dco_decode_blockchain_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -1912,22 +1928,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Config dco_decode_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 14) throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
+    if (arr.length != 13) throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
     return Config(
-      liquidElectrumUrl: dco_decode_String(arr[0]),
-      bitcoinElectrumUrl: dco_decode_String(arr[1]),
-      mempoolspaceUrl: dco_decode_String(arr[2]),
-      workingDir: dco_decode_String(arr[3]),
-      cacheDir: dco_decode_opt_String(arr[4]),
-      network: dco_decode_liquid_network(arr[5]),
-      paymentTimeoutSec: dco_decode_u_64(arr[6]),
-      syncServiceUrl: dco_decode_opt_String(arr[7]),
-      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[8]),
-      breezApiKey: dco_decode_opt_String(arr[9]),
-      externalInputParsers: dco_decode_opt_list_external_input_parser(arr[10]),
-      useDefaultExternalInputParsers: dco_decode_bool(arr[11]),
-      onchainFeeRateLeewaySatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[12]),
-      assetMetadata: dco_decode_opt_list_asset_metadata(arr[13]),
+      liquidExplorers: dco_decode_list_blockchain_explorer(arr[0]),
+      bitcoinExplorers: dco_decode_list_blockchain_explorer(arr[1]),
+      workingDir: dco_decode_String(arr[2]),
+      cacheDir: dco_decode_opt_String(arr[3]),
+      network: dco_decode_liquid_network(arr[4]),
+      paymentTimeoutSec: dco_decode_u_64(arr[5]),
+      syncServiceUrl: dco_decode_opt_String(arr[6]),
+      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[7]),
+      breezApiKey: dco_decode_opt_String(arr[8]),
+      externalInputParsers: dco_decode_opt_list_external_input_parser(arr[9]),
+      useDefaultExternalInputParsers: dco_decode_bool(arr[10]),
+      onchainFeeRateLeewaySatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[11]),
+      assetMetadata: dco_decode_opt_list_asset_metadata(arr[12]),
     );
   }
 
@@ -2139,6 +2154,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AssetMetadata> dco_decode_list_asset_metadata(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_asset_metadata).toList();
+  }
+
+  @protected
+  List<BlockchainExplorer> dco_decode_list_blockchain_explorer(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_blockchain_explorer).toList();
   }
 
   @protected
@@ -3526,6 +3547,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  BlockchainExplorer sse_decode_blockchain_explorer(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_url = sse_decode_String(deserializer);
+        return BlockchainExplorer_Electrum(url: var_url);
+      case 1:
+        var var_url = sse_decode_String(deserializer);
+        var var_useWaterfalls = sse_decode_bool(deserializer);
+        return BlockchainExplorer_Esplora(url: var_url, useWaterfalls: var_useWaterfalls);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   BlockchainInfo sse_decode_blockchain_info(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_liquidTip = sse_decode_u_32(deserializer);
@@ -3911,9 +3950,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Config sse_decode_config(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_liquidElectrumUrl = sse_decode_String(deserializer);
-    var var_bitcoinElectrumUrl = sse_decode_String(deserializer);
-    var var_mempoolspaceUrl = sse_decode_String(deserializer);
+    var var_liquidExplorers = sse_decode_list_blockchain_explorer(deserializer);
+    var var_bitcoinExplorers = sse_decode_list_blockchain_explorer(deserializer);
     var var_workingDir = sse_decode_String(deserializer);
     var var_cacheDir = sse_decode_opt_String(deserializer);
     var var_network = sse_decode_liquid_network(deserializer);
@@ -3926,9 +3964,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_onchainFeeRateLeewaySatPerVbyte = sse_decode_opt_box_autoadd_u_32(deserializer);
     var var_assetMetadata = sse_decode_opt_list_asset_metadata(deserializer);
     return Config(
-      liquidElectrumUrl: var_liquidElectrumUrl,
-      bitcoinElectrumUrl: var_bitcoinElectrumUrl,
-      mempoolspaceUrl: var_mempoolspaceUrl,
+      liquidExplorers: var_liquidExplorers,
+      bitcoinExplorers: var_bitcoinExplorers,
       workingDir: var_workingDir,
       cacheDir: var_cacheDir,
       network: var_network,
@@ -4189,6 +4226,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <AssetMetadata>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_asset_metadata(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<BlockchainExplorer> sse_decode_list_blockchain_explorer(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <BlockchainExplorer>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_blockchain_explorer(deserializer));
     }
     return ans_;
   }
@@ -5978,6 +6027,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_blockchain_explorer(BlockchainExplorer self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case BlockchainExplorer_Electrum(url: final url):
+        sse_encode_i_32(0, serializer);
+        sse_encode_String(url, serializer);
+      case BlockchainExplorer_Esplora(url: final url, useWaterfalls: final useWaterfalls):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(url, serializer);
+        sse_encode_bool(useWaterfalls, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_blockchain_info(BlockchainInfo self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.liquidTip, serializer);
@@ -6383,9 +6446,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_config(Config self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.liquidElectrumUrl, serializer);
-    sse_encode_String(self.bitcoinElectrumUrl, serializer);
-    sse_encode_String(self.mempoolspaceUrl, serializer);
+    sse_encode_list_blockchain_explorer(self.liquidExplorers, serializer);
+    sse_encode_list_blockchain_explorer(self.bitcoinExplorers, serializer);
     sse_encode_String(self.workingDir, serializer);
     sse_encode_opt_String(self.cacheDir, serializer);
     sse_encode_liquid_network(self.network, serializer);
@@ -6593,6 +6655,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_asset_metadata(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_blockchain_explorer(List<BlockchainExplorer> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_blockchain_explorer(item, serializer);
     }
   }
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -87,6 +87,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BitcoinAddressData dco_decode_bitcoin_address_data(dynamic raw);
 
   @protected
+  BlockchainExplorer dco_decode_blockchain_explorer(dynamic raw);
+
+  @protected
   BlockchainInfo dco_decode_blockchain_info(dynamic raw);
 
   @protected
@@ -328,6 +331,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<AssetMetadata> dco_decode_list_asset_metadata(dynamic raw);
+
+  @protected
+  List<BlockchainExplorer> dco_decode_list_blockchain_explorer(dynamic raw);
 
   @protected
   List<ExternalInputParser> dco_decode_list_external_input_parser(dynamic raw);
@@ -724,6 +730,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BitcoinAddressData sse_decode_bitcoin_address_data(SseDeserializer deserializer);
 
   @protected
+  BlockchainExplorer sse_decode_blockchain_explorer(SseDeserializer deserializer);
+
+  @protected
   BlockchainInfo sse_decode_blockchain_info(SseDeserializer deserializer);
 
   @protected
@@ -977,6 +986,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<AssetMetadata> sse_decode_list_asset_metadata(SseDeserializer deserializer);
+
+  @protected
+  List<BlockchainExplorer> sse_decode_list_blockchain_explorer(SseDeserializer deserializer);
 
   @protected
   List<ExternalInputParser> sse_decode_list_external_input_parser(SseDeserializer deserializer);
@@ -1874,6 +1886,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_blockchain_explorer> cst_encode_list_blockchain_explorer(
+    List<BlockchainExplorer> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_blockchain_explorer(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_blockchain_explorer(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_external_input_parser> cst_encode_list_external_input_parser(
     List<ExternalInputParser> raw,
   ) {
@@ -2260,6 +2284,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.amountSat);
     wireObj.label = cst_encode_opt_String(apiObj.label);
     wireObj.message = cst_encode_opt_String(apiObj.message);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_blockchain_explorer(
+    BlockchainExplorer apiObj,
+    wire_cst_blockchain_explorer wireObj,
+  ) {
+    if (apiObj is BlockchainExplorer_Electrum) {
+      var pre_url = cst_encode_String(apiObj.url);
+      wireObj.tag = 0;
+      wireObj.kind.Electrum.url = pre_url;
+      return;
+    }
+    if (apiObj is BlockchainExplorer_Esplora) {
+      var pre_url = cst_encode_String(apiObj.url);
+      var pre_use_waterfalls = cst_encode_bool(apiObj.useWaterfalls);
+      wireObj.tag = 1;
+      wireObj.kind.Esplora.url = pre_url;
+      wireObj.kind.Esplora.use_waterfalls = pre_use_waterfalls;
+      return;
+    }
   }
 
   @protected
@@ -2682,9 +2727,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_api_fill_to_wire_config(Config apiObj, wire_cst_config wireObj) {
-    wireObj.liquid_electrum_url = cst_encode_String(apiObj.liquidElectrumUrl);
-    wireObj.bitcoin_electrum_url = cst_encode_String(apiObj.bitcoinElectrumUrl);
-    wireObj.mempoolspace_url = cst_encode_String(apiObj.mempoolspaceUrl);
+    wireObj.liquid_explorers = cst_encode_list_blockchain_explorer(apiObj.liquidExplorers);
+    wireObj.bitcoin_explorers = cst_encode_list_blockchain_explorer(apiObj.bitcoinExplorers);
     wireObj.working_dir = cst_encode_String(apiObj.workingDir);
     wireObj.cache_dir = cst_encode_opt_String(apiObj.cacheDir);
     wireObj.network = cst_encode_liquid_network(apiObj.network);
@@ -4066,6 +4110,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_bitcoin_address_data(BitcoinAddressData self, SseSerializer serializer);
 
   @protected
+  void sse_encode_blockchain_explorer(BlockchainExplorer self, SseSerializer serializer);
+
+  @protected
   void sse_encode_blockchain_info(BlockchainInfo self, SseSerializer serializer);
 
   @protected
@@ -4346,6 +4393,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_asset_metadata(List<AssetMetadata> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_blockchain_explorer(List<BlockchainExplorer> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_external_input_parser(List<ExternalInputParser> self, SseSerializer serializer);
@@ -6027,6 +6077,18 @@ class RustLibWire implements BaseWire {
   late final _cst_new_list_asset_metadata =
       _cst_new_list_asset_metadataPtr.asFunction<ffi.Pointer<wire_cst_list_asset_metadata> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_blockchain_explorer> cst_new_list_blockchain_explorer(int len) {
+    return _cst_new_list_blockchain_explorer(len);
+  }
+
+  late final _cst_new_list_blockchain_explorerPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_cst_list_blockchain_explorer> Function(ffi.Int32)>>(
+        'frbgen_breez_liquid_cst_new_list_blockchain_explorer',
+      );
+  late final _cst_new_list_blockchain_explorer =
+      _cst_new_list_blockchain_explorerPtr
+          .asFunction<ffi.Pointer<wire_cst_list_blockchain_explorer> Function(int)>();
+
   ffi.Pointer<wire_cst_list_external_input_parser> cst_new_list_external_input_parser(int len) {
     return _cst_new_list_external_input_parser(len);
   }
@@ -7031,6 +7093,37 @@ final class wire_cst_sdk_event extends ffi.Struct {
   external SdkEventKind kind;
 }
 
+final class wire_cst_BlockchainExplorer_Electrum extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
+}
+
+final class wire_cst_BlockchainExplorer_Esplora extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> url;
+
+  @ffi.Bool()
+  external bool use_waterfalls;
+}
+
+final class BlockchainExplorerKind extends ffi.Union {
+  external wire_cst_BlockchainExplorer_Electrum Electrum;
+
+  external wire_cst_BlockchainExplorer_Esplora Esplora;
+}
+
+final class wire_cst_blockchain_explorer extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external BlockchainExplorerKind kind;
+}
+
+final class wire_cst_list_blockchain_explorer extends ffi.Struct {
+  external ffi.Pointer<wire_cst_blockchain_explorer> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_external_input_parser extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> provider_id;
 
@@ -7065,11 +7158,9 @@ final class wire_cst_list_asset_metadata extends ffi.Struct {
 }
 
 final class wire_cst_config extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> liquid_electrum_url;
+  external ffi.Pointer<wire_cst_list_blockchain_explorer> liquid_explorers;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bitcoin_electrum_url;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> mempoolspace_url;
+  external ffi.Pointer<wire_cst_list_blockchain_explorer> bitcoin_explorers;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> working_dir;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -139,6 +139,19 @@ class BackupRequest {
       other is BackupRequest && runtimeType == other.runtimeType && backupPath == other.backupPath;
 }
 
+@freezed
+sealed class BlockchainExplorer with _$BlockchainExplorer {
+  const BlockchainExplorer._();
+
+  const factory BlockchainExplorer.electrum({required String url}) = BlockchainExplorer_Electrum;
+  const factory BlockchainExplorer.esplora({
+    required String url,
+
+    /// Whether or not to use the "waterfalls" extension
+    required bool useWaterfalls,
+  }) = BlockchainExplorer_Esplora;
+}
+
 class BlockchainInfo {
   final int liquidTip;
   final int bitcoinTip;
@@ -228,11 +241,8 @@ class CheckMessageResponse {
 
 /// Configuration for the Liquid SDK
 class Config {
-  final String liquidElectrumUrl;
-  final String bitcoinElectrumUrl;
-
-  /// The mempool.space API URL, has to be in the format: `https://mempool.space/api`
-  final String mempoolspaceUrl;
+  final List<BlockchainExplorer> liquidExplorers;
+  final List<BlockchainExplorer> bitcoinExplorers;
 
   /// Directory in which the DB and log files are stored.
   ///
@@ -282,9 +292,8 @@ class Config {
   final List<AssetMetadata>? assetMetadata;
 
   const Config({
-    required this.liquidElectrumUrl,
-    required this.bitcoinElectrumUrl,
-    required this.mempoolspaceUrl,
+    required this.liquidExplorers,
+    required this.bitcoinExplorers,
     required this.workingDir,
     this.cacheDir,
     required this.network,
@@ -300,9 +309,8 @@ class Config {
 
   @override
   int get hashCode =>
-      liquidElectrumUrl.hashCode ^
-      bitcoinElectrumUrl.hashCode ^
-      mempoolspaceUrl.hashCode ^
+      liquidExplorers.hashCode ^
+      bitcoinExplorers.hashCode ^
       workingDir.hashCode ^
       cacheDir.hashCode ^
       network.hashCode ^
@@ -320,9 +328,8 @@ class Config {
       identical(this, other) ||
       other is Config &&
           runtimeType == other.runtimeType &&
-          liquidElectrumUrl == other.liquidElectrumUrl &&
-          bitcoinElectrumUrl == other.bitcoinElectrumUrl &&
-          mempoolspaceUrl == other.mempoolspaceUrl &&
+          liquidExplorers == other.liquidExplorers &&
+          bitcoinExplorers == other.bitcoinExplorers &&
           workingDir == other.workingDir &&
           cacheDir == other.cacheDir &&
           network == other.network &&

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -16,6 +16,236 @@ final _privateConstructorUsedError = UnsupportedError(
 );
 
 /// @nodoc
+mixin _$BlockchainExplorer {
+  String get url => throw _privateConstructorUsedError;
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $BlockchainExplorerCopyWith<BlockchainExplorer> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BlockchainExplorerCopyWith<$Res> {
+  factory $BlockchainExplorerCopyWith(BlockchainExplorer value, $Res Function(BlockchainExplorer) then) =
+      _$BlockchainExplorerCopyWithImpl<$Res, BlockchainExplorer>;
+  @useResult
+  $Res call({String url});
+}
+
+/// @nodoc
+class _$BlockchainExplorerCopyWithImpl<$Res, $Val extends BlockchainExplorer>
+    implements $BlockchainExplorerCopyWith<$Res> {
+  _$BlockchainExplorerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? url = null}) {
+    return _then(
+      _value.copyWith(
+            url:
+                null == url
+                    ? _value.url
+                    : url // ignore: cast_nullable_to_non_nullable
+                        as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$BlockchainExplorer_ElectrumImplCopyWith<$Res> implements $BlockchainExplorerCopyWith<$Res> {
+  factory _$$BlockchainExplorer_ElectrumImplCopyWith(
+    _$BlockchainExplorer_ElectrumImpl value,
+    $Res Function(_$BlockchainExplorer_ElectrumImpl) then,
+  ) = __$$BlockchainExplorer_ElectrumImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String url});
+}
+
+/// @nodoc
+class __$$BlockchainExplorer_ElectrumImplCopyWithImpl<$Res>
+    extends _$BlockchainExplorerCopyWithImpl<$Res, _$BlockchainExplorer_ElectrumImpl>
+    implements _$$BlockchainExplorer_ElectrumImplCopyWith<$Res> {
+  __$$BlockchainExplorer_ElectrumImplCopyWithImpl(
+    _$BlockchainExplorer_ElectrumImpl _value,
+    $Res Function(_$BlockchainExplorer_ElectrumImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? url = null}) {
+    return _then(
+      _$BlockchainExplorer_ElectrumImpl(
+        url:
+            null == url
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$BlockchainExplorer_ElectrumImpl extends BlockchainExplorer_Electrum {
+  const _$BlockchainExplorer_ElectrumImpl({required this.url}) : super._();
+
+  @override
+  final String url;
+
+  @override
+  String toString() {
+    return 'BlockchainExplorer.electrum(url: $url)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BlockchainExplorer_ElectrumImpl &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, url);
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BlockchainExplorer_ElectrumImplCopyWith<_$BlockchainExplorer_ElectrumImpl> get copyWith =>
+      __$$BlockchainExplorer_ElectrumImplCopyWithImpl<_$BlockchainExplorer_ElectrumImpl>(this, _$identity);
+}
+
+abstract class BlockchainExplorer_Electrum extends BlockchainExplorer {
+  const factory BlockchainExplorer_Electrum({required final String url}) = _$BlockchainExplorer_ElectrumImpl;
+  const BlockchainExplorer_Electrum._() : super._();
+
+  @override
+  String get url;
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$BlockchainExplorer_ElectrumImplCopyWith<_$BlockchainExplorer_ElectrumImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$BlockchainExplorer_EsploraImplCopyWith<$Res> implements $BlockchainExplorerCopyWith<$Res> {
+  factory _$$BlockchainExplorer_EsploraImplCopyWith(
+    _$BlockchainExplorer_EsploraImpl value,
+    $Res Function(_$BlockchainExplorer_EsploraImpl) then,
+  ) = __$$BlockchainExplorer_EsploraImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String url, bool useWaterfalls});
+}
+
+/// @nodoc
+class __$$BlockchainExplorer_EsploraImplCopyWithImpl<$Res>
+    extends _$BlockchainExplorerCopyWithImpl<$Res, _$BlockchainExplorer_EsploraImpl>
+    implements _$$BlockchainExplorer_EsploraImplCopyWith<$Res> {
+  __$$BlockchainExplorer_EsploraImplCopyWithImpl(
+    _$BlockchainExplorer_EsploraImpl _value,
+    $Res Function(_$BlockchainExplorer_EsploraImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? url = null, Object? useWaterfalls = null}) {
+    return _then(
+      _$BlockchainExplorer_EsploraImpl(
+        url:
+            null == url
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String,
+        useWaterfalls:
+            null == useWaterfalls
+                ? _value.useWaterfalls
+                : useWaterfalls // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$BlockchainExplorer_EsploraImpl extends BlockchainExplorer_Esplora {
+  const _$BlockchainExplorer_EsploraImpl({required this.url, required this.useWaterfalls}) : super._();
+
+  @override
+  final String url;
+
+  /// Whether or not to use the "waterfalls" extension
+  @override
+  final bool useWaterfalls;
+
+  @override
+  String toString() {
+    return 'BlockchainExplorer.esplora(url: $url, useWaterfalls: $useWaterfalls)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BlockchainExplorer_EsploraImpl &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.useWaterfalls, useWaterfalls) || other.useWaterfalls == useWaterfalls));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, url, useWaterfalls);
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BlockchainExplorer_EsploraImplCopyWith<_$BlockchainExplorer_EsploraImpl> get copyWith =>
+      __$$BlockchainExplorer_EsploraImplCopyWithImpl<_$BlockchainExplorer_EsploraImpl>(this, _$identity);
+}
+
+abstract class BlockchainExplorer_Esplora extends BlockchainExplorer {
+  const factory BlockchainExplorer_Esplora({required final String url, required final bool useWaterfalls}) =
+      _$BlockchainExplorer_EsploraImpl;
+  const BlockchainExplorer_Esplora._() : super._();
+
+  @override
+  String get url;
+
+  /// Whether or not to use the "waterfalls" extension
+  bool get useWaterfalls;
+
+  /// Create a copy of BlockchainExplorer
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$BlockchainExplorer_EsploraImplCopyWith<_$BlockchainExplorer_EsploraImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$GetPaymentRequest {}
 
 /// @nodoc

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -1,120 +1,118 @@
-import BreezSDKLiquid
 import Foundation
+import BreezSDKLiquid
 
 enum BreezSDKLiquidMapper {
-    static func asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: [String: Any?]) throws -> AcceptPaymentProposedFeesRequest {
-        guard let responseTmp = acceptPaymentProposedFeesRequest["response"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "response", typeName: "AcceptPaymentProposedFeesRequest"))
-        }
-        let response = try asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: responseTmp)
-
-        return AcceptPaymentProposedFeesRequest(response: response)
+static func asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: [String: Any?]) throws -> AcceptPaymentProposedFeesRequest {
+    guard let responseTmp = acceptPaymentProposedFeesRequest["response"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "response", typeName: "AcceptPaymentProposedFeesRequest"))
     }
+    let response = try asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: responseTmp)
+    
+    
+    return AcceptPaymentProposedFeesRequest(response: response)    
+}
 
-    static func dictionaryOf(acceptPaymentProposedFeesRequest: AcceptPaymentProposedFeesRequest) -> [String: Any?] {
-        return [
-            "response": dictionaryOf(fetchPaymentProposedFeesResponse: acceptPaymentProposedFeesRequest.response),
-        ]
-    }
+static func  dictionaryOf(acceptPaymentProposedFeesRequest: AcceptPaymentProposedFeesRequest) -> [String: Any?] {
+    return [
+            "response": dictionaryOf(fetchPaymentProposedFeesResponse: acceptPaymentProposedFeesRequest.response),       
+    ]
+}
 
-    static func asAcceptPaymentProposedFeesRequestList(arr: [Any]) throws -> [AcceptPaymentProposedFeesRequest] {
-        var list = [AcceptPaymentProposedFeesRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var acceptPaymentProposedFeesRequest = try asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: val)
-                list.append(acceptPaymentProposedFeesRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AcceptPaymentProposedFeesRequest"))
-            }
+static func asAcceptPaymentProposedFeesRequestList(arr: [Any]) throws -> [AcceptPaymentProposedFeesRequest] {
+    var list = [AcceptPaymentProposedFeesRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var acceptPaymentProposedFeesRequest = try asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: val)
+            list.append(acceptPaymentProposedFeesRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AcceptPaymentProposedFeesRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(acceptPaymentProposedFeesRequestList: [AcceptPaymentProposedFeesRequest]) -> [Any] {
-        return acceptPaymentProposedFeesRequestList.map { v -> [String: Any?] in return dictionaryOf(acceptPaymentProposedFeesRequest: v) }
+static func arrayOf(`acceptPaymentProposedFeesRequestList`: [AcceptPaymentProposedFeesRequest]) -> [Any] {
+    return `acceptPaymentProposedFeesRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(acceptPaymentProposedFeesRequest: v) }
+}
+static func asAesSuccessActionData(aesSuccessActionData: [String: Any?]) throws -> AesSuccessActionData {
+    guard let description = aesSuccessActionData["description"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionData"))
     }
-
-    static func asAesSuccessActionData(aesSuccessActionData: [String: Any?]) throws -> AesSuccessActionData {
-        guard let description = aesSuccessActionData["description"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionData"))
-        }
-        guard let ciphertext = aesSuccessActionData["ciphertext"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ciphertext", typeName: "AesSuccessActionData"))
-        }
-        guard let iv = aesSuccessActionData["iv"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "iv", typeName: "AesSuccessActionData"))
-        }
-
-        return AesSuccessActionData(description: description, ciphertext: ciphertext, iv: iv)
+    guard let ciphertext = aesSuccessActionData["ciphertext"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ciphertext", typeName: "AesSuccessActionData"))
     }
+    guard let iv = aesSuccessActionData["iv"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "iv", typeName: "AesSuccessActionData"))
+    }
+    
+    return AesSuccessActionData(description: description, ciphertext: ciphertext, iv: iv)    
+}
 
-    static func dictionaryOf(aesSuccessActionData: AesSuccessActionData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(aesSuccessActionData: AesSuccessActionData) -> [String: Any?] {
+    return [
             "description": aesSuccessActionData.description,
             "ciphertext": aesSuccessActionData.ciphertext,
-            "iv": aesSuccessActionData.iv,
-        ]
-    }
+            "iv": aesSuccessActionData.iv,       
+    ]
+}
 
-    static func asAesSuccessActionDataList(arr: [Any]) throws -> [AesSuccessActionData] {
-        var list = [AesSuccessActionData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var aesSuccessActionData = try asAesSuccessActionData(aesSuccessActionData: val)
-                list.append(aesSuccessActionData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionData"))
-            }
+static func asAesSuccessActionDataList(arr: [Any]) throws -> [AesSuccessActionData] {
+    var list = [AesSuccessActionData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var aesSuccessActionData = try asAesSuccessActionData(aesSuccessActionData: val)
+            list.append(aesSuccessActionData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(aesSuccessActionDataList: [AesSuccessActionData]) -> [Any] {
-        return aesSuccessActionDataList.map { v -> [String: Any?] in return dictionaryOf(aesSuccessActionData: v) }
+static func arrayOf(`aesSuccessActionDataList`: [AesSuccessActionData]) -> [Any] {
+    return `aesSuccessActionDataList`.map { (v) -> [String: Any?] in return dictionaryOf(aesSuccessActionData: v) }
+}
+static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
+    guard let description = aesSuccessActionDataDecrypted["description"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionDataDecrypted"))
     }
-
-    static func asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: [String: Any?]) throws -> AesSuccessActionDataDecrypted {
-        guard let description = aesSuccessActionDataDecrypted["description"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "AesSuccessActionDataDecrypted"))
-        }
-        guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "plaintext", typeName: "AesSuccessActionDataDecrypted"))
-        }
-
-        return AesSuccessActionDataDecrypted(description: description, plaintext: plaintext)
+    guard let plaintext = aesSuccessActionDataDecrypted["plaintext"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "plaintext", typeName: "AesSuccessActionDataDecrypted"))
     }
+    
+    return AesSuccessActionDataDecrypted(description: description, plaintext: plaintext)    
+}
 
-    static func dictionaryOf(aesSuccessActionDataDecrypted: AesSuccessActionDataDecrypted) -> [String: Any?] {
-        return [
+static func  dictionaryOf(aesSuccessActionDataDecrypted: AesSuccessActionDataDecrypted) -> [String: Any?] {
+    return [
             "description": aesSuccessActionDataDecrypted.description,
-            "plaintext": aesSuccessActionDataDecrypted.plaintext,
-        ]
-    }
+            "plaintext": aesSuccessActionDataDecrypted.plaintext,       
+    ]
+}
 
-    static func asAesSuccessActionDataDecryptedList(arr: [Any]) throws -> [AesSuccessActionDataDecrypted] {
-        var list = [AesSuccessActionDataDecrypted]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var aesSuccessActionDataDecrypted = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: val)
-                list.append(aesSuccessActionDataDecrypted)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataDecrypted"))
-            }
+static func asAesSuccessActionDataDecryptedList(arr: [Any]) throws -> [AesSuccessActionDataDecrypted] {
+    var list = [AesSuccessActionDataDecrypted]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var aesSuccessActionDataDecrypted = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: val)
+            list.append(aesSuccessActionDataDecrypted)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataDecrypted"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(aesSuccessActionDataDecryptedList: [AesSuccessActionDataDecrypted]) -> [Any] {
-        return aesSuccessActionDataDecryptedList.map { v -> [String: Any?] in return dictionaryOf(aesSuccessActionDataDecrypted: v) }
+static func arrayOf(`aesSuccessActionDataDecryptedList`: [AesSuccessActionDataDecrypted]) -> [Any] {
+    return `aesSuccessActionDataDecryptedList`.map { (v) -> [String: Any?] in return dictionaryOf(aesSuccessActionDataDecrypted: v) }
+}
+static func asAssetBalance(assetBalance: [String: Any?]) throws -> AssetBalance {
+    guard let assetId = assetBalance["assetId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "AssetBalance"))
     }
-
-    static func asAssetBalance(assetBalance: [String: Any?]) throws -> AssetBalance {
-        guard let assetId = assetBalance["assetId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "AssetBalance"))
-        }
-        guard let balanceSat = assetBalance["balanceSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "balanceSat", typeName: "AssetBalance"))
-        }
+    guard let balanceSat = assetBalance["balanceSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "balanceSat", typeName: "AssetBalance"))
+    }
         var name: String?
         if hasNonNilKey(data: assetBalance, key: "name") {
             guard let nameTmp = assetBalance["name"] as? String else {
@@ -136,120 +134,117 @@ enum BreezSDKLiquidMapper {
             }
             balance = balanceTmp
         }
+    
+    return AssetBalance(assetId: assetId, balanceSat: balanceSat, name: name, ticker: ticker, balance: balance)    
+}
 
-        return AssetBalance(assetId: assetId, balanceSat: balanceSat, name: name, ticker: ticker, balance: balance)
-    }
-
-    static func dictionaryOf(assetBalance: AssetBalance) -> [String: Any?] {
-        return [
+static func  dictionaryOf(assetBalance: AssetBalance) -> [String: Any?] {
+    return [
             "assetId": assetBalance.assetId,
             "balanceSat": assetBalance.balanceSat,
             "name": assetBalance.name == nil ? nil : assetBalance.name,
             "ticker": assetBalance.ticker == nil ? nil : assetBalance.ticker,
-            "balance": assetBalance.balance == nil ? nil : assetBalance.balance,
-        ]
-    }
+            "balance": assetBalance.balance == nil ? nil : assetBalance.balance,       
+    ]
+}
 
-    static func asAssetBalanceList(arr: [Any]) throws -> [AssetBalance] {
-        var list = [AssetBalance]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var assetBalance = try asAssetBalance(assetBalance: val)
-                list.append(assetBalance)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetBalance"))
-            }
+static func asAssetBalanceList(arr: [Any]) throws -> [AssetBalance] {
+    var list = [AssetBalance]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var assetBalance = try asAssetBalance(assetBalance: val)
+            list.append(assetBalance)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetBalance"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(assetBalanceList: [AssetBalance]) -> [Any] {
-        return assetBalanceList.map { v -> [String: Any?] in return dictionaryOf(assetBalance: v) }
+static func arrayOf(`assetBalanceList`: [AssetBalance]) -> [Any] {
+    return `assetBalanceList`.map { (v) -> [String: Any?] in return dictionaryOf(assetBalance: v) }
+}
+static func asAssetInfo(assetInfo: [String: Any?]) throws -> AssetInfo {
+    guard let name = assetInfo["name"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "AssetInfo"))
     }
-
-    static func asAssetInfo(assetInfo: [String: Any?]) throws -> AssetInfo {
-        guard let name = assetInfo["name"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "AssetInfo"))
-        }
-        guard let ticker = assetInfo["ticker"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ticker", typeName: "AssetInfo"))
-        }
-        guard let amount = assetInfo["amount"] as? Double else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "AssetInfo"))
-        }
-
-        return AssetInfo(name: name, ticker: ticker, amount: amount)
+    guard let ticker = assetInfo["ticker"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ticker", typeName: "AssetInfo"))
     }
+    guard let amount = assetInfo["amount"] as? Double else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "AssetInfo"))
+    }
+    
+    return AssetInfo(name: name, ticker: ticker, amount: amount)    
+}
 
-    static func dictionaryOf(assetInfo: AssetInfo) -> [String: Any?] {
-        return [
+static func  dictionaryOf(assetInfo: AssetInfo) -> [String: Any?] {
+    return [
             "name": assetInfo.name,
             "ticker": assetInfo.ticker,
-            "amount": assetInfo.amount,
-        ]
+            "amount": assetInfo.amount,       
+    ]
+}
+
+static func asAssetInfoList(arr: [Any]) throws -> [AssetInfo] {
+    var list = [AssetInfo]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var assetInfo = try asAssetInfo(assetInfo: val)
+            list.append(assetInfo)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetInfo"))
+        }
     }
+    return list
+}
 
-    static func asAssetInfoList(arr: [Any]) throws -> [AssetInfo] {
-        var list = [AssetInfo]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var assetInfo = try asAssetInfo(assetInfo: val)
-                list.append(assetInfo)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetInfo"))
-            }
-        }
-        return list
+static func arrayOf(`assetInfoList`: [AssetInfo]) -> [Any] {
+    return `assetInfoList`.map { (v) -> [String: Any?] in return dictionaryOf(assetInfo: v) }
+}
+static func asAssetMetadata(assetMetadata: [String: Any?]) throws -> AssetMetadata {
+    guard let assetId = assetMetadata["assetId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "AssetMetadata"))
     }
-
-    static func arrayOf(assetInfoList: [AssetInfo]) -> [Any] {
-        return assetInfoList.map { v -> [String: Any?] in return dictionaryOf(assetInfo: v) }
+    guard let name = assetMetadata["name"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "AssetMetadata"))
     }
-
-    static func asAssetMetadata(assetMetadata: [String: Any?]) throws -> AssetMetadata {
-        guard let assetId = assetMetadata["assetId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "AssetMetadata"))
-        }
-        guard let name = assetMetadata["name"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "AssetMetadata"))
-        }
-        guard let ticker = assetMetadata["ticker"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ticker", typeName: "AssetMetadata"))
-        }
-        guard let precision = assetMetadata["precision"] as? UInt8 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "precision", typeName: "AssetMetadata"))
-        }
-
-        return AssetMetadata(assetId: assetId, name: name, ticker: ticker, precision: precision)
+    guard let ticker = assetMetadata["ticker"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "ticker", typeName: "AssetMetadata"))
     }
+    guard let precision = assetMetadata["precision"] as? UInt8 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "precision", typeName: "AssetMetadata"))
+    }
+    
+    return AssetMetadata(assetId: assetId, name: name, ticker: ticker, precision: precision)    
+}
 
-    static func dictionaryOf(assetMetadata: AssetMetadata) -> [String: Any?] {
-        return [
+static func  dictionaryOf(assetMetadata: AssetMetadata) -> [String: Any?] {
+    return [
             "assetId": assetMetadata.assetId,
             "name": assetMetadata.name,
             "ticker": assetMetadata.ticker,
-            "precision": assetMetadata.precision,
-        ]
-    }
+            "precision": assetMetadata.precision,       
+    ]
+}
 
-    static func asAssetMetadataList(arr: [Any]) throws -> [AssetMetadata] {
-        var list = [AssetMetadata]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var assetMetadata = try asAssetMetadata(assetMetadata: val)
-                list.append(assetMetadata)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetMetadata"))
-            }
+static func asAssetMetadataList(arr: [Any]) throws -> [AssetMetadata] {
+    var list = [AssetMetadata]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var assetMetadata = try asAssetMetadata(assetMetadata: val)
+            list.append(assetMetadata)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AssetMetadata"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(assetMetadataList: [AssetMetadata]) -> [Any] {
-        return assetMetadataList.map { v -> [String: Any?] in return dictionaryOf(assetMetadata: v) }
-    }
-
-    static func asBackupRequest(backupRequest: [String: Any?]) throws -> BackupRequest {
+static func arrayOf(`assetMetadataList`: [AssetMetadata]) -> [Any] {
+    return `assetMetadataList`.map { (v) -> [String: Any?] in return dictionaryOf(assetMetadata: v) }
+}
+static func asBackupRequest(backupRequest: [String: Any?]) throws -> BackupRequest {
         var backupPath: String?
         if hasNonNilKey(data: backupRequest, key: "backupPath") {
             guard let backupPathTmp = backupRequest["backupPath"] as? String else {
@@ -257,42 +252,41 @@ enum BreezSDKLiquidMapper {
             }
             backupPath = backupPathTmp
         }
+    
+    return BackupRequest(backupPath: backupPath)    
+}
 
-        return BackupRequest(backupPath: backupPath)
-    }
+static func  dictionaryOf(backupRequest: BackupRequest) -> [String: Any?] {
+    return [
+            "backupPath": backupRequest.backupPath == nil ? nil : backupRequest.backupPath,       
+    ]
+}
 
-    static func dictionaryOf(backupRequest: BackupRequest) -> [String: Any?] {
-        return [
-            "backupPath": backupRequest.backupPath == nil ? nil : backupRequest.backupPath,
-        ]
-    }
-
-    static func asBackupRequestList(arr: [Any]) throws -> [BackupRequest] {
-        var list = [BackupRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var backupRequest = try asBackupRequest(backupRequest: val)
-                list.append(backupRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "BackupRequest"))
-            }
+static func asBackupRequestList(arr: [Any]) throws -> [BackupRequest] {
+    var list = [BackupRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var backupRequest = try asBackupRequest(backupRequest: val)
+            list.append(backupRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BackupRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(backupRequestList: [BackupRequest]) -> [Any] {
-        return backupRequestList.map { v -> [String: Any?] in return dictionaryOf(backupRequest: v) }
+static func arrayOf(`backupRequestList`: [BackupRequest]) -> [Any] {
+    return `backupRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(backupRequest: v) }
+}
+static func asBitcoinAddressData(bitcoinAddressData: [String: Any?]) throws -> BitcoinAddressData {
+    guard let address = bitcoinAddressData["address"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "BitcoinAddressData"))
     }
-
-    static func asBitcoinAddressData(bitcoinAddressData: [String: Any?]) throws -> BitcoinAddressData {
-        guard let address = bitcoinAddressData["address"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "BitcoinAddressData"))
-        }
-        guard let networkTmp = bitcoinAddressData["network"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "BitcoinAddressData"))
-        }
-        let network = try asNetwork(network: networkTmp)
-
+    guard let networkTmp = bitcoinAddressData["network"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "BitcoinAddressData"))
+    }
+    let network = try asNetwork(network: networkTmp)
+    
         var amountSat: UInt64?
         if hasNonNilKey(data: bitcoinAddressData, key: "amountSat") {
             guard let amountSatTmp = bitcoinAddressData["amountSat"] as? UInt64 else {
@@ -314,78 +308,76 @@ enum BreezSDKLiquidMapper {
             }
             message = messageTmp
         }
+    
+    return BitcoinAddressData(address: address, network: network, amountSat: amountSat, label: label, message: message)    
+}
 
-        return BitcoinAddressData(address: address, network: network, amountSat: amountSat, label: label, message: message)
-    }
-
-    static func dictionaryOf(bitcoinAddressData: BitcoinAddressData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(bitcoinAddressData: BitcoinAddressData) -> [String: Any?] {
+    return [
             "address": bitcoinAddressData.address,
-            "network": valueOf(network: bitcoinAddressData.network),
+            "network": valueOf( network: bitcoinAddressData.network),
             "amountSat": bitcoinAddressData.amountSat == nil ? nil : bitcoinAddressData.amountSat,
             "label": bitcoinAddressData.label == nil ? nil : bitcoinAddressData.label,
-            "message": bitcoinAddressData.message == nil ? nil : bitcoinAddressData.message,
-        ]
-    }
+            "message": bitcoinAddressData.message == nil ? nil : bitcoinAddressData.message,       
+    ]
+}
 
-    static func asBitcoinAddressDataList(arr: [Any]) throws -> [BitcoinAddressData] {
-        var list = [BitcoinAddressData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var bitcoinAddressData = try asBitcoinAddressData(bitcoinAddressData: val)
-                list.append(bitcoinAddressData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "BitcoinAddressData"))
-            }
+static func asBitcoinAddressDataList(arr: [Any]) throws -> [BitcoinAddressData] {
+    var list = [BitcoinAddressData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var bitcoinAddressData = try asBitcoinAddressData(bitcoinAddressData: val)
+            list.append(bitcoinAddressData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BitcoinAddressData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(bitcoinAddressDataList: [BitcoinAddressData]) -> [Any] {
-        return bitcoinAddressDataList.map { v -> [String: Any?] in return dictionaryOf(bitcoinAddressData: v) }
+static func arrayOf(`bitcoinAddressDataList`: [BitcoinAddressData]) -> [Any] {
+    return `bitcoinAddressDataList`.map { (v) -> [String: Any?] in return dictionaryOf(bitcoinAddressData: v) }
+}
+static func asBlockchainInfo(blockchainInfo: [String: Any?]) throws -> BlockchainInfo {
+    guard let liquidTip = blockchainInfo["liquidTip"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidTip", typeName: "BlockchainInfo"))
     }
-
-    static func asBlockchainInfo(blockchainInfo: [String: Any?]) throws -> BlockchainInfo {
-        guard let liquidTip = blockchainInfo["liquidTip"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidTip", typeName: "BlockchainInfo"))
-        }
-        guard let bitcoinTip = blockchainInfo["bitcoinTip"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinTip", typeName: "BlockchainInfo"))
-        }
-
-        return BlockchainInfo(liquidTip: liquidTip, bitcoinTip: bitcoinTip)
+    guard let bitcoinTip = blockchainInfo["bitcoinTip"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinTip", typeName: "BlockchainInfo"))
     }
+    
+    return BlockchainInfo(liquidTip: liquidTip, bitcoinTip: bitcoinTip)    
+}
 
-    static func dictionaryOf(blockchainInfo: BlockchainInfo) -> [String: Any?] {
-        return [
+static func  dictionaryOf(blockchainInfo: BlockchainInfo) -> [String: Any?] {
+    return [
             "liquidTip": blockchainInfo.liquidTip,
-            "bitcoinTip": blockchainInfo.bitcoinTip,
-        ]
-    }
+            "bitcoinTip": blockchainInfo.bitcoinTip,       
+    ]
+}
 
-    static func asBlockchainInfoList(arr: [Any]) throws -> [BlockchainInfo] {
-        var list = [BlockchainInfo]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var blockchainInfo = try asBlockchainInfo(blockchainInfo: val)
-                list.append(blockchainInfo)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "BlockchainInfo"))
-            }
+static func asBlockchainInfoList(arr: [Any]) throws -> [BlockchainInfo] {
+    var list = [BlockchainInfo]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var blockchainInfo = try asBlockchainInfo(blockchainInfo: val)
+            list.append(blockchainInfo)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BlockchainInfo"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(blockchainInfoList: [BlockchainInfo]) -> [Any] {
-        return blockchainInfoList.map { v -> [String: Any?] in return dictionaryOf(blockchainInfo: v) }
+static func arrayOf(`blockchainInfoList`: [BlockchainInfo]) -> [Any] {
+    return `blockchainInfoList`.map { (v) -> [String: Any?] in return dictionaryOf(blockchainInfo: v) }
+}
+static func asBuyBitcoinRequest(buyBitcoinRequest: [String: Any?]) throws -> BuyBitcoinRequest {
+    guard let prepareResponseTmp = buyBitcoinRequest["prepareResponse"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "BuyBitcoinRequest"))
     }
-
-    static func asBuyBitcoinRequest(buyBitcoinRequest: [String: Any?]) throws -> BuyBitcoinRequest {
-        guard let prepareResponseTmp = buyBitcoinRequest["prepareResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "BuyBitcoinRequest"))
-        }
-        let prepareResponse = try asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: prepareResponseTmp)
-
+    let prepareResponse = try asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: prepareResponseTmp)
+    
         var redirectUrl: String?
         if hasNonNilKey(data: buyBitcoinRequest, key: "redirectUrl") {
             guard let redirectUrlTmp = buyBitcoinRequest["redirectUrl"] as? String else {
@@ -393,125 +385,123 @@ enum BreezSDKLiquidMapper {
             }
             redirectUrl = redirectUrlTmp
         }
+    
+    return BuyBitcoinRequest(prepareResponse: prepareResponse, redirectUrl: redirectUrl)    
+}
 
-        return BuyBitcoinRequest(prepareResponse: prepareResponse, redirectUrl: redirectUrl)
-    }
-
-    static func dictionaryOf(buyBitcoinRequest: BuyBitcoinRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(buyBitcoinRequest: BuyBitcoinRequest) -> [String: Any?] {
+    return [
             "prepareResponse": dictionaryOf(prepareBuyBitcoinResponse: buyBitcoinRequest.prepareResponse),
-            "redirectUrl": buyBitcoinRequest.redirectUrl == nil ? nil : buyBitcoinRequest.redirectUrl,
-        ]
-    }
+            "redirectUrl": buyBitcoinRequest.redirectUrl == nil ? nil : buyBitcoinRequest.redirectUrl,       
+    ]
+}
 
-    static func asBuyBitcoinRequestList(arr: [Any]) throws -> [BuyBitcoinRequest] {
-        var list = [BuyBitcoinRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var buyBitcoinRequest = try asBuyBitcoinRequest(buyBitcoinRequest: val)
-                list.append(buyBitcoinRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinRequest"))
-            }
+static func asBuyBitcoinRequestList(arr: [Any]) throws -> [BuyBitcoinRequest] {
+    var list = [BuyBitcoinRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var buyBitcoinRequest = try asBuyBitcoinRequest(buyBitcoinRequest: val)
+            list.append(buyBitcoinRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(buyBitcoinRequestList: [BuyBitcoinRequest]) -> [Any] {
-        return buyBitcoinRequestList.map { v -> [String: Any?] in return dictionaryOf(buyBitcoinRequest: v) }
+static func arrayOf(`buyBitcoinRequestList`: [BuyBitcoinRequest]) -> [Any] {
+    return `buyBitcoinRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(buyBitcoinRequest: v) }
+}
+static func asCheckMessageRequest(checkMessageRequest: [String: Any?]) throws -> CheckMessageRequest {
+    guard let message = checkMessageRequest["message"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "CheckMessageRequest"))
     }
-
-    static func asCheckMessageRequest(checkMessageRequest: [String: Any?]) throws -> CheckMessageRequest {
-        guard let message = checkMessageRequest["message"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "CheckMessageRequest"))
-        }
-        guard let pubkey = checkMessageRequest["pubkey"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "CheckMessageRequest"))
-        }
-        guard let signature = checkMessageRequest["signature"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "CheckMessageRequest"))
-        }
-
-        return CheckMessageRequest(message: message, pubkey: pubkey, signature: signature)
+    guard let pubkey = checkMessageRequest["pubkey"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "CheckMessageRequest"))
     }
+    guard let signature = checkMessageRequest["signature"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "CheckMessageRequest"))
+    }
+    
+    return CheckMessageRequest(message: message, pubkey: pubkey, signature: signature)    
+}
 
-    static func dictionaryOf(checkMessageRequest: CheckMessageRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(checkMessageRequest: CheckMessageRequest) -> [String: Any?] {
+    return [
             "message": checkMessageRequest.message,
             "pubkey": checkMessageRequest.pubkey,
-            "signature": checkMessageRequest.signature,
-        ]
+            "signature": checkMessageRequest.signature,       
+    ]
+}
+
+static func asCheckMessageRequestList(arr: [Any]) throws -> [CheckMessageRequest] {
+    var list = [CheckMessageRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var checkMessageRequest = try asCheckMessageRequest(checkMessageRequest: val)
+            list.append(checkMessageRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageRequest"))
+        }
     }
+    return list
+}
 
-    static func asCheckMessageRequestList(arr: [Any]) throws -> [CheckMessageRequest] {
-        var list = [CheckMessageRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var checkMessageRequest = try asCheckMessageRequest(checkMessageRequest: val)
-                list.append(checkMessageRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageRequest"))
-            }
-        }
-        return list
+static func arrayOf(`checkMessageRequestList`: [CheckMessageRequest]) -> [Any] {
+    return `checkMessageRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(checkMessageRequest: v) }
+}
+static func asCheckMessageResponse(checkMessageResponse: [String: Any?]) throws -> CheckMessageResponse {
+    guard let isValid = checkMessageResponse["isValid"] as? Bool else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "isValid", typeName: "CheckMessageResponse"))
     }
+    
+    return CheckMessageResponse(isValid: isValid)    
+}
 
-    static func arrayOf(checkMessageRequestList: [CheckMessageRequest]) -> [Any] {
-        return checkMessageRequestList.map { v -> [String: Any?] in return dictionaryOf(checkMessageRequest: v) }
+static func  dictionaryOf(checkMessageResponse: CheckMessageResponse) -> [String: Any?] {
+    return [
+            "isValid": checkMessageResponse.isValid,       
+    ]
+}
+
+static func asCheckMessageResponseList(arr: [Any]) throws -> [CheckMessageResponse] {
+    var list = [CheckMessageResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var checkMessageResponse = try asCheckMessageResponse(checkMessageResponse: val)
+            list.append(checkMessageResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageResponse"))
+        }
     }
+    return list
+}
 
-    static func asCheckMessageResponse(checkMessageResponse: [String: Any?]) throws -> CheckMessageResponse {
-        guard let isValid = checkMessageResponse["isValid"] as? Bool else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "isValid", typeName: "CheckMessageResponse"))
-        }
-
-        return CheckMessageResponse(isValid: isValid)
+static func arrayOf(`checkMessageResponseList`: [CheckMessageResponse]) -> [Any] {
+    return `checkMessageResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(checkMessageResponse: v) }
+}
+static func asConfig(config: [String: Any?]) throws -> Config {
+    guard let liquidExplorersTmp = config["liquidExplorers"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidExplorers", typeName: "Config"))
     }
-
-    static func dictionaryOf(checkMessageResponse: CheckMessageResponse) -> [String: Any?] {
-        return [
-            "isValid": checkMessageResponse.isValid,
-        ]
+    let liquidExplorers = try asBlockchainExplorerList(arr: liquidExplorersTmp)
+    
+    guard let bitcoinExplorersTmp = config["bitcoinExplorers"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinExplorers", typeName: "Config"))
     }
-
-    static func asCheckMessageResponseList(arr: [Any]) throws -> [CheckMessageResponse] {
-        var list = [CheckMessageResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var checkMessageResponse = try asCheckMessageResponse(checkMessageResponse: val)
-                list.append(checkMessageResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "CheckMessageResponse"))
-            }
-        }
-        return list
+    let bitcoinExplorers = try asBlockchainExplorerList(arr: bitcoinExplorersTmp)
+    
+    guard let workingDir = config["workingDir"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "Config"))
     }
-
-    static func arrayOf(checkMessageResponseList: [CheckMessageResponse]) -> [Any] {
-        return checkMessageResponseList.map { v -> [String: Any?] in return dictionaryOf(checkMessageResponse: v) }
+    guard let networkTmp = config["network"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "Config"))
     }
-
-    static func asConfig(config: [String: Any?]) throws -> Config {
-        guard let liquidElectrumUrl = config["liquidElectrumUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidElectrumUrl", typeName: "Config"))
-        }
-        guard let bitcoinElectrumUrl = config["bitcoinElectrumUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinElectrumUrl", typeName: "Config"))
-        }
-        guard let mempoolspaceUrl = config["mempoolspaceUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "mempoolspaceUrl", typeName: "Config"))
-        }
-        guard let workingDir = config["workingDir"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "workingDir", typeName: "Config"))
-        }
-        guard let networkTmp = config["network"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "Config"))
-        }
-        let network = try asLiquidNetwork(liquidNetwork: networkTmp)
-
-        guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTimeoutSec", typeName: "Config"))
-        }
+    let network = try asLiquidNetwork(liquidNetwork: networkTmp)
+    
+    guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTimeoutSec", typeName: "Config"))
+    }
         var syncServiceUrl: String?
         if hasNonNilKey(data: config, key: "syncServiceUrl") {
             guard let syncServiceUrlTmp = config["syncServiceUrl"] as? String else {
@@ -540,14 +530,14 @@ enum BreezSDKLiquidMapper {
             }
             zeroConfMaxAmountSat = zeroConfMaxAmountSatTmp
         }
-        guard let useDefaultExternalInputParsers = config["useDefaultExternalInputParsers"] as? Bool else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "useDefaultExternalInputParsers", typeName: "Config"))
-        }
+    guard let useDefaultExternalInputParsers = config["useDefaultExternalInputParsers"] as? Bool else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "useDefaultExternalInputParsers", typeName: "Config"))
+    }
         var externalInputParsers: [ExternalInputParser]?
         if let externalInputParsersTmp = config["externalInputParsers"] as? [[String: Any?]] {
             externalInputParsers = try asExternalInputParserList(arr: externalInputParsersTmp)
         }
-
+        
         var onchainFeeRateLeewaySatPerVbyte: UInt32?
         if hasNonNilKey(data: config, key: "onchainFeeRateLeewaySatPerVbyte") {
             guard let onchainFeeRateLeewaySatPerVbyteTmp = config["onchainFeeRateLeewaySatPerVbyte"] as? UInt32 else {
@@ -559,17 +549,17 @@ enum BreezSDKLiquidMapper {
         if let assetMetadataTmp = config["assetMetadata"] as? [[String: Any?]] {
             assetMetadata = try asAssetMetadataList(arr: assetMetadataTmp)
         }
+        
+    
+    return Config(liquidExplorers: liquidExplorers, bitcoinExplorers: bitcoinExplorers, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, cacheDir: cacheDir, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySatPerVbyte: onchainFeeRateLeewaySatPerVbyte, assetMetadata: assetMetadata)    
+}
 
-        return Config(liquidElectrumUrl: liquidElectrumUrl, bitcoinElectrumUrl: bitcoinElectrumUrl, mempoolspaceUrl: mempoolspaceUrl, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, cacheDir: cacheDir, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySatPerVbyte: onchainFeeRateLeewaySatPerVbyte, assetMetadata: assetMetadata)
-    }
-
-    static func dictionaryOf(config: Config) -> [String: Any?] {
-        return [
-            "liquidElectrumUrl": config.liquidElectrumUrl,
-            "bitcoinElectrumUrl": config.bitcoinElectrumUrl,
-            "mempoolspaceUrl": config.mempoolspaceUrl,
+static func  dictionaryOf(config: Config) -> [String: Any?] {
+    return [
+            "liquidExplorers": arrayOf(blockchainExplorerList: config.liquidExplorers),
+            "bitcoinExplorers": arrayOf(blockchainExplorerList: config.bitcoinExplorers),
             "workingDir": config.workingDir,
-            "network": valueOf(liquidNetwork: config.network),
+            "network": valueOf( liquidNetwork: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,
             "syncServiceUrl": config.syncServiceUrl == nil ? nil : config.syncServiceUrl,
             "breezApiKey": config.breezApiKey == nil ? nil : config.breezApiKey,
@@ -578,33 +568,32 @@ enum BreezSDKLiquidMapper {
             "useDefaultExternalInputParsers": config.useDefaultExternalInputParsers,
             "externalInputParsers": config.externalInputParsers == nil ? nil : arrayOf(externalInputParserList: config.externalInputParsers!),
             "onchainFeeRateLeewaySatPerVbyte": config.onchainFeeRateLeewaySatPerVbyte == nil ? nil : config.onchainFeeRateLeewaySatPerVbyte,
-            "assetMetadata": config.assetMetadata == nil ? nil : arrayOf(assetMetadataList: config.assetMetadata!),
-        ]
-    }
+            "assetMetadata": config.assetMetadata == nil ? nil : arrayOf(assetMetadataList: config.assetMetadata!),       
+    ]
+}
 
-    static func asConfigList(arr: [Any]) throws -> [Config] {
-        var list = [Config]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var config = try asConfig(config: val)
-                list.append(config)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Config"))
-            }
+static func asConfigList(arr: [Any]) throws -> [Config] {
+    var list = [Config]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var config = try asConfig(config: val)
+            list.append(config)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Config"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(configList: [Config]) -> [Any] {
-        return configList.map { v -> [String: Any?] in return dictionaryOf(config: v) }
+static func arrayOf(`configList`: [Config]) -> [Any] {
+    return `configList`.map { (v) -> [String: Any?] in return dictionaryOf(config: v) }
+}
+static func asConnectRequest(connectRequest: [String: Any?]) throws -> ConnectRequest {
+    guard let configTmp = connectRequest["config"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "config", typeName: "ConnectRequest"))
     }
-
-    static func asConnectRequest(connectRequest: [String: Any?]) throws -> ConnectRequest {
-        guard let configTmp = connectRequest["config"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "config", typeName: "ConnectRequest"))
-        }
-        let config = try asConfig(config: configTmp)
-
+    let config = try asConfig(config: configTmp)
+    
         var mnemonic: String?
         if hasNonNilKey(data: connectRequest, key: "mnemonic") {
             guard let mnemonicTmp = connectRequest["mnemonic"] as? String else {
@@ -626,75 +615,74 @@ enum BreezSDKLiquidMapper {
             }
             seed = seedTmp
         }
+    
+    return ConnectRequest(config: config, mnemonic: mnemonic, passphrase: passphrase, seed: seed)    
+}
 
-        return ConnectRequest(config: config, mnemonic: mnemonic, passphrase: passphrase, seed: seed)
-    }
-
-    static func dictionaryOf(connectRequest: ConnectRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(connectRequest: ConnectRequest) -> [String: Any?] {
+    return [
             "config": dictionaryOf(config: connectRequest.config),
             "mnemonic": connectRequest.mnemonic == nil ? nil : connectRequest.mnemonic,
             "passphrase": connectRequest.passphrase == nil ? nil : connectRequest.passphrase,
-            "seed": connectRequest.seed == nil ? nil : connectRequest.seed,
-        ]
-    }
+            "seed": connectRequest.seed == nil ? nil : connectRequest.seed,       
+    ]
+}
 
-    static func asConnectRequestList(arr: [Any]) throws -> [ConnectRequest] {
-        var list = [ConnectRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var connectRequest = try asConnectRequest(connectRequest: val)
-                list.append(connectRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ConnectRequest"))
-            }
+static func asConnectRequestList(arr: [Any]) throws -> [ConnectRequest] {
+    var list = [ConnectRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var connectRequest = try asConnectRequest(connectRequest: val)
+            list.append(connectRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ConnectRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(connectRequestList: [ConnectRequest]) -> [Any] {
-        return connectRequestList.map { v -> [String: Any?] in return dictionaryOf(connectRequest: v) }
+static func arrayOf(`connectRequestList`: [ConnectRequest]) -> [Any] {
+    return `connectRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(connectRequest: v) }
+}
+static func asConnectWithSignerRequest(connectWithSignerRequest: [String: Any?]) throws -> ConnectWithSignerRequest {
+    guard let configTmp = connectWithSignerRequest["config"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "config", typeName: "ConnectWithSignerRequest"))
     }
+    let config = try asConfig(config: configTmp)
+    
+    
+    return ConnectWithSignerRequest(config: config)    
+}
 
-    static func asConnectWithSignerRequest(connectWithSignerRequest: [String: Any?]) throws -> ConnectWithSignerRequest {
-        guard let configTmp = connectWithSignerRequest["config"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "config", typeName: "ConnectWithSignerRequest"))
+static func  dictionaryOf(connectWithSignerRequest: ConnectWithSignerRequest) -> [String: Any?] {
+    return [
+            "config": dictionaryOf(config: connectWithSignerRequest.config),       
+    ]
+}
+
+static func asConnectWithSignerRequestList(arr: [Any]) throws -> [ConnectWithSignerRequest] {
+    var list = [ConnectWithSignerRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var connectWithSignerRequest = try asConnectWithSignerRequest(connectWithSignerRequest: val)
+            list.append(connectWithSignerRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ConnectWithSignerRequest"))
         }
-        let config = try asConfig(config: configTmp)
-
-        return ConnectWithSignerRequest(config: config)
     }
+    return list
+}
 
-    static func dictionaryOf(connectWithSignerRequest: ConnectWithSignerRequest) -> [String: Any?] {
-        return [
-            "config": dictionaryOf(config: connectWithSignerRequest.config),
-        ]
+static func arrayOf(`connectWithSignerRequestList`: [ConnectWithSignerRequest]) -> [Any] {
+    return `connectWithSignerRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(connectWithSignerRequest: v) }
+}
+static func asCurrencyInfo(currencyInfo: [String: Any?]) throws -> CurrencyInfo {
+    guard let name = currencyInfo["name"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "CurrencyInfo"))
     }
-
-    static func asConnectWithSignerRequestList(arr: [Any]) throws -> [ConnectWithSignerRequest] {
-        var list = [ConnectWithSignerRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var connectWithSignerRequest = try asConnectWithSignerRequest(connectWithSignerRequest: val)
-                list.append(connectWithSignerRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ConnectWithSignerRequest"))
-            }
-        }
-        return list
+    guard let fractionSize = currencyInfo["fractionSize"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fractionSize", typeName: "CurrencyInfo"))
     }
-
-    static func arrayOf(connectWithSignerRequestList: [ConnectWithSignerRequest]) -> [Any] {
-        return connectWithSignerRequestList.map { v -> [String: Any?] in return dictionaryOf(connectWithSignerRequest: v) }
-    }
-
-    static func asCurrencyInfo(currencyInfo: [String: Any?]) throws -> CurrencyInfo {
-        guard let name = currencyInfo["name"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "CurrencyInfo"))
-        }
-        guard let fractionSize = currencyInfo["fractionSize"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fractionSize", typeName: "CurrencyInfo"))
-        }
         var spacing: UInt32?
         if hasNonNilKey(data: currencyInfo, key: "spacing") {
             guard let spacingTmp = currencyInfo["spacing"] as? UInt32 else {
@@ -706,256 +694,253 @@ enum BreezSDKLiquidMapper {
         if let symbolTmp = currencyInfo["symbol"] as? [String: Any?] {
             symbol = try asSymbol(symbol: symbolTmp)
         }
-
+        
         var uniqSymbol: Symbol?
         if let uniqSymbolTmp = currencyInfo["uniqSymbol"] as? [String: Any?] {
             uniqSymbol = try asSymbol(symbol: uniqSymbolTmp)
         }
-
-        guard let localizedNameTmp = currencyInfo["localizedName"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "localizedName", typeName: "CurrencyInfo"))
-        }
-        let localizedName = try asLocalizedNameList(arr: localizedNameTmp)
-
-        guard let localeOverridesTmp = currencyInfo["localeOverrides"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "localeOverrides", typeName: "CurrencyInfo"))
-        }
-        let localeOverrides = try asLocaleOverridesList(arr: localeOverridesTmp)
-
-        return CurrencyInfo(name: name, fractionSize: fractionSize, spacing: spacing, symbol: symbol, uniqSymbol: uniqSymbol, localizedName: localizedName, localeOverrides: localeOverrides)
+        
+    guard let localizedNameTmp = currencyInfo["localizedName"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "localizedName", typeName: "CurrencyInfo"))
     }
+    let localizedName = try asLocalizedNameList(arr: localizedNameTmp)
+    
+    guard let localeOverridesTmp = currencyInfo["localeOverrides"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "localeOverrides", typeName: "CurrencyInfo"))
+    }
+    let localeOverrides = try asLocaleOverridesList(arr: localeOverridesTmp)
+    
+    
+    return CurrencyInfo(name: name, fractionSize: fractionSize, spacing: spacing, symbol: symbol, uniqSymbol: uniqSymbol, localizedName: localizedName, localeOverrides: localeOverrides)    
+}
 
-    static func dictionaryOf(currencyInfo: CurrencyInfo) -> [String: Any?] {
-        return [
+static func  dictionaryOf(currencyInfo: CurrencyInfo) -> [String: Any?] {
+    return [
             "name": currencyInfo.name,
             "fractionSize": currencyInfo.fractionSize,
             "spacing": currencyInfo.spacing == nil ? nil : currencyInfo.spacing,
             "symbol": currencyInfo.symbol == nil ? nil : dictionaryOf(symbol: currencyInfo.symbol!),
             "uniqSymbol": currencyInfo.uniqSymbol == nil ? nil : dictionaryOf(symbol: currencyInfo.uniqSymbol!),
             "localizedName": arrayOf(localizedNameList: currencyInfo.localizedName),
-            "localeOverrides": arrayOf(localeOverridesList: currencyInfo.localeOverrides),
-        ]
-    }
+            "localeOverrides": arrayOf(localeOverridesList: currencyInfo.localeOverrides),       
+    ]
+}
 
-    static func asCurrencyInfoList(arr: [Any]) throws -> [CurrencyInfo] {
-        var list = [CurrencyInfo]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var currencyInfo = try asCurrencyInfo(currencyInfo: val)
-                list.append(currencyInfo)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "CurrencyInfo"))
-            }
+static func asCurrencyInfoList(arr: [Any]) throws -> [CurrencyInfo] {
+    var list = [CurrencyInfo]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var currencyInfo = try asCurrencyInfo(currencyInfo: val)
+            list.append(currencyInfo)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "CurrencyInfo"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(currencyInfoList: [CurrencyInfo]) -> [Any] {
-        return currencyInfoList.map { v -> [String: Any?] in return dictionaryOf(currencyInfo: v) }
+static func arrayOf(`currencyInfoList`: [CurrencyInfo]) -> [Any] {
+    return `currencyInfoList`.map { (v) -> [String: Any?] in return dictionaryOf(currencyInfo: v) }
+}
+static func asExternalInputParser(externalInputParser: [String: Any?]) throws -> ExternalInputParser {
+    guard let providerId = externalInputParser["providerId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "providerId", typeName: "ExternalInputParser"))
     }
-
-    static func asExternalInputParser(externalInputParser: [String: Any?]) throws -> ExternalInputParser {
-        guard let providerId = externalInputParser["providerId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "providerId", typeName: "ExternalInputParser"))
-        }
-        guard let inputRegex = externalInputParser["inputRegex"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "inputRegex", typeName: "ExternalInputParser"))
-        }
-        guard let parserUrl = externalInputParser["parserUrl"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "parserUrl", typeName: "ExternalInputParser"))
-        }
-
-        return ExternalInputParser(providerId: providerId, inputRegex: inputRegex, parserUrl: parserUrl)
+    guard let inputRegex = externalInputParser["inputRegex"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "inputRegex", typeName: "ExternalInputParser"))
     }
+    guard let parserUrl = externalInputParser["parserUrl"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "parserUrl", typeName: "ExternalInputParser"))
+    }
+    
+    return ExternalInputParser(providerId: providerId, inputRegex: inputRegex, parserUrl: parserUrl)    
+}
 
-    static func dictionaryOf(externalInputParser: ExternalInputParser) -> [String: Any?] {
-        return [
+static func  dictionaryOf(externalInputParser: ExternalInputParser) -> [String: Any?] {
+    return [
             "providerId": externalInputParser.providerId,
             "inputRegex": externalInputParser.inputRegex,
-            "parserUrl": externalInputParser.parserUrl,
-        ]
-    }
+            "parserUrl": externalInputParser.parserUrl,       
+    ]
+}
 
-    static func asExternalInputParserList(arr: [Any]) throws -> [ExternalInputParser] {
-        var list = [ExternalInputParser]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var externalInputParser = try asExternalInputParser(externalInputParser: val)
-                list.append(externalInputParser)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ExternalInputParser"))
-            }
+static func asExternalInputParserList(arr: [Any]) throws -> [ExternalInputParser] {
+    var list = [ExternalInputParser]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var externalInputParser = try asExternalInputParser(externalInputParser: val)
+            list.append(externalInputParser)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ExternalInputParser"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(externalInputParserList: [ExternalInputParser]) -> [Any] {
-        return externalInputParserList.map { v -> [String: Any?] in return dictionaryOf(externalInputParser: v) }
+static func arrayOf(`externalInputParserList`: [ExternalInputParser]) -> [Any] {
+    return `externalInputParserList`.map { (v) -> [String: Any?] in return dictionaryOf(externalInputParser: v) }
+}
+static func asFetchPaymentProposedFeesRequest(fetchPaymentProposedFeesRequest: [String: Any?]) throws -> FetchPaymentProposedFeesRequest {
+    guard let swapId = fetchPaymentProposedFeesRequest["swapId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "FetchPaymentProposedFeesRequest"))
     }
+    
+    return FetchPaymentProposedFeesRequest(swapId: swapId)    
+}
 
-    static func asFetchPaymentProposedFeesRequest(fetchPaymentProposedFeesRequest: [String: Any?]) throws -> FetchPaymentProposedFeesRequest {
-        guard let swapId = fetchPaymentProposedFeesRequest["swapId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "FetchPaymentProposedFeesRequest"))
+static func  dictionaryOf(fetchPaymentProposedFeesRequest: FetchPaymentProposedFeesRequest) -> [String: Any?] {
+    return [
+            "swapId": fetchPaymentProposedFeesRequest.swapId,       
+    ]
+}
+
+static func asFetchPaymentProposedFeesRequestList(arr: [Any]) throws -> [FetchPaymentProposedFeesRequest] {
+    var list = [FetchPaymentProposedFeesRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var fetchPaymentProposedFeesRequest = try asFetchPaymentProposedFeesRequest(fetchPaymentProposedFeesRequest: val)
+            list.append(fetchPaymentProposedFeesRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "FetchPaymentProposedFeesRequest"))
         }
-
-        return FetchPaymentProposedFeesRequest(swapId: swapId)
     }
+    return list
+}
 
-    static func dictionaryOf(fetchPaymentProposedFeesRequest: FetchPaymentProposedFeesRequest) -> [String: Any?] {
-        return [
-            "swapId": fetchPaymentProposedFeesRequest.swapId,
-        ]
+static func arrayOf(`fetchPaymentProposedFeesRequestList`: [FetchPaymentProposedFeesRequest]) -> [Any] {
+    return `fetchPaymentProposedFeesRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(fetchPaymentProposedFeesRequest: v) }
+}
+static func asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: [String: Any?]) throws -> FetchPaymentProposedFeesResponse {
+    guard let swapId = fetchPaymentProposedFeesResponse["swapId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "FetchPaymentProposedFeesResponse"))
     }
-
-    static func asFetchPaymentProposedFeesRequestList(arr: [Any]) throws -> [FetchPaymentProposedFeesRequest] {
-        var list = [FetchPaymentProposedFeesRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var fetchPaymentProposedFeesRequest = try asFetchPaymentProposedFeesRequest(fetchPaymentProposedFeesRequest: val)
-                list.append(fetchPaymentProposedFeesRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "FetchPaymentProposedFeesRequest"))
-            }
-        }
-        return list
+    guard let feesSat = fetchPaymentProposedFeesResponse["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "FetchPaymentProposedFeesResponse"))
     }
-
-    static func arrayOf(fetchPaymentProposedFeesRequestList: [FetchPaymentProposedFeesRequest]) -> [Any] {
-        return fetchPaymentProposedFeesRequestList.map { v -> [String: Any?] in return dictionaryOf(fetchPaymentProposedFeesRequest: v) }
+    guard let payerAmountSat = fetchPaymentProposedFeesResponse["payerAmountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payerAmountSat", typeName: "FetchPaymentProposedFeesResponse"))
     }
-
-    static func asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: [String: Any?]) throws -> FetchPaymentProposedFeesResponse {
-        guard let swapId = fetchPaymentProposedFeesResponse["swapId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "FetchPaymentProposedFeesResponse"))
-        }
-        guard let feesSat = fetchPaymentProposedFeesResponse["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "FetchPaymentProposedFeesResponse"))
-        }
-        guard let payerAmountSat = fetchPaymentProposedFeesResponse["payerAmountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payerAmountSat", typeName: "FetchPaymentProposedFeesResponse"))
-        }
-        guard let receiverAmountSat = fetchPaymentProposedFeesResponse["receiverAmountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "FetchPaymentProposedFeesResponse"))
-        }
-
-        return FetchPaymentProposedFeesResponse(swapId: swapId, feesSat: feesSat, payerAmountSat: payerAmountSat, receiverAmountSat: receiverAmountSat)
+    guard let receiverAmountSat = fetchPaymentProposedFeesResponse["receiverAmountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "FetchPaymentProposedFeesResponse"))
     }
+    
+    return FetchPaymentProposedFeesResponse(swapId: swapId, feesSat: feesSat, payerAmountSat: payerAmountSat, receiverAmountSat: receiverAmountSat)    
+}
 
-    static func dictionaryOf(fetchPaymentProposedFeesResponse: FetchPaymentProposedFeesResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(fetchPaymentProposedFeesResponse: FetchPaymentProposedFeesResponse) -> [String: Any?] {
+    return [
             "swapId": fetchPaymentProposedFeesResponse.swapId,
             "feesSat": fetchPaymentProposedFeesResponse.feesSat,
             "payerAmountSat": fetchPaymentProposedFeesResponse.payerAmountSat,
-            "receiverAmountSat": fetchPaymentProposedFeesResponse.receiverAmountSat,
-        ]
-    }
+            "receiverAmountSat": fetchPaymentProposedFeesResponse.receiverAmountSat,       
+    ]
+}
 
-    static func asFetchPaymentProposedFeesResponseList(arr: [Any]) throws -> [FetchPaymentProposedFeesResponse] {
-        var list = [FetchPaymentProposedFeesResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var fetchPaymentProposedFeesResponse = try asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: val)
-                list.append(fetchPaymentProposedFeesResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "FetchPaymentProposedFeesResponse"))
-            }
+static func asFetchPaymentProposedFeesResponseList(arr: [Any]) throws -> [FetchPaymentProposedFeesResponse] {
+    var list = [FetchPaymentProposedFeesResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var fetchPaymentProposedFeesResponse = try asFetchPaymentProposedFeesResponse(fetchPaymentProposedFeesResponse: val)
+            list.append(fetchPaymentProposedFeesResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "FetchPaymentProposedFeesResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(fetchPaymentProposedFeesResponseList: [FetchPaymentProposedFeesResponse]) -> [Any] {
-        return fetchPaymentProposedFeesResponseList.map { v -> [String: Any?] in return dictionaryOf(fetchPaymentProposedFeesResponse: v) }
+static func arrayOf(`fetchPaymentProposedFeesResponseList`: [FetchPaymentProposedFeesResponse]) -> [Any] {
+    return `fetchPaymentProposedFeesResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(fetchPaymentProposedFeesResponse: v) }
+}
+static func asFiatCurrency(fiatCurrency: [String: Any?]) throws -> FiatCurrency {
+    guard let id = fiatCurrency["id"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "FiatCurrency"))
     }
-
-    static func asFiatCurrency(fiatCurrency: [String: Any?]) throws -> FiatCurrency {
-        guard let id = fiatCurrency["id"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "id", typeName: "FiatCurrency"))
-        }
-        guard let infoTmp = fiatCurrency["info"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "info", typeName: "FiatCurrency"))
-        }
-        let info = try asCurrencyInfo(currencyInfo: infoTmp)
-
-        return FiatCurrency(id: id, info: info)
+    guard let infoTmp = fiatCurrency["info"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "info", typeName: "FiatCurrency"))
     }
+    let info = try asCurrencyInfo(currencyInfo: infoTmp)
+    
+    
+    return FiatCurrency(id: id, info: info)    
+}
 
-    static func dictionaryOf(fiatCurrency: FiatCurrency) -> [String: Any?] {
-        return [
+static func  dictionaryOf(fiatCurrency: FiatCurrency) -> [String: Any?] {
+    return [
             "id": fiatCurrency.id,
-            "info": dictionaryOf(currencyInfo: fiatCurrency.info),
-        ]
-    }
+            "info": dictionaryOf(currencyInfo: fiatCurrency.info),       
+    ]
+}
 
-    static func asFiatCurrencyList(arr: [Any]) throws -> [FiatCurrency] {
-        var list = [FiatCurrency]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var fiatCurrency = try asFiatCurrency(fiatCurrency: val)
-                list.append(fiatCurrency)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "FiatCurrency"))
-            }
+static func asFiatCurrencyList(arr: [Any]) throws -> [FiatCurrency] {
+    var list = [FiatCurrency]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var fiatCurrency = try asFiatCurrency(fiatCurrency: val)
+            list.append(fiatCurrency)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "FiatCurrency"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(fiatCurrencyList: [FiatCurrency]) -> [Any] {
-        return fiatCurrencyList.map { v -> [String: Any?] in return dictionaryOf(fiatCurrency: v) }
+static func arrayOf(`fiatCurrencyList`: [FiatCurrency]) -> [Any] {
+    return `fiatCurrencyList`.map { (v) -> [String: Any?] in return dictionaryOf(fiatCurrency: v) }
+}
+static func asGetInfoResponse(getInfoResponse: [String: Any?]) throws -> GetInfoResponse {
+    guard let walletInfoTmp = getInfoResponse["walletInfo"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "walletInfo", typeName: "GetInfoResponse"))
     }
-
-    static func asGetInfoResponse(getInfoResponse: [String: Any?]) throws -> GetInfoResponse {
-        guard let walletInfoTmp = getInfoResponse["walletInfo"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "walletInfo", typeName: "GetInfoResponse"))
-        }
-        let walletInfo = try asWalletInfo(walletInfo: walletInfoTmp)
-
-        guard let blockchainInfoTmp = getInfoResponse["blockchainInfo"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "blockchainInfo", typeName: "GetInfoResponse"))
-        }
-        let blockchainInfo = try asBlockchainInfo(blockchainInfo: blockchainInfoTmp)
-
-        return GetInfoResponse(walletInfo: walletInfo, blockchainInfo: blockchainInfo)
+    let walletInfo = try asWalletInfo(walletInfo: walletInfoTmp)
+    
+    guard let blockchainInfoTmp = getInfoResponse["blockchainInfo"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "blockchainInfo", typeName: "GetInfoResponse"))
     }
+    let blockchainInfo = try asBlockchainInfo(blockchainInfo: blockchainInfoTmp)
+    
+    
+    return GetInfoResponse(walletInfo: walletInfo, blockchainInfo: blockchainInfo)    
+}
 
-    static func dictionaryOf(getInfoResponse: GetInfoResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(getInfoResponse: GetInfoResponse) -> [String: Any?] {
+    return [
             "walletInfo": dictionaryOf(walletInfo: getInfoResponse.walletInfo),
-            "blockchainInfo": dictionaryOf(blockchainInfo: getInfoResponse.blockchainInfo),
-        ]
+            "blockchainInfo": dictionaryOf(blockchainInfo: getInfoResponse.blockchainInfo),       
+    ]
+}
+
+static func asGetInfoResponseList(arr: [Any]) throws -> [GetInfoResponse] {
+    var list = [GetInfoResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var getInfoResponse = try asGetInfoResponse(getInfoResponse: val)
+            list.append(getInfoResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "GetInfoResponse"))
+        }
     }
+    return list
+}
 
-    static func asGetInfoResponseList(arr: [Any]) throws -> [GetInfoResponse] {
-        var list = [GetInfoResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var getInfoResponse = try asGetInfoResponse(getInfoResponse: val)
-                list.append(getInfoResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "GetInfoResponse"))
-            }
-        }
-        return list
+static func arrayOf(`getInfoResponseList`: [GetInfoResponse]) -> [Any] {
+    return `getInfoResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(getInfoResponse: v) }
+}
+static func asLnInvoice(lnInvoice: [String: Any?]) throws -> LnInvoice {
+    guard let bolt11 = lnInvoice["bolt11"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "LnInvoice"))
     }
-
-    static func arrayOf(getInfoResponseList: [GetInfoResponse]) -> [Any] {
-        return getInfoResponseList.map { v -> [String: Any?] in return dictionaryOf(getInfoResponse: v) }
+    guard let networkTmp = lnInvoice["network"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "LnInvoice"))
     }
-
-    static func asLnInvoice(lnInvoice: [String: Any?]) throws -> LnInvoice {
-        guard let bolt11 = lnInvoice["bolt11"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "LnInvoice"))
-        }
-        guard let networkTmp = lnInvoice["network"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "LnInvoice"))
-        }
-        let network = try asNetwork(network: networkTmp)
-
-        guard let payeePubkey = lnInvoice["payeePubkey"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payeePubkey", typeName: "LnInvoice"))
-        }
-        guard let paymentHash = lnInvoice["paymentHash"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnInvoice"))
-        }
+    let network = try asNetwork(network: networkTmp)
+    
+    guard let payeePubkey = lnInvoice["payeePubkey"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payeePubkey", typeName: "LnInvoice"))
+    }
+    guard let paymentHash = lnInvoice["paymentHash"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnInvoice"))
+    }
         var description: String?
         if hasNonNilKey(data: lnInvoice, key: "description") {
             guard let descriptionTmp = lnInvoice["description"] as? String else {
@@ -977,31 +962,31 @@ enum BreezSDKLiquidMapper {
             }
             amountMsat = amountMsatTmp
         }
-        guard let timestamp = lnInvoice["timestamp"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "LnInvoice"))
-        }
-        guard let expiry = lnInvoice["expiry"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "expiry", typeName: "LnInvoice"))
-        }
-        guard let routingHintsTmp = lnInvoice["routingHints"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "routingHints", typeName: "LnInvoice"))
-        }
-        let routingHints = try asRouteHintList(arr: routingHintsTmp)
-
-        guard let paymentSecret = lnInvoice["paymentSecret"] as? [UInt8] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentSecret", typeName: "LnInvoice"))
-        }
-        guard let minFinalCltvExpiryDelta = lnInvoice["minFinalCltvExpiryDelta"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minFinalCltvExpiryDelta", typeName: "LnInvoice"))
-        }
-
-        return LnInvoice(bolt11: bolt11, network: network, payeePubkey: payeePubkey, paymentHash: paymentHash, description: description, descriptionHash: descriptionHash, amountMsat: amountMsat, timestamp: timestamp, expiry: expiry, routingHints: routingHints, paymentSecret: paymentSecret, minFinalCltvExpiryDelta: minFinalCltvExpiryDelta)
+    guard let timestamp = lnInvoice["timestamp"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "LnInvoice"))
     }
+    guard let expiry = lnInvoice["expiry"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "expiry", typeName: "LnInvoice"))
+    }
+    guard let routingHintsTmp = lnInvoice["routingHints"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "routingHints", typeName: "LnInvoice"))
+    }
+    let routingHints = try asRouteHintList(arr: routingHintsTmp)
+    
+    guard let paymentSecret = lnInvoice["paymentSecret"] as? [UInt8] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentSecret", typeName: "LnInvoice"))
+    }
+    guard let minFinalCltvExpiryDelta = lnInvoice["minFinalCltvExpiryDelta"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minFinalCltvExpiryDelta", typeName: "LnInvoice"))
+    }
+    
+    return LnInvoice(bolt11: bolt11, network: network, payeePubkey: payeePubkey, paymentHash: paymentHash, description: description, descriptionHash: descriptionHash, amountMsat: amountMsat, timestamp: timestamp, expiry: expiry, routingHints: routingHints, paymentSecret: paymentSecret, minFinalCltvExpiryDelta: minFinalCltvExpiryDelta)    
+}
 
-    static func dictionaryOf(lnInvoice: LnInvoice) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnInvoice: LnInvoice) -> [String: Any?] {
+    return [
             "bolt11": lnInvoice.bolt11,
-            "network": valueOf(network: lnInvoice.network),
+            "network": valueOf( network: lnInvoice.network),
             "payeePubkey": lnInvoice.payeePubkey,
             "paymentHash": lnInvoice.paymentHash,
             "description": lnInvoice.description == nil ? nil : lnInvoice.description,
@@ -1011,39 +996,38 @@ enum BreezSDKLiquidMapper {
             "expiry": lnInvoice.expiry,
             "routingHints": arrayOf(routeHintList: lnInvoice.routingHints),
             "paymentSecret": lnInvoice.paymentSecret,
-            "minFinalCltvExpiryDelta": lnInvoice.minFinalCltvExpiryDelta,
-        ]
+            "minFinalCltvExpiryDelta": lnInvoice.minFinalCltvExpiryDelta,       
+    ]
+}
+
+static func asLnInvoiceList(arr: [Any]) throws -> [LnInvoice] {
+    var list = [LnInvoice]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnInvoice = try asLnInvoice(lnInvoice: val)
+            list.append(lnInvoice)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnInvoice"))
+        }
     }
+    return list
+}
 
-    static func asLnInvoiceList(arr: [Any]) throws -> [LnInvoice] {
-        var list = [LnInvoice]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnInvoice = try asLnInvoice(lnInvoice: val)
-                list.append(lnInvoice)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnInvoice"))
-            }
-        }
-        return list
+static func arrayOf(`lnInvoiceList`: [LnInvoice]) -> [Any] {
+    return `lnInvoiceList`.map { (v) -> [String: Any?] in return dictionaryOf(lnInvoice: v) }
+}
+static func asLnOffer(lnOffer: [String: Any?]) throws -> LnOffer {
+    guard let offer = lnOffer["offer"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "LnOffer"))
     }
-
-    static func arrayOf(lnInvoiceList: [LnInvoice]) -> [Any] {
-        return lnInvoiceList.map { v -> [String: Any?] in return dictionaryOf(lnInvoice: v) }
+    guard let chains = lnOffer["chains"] as? [String] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "chains", typeName: "LnOffer"))
     }
-
-    static func asLnOffer(lnOffer: [String: Any?]) throws -> LnOffer {
-        guard let offer = lnOffer["offer"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "LnOffer"))
-        }
-        guard let chains = lnOffer["chains"] as? [String] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "chains", typeName: "LnOffer"))
-        }
-        guard let pathsTmp = lnOffer["paths"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paths", typeName: "LnOffer"))
-        }
-        let paths = try asLnOfferBlindedPathList(arr: pathsTmp)
-
+    guard let pathsTmp = lnOffer["paths"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paths", typeName: "LnOffer"))
+    }
+    let paths = try asLnOfferBlindedPathList(arr: pathsTmp)
+    
         var description: String?
         if hasNonNilKey(data: lnOffer, key: "description") {
             guard let descriptionTmp = lnOffer["description"] as? String else {
@@ -1062,7 +1046,7 @@ enum BreezSDKLiquidMapper {
         if let minAmountTmp = lnOffer["minAmount"] as? [String: Any?] {
             minAmount = try asAmount(amount: minAmountTmp)
         }
-
+        
         var absoluteExpiry: UInt64?
         if hasNonNilKey(data: lnOffer, key: "absoluteExpiry") {
             guard let absoluteExpiryTmp = lnOffer["absoluteExpiry"] as? UInt64 else {
@@ -1077,12 +1061,12 @@ enum BreezSDKLiquidMapper {
             }
             issuer = issuerTmp
         }
+    
+    return LnOffer(offer: offer, chains: chains, paths: paths, description: description, signingPubkey: signingPubkey, minAmount: minAmount, absoluteExpiry: absoluteExpiry, issuer: issuer)    
+}
 
-        return LnOffer(offer: offer, chains: chains, paths: paths, description: description, signingPubkey: signingPubkey, minAmount: minAmount, absoluteExpiry: absoluteExpiry, issuer: issuer)
-    }
-
-    static func dictionaryOf(lnOffer: LnOffer) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnOffer: LnOffer) -> [String: Any?] {
+    return [
             "offer": lnOffer.offer,
             "chains": lnOffer.chains,
             "paths": arrayOf(lnOfferBlindedPathList: lnOffer.paths),
@@ -1090,113 +1074,111 @@ enum BreezSDKLiquidMapper {
             "signingPubkey": lnOffer.signingPubkey == nil ? nil : lnOffer.signingPubkey,
             "minAmount": lnOffer.minAmount == nil ? nil : dictionaryOf(amount: lnOffer.minAmount!),
             "absoluteExpiry": lnOffer.absoluteExpiry == nil ? nil : lnOffer.absoluteExpiry,
-            "issuer": lnOffer.issuer == nil ? nil : lnOffer.issuer,
-        ]
-    }
+            "issuer": lnOffer.issuer == nil ? nil : lnOffer.issuer,       
+    ]
+}
 
-    static func asLnOfferList(arr: [Any]) throws -> [LnOffer] {
-        var list = [LnOffer]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnOffer = try asLnOffer(lnOffer: val)
-                list.append(lnOffer)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnOffer"))
-            }
+static func asLnOfferList(arr: [Any]) throws -> [LnOffer] {
+    var list = [LnOffer]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnOffer = try asLnOffer(lnOffer: val)
+            list.append(lnOffer)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnOffer"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnOfferList: [LnOffer]) -> [Any] {
-        return lnOfferList.map { v -> [String: Any?] in return dictionaryOf(lnOffer: v) }
+static func arrayOf(`lnOfferList`: [LnOffer]) -> [Any] {
+    return `lnOfferList`.map { (v) -> [String: Any?] in return dictionaryOf(lnOffer: v) }
+}
+static func asLightningPaymentLimitsResponse(lightningPaymentLimitsResponse: [String: Any?]) throws -> LightningPaymentLimitsResponse {
+    guard let sendTmp = lightningPaymentLimitsResponse["send"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "send", typeName: "LightningPaymentLimitsResponse"))
     }
-
-    static func asLightningPaymentLimitsResponse(lightningPaymentLimitsResponse: [String: Any?]) throws -> LightningPaymentLimitsResponse {
-        guard let sendTmp = lightningPaymentLimitsResponse["send"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "send", typeName: "LightningPaymentLimitsResponse"))
-        }
-        let send = try asLimits(limits: sendTmp)
-
-        guard let receiveTmp = lightningPaymentLimitsResponse["receive"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receive", typeName: "LightningPaymentLimitsResponse"))
-        }
-        let receive = try asLimits(limits: receiveTmp)
-
-        return LightningPaymentLimitsResponse(send: send, receive: receive)
+    let send = try asLimits(limits: sendTmp)
+    
+    guard let receiveTmp = lightningPaymentLimitsResponse["receive"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receive", typeName: "LightningPaymentLimitsResponse"))
     }
+    let receive = try asLimits(limits: receiveTmp)
+    
+    
+    return LightningPaymentLimitsResponse(send: send, receive: receive)    
+}
 
-    static func dictionaryOf(lightningPaymentLimitsResponse: LightningPaymentLimitsResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lightningPaymentLimitsResponse: LightningPaymentLimitsResponse) -> [String: Any?] {
+    return [
             "send": dictionaryOf(limits: lightningPaymentLimitsResponse.send),
-            "receive": dictionaryOf(limits: lightningPaymentLimitsResponse.receive),
-        ]
-    }
+            "receive": dictionaryOf(limits: lightningPaymentLimitsResponse.receive),       
+    ]
+}
 
-    static func asLightningPaymentLimitsResponseList(arr: [Any]) throws -> [LightningPaymentLimitsResponse] {
-        var list = [LightningPaymentLimitsResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lightningPaymentLimitsResponse = try asLightningPaymentLimitsResponse(lightningPaymentLimitsResponse: val)
-                list.append(lightningPaymentLimitsResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LightningPaymentLimitsResponse"))
-            }
+static func asLightningPaymentLimitsResponseList(arr: [Any]) throws -> [LightningPaymentLimitsResponse] {
+    var list = [LightningPaymentLimitsResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lightningPaymentLimitsResponse = try asLightningPaymentLimitsResponse(lightningPaymentLimitsResponse: val)
+            list.append(lightningPaymentLimitsResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LightningPaymentLimitsResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lightningPaymentLimitsResponseList: [LightningPaymentLimitsResponse]) -> [Any] {
-        return lightningPaymentLimitsResponseList.map { v -> [String: Any?] in return dictionaryOf(lightningPaymentLimitsResponse: v) }
+static func arrayOf(`lightningPaymentLimitsResponseList`: [LightningPaymentLimitsResponse]) -> [Any] {
+    return `lightningPaymentLimitsResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(lightningPaymentLimitsResponse: v) }
+}
+static func asLimits(limits: [String: Any?]) throws -> Limits {
+    guard let minSat = limits["minSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minSat", typeName: "Limits"))
     }
-
-    static func asLimits(limits: [String: Any?]) throws -> Limits {
-        guard let minSat = limits["minSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minSat", typeName: "Limits"))
-        }
-        guard let maxSat = limits["maxSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSat", typeName: "Limits"))
-        }
-        guard let maxZeroConfSat = limits["maxZeroConfSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxZeroConfSat", typeName: "Limits"))
-        }
-
-        return Limits(minSat: minSat, maxSat: maxSat, maxZeroConfSat: maxZeroConfSat)
+    guard let maxSat = limits["maxSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSat", typeName: "Limits"))
     }
+    guard let maxZeroConfSat = limits["maxZeroConfSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxZeroConfSat", typeName: "Limits"))
+    }
+    
+    return Limits(minSat: minSat, maxSat: maxSat, maxZeroConfSat: maxZeroConfSat)    
+}
 
-    static func dictionaryOf(limits: Limits) -> [String: Any?] {
-        return [
+static func  dictionaryOf(limits: Limits) -> [String: Any?] {
+    return [
             "minSat": limits.minSat,
             "maxSat": limits.maxSat,
-            "maxZeroConfSat": limits.maxZeroConfSat,
-        ]
-    }
+            "maxZeroConfSat": limits.maxZeroConfSat,       
+    ]
+}
 
-    static func asLimitsList(arr: [Any]) throws -> [Limits] {
-        var list = [Limits]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var limits = try asLimits(limits: val)
-                list.append(limits)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Limits"))
-            }
+static func asLimitsList(arr: [Any]) throws -> [Limits] {
+    var list = [Limits]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var limits = try asLimits(limits: val)
+            list.append(limits)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Limits"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(limitsList: [Limits]) -> [Any] {
-        return limitsList.map { v -> [String: Any?] in return dictionaryOf(limits: v) }
+static func arrayOf(`limitsList`: [Limits]) -> [Any] {
+    return `limitsList`.map { (v) -> [String: Any?] in return dictionaryOf(limits: v) }
+}
+static func asLiquidAddressData(liquidAddressData: [String: Any?]) throws -> LiquidAddressData {
+    guard let address = liquidAddressData["address"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "LiquidAddressData"))
     }
-
-    static func asLiquidAddressData(liquidAddressData: [String: Any?]) throws -> LiquidAddressData {
-        guard let address = liquidAddressData["address"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "LiquidAddressData"))
-        }
-        guard let networkTmp = liquidAddressData["network"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "LiquidAddressData"))
-        }
-        let network = try asNetwork(network: networkTmp)
-
+    guard let networkTmp = liquidAddressData["network"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "network", typeName: "LiquidAddressData"))
+    }
+    let network = try asNetwork(network: networkTmp)
+    
         var assetId: String?
         if hasNonNilKey(data: liquidAddressData, key: "assetId") {
             guard let assetIdTmp = liquidAddressData["assetId"] as? String else {
@@ -1232,50 +1214,49 @@ enum BreezSDKLiquidMapper {
             }
             message = messageTmp
         }
+    
+    return LiquidAddressData(address: address, network: network, assetId: assetId, amount: amount, amountSat: amountSat, label: label, message: message)    
+}
 
-        return LiquidAddressData(address: address, network: network, assetId: assetId, amount: amount, amountSat: amountSat, label: label, message: message)
-    }
-
-    static func dictionaryOf(liquidAddressData: LiquidAddressData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(liquidAddressData: LiquidAddressData) -> [String: Any?] {
+    return [
             "address": liquidAddressData.address,
-            "network": valueOf(network: liquidAddressData.network),
+            "network": valueOf( network: liquidAddressData.network),
             "assetId": liquidAddressData.assetId == nil ? nil : liquidAddressData.assetId,
             "amount": liquidAddressData.amount == nil ? nil : liquidAddressData.amount,
             "amountSat": liquidAddressData.amountSat == nil ? nil : liquidAddressData.amountSat,
             "label": liquidAddressData.label == nil ? nil : liquidAddressData.label,
-            "message": liquidAddressData.message == nil ? nil : liquidAddressData.message,
-        ]
-    }
+            "message": liquidAddressData.message == nil ? nil : liquidAddressData.message,       
+    ]
+}
 
-    static func asLiquidAddressDataList(arr: [Any]) throws -> [LiquidAddressData] {
-        var list = [LiquidAddressData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var liquidAddressData = try asLiquidAddressData(liquidAddressData: val)
-                list.append(liquidAddressData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LiquidAddressData"))
-            }
+static func asLiquidAddressDataList(arr: [Any]) throws -> [LiquidAddressData] {
+    var list = [LiquidAddressData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var liquidAddressData = try asLiquidAddressData(liquidAddressData: val)
+            list.append(liquidAddressData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LiquidAddressData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(liquidAddressDataList: [LiquidAddressData]) -> [Any] {
-        return liquidAddressDataList.map { v -> [String: Any?] in return dictionaryOf(liquidAddressData: v) }
-    }
-
-    static func asListPaymentsRequest(listPaymentsRequest: [String: Any?]) throws -> ListPaymentsRequest {
+static func arrayOf(`liquidAddressDataList`: [LiquidAddressData]) -> [Any] {
+    return `liquidAddressDataList`.map { (v) -> [String: Any?] in return dictionaryOf(liquidAddressData: v) }
+}
+static func asListPaymentsRequest(listPaymentsRequest: [String: Any?]) throws -> ListPaymentsRequest {
         var filters: [PaymentType]?
         if let filtersTmp = listPaymentsRequest["filters"] as? [String] {
             filters = try asPaymentTypeList(arr: filtersTmp)
         }
-
+        
         var states: [PaymentState]?
         if let statesTmp = listPaymentsRequest["states"] as? [String] {
             states = try asPaymentStateList(arr: statesTmp)
         }
-
+        
         var fromTimestamp: Int64?
         if hasNonNilKey(data: listPaymentsRequest, key: "fromTimestamp") {
             guard let fromTimestampTmp = listPaymentsRequest["fromTimestamp"] as? Int64 else {
@@ -1308,7 +1289,7 @@ enum BreezSDKLiquidMapper {
         if let detailsTmp = listPaymentsRequest["details"] as? [String: Any?] {
             details = try asListPaymentDetails(listPaymentDetails: detailsTmp)
         }
-
+        
         var sortAscending: Bool?
         if hasNonNilKey(data: listPaymentsRequest, key: "sortAscending") {
             guard let sortAscendingTmp = listPaymentsRequest["sortAscending"] as? Bool else {
@@ -1316,12 +1297,12 @@ enum BreezSDKLiquidMapper {
             }
             sortAscending = sortAscendingTmp
         }
+    
+    return ListPaymentsRequest(filters: filters, states: states, fromTimestamp: fromTimestamp, toTimestamp: toTimestamp, offset: offset, limit: limit, details: details, sortAscending: sortAscending)    
+}
 
-        return ListPaymentsRequest(filters: filters, states: states, fromTimestamp: fromTimestamp, toTimestamp: toTimestamp, offset: offset, limit: limit, details: details, sortAscending: sortAscending)
-    }
-
-    static func dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(listPaymentsRequest: ListPaymentsRequest) -> [String: Any?] {
+    return [
             "filters": listPaymentsRequest.filters == nil ? nil : arrayOf(paymentTypeList: listPaymentsRequest.filters!),
             "states": listPaymentsRequest.states == nil ? nil : arrayOf(paymentStateList: listPaymentsRequest.states!),
             "fromTimestamp": listPaymentsRequest.fromTimestamp == nil ? nil : listPaymentsRequest.fromTimestamp,
@@ -1329,68 +1310,66 @@ enum BreezSDKLiquidMapper {
             "offset": listPaymentsRequest.offset == nil ? nil : listPaymentsRequest.offset,
             "limit": listPaymentsRequest.limit == nil ? nil : listPaymentsRequest.limit,
             "details": listPaymentsRequest.details == nil ? nil : dictionaryOf(listPaymentDetails: listPaymentsRequest.details!),
-            "sortAscending": listPaymentsRequest.sortAscending == nil ? nil : listPaymentsRequest.sortAscending,
-        ]
-    }
+            "sortAscending": listPaymentsRequest.sortAscending == nil ? nil : listPaymentsRequest.sortAscending,       
+    ]
+}
 
-    static func asListPaymentsRequestList(arr: [Any]) throws -> [ListPaymentsRequest] {
-        var list = [ListPaymentsRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var listPaymentsRequest = try asListPaymentsRequest(listPaymentsRequest: val)
-                list.append(listPaymentsRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ListPaymentsRequest"))
-            }
+static func asListPaymentsRequestList(arr: [Any]) throws -> [ListPaymentsRequest] {
+    var list = [ListPaymentsRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var listPaymentsRequest = try asListPaymentsRequest(listPaymentsRequest: val)
+            list.append(listPaymentsRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ListPaymentsRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(listPaymentsRequestList: [ListPaymentsRequest]) -> [Any] {
-        return listPaymentsRequestList.map { v -> [String: Any?] in return dictionaryOf(listPaymentsRequest: v) }
+static func arrayOf(`listPaymentsRequestList`: [ListPaymentsRequest]) -> [Any] {
+    return `listPaymentsRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(listPaymentsRequest: v) }
+}
+static func asLnOfferBlindedPath(lnOfferBlindedPath: [String: Any?]) throws -> LnOfferBlindedPath {
+    guard let blindedHops = lnOfferBlindedPath["blindedHops"] as? [String] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "blindedHops", typeName: "LnOfferBlindedPath"))
     }
+    
+    return LnOfferBlindedPath(blindedHops: blindedHops)    
+}
 
-    static func asLnOfferBlindedPath(lnOfferBlindedPath: [String: Any?]) throws -> LnOfferBlindedPath {
-        guard let blindedHops = lnOfferBlindedPath["blindedHops"] as? [String] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "blindedHops", typeName: "LnOfferBlindedPath"))
+static func  dictionaryOf(lnOfferBlindedPath: LnOfferBlindedPath) -> [String: Any?] {
+    return [
+            "blindedHops": lnOfferBlindedPath.blindedHops,       
+    ]
+}
+
+static func asLnOfferBlindedPathList(arr: [Any]) throws -> [LnOfferBlindedPath] {
+    var list = [LnOfferBlindedPath]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnOfferBlindedPath = try asLnOfferBlindedPath(lnOfferBlindedPath: val)
+            list.append(lnOfferBlindedPath)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnOfferBlindedPath"))
         }
-
-        return LnOfferBlindedPath(blindedHops: blindedHops)
     }
+    return list
+}
 
-    static func dictionaryOf(lnOfferBlindedPath: LnOfferBlindedPath) -> [String: Any?] {
-        return [
-            "blindedHops": lnOfferBlindedPath.blindedHops,
-        ]
+static func arrayOf(`lnOfferBlindedPathList`: [LnOfferBlindedPath]) -> [Any] {
+    return `lnOfferBlindedPathList`.map { (v) -> [String: Any?] in return dictionaryOf(lnOfferBlindedPath: v) }
+}
+static func asLnUrlAuthRequestData(lnUrlAuthRequestData: [String: Any?]) throws -> LnUrlAuthRequestData {
+    guard let k1 = lnUrlAuthRequestData["k1"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlAuthRequestData"))
     }
-
-    static func asLnOfferBlindedPathList(arr: [Any]) throws -> [LnOfferBlindedPath] {
-        var list = [LnOfferBlindedPath]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnOfferBlindedPath = try asLnOfferBlindedPath(lnOfferBlindedPath: val)
-                list.append(lnOfferBlindedPath)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnOfferBlindedPath"))
-            }
-        }
-        return list
+    guard let domain = lnUrlAuthRequestData["domain"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlAuthRequestData"))
     }
-
-    static func arrayOf(lnOfferBlindedPathList: [LnOfferBlindedPath]) -> [Any] {
-        return lnOfferBlindedPathList.map { v -> [String: Any?] in return dictionaryOf(lnOfferBlindedPath: v) }
+    guard let url = lnUrlAuthRequestData["url"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "LnUrlAuthRequestData"))
     }
-
-    static func asLnUrlAuthRequestData(lnUrlAuthRequestData: [String: Any?]) throws -> LnUrlAuthRequestData {
-        guard let k1 = lnUrlAuthRequestData["k1"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlAuthRequestData"))
-        }
-        guard let domain = lnUrlAuthRequestData["domain"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlAuthRequestData"))
-        }
-        guard let url = lnUrlAuthRequestData["url"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "LnUrlAuthRequestData"))
-        }
         var action: String?
         if hasNonNilKey(data: lnUrlAuthRequestData, key: "action") {
             guard let actionTmp = lnUrlAuthRequestData["action"] as? String else {
@@ -1398,68 +1377,66 @@ enum BreezSDKLiquidMapper {
             }
             action = actionTmp
         }
+    
+    return LnUrlAuthRequestData(k1: k1, domain: domain, url: url, action: action)    
+}
 
-        return LnUrlAuthRequestData(k1: k1, domain: domain, url: url, action: action)
-    }
-
-    static func dictionaryOf(lnUrlAuthRequestData: LnUrlAuthRequestData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlAuthRequestData: LnUrlAuthRequestData) -> [String: Any?] {
+    return [
             "k1": lnUrlAuthRequestData.k1,
             "domain": lnUrlAuthRequestData.domain,
             "url": lnUrlAuthRequestData.url,
-            "action": lnUrlAuthRequestData.action == nil ? nil : lnUrlAuthRequestData.action,
-        ]
-    }
+            "action": lnUrlAuthRequestData.action == nil ? nil : lnUrlAuthRequestData.action,       
+    ]
+}
 
-    static func asLnUrlAuthRequestDataList(arr: [Any]) throws -> [LnUrlAuthRequestData] {
-        var list = [LnUrlAuthRequestData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlAuthRequestData = try asLnUrlAuthRequestData(lnUrlAuthRequestData: val)
-                list.append(lnUrlAuthRequestData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlAuthRequestData"))
-            }
+static func asLnUrlAuthRequestDataList(arr: [Any]) throws -> [LnUrlAuthRequestData] {
+    var list = [LnUrlAuthRequestData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlAuthRequestData = try asLnUrlAuthRequestData(lnUrlAuthRequestData: val)
+            list.append(lnUrlAuthRequestData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlAuthRequestData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnUrlAuthRequestDataList: [LnUrlAuthRequestData]) -> [Any] {
-        return lnUrlAuthRequestDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlAuthRequestData: v) }
+static func arrayOf(`lnUrlAuthRequestDataList`: [LnUrlAuthRequestData]) -> [Any] {
+    return `lnUrlAuthRequestDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlAuthRequestData: v) }
+}
+static func asLnUrlErrorData(lnUrlErrorData: [String: Any?]) throws -> LnUrlErrorData {
+    guard let reason = lnUrlErrorData["reason"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlErrorData"))
     }
+    
+    return LnUrlErrorData(reason: reason)    
+}
 
-    static func asLnUrlErrorData(lnUrlErrorData: [String: Any?]) throws -> LnUrlErrorData {
-        guard let reason = lnUrlErrorData["reason"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlErrorData"))
+static func  dictionaryOf(lnUrlErrorData: LnUrlErrorData) -> [String: Any?] {
+    return [
+            "reason": lnUrlErrorData.reason,       
+    ]
+}
+
+static func asLnUrlErrorDataList(arr: [Any]) throws -> [LnUrlErrorData] {
+    var list = [LnUrlErrorData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlErrorData = try asLnUrlErrorData(lnUrlErrorData: val)
+            list.append(lnUrlErrorData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlErrorData"))
         }
-
-        return LnUrlErrorData(reason: reason)
     }
+    return list
+}
 
-    static func dictionaryOf(lnUrlErrorData: LnUrlErrorData) -> [String: Any?] {
-        return [
-            "reason": lnUrlErrorData.reason,
-        ]
-    }
-
-    static func asLnUrlErrorDataList(arr: [Any]) throws -> [LnUrlErrorData] {
-        var list = [LnUrlErrorData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlErrorData = try asLnUrlErrorData(lnUrlErrorData: val)
-                list.append(lnUrlErrorData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlErrorData"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(lnUrlErrorDataList: [LnUrlErrorData]) -> [Any] {
-        return lnUrlErrorDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlErrorData: v) }
-    }
-
-    static func asLnUrlInfo(lnUrlInfo: [String: Any?]) throws -> LnUrlInfo {
+static func arrayOf(`lnUrlErrorDataList`: [LnUrlErrorData]) -> [Any] {
+    return `lnUrlErrorDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlErrorData: v) }
+}
+static func asLnUrlInfo(lnUrlInfo: [String: Any?]) throws -> LnUrlInfo {
         var lnAddress: String?
         if hasNonNilKey(data: lnUrlInfo, key: "lnAddress") {
             guard let lnAddressTmp = lnUrlInfo["lnAddress"] as? String else {
@@ -1492,12 +1469,12 @@ enum BreezSDKLiquidMapper {
         if let lnurlPaySuccessActionTmp = lnUrlInfo["lnurlPaySuccessAction"] as? [String: Any?] {
             lnurlPaySuccessAction = try asSuccessActionProcessed(successActionProcessed: lnurlPaySuccessActionTmp)
         }
-
+        
         var lnurlPayUnprocessedSuccessAction: SuccessAction?
         if let lnurlPayUnprocessedSuccessActionTmp = lnUrlInfo["lnurlPayUnprocessedSuccessAction"] as? [String: Any?] {
             lnurlPayUnprocessedSuccessAction = try asSuccessAction(successAction: lnurlPayUnprocessedSuccessActionTmp)
         }
-
+        
         var lnurlWithdrawEndpoint: String?
         if hasNonNilKey(data: lnUrlInfo, key: "lnurlWithdrawEndpoint") {
             guard let lnurlWithdrawEndpointTmp = lnUrlInfo["lnurlWithdrawEndpoint"] as? String else {
@@ -1505,128 +1482,126 @@ enum BreezSDKLiquidMapper {
             }
             lnurlWithdrawEndpoint = lnurlWithdrawEndpointTmp
         }
+    
+    return LnUrlInfo(lnAddress: lnAddress, lnurlPayComment: lnurlPayComment, lnurlPayDomain: lnurlPayDomain, lnurlPayMetadata: lnurlPayMetadata, lnurlPaySuccessAction: lnurlPaySuccessAction, lnurlPayUnprocessedSuccessAction: lnurlPayUnprocessedSuccessAction, lnurlWithdrawEndpoint: lnurlWithdrawEndpoint)    
+}
 
-        return LnUrlInfo(lnAddress: lnAddress, lnurlPayComment: lnurlPayComment, lnurlPayDomain: lnurlPayDomain, lnurlPayMetadata: lnurlPayMetadata, lnurlPaySuccessAction: lnurlPaySuccessAction, lnurlPayUnprocessedSuccessAction: lnurlPayUnprocessedSuccessAction, lnurlWithdrawEndpoint: lnurlWithdrawEndpoint)
-    }
-
-    static func dictionaryOf(lnUrlInfo: LnUrlInfo) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlInfo: LnUrlInfo) -> [String: Any?] {
+    return [
             "lnAddress": lnUrlInfo.lnAddress == nil ? nil : lnUrlInfo.lnAddress,
             "lnurlPayComment": lnUrlInfo.lnurlPayComment == nil ? nil : lnUrlInfo.lnurlPayComment,
             "lnurlPayDomain": lnUrlInfo.lnurlPayDomain == nil ? nil : lnUrlInfo.lnurlPayDomain,
             "lnurlPayMetadata": lnUrlInfo.lnurlPayMetadata == nil ? nil : lnUrlInfo.lnurlPayMetadata,
             "lnurlPaySuccessAction": lnUrlInfo.lnurlPaySuccessAction == nil ? nil : dictionaryOf(successActionProcessed: lnUrlInfo.lnurlPaySuccessAction!),
             "lnurlPayUnprocessedSuccessAction": lnUrlInfo.lnurlPayUnprocessedSuccessAction == nil ? nil : dictionaryOf(successAction: lnUrlInfo.lnurlPayUnprocessedSuccessAction!),
-            "lnurlWithdrawEndpoint": lnUrlInfo.lnurlWithdrawEndpoint == nil ? nil : lnUrlInfo.lnurlWithdrawEndpoint,
-        ]
-    }
+            "lnurlWithdrawEndpoint": lnUrlInfo.lnurlWithdrawEndpoint == nil ? nil : lnUrlInfo.lnurlWithdrawEndpoint,       
+    ]
+}
 
-    static func asLnUrlInfoList(arr: [Any]) throws -> [LnUrlInfo] {
-        var list = [LnUrlInfo]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlInfo = try asLnUrlInfo(lnUrlInfo: val)
-                list.append(lnUrlInfo)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlInfo"))
-            }
+static func asLnUrlInfoList(arr: [Any]) throws -> [LnUrlInfo] {
+    var list = [LnUrlInfo]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlInfo = try asLnUrlInfo(lnUrlInfo: val)
+            list.append(lnUrlInfo)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlInfo"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnUrlInfoList: [LnUrlInfo]) -> [Any] {
-        return lnUrlInfoList.map { v -> [String: Any?] in return dictionaryOf(lnUrlInfo: v) }
+static func arrayOf(`lnUrlInfoList`: [LnUrlInfo]) -> [Any] {
+    return `lnUrlInfoList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlInfo: v) }
+}
+static func asLnUrlPayErrorData(lnUrlPayErrorData: [String: Any?]) throws -> LnUrlPayErrorData {
+    guard let paymentHash = lnUrlPayErrorData["paymentHash"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPayErrorData"))
     }
-
-    static func asLnUrlPayErrorData(lnUrlPayErrorData: [String: Any?]) throws -> LnUrlPayErrorData {
-        guard let paymentHash = lnUrlPayErrorData["paymentHash"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnUrlPayErrorData"))
-        }
-        guard let reason = lnUrlPayErrorData["reason"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlPayErrorData"))
-        }
-
-        return LnUrlPayErrorData(paymentHash: paymentHash, reason: reason)
+    guard let reason = lnUrlPayErrorData["reason"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "LnUrlPayErrorData"))
     }
+    
+    return LnUrlPayErrorData(paymentHash: paymentHash, reason: reason)    
+}
 
-    static func dictionaryOf(lnUrlPayErrorData: LnUrlPayErrorData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlPayErrorData: LnUrlPayErrorData) -> [String: Any?] {
+    return [
             "paymentHash": lnUrlPayErrorData.paymentHash,
-            "reason": lnUrlPayErrorData.reason,
-        ]
+            "reason": lnUrlPayErrorData.reason,       
+    ]
+}
+
+static func asLnUrlPayErrorDataList(arr: [Any]) throws -> [LnUrlPayErrorData] {
+    var list = [LnUrlPayErrorData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlPayErrorData = try asLnUrlPayErrorData(lnUrlPayErrorData: val)
+            list.append(lnUrlPayErrorData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayErrorData"))
+        }
     }
+    return list
+}
 
-    static func asLnUrlPayErrorDataList(arr: [Any]) throws -> [LnUrlPayErrorData] {
-        var list = [LnUrlPayErrorData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlPayErrorData = try asLnUrlPayErrorData(lnUrlPayErrorData: val)
-                list.append(lnUrlPayErrorData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayErrorData"))
-            }
-        }
-        return list
+static func arrayOf(`lnUrlPayErrorDataList`: [LnUrlPayErrorData]) -> [Any] {
+    return `lnUrlPayErrorDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlPayErrorData: v) }
+}
+static func asLnUrlPayRequest(lnUrlPayRequest: [String: Any?]) throws -> LnUrlPayRequest {
+    guard let prepareResponseTmp = lnUrlPayRequest["prepareResponse"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "LnUrlPayRequest"))
     }
+    let prepareResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: prepareResponseTmp)
+    
+    
+    return LnUrlPayRequest(prepareResponse: prepareResponse)    
+}
 
-    static func arrayOf(lnUrlPayErrorDataList: [LnUrlPayErrorData]) -> [Any] {
-        return lnUrlPayErrorDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlPayErrorData: v) }
+static func  dictionaryOf(lnUrlPayRequest: LnUrlPayRequest) -> [String: Any?] {
+    return [
+            "prepareResponse": dictionaryOf(prepareLnUrlPayResponse: lnUrlPayRequest.prepareResponse),       
+    ]
+}
+
+static func asLnUrlPayRequestList(arr: [Any]) throws -> [LnUrlPayRequest] {
+    var list = [LnUrlPayRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlPayRequest = try asLnUrlPayRequest(lnUrlPayRequest: val)
+            list.append(lnUrlPayRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequest"))
+        }
     }
+    return list
+}
 
-    static func asLnUrlPayRequest(lnUrlPayRequest: [String: Any?]) throws -> LnUrlPayRequest {
-        guard let prepareResponseTmp = lnUrlPayRequest["prepareResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "LnUrlPayRequest"))
-        }
-        let prepareResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: prepareResponseTmp)
-
-        return LnUrlPayRequest(prepareResponse: prepareResponse)
+static func arrayOf(`lnUrlPayRequestList`: [LnUrlPayRequest]) -> [Any] {
+    return `lnUrlPayRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlPayRequest: v) }
+}
+static func asLnUrlPayRequestData(lnUrlPayRequestData: [String: Any?]) throws -> LnUrlPayRequestData {
+    guard let callback = lnUrlPayRequestData["callback"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlPayRequestData"))
     }
-
-    static func dictionaryOf(lnUrlPayRequest: LnUrlPayRequest) -> [String: Any?] {
-        return [
-            "prepareResponse": dictionaryOf(prepareLnUrlPayResponse: lnUrlPayRequest.prepareResponse),
-        ]
+    guard let minSendable = lnUrlPayRequestData["minSendable"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minSendable", typeName: "LnUrlPayRequestData"))
     }
-
-    static func asLnUrlPayRequestList(arr: [Any]) throws -> [LnUrlPayRequest] {
-        var list = [LnUrlPayRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlPayRequest = try asLnUrlPayRequest(lnUrlPayRequest: val)
-                list.append(lnUrlPayRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequest"))
-            }
-        }
-        return list
+    guard let maxSendable = lnUrlPayRequestData["maxSendable"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSendable", typeName: "LnUrlPayRequestData"))
     }
-
-    static func arrayOf(lnUrlPayRequestList: [LnUrlPayRequest]) -> [Any] {
-        return lnUrlPayRequestList.map { v -> [String: Any?] in return dictionaryOf(lnUrlPayRequest: v) }
+    guard let metadataStr = lnUrlPayRequestData["metadataStr"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "metadataStr", typeName: "LnUrlPayRequestData"))
     }
-
-    static func asLnUrlPayRequestData(lnUrlPayRequestData: [String: Any?]) throws -> LnUrlPayRequestData {
-        guard let callback = lnUrlPayRequestData["callback"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlPayRequestData"))
-        }
-        guard let minSendable = lnUrlPayRequestData["minSendable"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minSendable", typeName: "LnUrlPayRequestData"))
-        }
-        guard let maxSendable = lnUrlPayRequestData["maxSendable"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxSendable", typeName: "LnUrlPayRequestData"))
-        }
-        guard let metadataStr = lnUrlPayRequestData["metadataStr"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "metadataStr", typeName: "LnUrlPayRequestData"))
-        }
-        guard let commentAllowed = lnUrlPayRequestData["commentAllowed"] as? UInt16 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "commentAllowed", typeName: "LnUrlPayRequestData"))
-        }
-        guard let domain = lnUrlPayRequestData["domain"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlPayRequestData"))
-        }
-        guard let allowsNostr = lnUrlPayRequestData["allowsNostr"] as? Bool else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "allowsNostr", typeName: "LnUrlPayRequestData"))
-        }
+    guard let commentAllowed = lnUrlPayRequestData["commentAllowed"] as? UInt16 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "commentAllowed", typeName: "LnUrlPayRequestData"))
+    }
+    guard let domain = lnUrlPayRequestData["domain"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "domain", typeName: "LnUrlPayRequestData"))
+    }
+    guard let allowsNostr = lnUrlPayRequestData["allowsNostr"] as? Bool else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "allowsNostr", typeName: "LnUrlPayRequestData"))
+    }
         var nostrPubkey: String?
         if hasNonNilKey(data: lnUrlPayRequestData, key: "nostrPubkey") {
             guard let nostrPubkeyTmp = lnUrlPayRequestData["nostrPubkey"] as? String else {
@@ -1641,12 +1616,12 @@ enum BreezSDKLiquidMapper {
             }
             lnAddress = lnAddressTmp
         }
+    
+    return LnUrlPayRequestData(callback: callback, minSendable: minSendable, maxSendable: maxSendable, metadataStr: metadataStr, commentAllowed: commentAllowed, domain: domain, allowsNostr: allowsNostr, nostrPubkey: nostrPubkey, lnAddress: lnAddress)    
+}
 
-        return LnUrlPayRequestData(callback: callback, minSendable: minSendable, maxSendable: maxSendable, metadataStr: metadataStr, commentAllowed: commentAllowed, domain: domain, allowsNostr: allowsNostr, nostrPubkey: nostrPubkey, lnAddress: lnAddress)
-    }
-
-    static func dictionaryOf(lnUrlPayRequestData: LnUrlPayRequestData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlPayRequestData: LnUrlPayRequestData) -> [String: Any?] {
+    return [
             "callback": lnUrlPayRequestData.callback,
             "minSendable": lnUrlPayRequestData.minSendable,
             "maxSendable": lnUrlPayRequestData.maxSendable,
@@ -1655,74 +1630,73 @@ enum BreezSDKLiquidMapper {
             "domain": lnUrlPayRequestData.domain,
             "allowsNostr": lnUrlPayRequestData.allowsNostr,
             "nostrPubkey": lnUrlPayRequestData.nostrPubkey == nil ? nil : lnUrlPayRequestData.nostrPubkey,
-            "lnAddress": lnUrlPayRequestData.lnAddress == nil ? nil : lnUrlPayRequestData.lnAddress,
-        ]
-    }
+            "lnAddress": lnUrlPayRequestData.lnAddress == nil ? nil : lnUrlPayRequestData.lnAddress,       
+    ]
+}
 
-    static func asLnUrlPayRequestDataList(arr: [Any]) throws -> [LnUrlPayRequestData] {
-        var list = [LnUrlPayRequestData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlPayRequestData = try asLnUrlPayRequestData(lnUrlPayRequestData: val)
-                list.append(lnUrlPayRequestData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequestData"))
-            }
+static func asLnUrlPayRequestDataList(arr: [Any]) throws -> [LnUrlPayRequestData] {
+    var list = [LnUrlPayRequestData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlPayRequestData = try asLnUrlPayRequestData(lnUrlPayRequestData: val)
+            list.append(lnUrlPayRequestData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayRequestData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnUrlPayRequestDataList: [LnUrlPayRequestData]) -> [Any] {
-        return lnUrlPayRequestDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlPayRequestData: v) }
-    }
-
-    static func asLnUrlPaySuccessData(lnUrlPaySuccessData: [String: Any?]) throws -> LnUrlPaySuccessData {
+static func arrayOf(`lnUrlPayRequestDataList`: [LnUrlPayRequestData]) -> [Any] {
+    return `lnUrlPayRequestDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlPayRequestData: v) }
+}
+static func asLnUrlPaySuccessData(lnUrlPaySuccessData: [String: Any?]) throws -> LnUrlPaySuccessData {
         var successAction: SuccessActionProcessed?
         if let successActionTmp = lnUrlPaySuccessData["successAction"] as? [String: Any?] {
             successAction = try asSuccessActionProcessed(successActionProcessed: successActionTmp)
         }
-
-        guard let paymentTmp = lnUrlPaySuccessData["payment"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "LnUrlPaySuccessData"))
-        }
-        let payment = try asPayment(payment: paymentTmp)
-
-        return LnUrlPaySuccessData(successAction: successAction, payment: payment)
+        
+    guard let paymentTmp = lnUrlPaySuccessData["payment"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "LnUrlPaySuccessData"))
     }
+    let payment = try asPayment(payment: paymentTmp)
+    
+    
+    return LnUrlPaySuccessData(successAction: successAction, payment: payment)    
+}
 
-    static func dictionaryOf(lnUrlPaySuccessData: LnUrlPaySuccessData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlPaySuccessData: LnUrlPaySuccessData) -> [String: Any?] {
+    return [
             "successAction": lnUrlPaySuccessData.successAction == nil ? nil : dictionaryOf(successActionProcessed: lnUrlPaySuccessData.successAction!),
-            "payment": dictionaryOf(payment: lnUrlPaySuccessData.payment),
-        ]
-    }
+            "payment": dictionaryOf(payment: lnUrlPaySuccessData.payment),       
+    ]
+}
 
-    static func asLnUrlPaySuccessDataList(arr: [Any]) throws -> [LnUrlPaySuccessData] {
-        var list = [LnUrlPaySuccessData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlPaySuccessData = try asLnUrlPaySuccessData(lnUrlPaySuccessData: val)
-                list.append(lnUrlPaySuccessData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPaySuccessData"))
-            }
+static func asLnUrlPaySuccessDataList(arr: [Any]) throws -> [LnUrlPaySuccessData] {
+    var list = [LnUrlPaySuccessData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlPaySuccessData = try asLnUrlPaySuccessData(lnUrlPaySuccessData: val)
+            list.append(lnUrlPaySuccessData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPaySuccessData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnUrlPaySuccessDataList: [LnUrlPaySuccessData]) -> [Any] {
-        return lnUrlPaySuccessDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlPaySuccessData: v) }
+static func arrayOf(`lnUrlPaySuccessDataList`: [LnUrlPaySuccessData]) -> [Any] {
+    return `lnUrlPaySuccessDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlPaySuccessData: v) }
+}
+static func asLnUrlWithdrawRequest(lnUrlWithdrawRequest: [String: Any?]) throws -> LnUrlWithdrawRequest {
+    guard let dataTmp = lnUrlWithdrawRequest["data"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawRequest"))
     }
-
-    static func asLnUrlWithdrawRequest(lnUrlWithdrawRequest: [String: Any?]) throws -> LnUrlWithdrawRequest {
-        guard let dataTmp = lnUrlWithdrawRequest["data"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawRequest"))
-        }
-        let data = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: dataTmp)
-
-        guard let amountMsat = lnUrlWithdrawRequest["amountMsat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlWithdrawRequest"))
-        }
+    let data = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: dataTmp)
+    
+    guard let amountMsat = lnUrlWithdrawRequest["amountMsat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlWithdrawRequest"))
+    }
         var description: String?
         if hasNonNilKey(data: lnUrlWithdrawRequest, key: "description") {
             guard let descriptionTmp = lnUrlWithdrawRequest["description"] as? String else {
@@ -1730,118 +1704,116 @@ enum BreezSDKLiquidMapper {
             }
             description = descriptionTmp
         }
+    
+    return LnUrlWithdrawRequest(data: data, amountMsat: amountMsat, description: description)    
+}
 
-        return LnUrlWithdrawRequest(data: data, amountMsat: amountMsat, description: description)
-    }
-
-    static func dictionaryOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlWithdrawRequest: LnUrlWithdrawRequest) -> [String: Any?] {
+    return [
             "data": dictionaryOf(lnUrlWithdrawRequestData: lnUrlWithdrawRequest.data),
             "amountMsat": lnUrlWithdrawRequest.amountMsat,
-            "description": lnUrlWithdrawRequest.description == nil ? nil : lnUrlWithdrawRequest.description,
-        ]
+            "description": lnUrlWithdrawRequest.description == nil ? nil : lnUrlWithdrawRequest.description,       
+    ]
+}
+
+static func asLnUrlWithdrawRequestList(arr: [Any]) throws -> [LnUrlWithdrawRequest] {
+    var list = [LnUrlWithdrawRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlWithdrawRequest = try asLnUrlWithdrawRequest(lnUrlWithdrawRequest: val)
+            list.append(lnUrlWithdrawRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequest"))
+        }
     }
+    return list
+}
 
-    static func asLnUrlWithdrawRequestList(arr: [Any]) throws -> [LnUrlWithdrawRequest] {
-        var list = [LnUrlWithdrawRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlWithdrawRequest = try asLnUrlWithdrawRequest(lnUrlWithdrawRequest: val)
-                list.append(lnUrlWithdrawRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequest"))
-            }
-        }
-        return list
+static func arrayOf(`lnUrlWithdrawRequestList`: [LnUrlWithdrawRequest]) -> [Any] {
+    return `lnUrlWithdrawRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlWithdrawRequest: v) }
+}
+static func asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: [String: Any?]) throws -> LnUrlWithdrawRequestData {
+    guard let callback = lnUrlWithdrawRequestData["callback"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlWithdrawRequestData"))
     }
-
-    static func arrayOf(lnUrlWithdrawRequestList: [LnUrlWithdrawRequest]) -> [Any] {
-        return lnUrlWithdrawRequestList.map { v -> [String: Any?] in return dictionaryOf(lnUrlWithdrawRequest: v) }
+    guard let k1 = lnUrlWithdrawRequestData["k1"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlWithdrawRequestData"))
     }
-
-    static func asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: [String: Any?]) throws -> LnUrlWithdrawRequestData {
-        guard let callback = lnUrlWithdrawRequestData["callback"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "callback", typeName: "LnUrlWithdrawRequestData"))
-        }
-        guard let k1 = lnUrlWithdrawRequestData["k1"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "k1", typeName: "LnUrlWithdrawRequestData"))
-        }
-        guard let defaultDescription = lnUrlWithdrawRequestData["defaultDescription"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "defaultDescription", typeName: "LnUrlWithdrawRequestData"))
-        }
-        guard let minWithdrawable = lnUrlWithdrawRequestData["minWithdrawable"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minWithdrawable", typeName: "LnUrlWithdrawRequestData"))
-        }
-        guard let maxWithdrawable = lnUrlWithdrawRequestData["maxWithdrawable"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxWithdrawable", typeName: "LnUrlWithdrawRequestData"))
-        }
-
-        return LnUrlWithdrawRequestData(callback: callback, k1: k1, defaultDescription: defaultDescription, minWithdrawable: minWithdrawable, maxWithdrawable: maxWithdrawable)
+    guard let defaultDescription = lnUrlWithdrawRequestData["defaultDescription"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "defaultDescription", typeName: "LnUrlWithdrawRequestData"))
     }
+    guard let minWithdrawable = lnUrlWithdrawRequestData["minWithdrawable"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minWithdrawable", typeName: "LnUrlWithdrawRequestData"))
+    }
+    guard let maxWithdrawable = lnUrlWithdrawRequestData["maxWithdrawable"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "maxWithdrawable", typeName: "LnUrlWithdrawRequestData"))
+    }
+    
+    return LnUrlWithdrawRequestData(callback: callback, k1: k1, defaultDescription: defaultDescription, minWithdrawable: minWithdrawable, maxWithdrawable: maxWithdrawable)    
+}
 
-    static func dictionaryOf(lnUrlWithdrawRequestData: LnUrlWithdrawRequestData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(lnUrlWithdrawRequestData: LnUrlWithdrawRequestData) -> [String: Any?] {
+    return [
             "callback": lnUrlWithdrawRequestData.callback,
             "k1": lnUrlWithdrawRequestData.k1,
             "defaultDescription": lnUrlWithdrawRequestData.defaultDescription,
             "minWithdrawable": lnUrlWithdrawRequestData.minWithdrawable,
-            "maxWithdrawable": lnUrlWithdrawRequestData.maxWithdrawable,
-        ]
-    }
+            "maxWithdrawable": lnUrlWithdrawRequestData.maxWithdrawable,       
+    ]
+}
 
-    static func asLnUrlWithdrawRequestDataList(arr: [Any]) throws -> [LnUrlWithdrawRequestData] {
-        var list = [LnUrlWithdrawRequestData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlWithdrawRequestData = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: val)
-                list.append(lnUrlWithdrawRequestData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequestData"))
-            }
+static func asLnUrlWithdrawRequestDataList(arr: [Any]) throws -> [LnUrlWithdrawRequestData] {
+    var list = [LnUrlWithdrawRequestData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlWithdrawRequestData = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: val)
+            list.append(lnUrlWithdrawRequestData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawRequestData"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(lnUrlWithdrawRequestDataList: [LnUrlWithdrawRequestData]) -> [Any] {
-        return lnUrlWithdrawRequestDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlWithdrawRequestData: v) }
+static func arrayOf(`lnUrlWithdrawRequestDataList`: [LnUrlWithdrawRequestData]) -> [Any] {
+    return `lnUrlWithdrawRequestDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlWithdrawRequestData: v) }
+}
+static func asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: [String: Any?]) throws -> LnUrlWithdrawSuccessData {
+    guard let invoiceTmp = lnUrlWithdrawSuccessData["invoice"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "LnUrlWithdrawSuccessData"))
     }
+    let invoice = try asLnInvoice(lnInvoice: invoiceTmp)
+    
+    
+    return LnUrlWithdrawSuccessData(invoice: invoice)    
+}
 
-    static func asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: [String: Any?]) throws -> LnUrlWithdrawSuccessData {
-        guard let invoiceTmp = lnUrlWithdrawSuccessData["invoice"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "LnUrlWithdrawSuccessData"))
+static func  dictionaryOf(lnUrlWithdrawSuccessData: LnUrlWithdrawSuccessData) -> [String: Any?] {
+    return [
+            "invoice": dictionaryOf(lnInvoice: lnUrlWithdrawSuccessData.invoice),       
+    ]
+}
+
+static func asLnUrlWithdrawSuccessDataList(arr: [Any]) throws -> [LnUrlWithdrawSuccessData] {
+    var list = [LnUrlWithdrawSuccessData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlWithdrawSuccessData = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: val)
+            list.append(lnUrlWithdrawSuccessData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawSuccessData"))
         }
-        let invoice = try asLnInvoice(lnInvoice: invoiceTmp)
-
-        return LnUrlWithdrawSuccessData(invoice: invoice)
     }
+    return list
+}
 
-    static func dictionaryOf(lnUrlWithdrawSuccessData: LnUrlWithdrawSuccessData) -> [String: Any?] {
-        return [
-            "invoice": dictionaryOf(lnInvoice: lnUrlWithdrawSuccessData.invoice),
-        ]
+static func arrayOf(`lnUrlWithdrawSuccessDataList`: [LnUrlWithdrawSuccessData]) -> [Any] {
+    return `lnUrlWithdrawSuccessDataList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlWithdrawSuccessData: v) }
+}
+static func asLocaleOverrides(localeOverrides: [String: Any?]) throws -> LocaleOverrides {
+    guard let locale = localeOverrides["locale"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocaleOverrides"))
     }
-
-    static func asLnUrlWithdrawSuccessDataList(arr: [Any]) throws -> [LnUrlWithdrawSuccessData] {
-        var list = [LnUrlWithdrawSuccessData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlWithdrawSuccessData = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: val)
-                list.append(lnUrlWithdrawSuccessData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawSuccessData"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(lnUrlWithdrawSuccessDataList: [LnUrlWithdrawSuccessData]) -> [Any] {
-        return lnUrlWithdrawSuccessDataList.map { v -> [String: Any?] in return dictionaryOf(lnUrlWithdrawSuccessData: v) }
-    }
-
-    static func asLocaleOverrides(localeOverrides: [String: Any?]) throws -> LocaleOverrides {
-        guard let locale = localeOverrides["locale"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocaleOverrides"))
-        }
         var spacing: UInt32?
         if hasNonNilKey(data: localeOverrides, key: "spacing") {
             guard let spacingTmp = localeOverrides["spacing"] as? UInt32 else {
@@ -1849,239 +1821,236 @@ enum BreezSDKLiquidMapper {
             }
             spacing = spacingTmp
         }
-        guard let symbolTmp = localeOverrides["symbol"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "symbol", typeName: "LocaleOverrides"))
-        }
-        let symbol = try asSymbol(symbol: symbolTmp)
-
-        return LocaleOverrides(locale: locale, spacing: spacing, symbol: symbol)
+    guard let symbolTmp = localeOverrides["symbol"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "symbol", typeName: "LocaleOverrides"))
     }
+    let symbol = try asSymbol(symbol: symbolTmp)
+    
+    
+    return LocaleOverrides(locale: locale, spacing: spacing, symbol: symbol)    
+}
 
-    static func dictionaryOf(localeOverrides: LocaleOverrides) -> [String: Any?] {
-        return [
+static func  dictionaryOf(localeOverrides: LocaleOverrides) -> [String: Any?] {
+    return [
             "locale": localeOverrides.locale,
             "spacing": localeOverrides.spacing == nil ? nil : localeOverrides.spacing,
-            "symbol": dictionaryOf(symbol: localeOverrides.symbol),
-        ]
-    }
+            "symbol": dictionaryOf(symbol: localeOverrides.symbol),       
+    ]
+}
 
-    static func asLocaleOverridesList(arr: [Any]) throws -> [LocaleOverrides] {
-        var list = [LocaleOverrides]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var localeOverrides = try asLocaleOverrides(localeOverrides: val)
-                list.append(localeOverrides)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LocaleOverrides"))
-            }
+static func asLocaleOverridesList(arr: [Any]) throws -> [LocaleOverrides] {
+    var list = [LocaleOverrides]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var localeOverrides = try asLocaleOverrides(localeOverrides: val)
+            list.append(localeOverrides)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LocaleOverrides"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(localeOverridesList: [LocaleOverrides]) -> [Any] {
-        return localeOverridesList.map { v -> [String: Any?] in return dictionaryOf(localeOverrides: v) }
+static func arrayOf(`localeOverridesList`: [LocaleOverrides]) -> [Any] {
+    return `localeOverridesList`.map { (v) -> [String: Any?] in return dictionaryOf(localeOverrides: v) }
+}
+static func asLocalizedName(localizedName: [String: Any?]) throws -> LocalizedName {
+    guard let locale = localizedName["locale"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocalizedName"))
     }
-
-    static func asLocalizedName(localizedName: [String: Any?]) throws -> LocalizedName {
-        guard let locale = localizedName["locale"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "locale", typeName: "LocalizedName"))
-        }
-        guard let name = localizedName["name"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "LocalizedName"))
-        }
-
-        return LocalizedName(locale: locale, name: name)
+    guard let name = localizedName["name"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "name", typeName: "LocalizedName"))
     }
+    
+    return LocalizedName(locale: locale, name: name)    
+}
 
-    static func dictionaryOf(localizedName: LocalizedName) -> [String: Any?] {
-        return [
+static func  dictionaryOf(localizedName: LocalizedName) -> [String: Any?] {
+    return [
             "locale": localizedName.locale,
-            "name": localizedName.name,
-        ]
-    }
+            "name": localizedName.name,       
+    ]
+}
 
-    static func asLocalizedNameList(arr: [Any]) throws -> [LocalizedName] {
-        var list = [LocalizedName]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var localizedName = try asLocalizedName(localizedName: val)
-                list.append(localizedName)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LocalizedName"))
-            }
+static func asLocalizedNameList(arr: [Any]) throws -> [LocalizedName] {
+    var list = [LocalizedName]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var localizedName = try asLocalizedName(localizedName: val)
+            list.append(localizedName)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LocalizedName"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(localizedNameList: [LocalizedName]) -> [Any] {
-        return localizedNameList.map { v -> [String: Any?] in return dictionaryOf(localizedName: v) }
+static func arrayOf(`localizedNameList`: [LocalizedName]) -> [Any] {
+    return `localizedNameList`.map { (v) -> [String: Any?] in return dictionaryOf(localizedName: v) }
+}
+static func asLogEntry(logEntry: [String: Any?]) throws -> LogEntry {
+    guard let line = logEntry["line"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "line", typeName: "LogEntry"))
     }
-
-    static func asLogEntry(logEntry: [String: Any?]) throws -> LogEntry {
-        guard let line = logEntry["line"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "line", typeName: "LogEntry"))
-        }
-        guard let level = logEntry["level"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "level", typeName: "LogEntry"))
-        }
-
-        return LogEntry(line: line, level: level)
+    guard let level = logEntry["level"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "level", typeName: "LogEntry"))
     }
+    
+    return LogEntry(line: line, level: level)    
+}
 
-    static func dictionaryOf(logEntry: LogEntry) -> [String: Any?] {
-        return [
+static func  dictionaryOf(logEntry: LogEntry) -> [String: Any?] {
+    return [
             "line": logEntry.line,
-            "level": logEntry.level,
-        ]
-    }
+            "level": logEntry.level,       
+    ]
+}
 
-    static func asLogEntryList(arr: [Any]) throws -> [LogEntry] {
-        var list = [LogEntry]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var logEntry = try asLogEntry(logEntry: val)
-                list.append(logEntry)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LogEntry"))
-            }
+static func asLogEntryList(arr: [Any]) throws -> [LogEntry] {
+    var list = [LogEntry]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var logEntry = try asLogEntry(logEntry: val)
+            list.append(logEntry)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LogEntry"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(logEntryList: [LogEntry]) -> [Any] {
-        return logEntryList.map { v -> [String: Any?] in return dictionaryOf(logEntry: v) }
+static func arrayOf(`logEntryList`: [LogEntry]) -> [Any] {
+    return `logEntryList`.map { (v) -> [String: Any?] in return dictionaryOf(logEntry: v) }
+}
+static func asMessageSuccessActionData(messageSuccessActionData: [String: Any?]) throws -> MessageSuccessActionData {
+    guard let message = messageSuccessActionData["message"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "MessageSuccessActionData"))
     }
+    
+    return MessageSuccessActionData(message: message)    
+}
 
-    static func asMessageSuccessActionData(messageSuccessActionData: [String: Any?]) throws -> MessageSuccessActionData {
-        guard let message = messageSuccessActionData["message"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "MessageSuccessActionData"))
+static func  dictionaryOf(messageSuccessActionData: MessageSuccessActionData) -> [String: Any?] {
+    return [
+            "message": messageSuccessActionData.message,       
+    ]
+}
+
+static func asMessageSuccessActionDataList(arr: [Any]) throws -> [MessageSuccessActionData] {
+    var list = [MessageSuccessActionData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var messageSuccessActionData = try asMessageSuccessActionData(messageSuccessActionData: val)
+            list.append(messageSuccessActionData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "MessageSuccessActionData"))
         }
-
-        return MessageSuccessActionData(message: message)
     }
+    return list
+}
 
-    static func dictionaryOf(messageSuccessActionData: MessageSuccessActionData) -> [String: Any?] {
-        return [
-            "message": messageSuccessActionData.message,
-        ]
+static func arrayOf(`messageSuccessActionDataList`: [MessageSuccessActionData]) -> [Any] {
+    return `messageSuccessActionDataList`.map { (v) -> [String: Any?] in return dictionaryOf(messageSuccessActionData: v) }
+}
+static func asOnchainPaymentLimitsResponse(onchainPaymentLimitsResponse: [String: Any?]) throws -> OnchainPaymentLimitsResponse {
+    guard let sendTmp = onchainPaymentLimitsResponse["send"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "send", typeName: "OnchainPaymentLimitsResponse"))
     }
-
-    static func asMessageSuccessActionDataList(arr: [Any]) throws -> [MessageSuccessActionData] {
-        var list = [MessageSuccessActionData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var messageSuccessActionData = try asMessageSuccessActionData(messageSuccessActionData: val)
-                list.append(messageSuccessActionData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "MessageSuccessActionData"))
-            }
-        }
-        return list
+    let send = try asLimits(limits: sendTmp)
+    
+    guard let receiveTmp = onchainPaymentLimitsResponse["receive"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receive", typeName: "OnchainPaymentLimitsResponse"))
     }
+    let receive = try asLimits(limits: receiveTmp)
+    
+    
+    return OnchainPaymentLimitsResponse(send: send, receive: receive)    
+}
 
-    static func arrayOf(messageSuccessActionDataList: [MessageSuccessActionData]) -> [Any] {
-        return messageSuccessActionDataList.map { v -> [String: Any?] in return dictionaryOf(messageSuccessActionData: v) }
-    }
-
-    static func asOnchainPaymentLimitsResponse(onchainPaymentLimitsResponse: [String: Any?]) throws -> OnchainPaymentLimitsResponse {
-        guard let sendTmp = onchainPaymentLimitsResponse["send"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "send", typeName: "OnchainPaymentLimitsResponse"))
-        }
-        let send = try asLimits(limits: sendTmp)
-
-        guard let receiveTmp = onchainPaymentLimitsResponse["receive"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receive", typeName: "OnchainPaymentLimitsResponse"))
-        }
-        let receive = try asLimits(limits: receiveTmp)
-
-        return OnchainPaymentLimitsResponse(send: send, receive: receive)
-    }
-
-    static func dictionaryOf(onchainPaymentLimitsResponse: OnchainPaymentLimitsResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(onchainPaymentLimitsResponse: OnchainPaymentLimitsResponse) -> [String: Any?] {
+    return [
             "send": dictionaryOf(limits: onchainPaymentLimitsResponse.send),
-            "receive": dictionaryOf(limits: onchainPaymentLimitsResponse.receive),
-        ]
-    }
+            "receive": dictionaryOf(limits: onchainPaymentLimitsResponse.receive),       
+    ]
+}
 
-    static func asOnchainPaymentLimitsResponseList(arr: [Any]) throws -> [OnchainPaymentLimitsResponse] {
-        var list = [OnchainPaymentLimitsResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var onchainPaymentLimitsResponse = try asOnchainPaymentLimitsResponse(onchainPaymentLimitsResponse: val)
-                list.append(onchainPaymentLimitsResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "OnchainPaymentLimitsResponse"))
-            }
+static func asOnchainPaymentLimitsResponseList(arr: [Any]) throws -> [OnchainPaymentLimitsResponse] {
+    var list = [OnchainPaymentLimitsResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var onchainPaymentLimitsResponse = try asOnchainPaymentLimitsResponse(onchainPaymentLimitsResponse: val)
+            list.append(onchainPaymentLimitsResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "OnchainPaymentLimitsResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(onchainPaymentLimitsResponseList: [OnchainPaymentLimitsResponse]) -> [Any] {
-        return onchainPaymentLimitsResponseList.map { v -> [String: Any?] in return dictionaryOf(onchainPaymentLimitsResponse: v) }
+static func arrayOf(`onchainPaymentLimitsResponseList`: [OnchainPaymentLimitsResponse]) -> [Any] {
+    return `onchainPaymentLimitsResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(onchainPaymentLimitsResponse: v) }
+}
+static func asPayOnchainRequest(payOnchainRequest: [String: Any?]) throws -> PayOnchainRequest {
+    guard let address = payOnchainRequest["address"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "PayOnchainRequest"))
     }
-
-    static func asPayOnchainRequest(payOnchainRequest: [String: Any?]) throws -> PayOnchainRequest {
-        guard let address = payOnchainRequest["address"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "PayOnchainRequest"))
-        }
-        guard let prepareResponseTmp = payOnchainRequest["prepareResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "PayOnchainRequest"))
-        }
-        let prepareResponse = try asPreparePayOnchainResponse(preparePayOnchainResponse: prepareResponseTmp)
-
-        return PayOnchainRequest(address: address, prepareResponse: prepareResponse)
+    guard let prepareResponseTmp = payOnchainRequest["prepareResponse"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "PayOnchainRequest"))
     }
+    let prepareResponse = try asPreparePayOnchainResponse(preparePayOnchainResponse: prepareResponseTmp)
+    
+    
+    return PayOnchainRequest(address: address, prepareResponse: prepareResponse)    
+}
 
-    static func dictionaryOf(payOnchainRequest: PayOnchainRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(payOnchainRequest: PayOnchainRequest) -> [String: Any?] {
+    return [
             "address": payOnchainRequest.address,
-            "prepareResponse": dictionaryOf(preparePayOnchainResponse: payOnchainRequest.prepareResponse),
-        ]
+            "prepareResponse": dictionaryOf(preparePayOnchainResponse: payOnchainRequest.prepareResponse),       
+    ]
+}
+
+static func asPayOnchainRequestList(arr: [Any]) throws -> [PayOnchainRequest] {
+    var list = [PayOnchainRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var payOnchainRequest = try asPayOnchainRequest(payOnchainRequest: val)
+            list.append(payOnchainRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PayOnchainRequest"))
+        }
     }
+    return list
+}
 
-    static func asPayOnchainRequestList(arr: [Any]) throws -> [PayOnchainRequest] {
-        var list = [PayOnchainRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var payOnchainRequest = try asPayOnchainRequest(payOnchainRequest: val)
-                list.append(payOnchainRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PayOnchainRequest"))
-            }
-        }
-        return list
+static func arrayOf(`payOnchainRequestList`: [PayOnchainRequest]) -> [Any] {
+    return `payOnchainRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(payOnchainRequest: v) }
+}
+static func asPayment(payment: [String: Any?]) throws -> Payment {
+    guard let timestamp = payment["timestamp"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "Payment"))
     }
-
-    static func arrayOf(payOnchainRequestList: [PayOnchainRequest]) -> [Any] {
-        return payOnchainRequestList.map { v -> [String: Any?] in return dictionaryOf(payOnchainRequest: v) }
+    guard let amountSat = payment["amountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "Payment"))
     }
-
-    static func asPayment(payment: [String: Any?]) throws -> Payment {
-        guard let timestamp = payment["timestamp"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "Payment"))
-        }
-        guard let amountSat = payment["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "Payment"))
-        }
-        guard let feesSat = payment["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "Payment"))
-        }
-        guard let paymentTypeTmp = payment["paymentType"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
-        }
-        let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
-
-        guard let statusTmp = payment["status"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
-        }
-        let status = try asPaymentState(paymentState: statusTmp)
-
-        guard let detailsTmp = payment["details"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "Payment"))
-        }
-        let details = try asPaymentDetails(paymentDetails: detailsTmp)
-
+    guard let feesSat = payment["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "Payment"))
+    }
+    guard let paymentTypeTmp = payment["paymentType"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentType", typeName: "Payment"))
+    }
+    let paymentType = try asPaymentType(paymentType: paymentTypeTmp)
+    
+    guard let statusTmp = payment["status"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "status", typeName: "Payment"))
+    }
+    let status = try asPaymentState(paymentState: statusTmp)
+    
+    guard let detailsTmp = payment["details"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "Payment"))
+    }
+    let details = try asPaymentDetails(paymentDetails: detailsTmp)
+    
         var swapperFeesSat: UInt64?
         if hasNonNilKey(data: payment, key: "swapperFeesSat") {
             guard let swapperFeesSatTmp = payment["swapperFeesSat"] as? UInt64 else {
@@ -2110,131 +2079,128 @@ enum BreezSDKLiquidMapper {
             }
             unblindingData = unblindingDataTmp
         }
+    
+    return Payment(timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, destination: destination, txId: txId, unblindingData: unblindingData)    
+}
 
-        return Payment(timestamp: timestamp, amountSat: amountSat, feesSat: feesSat, paymentType: paymentType, status: status, details: details, swapperFeesSat: swapperFeesSat, destination: destination, txId: txId, unblindingData: unblindingData)
-    }
-
-    static func dictionaryOf(payment: Payment) -> [String: Any?] {
-        return [
+static func  dictionaryOf(payment: Payment) -> [String: Any?] {
+    return [
             "timestamp": payment.timestamp,
             "amountSat": payment.amountSat,
             "feesSat": payment.feesSat,
-            "paymentType": valueOf(paymentType: payment.paymentType),
-            "status": valueOf(paymentState: payment.status),
+            "paymentType": valueOf( paymentType: payment.paymentType),
+            "status": valueOf( paymentState: payment.status),
             "details": dictionaryOf(paymentDetails: payment.details),
             "swapperFeesSat": payment.swapperFeesSat == nil ? nil : payment.swapperFeesSat,
             "destination": payment.destination == nil ? nil : payment.destination,
             "txId": payment.txId == nil ? nil : payment.txId,
-            "unblindingData": payment.unblindingData == nil ? nil : payment.unblindingData,
-        ]
-    }
+            "unblindingData": payment.unblindingData == nil ? nil : payment.unblindingData,       
+    ]
+}
 
-    static func asPaymentList(arr: [Any]) throws -> [Payment] {
-        var list = [Payment]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var payment = try asPayment(payment: val)
-                list.append(payment)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Payment"))
-            }
+static func asPaymentList(arr: [Any]) throws -> [Payment] {
+    var list = [Payment]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var payment = try asPayment(payment: val)
+            list.append(payment)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Payment"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(paymentList: [Payment]) -> [Any] {
-        return paymentList.map { v -> [String: Any?] in return dictionaryOf(payment: v) }
+static func arrayOf(`paymentList`: [Payment]) -> [Any] {
+    return `paymentList`.map { (v) -> [String: Any?] in return dictionaryOf(payment: v) }
+}
+static func asPrepareBuyBitcoinRequest(prepareBuyBitcoinRequest: [String: Any?]) throws -> PrepareBuyBitcoinRequest {
+    guard let providerTmp = prepareBuyBitcoinRequest["provider"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "provider", typeName: "PrepareBuyBitcoinRequest"))
     }
+    let provider = try asBuyBitcoinProvider(buyBitcoinProvider: providerTmp)
+    
+    guard let amountSat = prepareBuyBitcoinRequest["amountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PrepareBuyBitcoinRequest"))
+    }
+    
+    return PrepareBuyBitcoinRequest(provider: provider, amountSat: amountSat)    
+}
 
-    static func asPrepareBuyBitcoinRequest(prepareBuyBitcoinRequest: [String: Any?]) throws -> PrepareBuyBitcoinRequest {
-        guard let providerTmp = prepareBuyBitcoinRequest["provider"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "provider", typeName: "PrepareBuyBitcoinRequest"))
+static func  dictionaryOf(prepareBuyBitcoinRequest: PrepareBuyBitcoinRequest) -> [String: Any?] {
+    return [
+            "provider": valueOf( buyBitcoinProvider: prepareBuyBitcoinRequest.provider),
+            "amountSat": prepareBuyBitcoinRequest.amountSat,       
+    ]
+}
+
+static func asPrepareBuyBitcoinRequestList(arr: [Any]) throws -> [PrepareBuyBitcoinRequest] {
+    var list = [PrepareBuyBitcoinRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareBuyBitcoinRequest = try asPrepareBuyBitcoinRequest(prepareBuyBitcoinRequest: val)
+            list.append(prepareBuyBitcoinRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareBuyBitcoinRequest"))
         }
-        let provider = try asBuyBitcoinProvider(buyBitcoinProvider: providerTmp)
-
-        guard let amountSat = prepareBuyBitcoinRequest["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PrepareBuyBitcoinRequest"))
-        }
-
-        return PrepareBuyBitcoinRequest(provider: provider, amountSat: amountSat)
     }
+    return list
+}
 
-    static func dictionaryOf(prepareBuyBitcoinRequest: PrepareBuyBitcoinRequest) -> [String: Any?] {
-        return [
-            "provider": valueOf(buyBitcoinProvider: prepareBuyBitcoinRequest.provider),
-            "amountSat": prepareBuyBitcoinRequest.amountSat,
-        ]
+static func arrayOf(`prepareBuyBitcoinRequestList`: [PrepareBuyBitcoinRequest]) -> [Any] {
+    return `prepareBuyBitcoinRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareBuyBitcoinRequest: v) }
+}
+static func asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: [String: Any?]) throws -> PrepareBuyBitcoinResponse {
+    guard let providerTmp = prepareBuyBitcoinResponse["provider"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "provider", typeName: "PrepareBuyBitcoinResponse"))
     }
-
-    static func asPrepareBuyBitcoinRequestList(arr: [Any]) throws -> [PrepareBuyBitcoinRequest] {
-        var list = [PrepareBuyBitcoinRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareBuyBitcoinRequest = try asPrepareBuyBitcoinRequest(prepareBuyBitcoinRequest: val)
-                list.append(prepareBuyBitcoinRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareBuyBitcoinRequest"))
-            }
-        }
-        return list
+    let provider = try asBuyBitcoinProvider(buyBitcoinProvider: providerTmp)
+    
+    guard let amountSat = prepareBuyBitcoinResponse["amountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PrepareBuyBitcoinResponse"))
     }
-
-    static func arrayOf(prepareBuyBitcoinRequestList: [PrepareBuyBitcoinRequest]) -> [Any] {
-        return prepareBuyBitcoinRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareBuyBitcoinRequest: v) }
+    guard let feesSat = prepareBuyBitcoinResponse["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareBuyBitcoinResponse"))
     }
+    
+    return PrepareBuyBitcoinResponse(provider: provider, amountSat: amountSat, feesSat: feesSat)    
+}
 
-    static func asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: [String: Any?]) throws -> PrepareBuyBitcoinResponse {
-        guard let providerTmp = prepareBuyBitcoinResponse["provider"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "provider", typeName: "PrepareBuyBitcoinResponse"))
-        }
-        let provider = try asBuyBitcoinProvider(buyBitcoinProvider: providerTmp)
-
-        guard let amountSat = prepareBuyBitcoinResponse["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "PrepareBuyBitcoinResponse"))
-        }
-        guard let feesSat = prepareBuyBitcoinResponse["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareBuyBitcoinResponse"))
-        }
-
-        return PrepareBuyBitcoinResponse(provider: provider, amountSat: amountSat, feesSat: feesSat)
-    }
-
-    static func dictionaryOf(prepareBuyBitcoinResponse: PrepareBuyBitcoinResponse) -> [String: Any?] {
-        return [
-            "provider": valueOf(buyBitcoinProvider: prepareBuyBitcoinResponse.provider),
+static func  dictionaryOf(prepareBuyBitcoinResponse: PrepareBuyBitcoinResponse) -> [String: Any?] {
+    return [
+            "provider": valueOf( buyBitcoinProvider: prepareBuyBitcoinResponse.provider),
             "amountSat": prepareBuyBitcoinResponse.amountSat,
-            "feesSat": prepareBuyBitcoinResponse.feesSat,
-        ]
-    }
+            "feesSat": prepareBuyBitcoinResponse.feesSat,       
+    ]
+}
 
-    static func asPrepareBuyBitcoinResponseList(arr: [Any]) throws -> [PrepareBuyBitcoinResponse] {
-        var list = [PrepareBuyBitcoinResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareBuyBitcoinResponse = try asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: val)
-                list.append(prepareBuyBitcoinResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareBuyBitcoinResponse"))
-            }
+static func asPrepareBuyBitcoinResponseList(arr: [Any]) throws -> [PrepareBuyBitcoinResponse] {
+    var list = [PrepareBuyBitcoinResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareBuyBitcoinResponse = try asPrepareBuyBitcoinResponse(prepareBuyBitcoinResponse: val)
+            list.append(prepareBuyBitcoinResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareBuyBitcoinResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareBuyBitcoinResponseList: [PrepareBuyBitcoinResponse]) -> [Any] {
-        return prepareBuyBitcoinResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareBuyBitcoinResponse: v) }
+static func arrayOf(`prepareBuyBitcoinResponseList`: [PrepareBuyBitcoinResponse]) -> [Any] {
+    return `prepareBuyBitcoinResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareBuyBitcoinResponse: v) }
+}
+static func asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: [String: Any?]) throws -> PrepareLnUrlPayRequest {
+    guard let dataTmp = prepareLnUrlPayRequest["data"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayRequest"))
     }
-
-    static func asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: [String: Any?]) throws -> PrepareLnUrlPayRequest {
-        guard let dataTmp = prepareLnUrlPayRequest["data"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayRequest"))
-        }
-        let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
-
-        guard let amountTmp = prepareLnUrlPayRequest["amount"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PrepareLnUrlPayRequest"))
-        }
-        let amount = try asPayAmount(payAmount: amountTmp)
-
+    let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
+    
+    guard let amountTmp = prepareLnUrlPayRequest["amount"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PrepareLnUrlPayRequest"))
+    }
+    let amount = try asPayAmount(payAmount: amountTmp)
+    
         var bip353Address: String?
         if hasNonNilKey(data: prepareLnUrlPayRequest, key: "bip353Address") {
             guard let bip353AddressTmp = prepareLnUrlPayRequest["bip353Address"] as? String else {
@@ -2256,51 +2222,50 @@ enum BreezSDKLiquidMapper {
             }
             validateSuccessActionUrl = validateSuccessActionUrlTmp
         }
+    
+    return PrepareLnUrlPayRequest(data: data, amount: amount, bip353Address: bip353Address, comment: comment, validateSuccessActionUrl: validateSuccessActionUrl)    
+}
 
-        return PrepareLnUrlPayRequest(data: data, amount: amount, bip353Address: bip353Address, comment: comment, validateSuccessActionUrl: validateSuccessActionUrl)
-    }
-
-    static func dictionaryOf(prepareLnUrlPayRequest: PrepareLnUrlPayRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareLnUrlPayRequest: PrepareLnUrlPayRequest) -> [String: Any?] {
+    return [
             "data": dictionaryOf(lnUrlPayRequestData: prepareLnUrlPayRequest.data),
             "amount": dictionaryOf(payAmount: prepareLnUrlPayRequest.amount),
             "bip353Address": prepareLnUrlPayRequest.bip353Address == nil ? nil : prepareLnUrlPayRequest.bip353Address,
             "comment": prepareLnUrlPayRequest.comment == nil ? nil : prepareLnUrlPayRequest.comment,
-            "validateSuccessActionUrl": prepareLnUrlPayRequest.validateSuccessActionUrl == nil ? nil : prepareLnUrlPayRequest.validateSuccessActionUrl,
-        ]
+            "validateSuccessActionUrl": prepareLnUrlPayRequest.validateSuccessActionUrl == nil ? nil : prepareLnUrlPayRequest.validateSuccessActionUrl,       
+    ]
+}
+
+static func asPrepareLnUrlPayRequestList(arr: [Any]) throws -> [PrepareLnUrlPayRequest] {
+    var list = [PrepareLnUrlPayRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareLnUrlPayRequest = try asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: val)
+            list.append(prepareLnUrlPayRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayRequest"))
+        }
     }
+    return list
+}
 
-    static func asPrepareLnUrlPayRequestList(arr: [Any]) throws -> [PrepareLnUrlPayRequest] {
-        var list = [PrepareLnUrlPayRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareLnUrlPayRequest = try asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: val)
-                list.append(prepareLnUrlPayRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayRequest"))
-            }
-        }
-        return list
+static func arrayOf(`prepareLnUrlPayRequestList`: [PrepareLnUrlPayRequest]) -> [Any] {
+    return `prepareLnUrlPayRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareLnUrlPayRequest: v) }
+}
+static func asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: [String: Any?]) throws -> PrepareLnUrlPayResponse {
+    guard let destinationTmp = prepareLnUrlPayResponse["destination"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareLnUrlPayResponse"))
     }
-
-    static func arrayOf(prepareLnUrlPayRequestList: [PrepareLnUrlPayRequest]) -> [Any] {
-        return prepareLnUrlPayRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareLnUrlPayRequest: v) }
+    let destination = try asSendDestination(sendDestination: destinationTmp)
+    
+    guard let feesSat = prepareLnUrlPayResponse["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareLnUrlPayResponse"))
     }
-
-    static func asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: [String: Any?]) throws -> PrepareLnUrlPayResponse {
-        guard let destinationTmp = prepareLnUrlPayResponse["destination"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareLnUrlPayResponse"))
-        }
-        let destination = try asSendDestination(sendDestination: destinationTmp)
-
-        guard let feesSat = prepareLnUrlPayResponse["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareLnUrlPayResponse"))
-        }
-        guard let dataTmp = prepareLnUrlPayResponse["data"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayResponse"))
-        }
-        let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
-
+    guard let dataTmp = prepareLnUrlPayResponse["data"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "PrepareLnUrlPayResponse"))
+    }
+    let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
+    
         var comment: String?
         if hasNonNilKey(data: prepareLnUrlPayResponse, key: "comment") {
             guard let commentTmp = prepareLnUrlPayResponse["comment"] as? String else {
@@ -2312,43 +2277,43 @@ enum BreezSDKLiquidMapper {
         if let successActionTmp = prepareLnUrlPayResponse["successAction"] as? [String: Any?] {
             successAction = try asSuccessAction(successAction: successActionTmp)
         }
+        
+    
+    return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, data: data, comment: comment, successAction: successAction)    
+}
 
-        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, data: data, comment: comment, successAction: successAction)
-    }
-
-    static func dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
+    return [
             "destination": dictionaryOf(sendDestination: prepareLnUrlPayResponse.destination),
             "feesSat": prepareLnUrlPayResponse.feesSat,
             "data": dictionaryOf(lnUrlPayRequestData: prepareLnUrlPayResponse.data),
             "comment": prepareLnUrlPayResponse.comment == nil ? nil : prepareLnUrlPayResponse.comment,
-            "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),
-        ]
-    }
+            "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),       
+    ]
+}
 
-    static func asPrepareLnUrlPayResponseList(arr: [Any]) throws -> [PrepareLnUrlPayResponse] {
-        var list = [PrepareLnUrlPayResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareLnUrlPayResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: val)
-                list.append(prepareLnUrlPayResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayResponse"))
-            }
+static func asPrepareLnUrlPayResponseList(arr: [Any]) throws -> [PrepareLnUrlPayResponse] {
+    var list = [PrepareLnUrlPayResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareLnUrlPayResponse = try asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: val)
+            list.append(prepareLnUrlPayResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareLnUrlPayResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareLnUrlPayResponseList: [PrepareLnUrlPayResponse]) -> [Any] {
-        return prepareLnUrlPayResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareLnUrlPayResponse: v) }
+static func arrayOf(`prepareLnUrlPayResponseList`: [PrepareLnUrlPayResponse]) -> [Any] {
+    return `prepareLnUrlPayResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareLnUrlPayResponse: v) }
+}
+static func asPreparePayOnchainRequest(preparePayOnchainRequest: [String: Any?]) throws -> PreparePayOnchainRequest {
+    guard let amountTmp = preparePayOnchainRequest["amount"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PreparePayOnchainRequest"))
     }
-
-    static func asPreparePayOnchainRequest(preparePayOnchainRequest: [String: Any?]) throws -> PreparePayOnchainRequest {
-        guard let amountTmp = preparePayOnchainRequest["amount"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PreparePayOnchainRequest"))
-        }
-        let amount = try asPayAmount(payAmount: amountTmp)
-
+    let amount = try asPayAmount(payAmount: amountTmp)
+    
         var feeRateSatPerVbyte: UInt32?
         if hasNonNilKey(data: preparePayOnchainRequest, key: "feeRateSatPerVbyte") {
             guard let feeRateSatPerVbyteTmp = preparePayOnchainRequest["feeRateSatPerVbyte"] as? UInt32 else {
@@ -2356,125 +2321,123 @@ enum BreezSDKLiquidMapper {
             }
             feeRateSatPerVbyte = feeRateSatPerVbyteTmp
         }
+    
+    return PreparePayOnchainRequest(amount: amount, feeRateSatPerVbyte: feeRateSatPerVbyte)    
+}
 
-        return PreparePayOnchainRequest(amount: amount, feeRateSatPerVbyte: feeRateSatPerVbyte)
-    }
-
-    static func dictionaryOf(preparePayOnchainRequest: PreparePayOnchainRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(preparePayOnchainRequest: PreparePayOnchainRequest) -> [String: Any?] {
+    return [
             "amount": dictionaryOf(payAmount: preparePayOnchainRequest.amount),
-            "feeRateSatPerVbyte": preparePayOnchainRequest.feeRateSatPerVbyte == nil ? nil : preparePayOnchainRequest.feeRateSatPerVbyte,
-        ]
-    }
+            "feeRateSatPerVbyte": preparePayOnchainRequest.feeRateSatPerVbyte == nil ? nil : preparePayOnchainRequest.feeRateSatPerVbyte,       
+    ]
+}
 
-    static func asPreparePayOnchainRequestList(arr: [Any]) throws -> [PreparePayOnchainRequest] {
-        var list = [PreparePayOnchainRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var preparePayOnchainRequest = try asPreparePayOnchainRequest(preparePayOnchainRequest: val)
-                list.append(preparePayOnchainRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PreparePayOnchainRequest"))
-            }
+static func asPreparePayOnchainRequestList(arr: [Any]) throws -> [PreparePayOnchainRequest] {
+    var list = [PreparePayOnchainRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var preparePayOnchainRequest = try asPreparePayOnchainRequest(preparePayOnchainRequest: val)
+            list.append(preparePayOnchainRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PreparePayOnchainRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(preparePayOnchainRequestList: [PreparePayOnchainRequest]) -> [Any] {
-        return preparePayOnchainRequestList.map { v -> [String: Any?] in return dictionaryOf(preparePayOnchainRequest: v) }
+static func arrayOf(`preparePayOnchainRequestList`: [PreparePayOnchainRequest]) -> [Any] {
+    return `preparePayOnchainRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(preparePayOnchainRequest: v) }
+}
+static func asPreparePayOnchainResponse(preparePayOnchainResponse: [String: Any?]) throws -> PreparePayOnchainResponse {
+    guard let receiverAmountSat = preparePayOnchainResponse["receiverAmountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "PreparePayOnchainResponse"))
     }
-
-    static func asPreparePayOnchainResponse(preparePayOnchainResponse: [String: Any?]) throws -> PreparePayOnchainResponse {
-        guard let receiverAmountSat = preparePayOnchainResponse["receiverAmountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "PreparePayOnchainResponse"))
-        }
-        guard let claimFeesSat = preparePayOnchainResponse["claimFeesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "claimFeesSat", typeName: "PreparePayOnchainResponse"))
-        }
-        guard let totalFeesSat = preparePayOnchainResponse["totalFeesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "totalFeesSat", typeName: "PreparePayOnchainResponse"))
-        }
-
-        return PreparePayOnchainResponse(receiverAmountSat: receiverAmountSat, claimFeesSat: claimFeesSat, totalFeesSat: totalFeesSat)
+    guard let claimFeesSat = preparePayOnchainResponse["claimFeesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "claimFeesSat", typeName: "PreparePayOnchainResponse"))
     }
+    guard let totalFeesSat = preparePayOnchainResponse["totalFeesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "totalFeesSat", typeName: "PreparePayOnchainResponse"))
+    }
+    
+    return PreparePayOnchainResponse(receiverAmountSat: receiverAmountSat, claimFeesSat: claimFeesSat, totalFeesSat: totalFeesSat)    
+}
 
-    static func dictionaryOf(preparePayOnchainResponse: PreparePayOnchainResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(preparePayOnchainResponse: PreparePayOnchainResponse) -> [String: Any?] {
+    return [
             "receiverAmountSat": preparePayOnchainResponse.receiverAmountSat,
             "claimFeesSat": preparePayOnchainResponse.claimFeesSat,
-            "totalFeesSat": preparePayOnchainResponse.totalFeesSat,
-        ]
-    }
+            "totalFeesSat": preparePayOnchainResponse.totalFeesSat,       
+    ]
+}
 
-    static func asPreparePayOnchainResponseList(arr: [Any]) throws -> [PreparePayOnchainResponse] {
-        var list = [PreparePayOnchainResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var preparePayOnchainResponse = try asPreparePayOnchainResponse(preparePayOnchainResponse: val)
-                list.append(preparePayOnchainResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PreparePayOnchainResponse"))
-            }
+static func asPreparePayOnchainResponseList(arr: [Any]) throws -> [PreparePayOnchainResponse] {
+    var list = [PreparePayOnchainResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var preparePayOnchainResponse = try asPreparePayOnchainResponse(preparePayOnchainResponse: val)
+            list.append(preparePayOnchainResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PreparePayOnchainResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(preparePayOnchainResponseList: [PreparePayOnchainResponse]) -> [Any] {
-        return preparePayOnchainResponseList.map { v -> [String: Any?] in return dictionaryOf(preparePayOnchainResponse: v) }
+static func arrayOf(`preparePayOnchainResponseList`: [PreparePayOnchainResponse]) -> [Any] {
+    return `preparePayOnchainResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(preparePayOnchainResponse: v) }
+}
+static func asPrepareReceiveRequest(prepareReceiveRequest: [String: Any?]) throws -> PrepareReceiveRequest {
+    guard let paymentMethodTmp = prepareReceiveRequest["paymentMethod"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveRequest"))
     }
-
-    static func asPrepareReceiveRequest(prepareReceiveRequest: [String: Any?]) throws -> PrepareReceiveRequest {
-        guard let paymentMethodTmp = prepareReceiveRequest["paymentMethod"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveRequest"))
-        }
-        let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
-
+    let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
+    
         var amount: ReceiveAmount?
         if let amountTmp = prepareReceiveRequest["amount"] as? [String: Any?] {
             amount = try asReceiveAmount(receiveAmount: amountTmp)
         }
+        
+    
+    return PrepareReceiveRequest(paymentMethod: paymentMethod, amount: amount)    
+}
 
-        return PrepareReceiveRequest(paymentMethod: paymentMethod, amount: amount)
-    }
+static func  dictionaryOf(prepareReceiveRequest: PrepareReceiveRequest) -> [String: Any?] {
+    return [
+            "paymentMethod": valueOf( paymentMethod: prepareReceiveRequest.paymentMethod),
+            "amount": prepareReceiveRequest.amount == nil ? nil : dictionaryOf(receiveAmount: prepareReceiveRequest.amount!),       
+    ]
+}
 
-    static func dictionaryOf(prepareReceiveRequest: PrepareReceiveRequest) -> [String: Any?] {
-        return [
-            "paymentMethod": valueOf(paymentMethod: prepareReceiveRequest.paymentMethod),
-            "amount": prepareReceiveRequest.amount == nil ? nil : dictionaryOf(receiveAmount: prepareReceiveRequest.amount!),
-        ]
-    }
-
-    static func asPrepareReceiveRequestList(arr: [Any]) throws -> [PrepareReceiveRequest] {
-        var list = [PrepareReceiveRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareReceiveRequest = try asPrepareReceiveRequest(prepareReceiveRequest: val)
-                list.append(prepareReceiveRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareReceiveRequest"))
-            }
+static func asPrepareReceiveRequestList(arr: [Any]) throws -> [PrepareReceiveRequest] {
+    var list = [PrepareReceiveRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareReceiveRequest = try asPrepareReceiveRequest(prepareReceiveRequest: val)
+            list.append(prepareReceiveRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareReceiveRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareReceiveRequestList: [PrepareReceiveRequest]) -> [Any] {
-        return prepareReceiveRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareReceiveRequest: v) }
+static func arrayOf(`prepareReceiveRequestList`: [PrepareReceiveRequest]) -> [Any] {
+    return `prepareReceiveRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareReceiveRequest: v) }
+}
+static func asPrepareReceiveResponse(prepareReceiveResponse: [String: Any?]) throws -> PrepareReceiveResponse {
+    guard let paymentMethodTmp = prepareReceiveResponse["paymentMethod"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveResponse"))
     }
-
-    static func asPrepareReceiveResponse(prepareReceiveResponse: [String: Any?]) throws -> PrepareReceiveResponse {
-        guard let paymentMethodTmp = prepareReceiveResponse["paymentMethod"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentMethod", typeName: "PrepareReceiveResponse"))
-        }
-        let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
-
-        guard let feesSat = prepareReceiveResponse["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareReceiveResponse"))
-        }
+    let paymentMethod = try asPaymentMethod(paymentMethod: paymentMethodTmp)
+    
+    guard let feesSat = prepareReceiveResponse["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareReceiveResponse"))
+    }
         var amount: ReceiveAmount?
         if let amountTmp = prepareReceiveResponse["amount"] as? [String: Any?] {
             amount = try asReceiveAmount(receiveAmount: amountTmp)
         }
-
+        
         var minPayerAmountSat: UInt64?
         if hasNonNilKey(data: prepareReceiveResponse, key: "minPayerAmountSat") {
             guard let minPayerAmountSatTmp = prepareReceiveResponse["minPayerAmountSat"] as? UInt64 else {
@@ -2496,84 +2459,82 @@ enum BreezSDKLiquidMapper {
             }
             swapperFeerate = swapperFeerateTmp
         }
+    
+    return PrepareReceiveResponse(paymentMethod: paymentMethod, feesSat: feesSat, amount: amount, minPayerAmountSat: minPayerAmountSat, maxPayerAmountSat: maxPayerAmountSat, swapperFeerate: swapperFeerate)    
+}
 
-        return PrepareReceiveResponse(paymentMethod: paymentMethod, feesSat: feesSat, amount: amount, minPayerAmountSat: minPayerAmountSat, maxPayerAmountSat: maxPayerAmountSat, swapperFeerate: swapperFeerate)
-    }
-
-    static func dictionaryOf(prepareReceiveResponse: PrepareReceiveResponse) -> [String: Any?] {
-        return [
-            "paymentMethod": valueOf(paymentMethod: prepareReceiveResponse.paymentMethod),
+static func  dictionaryOf(prepareReceiveResponse: PrepareReceiveResponse) -> [String: Any?] {
+    return [
+            "paymentMethod": valueOf( paymentMethod: prepareReceiveResponse.paymentMethod),
             "feesSat": prepareReceiveResponse.feesSat,
             "amount": prepareReceiveResponse.amount == nil ? nil : dictionaryOf(receiveAmount: prepareReceiveResponse.amount!),
             "minPayerAmountSat": prepareReceiveResponse.minPayerAmountSat == nil ? nil : prepareReceiveResponse.minPayerAmountSat,
             "maxPayerAmountSat": prepareReceiveResponse.maxPayerAmountSat == nil ? nil : prepareReceiveResponse.maxPayerAmountSat,
-            "swapperFeerate": prepareReceiveResponse.swapperFeerate == nil ? nil : prepareReceiveResponse.swapperFeerate,
-        ]
-    }
+            "swapperFeerate": prepareReceiveResponse.swapperFeerate == nil ? nil : prepareReceiveResponse.swapperFeerate,       
+    ]
+}
 
-    static func asPrepareReceiveResponseList(arr: [Any]) throws -> [PrepareReceiveResponse] {
-        var list = [PrepareReceiveResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareReceiveResponse = try asPrepareReceiveResponse(prepareReceiveResponse: val)
-                list.append(prepareReceiveResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareReceiveResponse"))
-            }
+static func asPrepareReceiveResponseList(arr: [Any]) throws -> [PrepareReceiveResponse] {
+    var list = [PrepareReceiveResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareReceiveResponse = try asPrepareReceiveResponse(prepareReceiveResponse: val)
+            list.append(prepareReceiveResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareReceiveResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareReceiveResponseList: [PrepareReceiveResponse]) -> [Any] {
-        return prepareReceiveResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareReceiveResponse: v) }
+static func arrayOf(`prepareReceiveResponseList`: [PrepareReceiveResponse]) -> [Any] {
+    return `prepareReceiveResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareReceiveResponse: v) }
+}
+static func asPrepareRefundRequest(prepareRefundRequest: [String: Any?]) throws -> PrepareRefundRequest {
+    guard let swapAddress = prepareRefundRequest["swapAddress"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "PrepareRefundRequest"))
     }
-
-    static func asPrepareRefundRequest(prepareRefundRequest: [String: Any?]) throws -> PrepareRefundRequest {
-        guard let swapAddress = prepareRefundRequest["swapAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "PrepareRefundRequest"))
-        }
-        guard let refundAddress = prepareRefundRequest["refundAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundAddress", typeName: "PrepareRefundRequest"))
-        }
-        guard let feeRateSatPerVbyte = prepareRefundRequest["feeRateSatPerVbyte"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeRateSatPerVbyte", typeName: "PrepareRefundRequest"))
-        }
-
-        return PrepareRefundRequest(swapAddress: swapAddress, refundAddress: refundAddress, feeRateSatPerVbyte: feeRateSatPerVbyte)
+    guard let refundAddress = prepareRefundRequest["refundAddress"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundAddress", typeName: "PrepareRefundRequest"))
     }
+    guard let feeRateSatPerVbyte = prepareRefundRequest["feeRateSatPerVbyte"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeRateSatPerVbyte", typeName: "PrepareRefundRequest"))
+    }
+    
+    return PrepareRefundRequest(swapAddress: swapAddress, refundAddress: refundAddress, feeRateSatPerVbyte: feeRateSatPerVbyte)    
+}
 
-    static func dictionaryOf(prepareRefundRequest: PrepareRefundRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareRefundRequest: PrepareRefundRequest) -> [String: Any?] {
+    return [
             "swapAddress": prepareRefundRequest.swapAddress,
             "refundAddress": prepareRefundRequest.refundAddress,
-            "feeRateSatPerVbyte": prepareRefundRequest.feeRateSatPerVbyte,
-        ]
-    }
+            "feeRateSatPerVbyte": prepareRefundRequest.feeRateSatPerVbyte,       
+    ]
+}
 
-    static func asPrepareRefundRequestList(arr: [Any]) throws -> [PrepareRefundRequest] {
-        var list = [PrepareRefundRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareRefundRequest = try asPrepareRefundRequest(prepareRefundRequest: val)
-                list.append(prepareRefundRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundRequest"))
-            }
+static func asPrepareRefundRequestList(arr: [Any]) throws -> [PrepareRefundRequest] {
+    var list = [PrepareRefundRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareRefundRequest = try asPrepareRefundRequest(prepareRefundRequest: val)
+            list.append(prepareRefundRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareRefundRequestList: [PrepareRefundRequest]) -> [Any] {
-        return prepareRefundRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareRefundRequest: v) }
+static func arrayOf(`prepareRefundRequestList`: [PrepareRefundRequest]) -> [Any] {
+    return `prepareRefundRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareRefundRequest: v) }
+}
+static func asPrepareRefundResponse(prepareRefundResponse: [String: Any?]) throws -> PrepareRefundResponse {
+    guard let txVsize = prepareRefundResponse["txVsize"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txVsize", typeName: "PrepareRefundResponse"))
     }
-
-    static func asPrepareRefundResponse(prepareRefundResponse: [String: Any?]) throws -> PrepareRefundResponse {
-        guard let txVsize = prepareRefundResponse["txVsize"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txVsize", typeName: "PrepareRefundResponse"))
-        }
-        guard let txFeeSat = prepareRefundResponse["txFeeSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRefundResponse"))
-        }
+    guard let txFeeSat = prepareRefundResponse["txFeeSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRefundResponse"))
+    }
         var lastRefundTxId: String?
         if hasNonNilKey(data: prepareRefundResponse, key: "lastRefundTxId") {
             guard let lastRefundTxIdTmp = prepareRefundResponse["lastRefundTxId"] as? String else {
@@ -2581,149 +2542,146 @@ enum BreezSDKLiquidMapper {
             }
             lastRefundTxId = lastRefundTxIdTmp
         }
+    
+    return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, lastRefundTxId: lastRefundTxId)    
+}
 
-        return PrepareRefundResponse(txVsize: txVsize, txFeeSat: txFeeSat, lastRefundTxId: lastRefundTxId)
-    }
-
-    static func dictionaryOf(prepareRefundResponse: PrepareRefundResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareRefundResponse: PrepareRefundResponse) -> [String: Any?] {
+    return [
             "txVsize": prepareRefundResponse.txVsize,
             "txFeeSat": prepareRefundResponse.txFeeSat,
-            "lastRefundTxId": prepareRefundResponse.lastRefundTxId == nil ? nil : prepareRefundResponse.lastRefundTxId,
-        ]
-    }
+            "lastRefundTxId": prepareRefundResponse.lastRefundTxId == nil ? nil : prepareRefundResponse.lastRefundTxId,       
+    ]
+}
 
-    static func asPrepareRefundResponseList(arr: [Any]) throws -> [PrepareRefundResponse] {
-        var list = [PrepareRefundResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareRefundResponse = try asPrepareRefundResponse(prepareRefundResponse: val)
-                list.append(prepareRefundResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundResponse"))
-            }
+static func asPrepareRefundResponseList(arr: [Any]) throws -> [PrepareRefundResponse] {
+    var list = [PrepareRefundResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareRefundResponse = try asPrepareRefundResponse(prepareRefundResponse: val)
+            list.append(prepareRefundResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareRefundResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareRefundResponseList: [PrepareRefundResponse]) -> [Any] {
-        return prepareRefundResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareRefundResponse: v) }
+static func arrayOf(`prepareRefundResponseList`: [PrepareRefundResponse]) -> [Any] {
+    return `prepareRefundResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareRefundResponse: v) }
+}
+static func asPrepareSendRequest(prepareSendRequest: [String: Any?]) throws -> PrepareSendRequest {
+    guard let destination = prepareSendRequest["destination"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendRequest"))
     }
-
-    static func asPrepareSendRequest(prepareSendRequest: [String: Any?]) throws -> PrepareSendRequest {
-        guard let destination = prepareSendRequest["destination"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendRequest"))
-        }
         var amount: PayAmount?
         if let amountTmp = prepareSendRequest["amount"] as? [String: Any?] {
             amount = try asPayAmount(payAmount: amountTmp)
         }
+        
+    
+    return PrepareSendRequest(destination: destination, amount: amount)    
+}
 
-        return PrepareSendRequest(destination: destination, amount: amount)
-    }
-
-    static func dictionaryOf(prepareSendRequest: PrepareSendRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareSendRequest: PrepareSendRequest) -> [String: Any?] {
+    return [
             "destination": prepareSendRequest.destination,
-            "amount": prepareSendRequest.amount == nil ? nil : dictionaryOf(payAmount: prepareSendRequest.amount!),
-        ]
-    }
+            "amount": prepareSendRequest.amount == nil ? nil : dictionaryOf(payAmount: prepareSendRequest.amount!),       
+    ]
+}
 
-    static func asPrepareSendRequestList(arr: [Any]) throws -> [PrepareSendRequest] {
-        var list = [PrepareSendRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareSendRequest = try asPrepareSendRequest(prepareSendRequest: val)
-                list.append(prepareSendRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSendRequest"))
-            }
+static func asPrepareSendRequestList(arr: [Any]) throws -> [PrepareSendRequest] {
+    var list = [PrepareSendRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareSendRequest = try asPrepareSendRequest(prepareSendRequest: val)
+            list.append(prepareSendRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSendRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareSendRequestList: [PrepareSendRequest]) -> [Any] {
-        return prepareSendRequestList.map { v -> [String: Any?] in return dictionaryOf(prepareSendRequest: v) }
+static func arrayOf(`prepareSendRequestList`: [PrepareSendRequest]) -> [Any] {
+    return `prepareSendRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareSendRequest: v) }
+}
+static func asPrepareSendResponse(prepareSendResponse: [String: Any?]) throws -> PrepareSendResponse {
+    guard let destinationTmp = prepareSendResponse["destination"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendResponse"))
     }
-
-    static func asPrepareSendResponse(prepareSendResponse: [String: Any?]) throws -> PrepareSendResponse {
-        guard let destinationTmp = prepareSendResponse["destination"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PrepareSendResponse"))
-        }
-        let destination = try asSendDestination(sendDestination: destinationTmp)
-
-        guard let feesSat = prepareSendResponse["feesSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareSendResponse"))
-        }
-
-        return PrepareSendResponse(destination: destination, feesSat: feesSat)
+    let destination = try asSendDestination(sendDestination: destinationTmp)
+    
+    guard let feesSat = prepareSendResponse["feesSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareSendResponse"))
     }
+    
+    return PrepareSendResponse(destination: destination, feesSat: feesSat)    
+}
 
-    static func dictionaryOf(prepareSendResponse: PrepareSendResponse) -> [String: Any?] {
-        return [
+static func  dictionaryOf(prepareSendResponse: PrepareSendResponse) -> [String: Any?] {
+    return [
             "destination": dictionaryOf(sendDestination: prepareSendResponse.destination),
-            "feesSat": prepareSendResponse.feesSat,
-        ]
-    }
+            "feesSat": prepareSendResponse.feesSat,       
+    ]
+}
 
-    static func asPrepareSendResponseList(arr: [Any]) throws -> [PrepareSendResponse] {
-        var list = [PrepareSendResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var prepareSendResponse = try asPrepareSendResponse(prepareSendResponse: val)
-                list.append(prepareSendResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSendResponse"))
-            }
+static func asPrepareSendResponseList(arr: [Any]) throws -> [PrepareSendResponse] {
+    var list = [PrepareSendResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var prepareSendResponse = try asPrepareSendResponse(prepareSendResponse: val)
+            list.append(prepareSendResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PrepareSendResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(prepareSendResponseList: [PrepareSendResponse]) -> [Any] {
-        return prepareSendResponseList.map { v -> [String: Any?] in return dictionaryOf(prepareSendResponse: v) }
+static func arrayOf(`prepareSendResponseList`: [PrepareSendResponse]) -> [Any] {
+    return `prepareSendResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(prepareSendResponse: v) }
+}
+static func asRate(rate: [String: Any?]) throws -> Rate {
+    guard let coin = rate["coin"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "coin", typeName: "Rate"))
     }
-
-    static func asRate(rate: [String: Any?]) throws -> Rate {
-        guard let coin = rate["coin"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "coin", typeName: "Rate"))
-        }
-        guard let value = rate["value"] as? Double else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "value", typeName: "Rate"))
-        }
-
-        return Rate(coin: coin, value: value)
+    guard let value = rate["value"] as? Double else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "value", typeName: "Rate"))
     }
+    
+    return Rate(coin: coin, value: value)    
+}
 
-    static func dictionaryOf(rate: Rate) -> [String: Any?] {
-        return [
+static func  dictionaryOf(rate: Rate) -> [String: Any?] {
+    return [
             "coin": rate.coin,
-            "value": rate.value,
-        ]
-    }
+            "value": rate.value,       
+    ]
+}
 
-    static func asRateList(arr: [Any]) throws -> [Rate] {
-        var list = [Rate]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var rate = try asRate(rate: val)
-                list.append(rate)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Rate"))
-            }
+static func asRateList(arr: [Any]) throws -> [Rate] {
+    var list = [Rate]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var rate = try asRate(rate: val)
+            list.append(rate)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Rate"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(rateList: [Rate]) -> [Any] {
-        return rateList.map { v -> [String: Any?] in return dictionaryOf(rate: v) }
+static func arrayOf(`rateList`: [Rate]) -> [Any] {
+    return `rateList`.map { (v) -> [String: Any?] in return dictionaryOf(rate: v) }
+}
+static func asReceivePaymentRequest(receivePaymentRequest: [String: Any?]) throws -> ReceivePaymentRequest {
+    guard let prepareResponseTmp = receivePaymentRequest["prepareResponse"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "ReceivePaymentRequest"))
     }
-
-    static func asReceivePaymentRequest(receivePaymentRequest: [String: Any?]) throws -> ReceivePaymentRequest {
-        guard let prepareResponseTmp = receivePaymentRequest["prepareResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "ReceivePaymentRequest"))
-        }
-        let prepareResponse = try asPrepareReceiveResponse(prepareReceiveResponse: prepareResponseTmp)
-
+    let prepareResponse = try asPrepareReceiveResponse(prepareReceiveResponse: prepareResponseTmp)
+    
         var description: String?
         if hasNonNilKey(data: receivePaymentRequest, key: "description") {
             guard let descriptionTmp = receivePaymentRequest["description"] as? String else {
@@ -2738,193 +2696,188 @@ enum BreezSDKLiquidMapper {
             }
             useDescriptionHash = useDescriptionHashTmp
         }
+    
+    return ReceivePaymentRequest(prepareResponse: prepareResponse, description: description, useDescriptionHash: useDescriptionHash)    
+}
 
-        return ReceivePaymentRequest(prepareResponse: prepareResponse, description: description, useDescriptionHash: useDescriptionHash)
-    }
-
-    static func dictionaryOf(receivePaymentRequest: ReceivePaymentRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(receivePaymentRequest: ReceivePaymentRequest) -> [String: Any?] {
+    return [
             "prepareResponse": dictionaryOf(prepareReceiveResponse: receivePaymentRequest.prepareResponse),
             "description": receivePaymentRequest.description == nil ? nil : receivePaymentRequest.description,
-            "useDescriptionHash": receivePaymentRequest.useDescriptionHash == nil ? nil : receivePaymentRequest.useDescriptionHash,
-        ]
-    }
+            "useDescriptionHash": receivePaymentRequest.useDescriptionHash == nil ? nil : receivePaymentRequest.useDescriptionHash,       
+    ]
+}
 
-    static func asReceivePaymentRequestList(arr: [Any]) throws -> [ReceivePaymentRequest] {
-        var list = [ReceivePaymentRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var receivePaymentRequest = try asReceivePaymentRequest(receivePaymentRequest: val)
-                list.append(receivePaymentRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentRequest"))
-            }
+static func asReceivePaymentRequestList(arr: [Any]) throws -> [ReceivePaymentRequest] {
+    var list = [ReceivePaymentRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var receivePaymentRequest = try asReceivePaymentRequest(receivePaymentRequest: val)
+            list.append(receivePaymentRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(receivePaymentRequestList: [ReceivePaymentRequest]) -> [Any] {
-        return receivePaymentRequestList.map { v -> [String: Any?] in return dictionaryOf(receivePaymentRequest: v) }
+static func arrayOf(`receivePaymentRequestList`: [ReceivePaymentRequest]) -> [Any] {
+    return `receivePaymentRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(receivePaymentRequest: v) }
+}
+static func asReceivePaymentResponse(receivePaymentResponse: [String: Any?]) throws -> ReceivePaymentResponse {
+    guard let destination = receivePaymentResponse["destination"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "ReceivePaymentResponse"))
     }
+    
+    return ReceivePaymentResponse(destination: destination)    
+}
 
-    static func asReceivePaymentResponse(receivePaymentResponse: [String: Any?]) throws -> ReceivePaymentResponse {
-        guard let destination = receivePaymentResponse["destination"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "ReceivePaymentResponse"))
+static func  dictionaryOf(receivePaymentResponse: ReceivePaymentResponse) -> [String: Any?] {
+    return [
+            "destination": receivePaymentResponse.destination,       
+    ]
+}
+
+static func asReceivePaymentResponseList(arr: [Any]) throws -> [ReceivePaymentResponse] {
+    var list = [ReceivePaymentResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var receivePaymentResponse = try asReceivePaymentResponse(receivePaymentResponse: val)
+            list.append(receivePaymentResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentResponse"))
         }
-
-        return ReceivePaymentResponse(destination: destination)
     }
+    return list
+}
 
-    static func dictionaryOf(receivePaymentResponse: ReceivePaymentResponse) -> [String: Any?] {
-        return [
-            "destination": receivePaymentResponse.destination,
-        ]
+static func arrayOf(`receivePaymentResponseList`: [ReceivePaymentResponse]) -> [Any] {
+    return `receivePaymentResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(receivePaymentResponse: v) }
+}
+static func asRecommendedFees(recommendedFees: [String: Any?]) throws -> RecommendedFees {
+    guard let fastestFee = recommendedFees["fastestFee"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fastestFee", typeName: "RecommendedFees"))
     }
-
-    static func asReceivePaymentResponseList(arr: [Any]) throws -> [ReceivePaymentResponse] {
-        var list = [ReceivePaymentResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var receivePaymentResponse = try asReceivePaymentResponse(receivePaymentResponse: val)
-                list.append(receivePaymentResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceivePaymentResponse"))
-            }
-        }
-        return list
+    guard let halfHourFee = recommendedFees["halfHourFee"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "halfHourFee", typeName: "RecommendedFees"))
     }
-
-    static func arrayOf(receivePaymentResponseList: [ReceivePaymentResponse]) -> [Any] {
-        return receivePaymentResponseList.map { v -> [String: Any?] in return dictionaryOf(receivePaymentResponse: v) }
+    guard let hourFee = recommendedFees["hourFee"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hourFee", typeName: "RecommendedFees"))
     }
-
-    static func asRecommendedFees(recommendedFees: [String: Any?]) throws -> RecommendedFees {
-        guard let fastestFee = recommendedFees["fastestFee"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fastestFee", typeName: "RecommendedFees"))
-        }
-        guard let halfHourFee = recommendedFees["halfHourFee"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "halfHourFee", typeName: "RecommendedFees"))
-        }
-        guard let hourFee = recommendedFees["hourFee"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hourFee", typeName: "RecommendedFees"))
-        }
-        guard let economyFee = recommendedFees["economyFee"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "economyFee", typeName: "RecommendedFees"))
-        }
-        guard let minimumFee = recommendedFees["minimumFee"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minimumFee", typeName: "RecommendedFees"))
-        }
-
-        return RecommendedFees(fastestFee: fastestFee, halfHourFee: halfHourFee, hourFee: hourFee, economyFee: economyFee, minimumFee: minimumFee)
+    guard let economyFee = recommendedFees["economyFee"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "economyFee", typeName: "RecommendedFees"))
     }
+    guard let minimumFee = recommendedFees["minimumFee"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "minimumFee", typeName: "RecommendedFees"))
+    }
+    
+    return RecommendedFees(fastestFee: fastestFee, halfHourFee: halfHourFee, hourFee: hourFee, economyFee: economyFee, minimumFee: minimumFee)    
+}
 
-    static func dictionaryOf(recommendedFees: RecommendedFees) -> [String: Any?] {
-        return [
+static func  dictionaryOf(recommendedFees: RecommendedFees) -> [String: Any?] {
+    return [
             "fastestFee": recommendedFees.fastestFee,
             "halfHourFee": recommendedFees.halfHourFee,
             "hourFee": recommendedFees.hourFee,
             "economyFee": recommendedFees.economyFee,
-            "minimumFee": recommendedFees.minimumFee,
-        ]
-    }
+            "minimumFee": recommendedFees.minimumFee,       
+    ]
+}
 
-    static func asRecommendedFeesList(arr: [Any]) throws -> [RecommendedFees] {
-        var list = [RecommendedFees]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var recommendedFees = try asRecommendedFees(recommendedFees: val)
-                list.append(recommendedFees)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RecommendedFees"))
-            }
+static func asRecommendedFeesList(arr: [Any]) throws -> [RecommendedFees] {
+    var list = [RecommendedFees]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var recommendedFees = try asRecommendedFees(recommendedFees: val)
+            list.append(recommendedFees)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RecommendedFees"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(recommendedFeesList: [RecommendedFees]) -> [Any] {
-        return recommendedFeesList.map { v -> [String: Any?] in return dictionaryOf(recommendedFees: v) }
+static func arrayOf(`recommendedFeesList`: [RecommendedFees]) -> [Any] {
+    return `recommendedFeesList`.map { (v) -> [String: Any?] in return dictionaryOf(recommendedFees: v) }
+}
+static func asRefundRequest(refundRequest: [String: Any?]) throws -> RefundRequest {
+    guard let swapAddress = refundRequest["swapAddress"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "RefundRequest"))
     }
-
-    static func asRefundRequest(refundRequest: [String: Any?]) throws -> RefundRequest {
-        guard let swapAddress = refundRequest["swapAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "RefundRequest"))
-        }
-        guard let refundAddress = refundRequest["refundAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundAddress", typeName: "RefundRequest"))
-        }
-        guard let feeRateSatPerVbyte = refundRequest["feeRateSatPerVbyte"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeRateSatPerVbyte", typeName: "RefundRequest"))
-        }
-
-        return RefundRequest(swapAddress: swapAddress, refundAddress: refundAddress, feeRateSatPerVbyte: feeRateSatPerVbyte)
+    guard let refundAddress = refundRequest["refundAddress"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundAddress", typeName: "RefundRequest"))
     }
+    guard let feeRateSatPerVbyte = refundRequest["feeRateSatPerVbyte"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feeRateSatPerVbyte", typeName: "RefundRequest"))
+    }
+    
+    return RefundRequest(swapAddress: swapAddress, refundAddress: refundAddress, feeRateSatPerVbyte: feeRateSatPerVbyte)    
+}
 
-    static func dictionaryOf(refundRequest: RefundRequest) -> [String: Any?] {
-        return [
+static func  dictionaryOf(refundRequest: RefundRequest) -> [String: Any?] {
+    return [
             "swapAddress": refundRequest.swapAddress,
             "refundAddress": refundRequest.refundAddress,
-            "feeRateSatPerVbyte": refundRequest.feeRateSatPerVbyte,
-        ]
-    }
+            "feeRateSatPerVbyte": refundRequest.feeRateSatPerVbyte,       
+    ]
+}
 
-    static func asRefundRequestList(arr: [Any]) throws -> [RefundRequest] {
-        var list = [RefundRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var refundRequest = try asRefundRequest(refundRequest: val)
-                list.append(refundRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundRequest"))
-            }
+static func asRefundRequestList(arr: [Any]) throws -> [RefundRequest] {
+    var list = [RefundRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var refundRequest = try asRefundRequest(refundRequest: val)
+            list.append(refundRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(refundRequestList: [RefundRequest]) -> [Any] {
-        return refundRequestList.map { v -> [String: Any?] in return dictionaryOf(refundRequest: v) }
+static func arrayOf(`refundRequestList`: [RefundRequest]) -> [Any] {
+    return `refundRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(refundRequest: v) }
+}
+static func asRefundResponse(refundResponse: [String: Any?]) throws -> RefundResponse {
+    guard let refundTxId = refundResponse["refundTxId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxId", typeName: "RefundResponse"))
     }
+    
+    return RefundResponse(refundTxId: refundTxId)    
+}
 
-    static func asRefundResponse(refundResponse: [String: Any?]) throws -> RefundResponse {
-        guard let refundTxId = refundResponse["refundTxId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxId", typeName: "RefundResponse"))
+static func  dictionaryOf(refundResponse: RefundResponse) -> [String: Any?] {
+    return [
+            "refundTxId": refundResponse.refundTxId,       
+    ]
+}
+
+static func asRefundResponseList(arr: [Any]) throws -> [RefundResponse] {
+    var list = [RefundResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var refundResponse = try asRefundResponse(refundResponse: val)
+            list.append(refundResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundResponse"))
         }
-
-        return RefundResponse(refundTxId: refundTxId)
     }
+    return list
+}
 
-    static func dictionaryOf(refundResponse: RefundResponse) -> [String: Any?] {
-        return [
-            "refundTxId": refundResponse.refundTxId,
-        ]
+static func arrayOf(`refundResponseList`: [RefundResponse]) -> [Any] {
+    return `refundResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(refundResponse: v) }
+}
+static func asRefundableSwap(refundableSwap: [String: Any?]) throws -> RefundableSwap {
+    guard let swapAddress = refundableSwap["swapAddress"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "RefundableSwap"))
     }
-
-    static func asRefundResponseList(arr: [Any]) throws -> [RefundResponse] {
-        var list = [RefundResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var refundResponse = try asRefundResponse(refundResponse: val)
-                list.append(refundResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundResponse"))
-            }
-        }
-        return list
+    guard let timestamp = refundableSwap["timestamp"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "RefundableSwap"))
     }
-
-    static func arrayOf(refundResponseList: [RefundResponse]) -> [Any] {
-        return refundResponseList.map { v -> [String: Any?] in return dictionaryOf(refundResponse: v) }
+    guard let amountSat = refundableSwap["amountSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "RefundableSwap"))
     }
-
-    static func asRefundableSwap(refundableSwap: [String: Any?]) throws -> RefundableSwap {
-        guard let swapAddress = refundableSwap["swapAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapAddress", typeName: "RefundableSwap"))
-        }
-        guard let timestamp = refundableSwap["timestamp"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "timestamp", typeName: "RefundableSwap"))
-        }
-        guard let amountSat = refundableSwap["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "RefundableSwap"))
-        }
         var lastRefundTxId: String?
         if hasNonNilKey(data: refundableSwap, key: "lastRefundTxId") {
             guard let lastRefundTxIdTmp = refundableSwap["lastRefundTxId"] as? String else {
@@ -2932,37 +2885,36 @@ enum BreezSDKLiquidMapper {
             }
             lastRefundTxId = lastRefundTxIdTmp
         }
+    
+    return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, lastRefundTxId: lastRefundTxId)    
+}
 
-        return RefundableSwap(swapAddress: swapAddress, timestamp: timestamp, amountSat: amountSat, lastRefundTxId: lastRefundTxId)
-    }
-
-    static func dictionaryOf(refundableSwap: RefundableSwap) -> [String: Any?] {
-        return [
+static func  dictionaryOf(refundableSwap: RefundableSwap) -> [String: Any?] {
+    return [
             "swapAddress": refundableSwap.swapAddress,
             "timestamp": refundableSwap.timestamp,
             "amountSat": refundableSwap.amountSat,
-            "lastRefundTxId": refundableSwap.lastRefundTxId == nil ? nil : refundableSwap.lastRefundTxId,
-        ]
-    }
+            "lastRefundTxId": refundableSwap.lastRefundTxId == nil ? nil : refundableSwap.lastRefundTxId,       
+    ]
+}
 
-    static func asRefundableSwapList(arr: [Any]) throws -> [RefundableSwap] {
-        var list = [RefundableSwap]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var refundableSwap = try asRefundableSwap(refundableSwap: val)
-                list.append(refundableSwap)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundableSwap"))
-            }
+static func asRefundableSwapList(arr: [Any]) throws -> [RefundableSwap] {
+    var list = [RefundableSwap]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var refundableSwap = try asRefundableSwap(refundableSwap: val)
+            list.append(refundableSwap)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RefundableSwap"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(refundableSwapList: [RefundableSwap]) -> [Any] {
-        return refundableSwapList.map { v -> [String: Any?] in return dictionaryOf(refundableSwap: v) }
-    }
-
-    static func asRestoreRequest(restoreRequest: [String: Any?]) throws -> RestoreRequest {
+static func arrayOf(`refundableSwapList`: [RefundableSwap]) -> [Any] {
+    return `refundableSwapList`.map { (v) -> [String: Any?] in return dictionaryOf(refundableSwap: v) }
+}
+static func asRestoreRequest(restoreRequest: [String: Any?]) throws -> RestoreRequest {
         var backupPath: String?
         if hasNonNilKey(data: restoreRequest, key: "backupPath") {
             guard let backupPathTmp = restoreRequest["backupPath"] as? String else {
@@ -2970,81 +2922,80 @@ enum BreezSDKLiquidMapper {
             }
             backupPath = backupPathTmp
         }
+    
+    return RestoreRequest(backupPath: backupPath)    
+}
 
-        return RestoreRequest(backupPath: backupPath)
-    }
+static func  dictionaryOf(restoreRequest: RestoreRequest) -> [String: Any?] {
+    return [
+            "backupPath": restoreRequest.backupPath == nil ? nil : restoreRequest.backupPath,       
+    ]
+}
 
-    static func dictionaryOf(restoreRequest: RestoreRequest) -> [String: Any?] {
-        return [
-            "backupPath": restoreRequest.backupPath == nil ? nil : restoreRequest.backupPath,
-        ]
-    }
-
-    static func asRestoreRequestList(arr: [Any]) throws -> [RestoreRequest] {
-        var list = [RestoreRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var restoreRequest = try asRestoreRequest(restoreRequest: val)
-                list.append(restoreRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RestoreRequest"))
-            }
+static func asRestoreRequestList(arr: [Any]) throws -> [RestoreRequest] {
+    var list = [RestoreRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var restoreRequest = try asRestoreRequest(restoreRequest: val)
+            list.append(restoreRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RestoreRequest"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(restoreRequestList: [RestoreRequest]) -> [Any] {
-        return restoreRequestList.map { v -> [String: Any?] in return dictionaryOf(restoreRequest: v) }
+static func arrayOf(`restoreRequestList`: [RestoreRequest]) -> [Any] {
+    return `restoreRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(restoreRequest: v) }
+}
+static func asRouteHint(routeHint: [String: Any?]) throws -> RouteHint {
+    guard let hopsTmp = routeHint["hops"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hops", typeName: "RouteHint"))
     }
+    let hops = try asRouteHintHopList(arr: hopsTmp)
+    
+    
+    return RouteHint(hops: hops)    
+}
 
-    static func asRouteHint(routeHint: [String: Any?]) throws -> RouteHint {
-        guard let hopsTmp = routeHint["hops"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "hops", typeName: "RouteHint"))
+static func  dictionaryOf(routeHint: RouteHint) -> [String: Any?] {
+    return [
+            "hops": arrayOf(routeHintHopList: routeHint.hops),       
+    ]
+}
+
+static func asRouteHintList(arr: [Any]) throws -> [RouteHint] {
+    var list = [RouteHint]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var routeHint = try asRouteHint(routeHint: val)
+            list.append(routeHint)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHint"))
         }
-        let hops = try asRouteHintHopList(arr: hopsTmp)
-
-        return RouteHint(hops: hops)
     }
+    return list
+}
 
-    static func dictionaryOf(routeHint: RouteHint) -> [String: Any?] {
-        return [
-            "hops": arrayOf(routeHintHopList: routeHint.hops),
-        ]
+static func arrayOf(`routeHintList`: [RouteHint]) -> [Any] {
+    return `routeHintList`.map { (v) -> [String: Any?] in return dictionaryOf(routeHint: v) }
+}
+static func asRouteHintHop(routeHintHop: [String: Any?]) throws -> RouteHintHop {
+    guard let srcNodeId = routeHintHop["srcNodeId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "srcNodeId", typeName: "RouteHintHop"))
     }
-
-    static func asRouteHintList(arr: [Any]) throws -> [RouteHint] {
-        var list = [RouteHint]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var routeHint = try asRouteHint(routeHint: val)
-                list.append(routeHint)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHint"))
-            }
-        }
-        return list
+    guard let shortChannelId = routeHintHop["shortChannelId"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "RouteHintHop"))
     }
-
-    static func arrayOf(routeHintList: [RouteHint]) -> [Any] {
-        return routeHintList.map { v -> [String: Any?] in return dictionaryOf(routeHint: v) }
+    guard let feesBaseMsat = routeHintHop["feesBaseMsat"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesBaseMsat", typeName: "RouteHintHop"))
     }
-
-    static func asRouteHintHop(routeHintHop: [String: Any?]) throws -> RouteHintHop {
-        guard let srcNodeId = routeHintHop["srcNodeId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "srcNodeId", typeName: "RouteHintHop"))
-        }
-        guard let shortChannelId = routeHintHop["shortChannelId"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "shortChannelId", typeName: "RouteHintHop"))
-        }
-        guard let feesBaseMsat = routeHintHop["feesBaseMsat"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesBaseMsat", typeName: "RouteHintHop"))
-        }
-        guard let feesProportionalMillionths = routeHintHop["feesProportionalMillionths"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesProportionalMillionths", typeName: "RouteHintHop"))
-        }
-        guard let cltvExpiryDelta = routeHintHop["cltvExpiryDelta"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "cltvExpiryDelta", typeName: "RouteHintHop"))
-        }
+    guard let feesProportionalMillionths = routeHintHop["feesProportionalMillionths"] as? UInt32 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "feesProportionalMillionths", typeName: "RouteHintHop"))
+    }
+    guard let cltvExpiryDelta = routeHintHop["cltvExpiryDelta"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "cltvExpiryDelta", typeName: "RouteHintHop"))
+    }
         var htlcMinimumMsat: UInt64?
         if hasNonNilKey(data: routeHintHop, key: "htlcMinimumMsat") {
             guard let htlcMinimumMsatTmp = routeHintHop["htlcMinimumMsat"] as? UInt64 else {
@@ -3059,166 +3010,163 @@ enum BreezSDKLiquidMapper {
             }
             htlcMaximumMsat = htlcMaximumMsatTmp
         }
+    
+    return RouteHintHop(srcNodeId: srcNodeId, shortChannelId: shortChannelId, feesBaseMsat: feesBaseMsat, feesProportionalMillionths: feesProportionalMillionths, cltvExpiryDelta: cltvExpiryDelta, htlcMinimumMsat: htlcMinimumMsat, htlcMaximumMsat: htlcMaximumMsat)    
+}
 
-        return RouteHintHop(srcNodeId: srcNodeId, shortChannelId: shortChannelId, feesBaseMsat: feesBaseMsat, feesProportionalMillionths: feesProportionalMillionths, cltvExpiryDelta: cltvExpiryDelta, htlcMinimumMsat: htlcMinimumMsat, htlcMaximumMsat: htlcMaximumMsat)
-    }
-
-    static func dictionaryOf(routeHintHop: RouteHintHop) -> [String: Any?] {
-        return [
+static func  dictionaryOf(routeHintHop: RouteHintHop) -> [String: Any?] {
+    return [
             "srcNodeId": routeHintHop.srcNodeId,
             "shortChannelId": routeHintHop.shortChannelId,
             "feesBaseMsat": routeHintHop.feesBaseMsat,
             "feesProportionalMillionths": routeHintHop.feesProportionalMillionths,
             "cltvExpiryDelta": routeHintHop.cltvExpiryDelta,
             "htlcMinimumMsat": routeHintHop.htlcMinimumMsat == nil ? nil : routeHintHop.htlcMinimumMsat,
-            "htlcMaximumMsat": routeHintHop.htlcMaximumMsat == nil ? nil : routeHintHop.htlcMaximumMsat,
-        ]
-    }
+            "htlcMaximumMsat": routeHintHop.htlcMaximumMsat == nil ? nil : routeHintHop.htlcMaximumMsat,       
+    ]
+}
 
-    static func asRouteHintHopList(arr: [Any]) throws -> [RouteHintHop] {
-        var list = [RouteHintHop]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var routeHintHop = try asRouteHintHop(routeHintHop: val)
-                list.append(routeHintHop)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHintHop"))
-            }
+static func asRouteHintHopList(arr: [Any]) throws -> [RouteHintHop] {
+    var list = [RouteHintHop]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var routeHintHop = try asRouteHintHop(routeHintHop: val)
+            list.append(routeHintHop)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "RouteHintHop"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(routeHintHopList: [RouteHintHop]) -> [Any] {
-        return routeHintHopList.map { v -> [String: Any?] in return dictionaryOf(routeHintHop: v) }
+static func arrayOf(`routeHintHopList`: [RouteHintHop]) -> [Any] {
+    return `routeHintHopList`.map { (v) -> [String: Any?] in return dictionaryOf(routeHintHop: v) }
+}
+static func asSendPaymentRequest(sendPaymentRequest: [String: Any?]) throws -> SendPaymentRequest {
+    guard let prepareResponseTmp = sendPaymentRequest["prepareResponse"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "SendPaymentRequest"))
     }
+    let prepareResponse = try asPrepareSendResponse(prepareSendResponse: prepareResponseTmp)
+    
+    
+    return SendPaymentRequest(prepareResponse: prepareResponse)    
+}
 
-    static func asSendPaymentRequest(sendPaymentRequest: [String: Any?]) throws -> SendPaymentRequest {
-        guard let prepareResponseTmp = sendPaymentRequest["prepareResponse"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "prepareResponse", typeName: "SendPaymentRequest"))
+static func  dictionaryOf(sendPaymentRequest: SendPaymentRequest) -> [String: Any?] {
+    return [
+            "prepareResponse": dictionaryOf(prepareSendResponse: sendPaymentRequest.prepareResponse),       
+    ]
+}
+
+static func asSendPaymentRequestList(arr: [Any]) throws -> [SendPaymentRequest] {
+    var list = [SendPaymentRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var sendPaymentRequest = try asSendPaymentRequest(sendPaymentRequest: val)
+            list.append(sendPaymentRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentRequest"))
         }
-        let prepareResponse = try asPrepareSendResponse(prepareSendResponse: prepareResponseTmp)
-
-        return SendPaymentRequest(prepareResponse: prepareResponse)
     }
+    return list
+}
 
-    static func dictionaryOf(sendPaymentRequest: SendPaymentRequest) -> [String: Any?] {
-        return [
-            "prepareResponse": dictionaryOf(prepareSendResponse: sendPaymentRequest.prepareResponse),
-        ]
+static func arrayOf(`sendPaymentRequestList`: [SendPaymentRequest]) -> [Any] {
+    return `sendPaymentRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(sendPaymentRequest: v) }
+}
+static func asSendPaymentResponse(sendPaymentResponse: [String: Any?]) throws -> SendPaymentResponse {
+    guard let paymentTmp = sendPaymentResponse["payment"] as? [String: Any?] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "SendPaymentResponse"))
     }
+    let payment = try asPayment(payment: paymentTmp)
+    
+    
+    return SendPaymentResponse(payment: payment)    
+}
 
-    static func asSendPaymentRequestList(arr: [Any]) throws -> [SendPaymentRequest] {
-        var list = [SendPaymentRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sendPaymentRequest = try asSendPaymentRequest(sendPaymentRequest: val)
-                list.append(sendPaymentRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentRequest"))
-            }
+static func  dictionaryOf(sendPaymentResponse: SendPaymentResponse) -> [String: Any?] {
+    return [
+            "payment": dictionaryOf(payment: sendPaymentResponse.payment),       
+    ]
+}
+
+static func asSendPaymentResponseList(arr: [Any]) throws -> [SendPaymentResponse] {
+    var list = [SendPaymentResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var sendPaymentResponse = try asSendPaymentResponse(sendPaymentResponse: val)
+            list.append(sendPaymentResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(sendPaymentRequestList: [SendPaymentRequest]) -> [Any] {
-        return sendPaymentRequestList.map { v -> [String: Any?] in return dictionaryOf(sendPaymentRequest: v) }
+static func arrayOf(`sendPaymentResponseList`: [SendPaymentResponse]) -> [Any] {
+    return `sendPaymentResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(sendPaymentResponse: v) }
+}
+static func asSignMessageRequest(signMessageRequest: [String: Any?]) throws -> SignMessageRequest {
+    guard let message = signMessageRequest["message"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "SignMessageRequest"))
     }
+    
+    return SignMessageRequest(message: message)    
+}
 
-    static func asSendPaymentResponse(sendPaymentResponse: [String: Any?]) throws -> SendPaymentResponse {
-        guard let paymentTmp = sendPaymentResponse["payment"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payment", typeName: "SendPaymentResponse"))
+static func  dictionaryOf(signMessageRequest: SignMessageRequest) -> [String: Any?] {
+    return [
+            "message": signMessageRequest.message,       
+    ]
+}
+
+static func asSignMessageRequestList(arr: [Any]) throws -> [SignMessageRequest] {
+    var list = [SignMessageRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var signMessageRequest = try asSignMessageRequest(signMessageRequest: val)
+            list.append(signMessageRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageRequest"))
         }
-        let payment = try asPayment(payment: paymentTmp)
-
-        return SendPaymentResponse(payment: payment)
     }
+    return list
+}
 
-    static func dictionaryOf(sendPaymentResponse: SendPaymentResponse) -> [String: Any?] {
-        return [
-            "payment": dictionaryOf(payment: sendPaymentResponse.payment),
-        ]
+static func arrayOf(`signMessageRequestList`: [SignMessageRequest]) -> [Any] {
+    return `signMessageRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(signMessageRequest: v) }
+}
+static func asSignMessageResponse(signMessageResponse: [String: Any?]) throws -> SignMessageResponse {
+    guard let signature = signMessageResponse["signature"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "SignMessageResponse"))
     }
+    
+    return SignMessageResponse(signature: signature)    
+}
 
-    static func asSendPaymentResponseList(arr: [Any]) throws -> [SendPaymentResponse] {
-        var list = [SendPaymentResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sendPaymentResponse = try asSendPaymentResponse(sendPaymentResponse: val)
-                list.append(sendPaymentResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendPaymentResponse"))
-            }
+static func  dictionaryOf(signMessageResponse: SignMessageResponse) -> [String: Any?] {
+    return [
+            "signature": signMessageResponse.signature,       
+    ]
+}
+
+static func asSignMessageResponseList(arr: [Any]) throws -> [SignMessageResponse] {
+    var list = [SignMessageResponse]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var signMessageResponse = try asSignMessageResponse(signMessageResponse: val)
+            list.append(signMessageResponse)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageResponse"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(sendPaymentResponseList: [SendPaymentResponse]) -> [Any] {
-        return sendPaymentResponseList.map { v -> [String: Any?] in return dictionaryOf(sendPaymentResponse: v) }
-    }
-
-    static func asSignMessageRequest(signMessageRequest: [String: Any?]) throws -> SignMessageRequest {
-        guard let message = signMessageRequest["message"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "SignMessageRequest"))
-        }
-
-        return SignMessageRequest(message: message)
-    }
-
-    static func dictionaryOf(signMessageRequest: SignMessageRequest) -> [String: Any?] {
-        return [
-            "message": signMessageRequest.message,
-        ]
-    }
-
-    static func asSignMessageRequestList(arr: [Any]) throws -> [SignMessageRequest] {
-        var list = [SignMessageRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var signMessageRequest = try asSignMessageRequest(signMessageRequest: val)
-                list.append(signMessageRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageRequest"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(signMessageRequestList: [SignMessageRequest]) -> [Any] {
-        return signMessageRequestList.map { v -> [String: Any?] in return dictionaryOf(signMessageRequest: v) }
-    }
-
-    static func asSignMessageResponse(signMessageResponse: [String: Any?]) throws -> SignMessageResponse {
-        guard let signature = signMessageResponse["signature"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "signature", typeName: "SignMessageResponse"))
-        }
-
-        return SignMessageResponse(signature: signature)
-    }
-
-    static func dictionaryOf(signMessageResponse: SignMessageResponse) -> [String: Any?] {
-        return [
-            "signature": signMessageResponse.signature,
-        ]
-    }
-
-    static func asSignMessageResponseList(arr: [Any]) throws -> [SignMessageResponse] {
-        var list = [SignMessageResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var signMessageResponse = try asSignMessageResponse(signMessageResponse: val)
-                list.append(signMessageResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SignMessageResponse"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(signMessageResponseList: [SignMessageResponse]) -> [Any] {
-        return signMessageResponseList.map { v -> [String: Any?] in return dictionaryOf(signMessageResponse: v) }
-    }
-
-    static func asSymbol(symbol: [String: Any?]) throws -> Symbol {
+static func arrayOf(`signMessageResponseList`: [SignMessageResponse]) -> [Any] {
+    return `signMessageResponseList`.map { (v) -> [String: Any?] in return dictionaryOf(signMessageResponse: v) }
+}
+static func asSymbol(symbol: [String: Any?]) throws -> Symbol {
         var grapheme: String?
         if hasNonNilKey(data: symbol, key: "grapheme") {
             guard let graphemeTmp = symbol["grapheme"] as? String else {
@@ -3247,1702 +3195,1793 @@ enum BreezSDKLiquidMapper {
             }
             position = positionTmp
         }
+    
+    return Symbol(grapheme: grapheme, template: template, rtl: rtl, position: position)    
+}
 
-        return Symbol(grapheme: grapheme, template: template, rtl: rtl, position: position)
-    }
-
-    static func dictionaryOf(symbol: Symbol) -> [String: Any?] {
-        return [
+static func  dictionaryOf(symbol: Symbol) -> [String: Any?] {
+    return [
             "grapheme": symbol.grapheme == nil ? nil : symbol.grapheme,
             "template": symbol.template == nil ? nil : symbol.template,
             "rtl": symbol.rtl == nil ? nil : symbol.rtl,
-            "position": symbol.position == nil ? nil : symbol.position,
-        ]
-    }
+            "position": symbol.position == nil ? nil : symbol.position,       
+    ]
+}
 
-    static func asSymbolList(arr: [Any]) throws -> [Symbol] {
-        var list = [Symbol]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var symbol = try asSymbol(symbol: val)
-                list.append(symbol)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Symbol"))
-            }
+static func asSymbolList(arr: [Any]) throws -> [Symbol] {
+    var list = [Symbol]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var symbol = try asSymbol(symbol: val)
+            list.append(symbol)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Symbol"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(symbolList: [Symbol]) -> [Any] {
-        return symbolList.map { v -> [String: Any?] in return dictionaryOf(symbol: v) }
+static func arrayOf(`symbolList`: [Symbol]) -> [Any] {
+    return `symbolList`.map { (v) -> [String: Any?] in return dictionaryOf(symbol: v) }
+}
+static func asUrlSuccessActionData(urlSuccessActionData: [String: Any?]) throws -> UrlSuccessActionData {
+    guard let description = urlSuccessActionData["description"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "UrlSuccessActionData"))
     }
-
-    static func asUrlSuccessActionData(urlSuccessActionData: [String: Any?]) throws -> UrlSuccessActionData {
-        guard let description = urlSuccessActionData["description"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "UrlSuccessActionData"))
-        }
-        guard let url = urlSuccessActionData["url"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "UrlSuccessActionData"))
-        }
-        guard let matchesCallbackDomain = urlSuccessActionData["matchesCallbackDomain"] as? Bool else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "matchesCallbackDomain", typeName: "UrlSuccessActionData"))
-        }
-
-        return UrlSuccessActionData(description: description, url: url, matchesCallbackDomain: matchesCallbackDomain)
+    guard let url = urlSuccessActionData["url"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "UrlSuccessActionData"))
     }
+    guard let matchesCallbackDomain = urlSuccessActionData["matchesCallbackDomain"] as? Bool else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "matchesCallbackDomain", typeName: "UrlSuccessActionData"))
+    }
+    
+    return UrlSuccessActionData(description: description, url: url, matchesCallbackDomain: matchesCallbackDomain)    
+}
 
-    static func dictionaryOf(urlSuccessActionData: UrlSuccessActionData) -> [String: Any?] {
-        return [
+static func  dictionaryOf(urlSuccessActionData: UrlSuccessActionData) -> [String: Any?] {
+    return [
             "description": urlSuccessActionData.description,
             "url": urlSuccessActionData.url,
-            "matchesCallbackDomain": urlSuccessActionData.matchesCallbackDomain,
-        ]
+            "matchesCallbackDomain": urlSuccessActionData.matchesCallbackDomain,       
+    ]
+}
+
+static func asUrlSuccessActionDataList(arr: [Any]) throws -> [UrlSuccessActionData] {
+    var list = [UrlSuccessActionData]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var urlSuccessActionData = try asUrlSuccessActionData(urlSuccessActionData: val)
+            list.append(urlSuccessActionData)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "UrlSuccessActionData"))
+        }
     }
+    return list
+}
 
-    static func asUrlSuccessActionDataList(arr: [Any]) throws -> [UrlSuccessActionData] {
-        var list = [UrlSuccessActionData]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var urlSuccessActionData = try asUrlSuccessActionData(urlSuccessActionData: val)
-                list.append(urlSuccessActionData)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "UrlSuccessActionData"))
-            }
-        }
-        return list
+static func arrayOf(`urlSuccessActionDataList`: [UrlSuccessActionData]) -> [Any] {
+    return `urlSuccessActionDataList`.map { (v) -> [String: Any?] in return dictionaryOf(urlSuccessActionData: v) }
+}
+static func asWalletInfo(walletInfo: [String: Any?]) throws -> WalletInfo {
+    guard let balanceSat = walletInfo["balanceSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "balanceSat", typeName: "WalletInfo"))
     }
-
-    static func arrayOf(urlSuccessActionDataList: [UrlSuccessActionData]) -> [Any] {
-        return urlSuccessActionDataList.map { v -> [String: Any?] in return dictionaryOf(urlSuccessActionData: v) }
+    guard let pendingSendSat = walletInfo["pendingSendSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pendingSendSat", typeName: "WalletInfo"))
     }
-
-    static func asWalletInfo(walletInfo: [String: Any?]) throws -> WalletInfo {
-        guard let balanceSat = walletInfo["balanceSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "balanceSat", typeName: "WalletInfo"))
-        }
-        guard let pendingSendSat = walletInfo["pendingSendSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pendingSendSat", typeName: "WalletInfo"))
-        }
-        guard let pendingReceiveSat = walletInfo["pendingReceiveSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pendingReceiveSat", typeName: "WalletInfo"))
-        }
-        guard let fingerprint = walletInfo["fingerprint"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fingerprint", typeName: "WalletInfo"))
-        }
-        guard let pubkey = walletInfo["pubkey"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "WalletInfo"))
-        }
-        guard let assetBalancesTmp = walletInfo["assetBalances"] as? [[String: Any?]] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetBalances", typeName: "WalletInfo"))
-        }
-        let assetBalances = try asAssetBalanceList(arr: assetBalancesTmp)
-
-        return WalletInfo(balanceSat: balanceSat, pendingSendSat: pendingSendSat, pendingReceiveSat: pendingReceiveSat, fingerprint: fingerprint, pubkey: pubkey, assetBalances: assetBalances)
+    guard let pendingReceiveSat = walletInfo["pendingReceiveSat"] as? UInt64 else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pendingReceiveSat", typeName: "WalletInfo"))
     }
+    guard let fingerprint = walletInfo["fingerprint"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fingerprint", typeName: "WalletInfo"))
+    }
+    guard let pubkey = walletInfo["pubkey"] as? String else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pubkey", typeName: "WalletInfo"))
+    }
+    guard let assetBalancesTmp = walletInfo["assetBalances"] as? [[String: Any?]] else {
+        throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetBalances", typeName: "WalletInfo"))
+    }
+    let assetBalances = try asAssetBalanceList(arr: assetBalancesTmp)
+    
+    
+    return WalletInfo(balanceSat: balanceSat, pendingSendSat: pendingSendSat, pendingReceiveSat: pendingReceiveSat, fingerprint: fingerprint, pubkey: pubkey, assetBalances: assetBalances)    
+}
 
-    static func dictionaryOf(walletInfo: WalletInfo) -> [String: Any?] {
-        return [
+static func  dictionaryOf(walletInfo: WalletInfo) -> [String: Any?] {
+    return [
             "balanceSat": walletInfo.balanceSat,
             "pendingSendSat": walletInfo.pendingSendSat,
             "pendingReceiveSat": walletInfo.pendingReceiveSat,
             "fingerprint": walletInfo.fingerprint,
             "pubkey": walletInfo.pubkey,
-            "assetBalances": arrayOf(assetBalanceList: walletInfo.assetBalances),
-        ]
-    }
+            "assetBalances": arrayOf(assetBalanceList: walletInfo.assetBalances),       
+    ]
+}
 
-    static func asWalletInfoList(arr: [Any]) throws -> [WalletInfo] {
-        var list = [WalletInfo]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var walletInfo = try asWalletInfo(walletInfo: val)
-                list.append(walletInfo)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "WalletInfo"))
-            }
+static func asWalletInfoList(arr: [Any]) throws -> [WalletInfo] {
+    var list = [WalletInfo]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var walletInfo = try asWalletInfo(walletInfo: val)
+            list.append(walletInfo)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "WalletInfo"))
         }
-        return list
     }
+    return list
+}
 
-    static func arrayOf(walletInfoList: [WalletInfo]) -> [Any] {
-        return walletInfoList.map { v -> [String: Any?] in return dictionaryOf(walletInfo: v) }
-    }
+static func arrayOf(`walletInfoList`: [WalletInfo]) -> [Any] {
+    return `walletInfoList`.map { (v) -> [String: Any?] in return dictionaryOf(walletInfo: v) }
+}
 
-    static func asAesSuccessActionDataResult(aesSuccessActionDataResult: [String: Any?]) throws -> AesSuccessActionDataResult {
-        let type = aesSuccessActionDataResult["type"] as! String
-        if type == "decrypted" {
-            guard let dataTmp = aesSuccessActionDataResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "AesSuccessActionDataResult"))
-            }
+static func asAesSuccessActionDataResult(aesSuccessActionDataResult: [String: Any?]) throws -> AesSuccessActionDataResult {
+    let type = aesSuccessActionDataResult["type"] as! String
+        if (type == "decrypted") {
+                guard let dataTmp = aesSuccessActionDataResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "AesSuccessActionDataResult"))
+                }
             let _data = try asAesSuccessActionDataDecrypted(aesSuccessActionDataDecrypted: dataTmp)
-
-            return AesSuccessActionDataResult.decrypted(data: _data)
+                        
+            return AesSuccessActionDataResult.decrypted(data: _data)       
         }
-        if type == "errorStatus" {
-            guard let _reason = aesSuccessActionDataResult["reason"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "AesSuccessActionDataResult"))
-            }
-            return AesSuccessActionDataResult.errorStatus(reason: _reason)
-        }
+        if (type == "errorStatus") {
+                guard let _reason = aesSuccessActionDataResult["reason"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reason", typeName: "AesSuccessActionDataResult"))
+                }            
+            return AesSuccessActionDataResult.errorStatus(reason: _reason)       
+        }    
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum AesSuccessActionDataResult")
-    }
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum AesSuccessActionDataResult")
+}
 
-    static func dictionaryOf(aesSuccessActionDataResult: AesSuccessActionDataResult) -> [String: Any?] {
-        switch aesSuccessActionDataResult {
-        case let .decrypted(
-            data
-        ):
-            return [
-                "type": "decrypted",
-                "data": dictionaryOf(aesSuccessActionDataDecrypted: data),
-            ]
+static func dictionaryOf(aesSuccessActionDataResult: AesSuccessActionDataResult) -> [String: Any?] {    
+    switch (aesSuccessActionDataResult) {
+    
+    case let .decrypted(
+        data
+    ):
+    return [
+            "type": "decrypted",
+            "data": dictionaryOf(aesSuccessActionDataDecrypted: data),
+        ]
+    
+    case let .errorStatus(
+        reason
+    ):
+    return [
+            "type": "errorStatus",
+            "reason": reason,
+        ]   
+    }    
+}
 
-        case let .errorStatus(
-            reason
-        ):
-            return [
-                "type": "errorStatus",
-                "reason": reason,
-            ]
-        }
-    }
+static func arrayOf(`aesSuccessActionDataResultList`: [AesSuccessActionDataResult]) -> [Any] {
+    return `aesSuccessActionDataResultList`.map { (v) -> [String: Any?] in return dictionaryOf(aesSuccessActionDataResult: v) }
+}
 
-    static func arrayOf(aesSuccessActionDataResultList: [AesSuccessActionDataResult]) -> [Any] {
-        return aesSuccessActionDataResultList.map { v -> [String: Any?] in return dictionaryOf(aesSuccessActionDataResult: v) }
-    }
-
-    static func asAesSuccessActionDataResultList(arr: [Any]) throws -> [AesSuccessActionDataResult] {
-        var list = [AesSuccessActionDataResult]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var aesSuccessActionDataResult = try asAesSuccessActionDataResult(aesSuccessActionDataResult: val)
-                list.append(aesSuccessActionDataResult)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataResult"))
-            }
-        }
-        return list
-    }
-
-    static func asAmount(amount: [String: Any?]) throws -> Amount {
-        let type = amount["type"] as! String
-        if type == "bitcoin" {
-            guard let _amountMsat = amount["amountMsat"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "Amount"))
-            }
-            return Amount.bitcoin(amountMsat: _amountMsat)
-        }
-        if type == "currency" {
-            guard let _iso4217Code = amount["iso4217Code"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "iso4217Code", typeName: "Amount"))
-            }
-            guard let _fractionalAmount = amount["fractionalAmount"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fractionalAmount", typeName: "Amount"))
-            }
-            return Amount.currency(iso4217Code: _iso4217Code, fractionalAmount: _fractionalAmount)
-        }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum Amount")
-    }
-
-    static func dictionaryOf(amount: Amount) -> [String: Any?] {
-        switch amount {
-        case let .bitcoin(
-            amountMsat
-        ):
-            return [
-                "type": "bitcoin",
-                "amountMsat": amountMsat,
-            ]
-
-        case let .currency(
-            iso4217Code, fractionalAmount
-        ):
-            return [
-                "type": "currency",
-                "iso4217Code": iso4217Code,
-                "fractionalAmount": fractionalAmount,
-            ]
+static func asAesSuccessActionDataResultList(arr: [Any]) throws -> [AesSuccessActionDataResult] {
+    var list = [AesSuccessActionDataResult]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var aesSuccessActionDataResult = try asAesSuccessActionDataResult(aesSuccessActionDataResult: val)
+            list.append(aesSuccessActionDataResult)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "AesSuccessActionDataResult"))
         }
     }
+    return list
+}
 
-    static func arrayOf(amountList: [Amount]) -> [Any] {
-        return amountList.map { v -> [String: Any?] in return dictionaryOf(amount: v) }
-    }
-
-    static func asAmountList(arr: [Any]) throws -> [Amount] {
-        var list = [Amount]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var amount = try asAmount(amount: val)
-                list.append(amount)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Amount"))
-            }
+static func asAmount(amount: [String: Any?]) throws -> Amount {
+    let type = amount["type"] as! String
+        if (type == "bitcoin") {
+                guard let _amountMsat = amount["amountMsat"] as? UInt64 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "Amount"))
+                }            
+            return Amount.bitcoin(amountMsat: _amountMsat)       
         }
-        return list
-    }
+        if (type == "currency") {
+                guard let _iso4217Code = amount["iso4217Code"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "iso4217Code", typeName: "Amount"))
+                }
+                guard let _fractionalAmount = amount["fractionalAmount"] as? UInt64 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "fractionalAmount", typeName: "Amount"))
+                }            
+            return Amount.currency(iso4217Code: _iso4217Code, fractionalAmount: _fractionalAmount)       
+        }    
 
-    static func asBuyBitcoinProvider(buyBitcoinProvider: String) throws -> BuyBitcoinProvider {
-        switch buyBitcoinProvider {
-        case "moonpay":
-            return BuyBitcoinProvider.moonpay
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum Amount")
+}
 
-        default: throw SdkError.Generic(message: "Invalid variant \(buyBitcoinProvider) for enum BuyBitcoinProvider")
-        }
-    }
+static func dictionaryOf(amount: Amount) -> [String: Any?] {    
+    switch (amount) {
+    
+    case let .bitcoin(
+        amountMsat
+    ):
+    return [
+            "type": "bitcoin",
+            "amountMsat": amountMsat,
+        ]
+    
+    case let .currency(
+        iso4217Code, fractionalAmount
+    ):
+    return [
+            "type": "currency",
+            "iso4217Code": iso4217Code,
+            "fractionalAmount": fractionalAmount,
+        ]   
+    }    
+}
 
-    static func valueOf(buyBitcoinProvider: BuyBitcoinProvider) -> String {
-        switch buyBitcoinProvider {
-        case .moonpay:
-            return "moonpay"
-        }
-    }
+static func arrayOf(`amountList`: [Amount]) -> [Any] {
+    return `amountList`.map { (v) -> [String: Any?] in return dictionaryOf(amount: v) }
+}
 
-    static func arrayOf(buyBitcoinProviderList: [BuyBitcoinProvider]) -> [String] {
-        return buyBitcoinProviderList.map { v -> String in return valueOf(buyBitcoinProvider: v) }
-    }
-
-    static func asBuyBitcoinProviderList(arr: [Any]) throws -> [BuyBitcoinProvider] {
-        var list = [BuyBitcoinProvider]()
-        for value in arr {
-            if let val = value as? String {
-                var buyBitcoinProvider = try asBuyBitcoinProvider(buyBitcoinProvider: val)
-                list.append(buyBitcoinProvider)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinProvider"))
-            }
-        }
-        return list
-    }
-
-    static func asGetPaymentRequest(getPaymentRequest: [String: Any?]) throws -> GetPaymentRequest {
-        let type = getPaymentRequest["type"] as! String
-        if type == "paymentHash" {
-            guard let _paymentHash = getPaymentRequest["paymentHash"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "GetPaymentRequest"))
-            }
-            return GetPaymentRequest.paymentHash(paymentHash: _paymentHash)
-        }
-        if type == "swapId" {
-            guard let _swapId = getPaymentRequest["swapId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "GetPaymentRequest"))
-            }
-            return GetPaymentRequest.swapId(swapId: _swapId)
-        }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum GetPaymentRequest")
-    }
-
-    static func dictionaryOf(getPaymentRequest: GetPaymentRequest) -> [String: Any?] {
-        switch getPaymentRequest {
-        case let .paymentHash(
-            paymentHash
-        ):
-            return [
-                "type": "paymentHash",
-                "paymentHash": paymentHash,
-            ]
-
-        case let .swapId(
-            swapId
-        ):
-            return [
-                "type": "swapId",
-                "swapId": swapId,
-            ]
+static func asAmountList(arr: [Any]) throws -> [Amount] {
+    var list = [Amount]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var amount = try asAmount(amount: val)
+            list.append(amount)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Amount"))
         }
     }
+    return list
+}
 
-    static func arrayOf(getPaymentRequestList: [GetPaymentRequest]) -> [Any] {
-        return getPaymentRequestList.map { v -> [String: Any?] in return dictionaryOf(getPaymentRequest: v) }
-    }
-
-    static func asGetPaymentRequestList(arr: [Any]) throws -> [GetPaymentRequest] {
-        var list = [GetPaymentRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var getPaymentRequest = try asGetPaymentRequest(getPaymentRequest: val)
-                list.append(getPaymentRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "GetPaymentRequest"))
-            }
+static func asBlockchainExplorer(blockchainExplorer: [String: Any?]) throws -> BlockchainExplorer {
+    let type = blockchainExplorer["type"] as! String
+        if (type == "electrum") {
+                guard let _url = blockchainExplorer["url"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "BlockchainExplorer"))
+                }            
+            return BlockchainExplorer.electrum(url: _url)       
         }
-        return list
-    }
+        if (type == "esplora") {
+                guard let _url = blockchainExplorer["url"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "BlockchainExplorer"))
+                }
+                guard let _useWaterfalls = blockchainExplorer["useWaterfalls"] as? Bool else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "useWaterfalls", typeName: "BlockchainExplorer"))
+                }            
+            return BlockchainExplorer.esplora(url: _url, useWaterfalls: _useWaterfalls)       
+        }    
 
-    static func asInputType(inputType: [String: Any?]) throws -> InputType {
-        let type = inputType["type"] as! String
-        if type == "bitcoinAddress" {
-            guard let addressTmp = inputType["address"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "InputType"))
-            }
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum BlockchainExplorer")
+}
+
+static func dictionaryOf(blockchainExplorer: BlockchainExplorer) -> [String: Any?] {    
+    switch (blockchainExplorer) {
+    
+    case let .electrum(
+        url
+    ):
+    return [
+            "type": "electrum",
+            "url": url,
+        ]
+    
+    case let .esplora(
+        url, useWaterfalls
+    ):
+    return [
+            "type": "esplora",
+            "url": url,
+            "useWaterfalls": useWaterfalls,
+        ]   
+    }    
+}
+
+static func arrayOf(`blockchainExplorerList`: [BlockchainExplorer]) -> [Any] {
+    return `blockchainExplorerList`.map { (v) -> [String: Any?] in return dictionaryOf(blockchainExplorer: v) }
+}
+
+static func asBlockchainExplorerList(arr: [Any]) throws -> [BlockchainExplorer] {
+    var list = [BlockchainExplorer]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var blockchainExplorer = try asBlockchainExplorer(blockchainExplorer: val)
+            list.append(blockchainExplorer)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BlockchainExplorer"))
+        }
+    }
+    return list
+}
+
+static func asBuyBitcoinProvider(buyBitcoinProvider: String) throws -> BuyBitcoinProvider {
+    switch(buyBitcoinProvider) {
+
+    case "moonpay":         
+        return BuyBitcoinProvider.moonpay
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(buyBitcoinProvider) for enum BuyBitcoinProvider")
+    }
+}
+
+static func valueOf(buyBitcoinProvider: BuyBitcoinProvider) -> String {
+    switch(buyBitcoinProvider) {
+
+    case .moonpay:         
+        return "moonpay"
+            
+    }
+}
+
+static func arrayOf(`buyBitcoinProviderList`: [BuyBitcoinProvider]) -> [String] {
+    return `buyBitcoinProviderList`.map { (v) -> String in return valueOf(buyBitcoinProvider: v) }
+}
+
+static func asBuyBitcoinProviderList(arr: [Any]) throws -> [BuyBitcoinProvider] {
+    var list = [BuyBitcoinProvider]()
+    for value in arr {
+        if let val = value as? String {
+            var buyBitcoinProvider = try asBuyBitcoinProvider(buyBitcoinProvider: val)
+            list.append(buyBitcoinProvider)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "BuyBitcoinProvider"))
+        }
+    }
+    return list
+}
+
+static func asGetPaymentRequest(getPaymentRequest: [String: Any?]) throws -> GetPaymentRequest {
+    let type = getPaymentRequest["type"] as! String
+        if (type == "paymentHash") {
+                guard let _paymentHash = getPaymentRequest["paymentHash"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "GetPaymentRequest"))
+                }            
+            return GetPaymentRequest.paymentHash(paymentHash: _paymentHash)       
+        }
+        if (type == "swapId") {
+                guard let _swapId = getPaymentRequest["swapId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "GetPaymentRequest"))
+                }            
+            return GetPaymentRequest.swapId(swapId: _swapId)       
+        }    
+
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum GetPaymentRequest")
+}
+
+static func dictionaryOf(getPaymentRequest: GetPaymentRequest) -> [String: Any?] {    
+    switch (getPaymentRequest) {
+    
+    case let .paymentHash(
+        paymentHash
+    ):
+    return [
+            "type": "paymentHash",
+            "paymentHash": paymentHash,
+        ]
+    
+    case let .swapId(
+        swapId
+    ):
+    return [
+            "type": "swapId",
+            "swapId": swapId,
+        ]   
+    }    
+}
+
+static func arrayOf(`getPaymentRequestList`: [GetPaymentRequest]) -> [Any] {
+    return `getPaymentRequestList`.map { (v) -> [String: Any?] in return dictionaryOf(getPaymentRequest: v) }
+}
+
+static func asGetPaymentRequestList(arr: [Any]) throws -> [GetPaymentRequest] {
+    var list = [GetPaymentRequest]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var getPaymentRequest = try asGetPaymentRequest(getPaymentRequest: val)
+            list.append(getPaymentRequest)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "GetPaymentRequest"))
+        }
+    }
+    return list
+}
+
+static func asInputType(inputType: [String: Any?]) throws -> InputType {
+    let type = inputType["type"] as! String
+        if (type == "bitcoinAddress") {
+                guard let addressTmp = inputType["address"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "InputType"))
+                }
             let _address = try asBitcoinAddressData(bitcoinAddressData: addressTmp)
-
-            return InputType.bitcoinAddress(address: _address)
+                        
+            return InputType.bitcoinAddress(address: _address)       
         }
-        if type == "liquidAddress" {
-            guard let addressTmp = inputType["address"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "InputType"))
-            }
+        if (type == "liquidAddress") {
+                guard let addressTmp = inputType["address"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "address", typeName: "InputType"))
+                }
             let _address = try asLiquidAddressData(liquidAddressData: addressTmp)
-
-            return InputType.liquidAddress(address: _address)
+                        
+            return InputType.liquidAddress(address: _address)       
         }
-        if type == "bolt11" {
-            guard let invoiceTmp = inputType["invoice"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "InputType"))
-            }
+        if (type == "bolt11") {
+                guard let invoiceTmp = inputType["invoice"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "InputType"))
+                }
             let _invoice = try asLnInvoice(lnInvoice: invoiceTmp)
-
-            return InputType.bolt11(invoice: _invoice)
+                        
+            return InputType.bolt11(invoice: _invoice)       
         }
-        if type == "bolt12Offer" {
-            guard let offerTmp = inputType["offer"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "InputType"))
-            }
+        if (type == "bolt12Offer") {
+                guard let offerTmp = inputType["offer"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "InputType"))
+                }
             let _offer = try asLnOffer(lnOffer: offerTmp)
-
-            let _bip353Address = inputType["bip353Address"] as? String
-
-            return InputType.bolt12Offer(offer: _offer, bip353Address: _bip353Address)
+            
+                    let _bip353Address = inputType["bip353Address"] as? String
+                                
+            return InputType.bolt12Offer(offer: _offer, bip353Address: _bip353Address)       
         }
-        if type == "nodeId" {
-            guard let _nodeId = inputType["nodeId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "InputType"))
-            }
-            return InputType.nodeId(nodeId: _nodeId)
+        if (type == "nodeId") {
+                guard let _nodeId = inputType["nodeId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "nodeId", typeName: "InputType"))
+                }            
+            return InputType.nodeId(nodeId: _nodeId)       
         }
-        if type == "url" {
-            guard let _url = inputType["url"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "InputType"))
-            }
-            return InputType.url(url: _url)
+        if (type == "url") {
+                guard let _url = inputType["url"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "url", typeName: "InputType"))
+                }            
+            return InputType.url(url: _url)       
         }
-        if type == "lnUrlPay" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
-            }
+        if (type == "lnUrlPay") {
+                guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+                }
             let _data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
-
-            let _bip353Address = inputType["bip353Address"] as? String
-
-            return InputType.lnUrlPay(data: _data, bip353Address: _bip353Address)
+            
+                    let _bip353Address = inputType["bip353Address"] as? String
+                                
+            return InputType.lnUrlPay(data: _data, bip353Address: _bip353Address)       
         }
-        if type == "lnUrlWithdraw" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
-            }
+        if (type == "lnUrlWithdraw") {
+                guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+                }
             let _data = try asLnUrlWithdrawRequestData(lnUrlWithdrawRequestData: dataTmp)
-
-            return InputType.lnUrlWithdraw(data: _data)
+                        
+            return InputType.lnUrlWithdraw(data: _data)       
         }
-        if type == "lnUrlAuth" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
-            }
+        if (type == "lnUrlAuth") {
+                guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+                }
             let _data = try asLnUrlAuthRequestData(lnUrlAuthRequestData: dataTmp)
-
-            return InputType.lnUrlAuth(data: _data)
+                        
+            return InputType.lnUrlAuth(data: _data)       
         }
-        if type == "lnUrlError" {
-            guard let dataTmp = inputType["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
-            }
+        if (type == "lnUrlError") {
+                guard let dataTmp = inputType["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "InputType"))
+                }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
+                        
+            return InputType.lnUrlError(data: _data)       
+        }    
 
-            return InputType.lnUrlError(data: _data)
-        }
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum InputType")
+}
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum InputType")
-    }
+static func dictionaryOf(inputType: InputType) -> [String: Any?] {    
+    switch (inputType) {
+    
+    case let .bitcoinAddress(
+        address
+    ):
+    return [
+            "type": "bitcoinAddress",
+            "address": dictionaryOf(bitcoinAddressData: address),
+        ]
+    
+    case let .liquidAddress(
+        address
+    ):
+    return [
+            "type": "liquidAddress",
+            "address": dictionaryOf(liquidAddressData: address),
+        ]
+    
+    case let .bolt11(
+        invoice
+    ):
+    return [
+            "type": "bolt11",
+            "invoice": dictionaryOf(lnInvoice: invoice),
+        ]
+    
+    case let .bolt12Offer(
+        offer, bip353Address
+    ):
+    return [
+            "type": "bolt12Offer",
+            "offer": dictionaryOf(lnOffer: offer),
+            "bip353Address": bip353Address == nil ? nil : bip353Address,
+        ]
+    
+    case let .nodeId(
+        nodeId
+    ):
+    return [
+            "type": "nodeId",
+            "nodeId": nodeId,
+        ]
+    
+    case let .url(
+        url
+    ):
+    return [
+            "type": "url",
+            "url": url,
+        ]
+    
+    case let .lnUrlPay(
+        data, bip353Address
+    ):
+    return [
+            "type": "lnUrlPay",
+            "data": dictionaryOf(lnUrlPayRequestData: data),
+            "bip353Address": bip353Address == nil ? nil : bip353Address,
+        ]
+    
+    case let .lnUrlWithdraw(
+        data
+    ):
+    return [
+            "type": "lnUrlWithdraw",
+            "data": dictionaryOf(lnUrlWithdrawRequestData: data),
+        ]
+    
+    case let .lnUrlAuth(
+        data
+    ):
+    return [
+            "type": "lnUrlAuth",
+            "data": dictionaryOf(lnUrlAuthRequestData: data),
+        ]
+    
+    case let .lnUrlError(
+        data
+    ):
+    return [
+            "type": "lnUrlError",
+            "data": dictionaryOf(lnUrlErrorData: data),
+        ]   
+    }    
+}
 
-    static func dictionaryOf(inputType: InputType) -> [String: Any?] {
-        switch inputType {
-        case let .bitcoinAddress(
-            address
-        ):
-            return [
-                "type": "bitcoinAddress",
-                "address": dictionaryOf(bitcoinAddressData: address),
-            ]
+static func arrayOf(`inputTypeList`: [InputType]) -> [Any] {
+    return `inputTypeList`.map { (v) -> [String: Any?] in return dictionaryOf(inputType: v) }
+}
 
-        case let .liquidAddress(
-            address
-        ):
-            return [
-                "type": "liquidAddress",
-                "address": dictionaryOf(liquidAddressData: address),
-            ]
-
-        case let .bolt11(
-            invoice
-        ):
-            return [
-                "type": "bolt11",
-                "invoice": dictionaryOf(lnInvoice: invoice),
-            ]
-
-        case let .bolt12Offer(
-            offer, bip353Address
-        ):
-            return [
-                "type": "bolt12Offer",
-                "offer": dictionaryOf(lnOffer: offer),
-                "bip353Address": bip353Address == nil ? nil : bip353Address,
-            ]
-
-        case let .nodeId(
-            nodeId
-        ):
-            return [
-                "type": "nodeId",
-                "nodeId": nodeId,
-            ]
-
-        case let .url(
-            url
-        ):
-            return [
-                "type": "url",
-                "url": url,
-            ]
-
-        case let .lnUrlPay(
-            data, bip353Address
-        ):
-            return [
-                "type": "lnUrlPay",
-                "data": dictionaryOf(lnUrlPayRequestData: data),
-                "bip353Address": bip353Address == nil ? nil : bip353Address,
-            ]
-
-        case let .lnUrlWithdraw(
-            data
-        ):
-            return [
-                "type": "lnUrlWithdraw",
-                "data": dictionaryOf(lnUrlWithdrawRequestData: data),
-            ]
-
-        case let .lnUrlAuth(
-            data
-        ):
-            return [
-                "type": "lnUrlAuth",
-                "data": dictionaryOf(lnUrlAuthRequestData: data),
-            ]
-
-        case let .lnUrlError(
-            data
-        ):
-            return [
-                "type": "lnUrlError",
-                "data": dictionaryOf(lnUrlErrorData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(inputTypeList: [InputType]) -> [Any] {
-        return inputTypeList.map { v -> [String: Any?] in return dictionaryOf(inputType: v) }
-    }
-
-    static func asInputTypeList(arr: [Any]) throws -> [InputType] {
-        var list = [InputType]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var inputType = try asInputType(inputType: val)
-                list.append(inputType)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "InputType"))
-            }
-        }
-        return list
-    }
-
-    static func asLiquidNetwork(liquidNetwork: String) throws -> LiquidNetwork {
-        switch liquidNetwork {
-        case "mainnet":
-            return LiquidNetwork.mainnet
-
-        case "testnet":
-            return LiquidNetwork.testnet
-
-        case "regtest":
-            return LiquidNetwork.regtest
-
-        default: throw SdkError.Generic(message: "Invalid variant \(liquidNetwork) for enum LiquidNetwork")
+static func asInputTypeList(arr: [Any]) throws -> [InputType] {
+    var list = [InputType]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var inputType = try asInputType(inputType: val)
+            list.append(inputType)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "InputType"))
         }
     }
+    return list
+}
 
-    static func valueOf(liquidNetwork: LiquidNetwork) -> String {
-        switch liquidNetwork {
-        case .mainnet:
-            return "mainnet"
+static func asLiquidNetwork(liquidNetwork: String) throws -> LiquidNetwork {
+    switch(liquidNetwork) {
 
-        case .testnet:
-            return "testnet"
+    case "mainnet":         
+        return LiquidNetwork.mainnet
 
-        case .regtest:
-            return "regtest"
+    case "testnet":         
+        return LiquidNetwork.testnet
+
+    case "regtest":         
+        return LiquidNetwork.regtest
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(liquidNetwork) for enum LiquidNetwork")
+    }
+}
+
+static func valueOf(liquidNetwork: LiquidNetwork) -> String {
+    switch(liquidNetwork) {
+
+    case .mainnet:         
+        return "mainnet"
+
+    case .testnet:         
+        return "testnet"
+
+    case .regtest:         
+        return "regtest"
+            
+    }
+}
+
+static func arrayOf(`liquidNetworkList`: [LiquidNetwork]) -> [String] {
+    return `liquidNetworkList`.map { (v) -> String in return valueOf(liquidNetwork: v) }
+}
+
+static func asLiquidNetworkList(arr: [Any]) throws -> [LiquidNetwork] {
+    var list = [LiquidNetwork]()
+    for value in arr {
+        if let val = value as? String {
+            var liquidNetwork = try asLiquidNetwork(liquidNetwork: val)
+            list.append(liquidNetwork)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LiquidNetwork"))
         }
     }
+    return list
+}
 
-    static func arrayOf(liquidNetworkList: [LiquidNetwork]) -> [String] {
-        return liquidNetworkList.map { v -> String in return valueOf(liquidNetwork: v) }
-    }
-
-    static func asLiquidNetworkList(arr: [Any]) throws -> [LiquidNetwork] {
-        var list = [LiquidNetwork]()
-        for value in arr {
-            if let val = value as? String {
-                var liquidNetwork = try asLiquidNetwork(liquidNetwork: val)
-                list.append(liquidNetwork)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LiquidNetwork"))
-            }
+static func asListPaymentDetails(listPaymentDetails: [String: Any?]) throws -> ListPaymentDetails {
+    let type = listPaymentDetails["type"] as! String
+        if (type == "liquid") {
+                    let _assetId = listPaymentDetails["assetId"] as? String
+                    
+                    let _destination = listPaymentDetails["destination"] as? String
+                                
+            return ListPaymentDetails.liquid(assetId: _assetId, destination: _destination)       
         }
-        return list
-    }
+        if (type == "bitcoin") {
+                    let _address = listPaymentDetails["address"] as? String
+                                
+            return ListPaymentDetails.bitcoin(address: _address)       
+        }    
 
-    static func asListPaymentDetails(listPaymentDetails: [String: Any?]) throws -> ListPaymentDetails {
-        let type = listPaymentDetails["type"] as! String
-        if type == "liquid" {
-            let _assetId = listPaymentDetails["assetId"] as? String
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum ListPaymentDetails")
+}
 
-            let _destination = listPaymentDetails["destination"] as? String
+static func dictionaryOf(listPaymentDetails: ListPaymentDetails) -> [String: Any?] {    
+    switch (listPaymentDetails) {
+    
+    case let .liquid(
+        assetId, destination
+    ):
+    return [
+            "type": "liquid",
+            "assetId": assetId == nil ? nil : assetId,
+            "destination": destination == nil ? nil : destination,
+        ]
+    
+    case let .bitcoin(
+        address
+    ):
+    return [
+            "type": "bitcoin",
+            "address": address == nil ? nil : address,
+        ]   
+    }    
+}
 
-            return ListPaymentDetails.liquid(assetId: _assetId, destination: _destination)
+static func arrayOf(`listPaymentDetailsList`: [ListPaymentDetails]) -> [Any] {
+    return `listPaymentDetailsList`.map { (v) -> [String: Any?] in return dictionaryOf(listPaymentDetails: v) }
+}
+
+static func asListPaymentDetailsList(arr: [Any]) throws -> [ListPaymentDetails] {
+    var list = [ListPaymentDetails]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var listPaymentDetails = try asListPaymentDetails(listPaymentDetails: val)
+            list.append(listPaymentDetails)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ListPaymentDetails"))
         }
-        if type == "bitcoin" {
-            let _address = listPaymentDetails["address"] as? String
-
-            return ListPaymentDetails.bitcoin(address: _address)
-        }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum ListPaymentDetails")
     }
+    return list
+}
 
-    static func dictionaryOf(listPaymentDetails: ListPaymentDetails) -> [String: Any?] {
-        switch listPaymentDetails {
-        case let .liquid(
-            assetId, destination
-        ):
-            return [
-                "type": "liquid",
-                "assetId": assetId == nil ? nil : assetId,
-                "destination": destination == nil ? nil : destination,
-            ]
-
-        case let .bitcoin(
-            address
-        ):
-            return [
-                "type": "bitcoin",
-                "address": address == nil ? nil : address,
-            ]
+static func asLnUrlCallbackStatus(lnUrlCallbackStatus: [String: Any?]) throws -> LnUrlCallbackStatus {
+    let type = lnUrlCallbackStatus["type"] as! String
+        if (type == "ok") {
+            return LnUrlCallbackStatus.ok       
         }
-    }
-
-    static func arrayOf(listPaymentDetailsList: [ListPaymentDetails]) -> [Any] {
-        return listPaymentDetailsList.map { v -> [String: Any?] in return dictionaryOf(listPaymentDetails: v) }
-    }
-
-    static func asListPaymentDetailsList(arr: [Any]) throws -> [ListPaymentDetails] {
-        var list = [ListPaymentDetails]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var listPaymentDetails = try asListPaymentDetails(listPaymentDetails: val)
-                list.append(listPaymentDetails)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ListPaymentDetails"))
-            }
-        }
-        return list
-    }
-
-    static func asLnUrlCallbackStatus(lnUrlCallbackStatus: [String: Any?]) throws -> LnUrlCallbackStatus {
-        let type = lnUrlCallbackStatus["type"] as! String
-        if type == "ok" {
-            return LnUrlCallbackStatus.ok
-        }
-        if type == "errorStatus" {
-            guard let dataTmp = lnUrlCallbackStatus["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlCallbackStatus"))
-            }
+        if (type == "errorStatus") {
+                guard let dataTmp = lnUrlCallbackStatus["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlCallbackStatus"))
+                }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
+                        
+            return LnUrlCallbackStatus.errorStatus(data: _data)       
+        }    
 
-            return LnUrlCallbackStatus.errorStatus(data: _data)
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlCallbackStatus")
+}
+
+static func dictionaryOf(lnUrlCallbackStatus: LnUrlCallbackStatus) -> [String: Any?] {    
+    switch (lnUrlCallbackStatus) {
+    
+    case .ok:  
+    return [
+            "type": "ok",
+        ]
+    
+    case let .errorStatus(
+        data
+    ):
+    return [
+            "type": "errorStatus",
+            "data": dictionaryOf(lnUrlErrorData: data),
+        ]   
+    }    
+}
+
+static func arrayOf(`lnUrlCallbackStatusList`: [LnUrlCallbackStatus]) -> [Any] {
+    return `lnUrlCallbackStatusList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlCallbackStatus: v) }
+}
+
+static func asLnUrlCallbackStatusList(arr: [Any]) throws -> [LnUrlCallbackStatus] {
+    var list = [LnUrlCallbackStatus]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlCallbackStatus = try asLnUrlCallbackStatus(lnUrlCallbackStatus: val)
+            list.append(lnUrlCallbackStatus)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlCallbackStatus"))
         }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlCallbackStatus")
     }
+    return list
+}
 
-    static func dictionaryOf(lnUrlCallbackStatus: LnUrlCallbackStatus) -> [String: Any?] {
-        switch lnUrlCallbackStatus {
-        case .ok:
-            return [
-                "type": "ok",
-            ]
-
-        case let .errorStatus(
-            data
-        ):
-            return [
-                "type": "errorStatus",
-                "data": dictionaryOf(lnUrlErrorData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(lnUrlCallbackStatusList: [LnUrlCallbackStatus]) -> [Any] {
-        return lnUrlCallbackStatusList.map { v -> [String: Any?] in return dictionaryOf(lnUrlCallbackStatus: v) }
-    }
-
-    static func asLnUrlCallbackStatusList(arr: [Any]) throws -> [LnUrlCallbackStatus] {
-        var list = [LnUrlCallbackStatus]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlCallbackStatus = try asLnUrlCallbackStatus(lnUrlCallbackStatus: val)
-                list.append(lnUrlCallbackStatus)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlCallbackStatus"))
-            }
-        }
-        return list
-    }
-
-    static func asLnUrlPayResult(lnUrlPayResult: [String: Any?]) throws -> LnUrlPayResult {
-        let type = lnUrlPayResult["type"] as! String
-        if type == "endpointSuccess" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
-            }
+static func asLnUrlPayResult(lnUrlPayResult: [String: Any?]) throws -> LnUrlPayResult {
+    let type = lnUrlPayResult["type"] as! String
+        if (type == "endpointSuccess") {
+                guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+                }
             let _data = try asLnUrlPaySuccessData(lnUrlPaySuccessData: dataTmp)
-
-            return LnUrlPayResult.endpointSuccess(data: _data)
+                        
+            return LnUrlPayResult.endpointSuccess(data: _data)       
         }
-        if type == "endpointError" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
-            }
+        if (type == "endpointError") {
+                guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+                }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
-
-            return LnUrlPayResult.endpointError(data: _data)
+                        
+            return LnUrlPayResult.endpointError(data: _data)       
         }
-        if type == "payError" {
-            guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
-            }
+        if (type == "payError") {
+                guard let dataTmp = lnUrlPayResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlPayResult"))
+                }
             let _data = try asLnUrlPayErrorData(lnUrlPayErrorData: dataTmp)
+                        
+            return LnUrlPayResult.payError(data: _data)       
+        }    
 
-            return LnUrlPayResult.payError(data: _data)
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlPayResult")
+}
+
+static func dictionaryOf(lnUrlPayResult: LnUrlPayResult) -> [String: Any?] {    
+    switch (lnUrlPayResult) {
+    
+    case let .endpointSuccess(
+        data
+    ):
+    return [
+            "type": "endpointSuccess",
+            "data": dictionaryOf(lnUrlPaySuccessData: data),
+        ]
+    
+    case let .endpointError(
+        data
+    ):
+    return [
+            "type": "endpointError",
+            "data": dictionaryOf(lnUrlErrorData: data),
+        ]
+    
+    case let .payError(
+        data
+    ):
+    return [
+            "type": "payError",
+            "data": dictionaryOf(lnUrlPayErrorData: data),
+        ]   
+    }    
+}
+
+static func arrayOf(`lnUrlPayResultList`: [LnUrlPayResult]) -> [Any] {
+    return `lnUrlPayResultList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlPayResult: v) }
+}
+
+static func asLnUrlPayResultList(arr: [Any]) throws -> [LnUrlPayResult] {
+    var list = [LnUrlPayResult]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlPayResult = try asLnUrlPayResult(lnUrlPayResult: val)
+            list.append(lnUrlPayResult)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayResult"))
         }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlPayResult")
     }
+    return list
+}
 
-    static func dictionaryOf(lnUrlPayResult: LnUrlPayResult) -> [String: Any?] {
-        switch lnUrlPayResult {
-        case let .endpointSuccess(
-            data
-        ):
-            return [
-                "type": "endpointSuccess",
-                "data": dictionaryOf(lnUrlPaySuccessData: data),
-            ]
-
-        case let .endpointError(
-            data
-        ):
-            return [
-                "type": "endpointError",
-                "data": dictionaryOf(lnUrlErrorData: data),
-            ]
-
-        case let .payError(
-            data
-        ):
-            return [
-                "type": "payError",
-                "data": dictionaryOf(lnUrlPayErrorData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(lnUrlPayResultList: [LnUrlPayResult]) -> [Any] {
-        return lnUrlPayResultList.map { v -> [String: Any?] in return dictionaryOf(lnUrlPayResult: v) }
-    }
-
-    static func asLnUrlPayResultList(arr: [Any]) throws -> [LnUrlPayResult] {
-        var list = [LnUrlPayResult]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlPayResult = try asLnUrlPayResult(lnUrlPayResult: val)
-                list.append(lnUrlPayResult)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlPayResult"))
-            }
-        }
-        return list
-    }
-
-    static func asLnUrlWithdrawResult(lnUrlWithdrawResult: [String: Any?]) throws -> LnUrlWithdrawResult {
-        let type = lnUrlWithdrawResult["type"] as! String
-        if type == "ok" {
-            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
-            }
+static func asLnUrlWithdrawResult(lnUrlWithdrawResult: [String: Any?]) throws -> LnUrlWithdrawResult {
+    let type = lnUrlWithdrawResult["type"] as! String
+        if (type == "ok") {
+                guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
+                }
             let _data = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: dataTmp)
-
-            return LnUrlWithdrawResult.ok(data: _data)
+                        
+            return LnUrlWithdrawResult.ok(data: _data)       
         }
-        if type == "timeout" {
-            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
-            }
+        if (type == "timeout") {
+                guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
+                }
             let _data = try asLnUrlWithdrawSuccessData(lnUrlWithdrawSuccessData: dataTmp)
-
-            return LnUrlWithdrawResult.timeout(data: _data)
+                        
+            return LnUrlWithdrawResult.timeout(data: _data)       
         }
-        if type == "errorStatus" {
-            guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
-            }
+        if (type == "errorStatus") {
+                guard let dataTmp = lnUrlWithdrawResult["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "LnUrlWithdrawResult"))
+                }
             let _data = try asLnUrlErrorData(lnUrlErrorData: dataTmp)
+                        
+            return LnUrlWithdrawResult.errorStatus(data: _data)       
+        }    
 
-            return LnUrlWithdrawResult.errorStatus(data: _data)
-        }
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlWithdrawResult")
+}
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum LnUrlWithdrawResult")
-    }
+static func dictionaryOf(lnUrlWithdrawResult: LnUrlWithdrawResult) -> [String: Any?] {    
+    switch (lnUrlWithdrawResult) {
+    
+    case let .ok(
+        data
+    ):
+    return [
+            "type": "ok",
+            "data": dictionaryOf(lnUrlWithdrawSuccessData: data),
+        ]
+    
+    case let .timeout(
+        data
+    ):
+    return [
+            "type": "timeout",
+            "data": dictionaryOf(lnUrlWithdrawSuccessData: data),
+        ]
+    
+    case let .errorStatus(
+        data
+    ):
+    return [
+            "type": "errorStatus",
+            "data": dictionaryOf(lnUrlErrorData: data),
+        ]   
+    }    
+}
 
-    static func dictionaryOf(lnUrlWithdrawResult: LnUrlWithdrawResult) -> [String: Any?] {
-        switch lnUrlWithdrawResult {
-        case let .ok(
-            data
-        ):
-            return [
-                "type": "ok",
-                "data": dictionaryOf(lnUrlWithdrawSuccessData: data),
-            ]
+static func arrayOf(`lnUrlWithdrawResultList`: [LnUrlWithdrawResult]) -> [Any] {
+    return `lnUrlWithdrawResultList`.map { (v) -> [String: Any?] in return dictionaryOf(lnUrlWithdrawResult: v) }
+}
 
-        case let .timeout(
-            data
-        ):
-            return [
-                "type": "timeout",
-                "data": dictionaryOf(lnUrlWithdrawSuccessData: data),
-            ]
-
-        case let .errorStatus(
-            data
-        ):
-            return [
-                "type": "errorStatus",
-                "data": dictionaryOf(lnUrlErrorData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(lnUrlWithdrawResultList: [LnUrlWithdrawResult]) -> [Any] {
-        return lnUrlWithdrawResultList.map { v -> [String: Any?] in return dictionaryOf(lnUrlWithdrawResult: v) }
-    }
-
-    static func asLnUrlWithdrawResultList(arr: [Any]) throws -> [LnUrlWithdrawResult] {
-        var list = [LnUrlWithdrawResult]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var lnUrlWithdrawResult = try asLnUrlWithdrawResult(lnUrlWithdrawResult: val)
-                list.append(lnUrlWithdrawResult)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawResult"))
-            }
-        }
-        return list
-    }
-
-    static func asNetwork(network: String) throws -> Network {
-        switch network {
-        case "bitcoin":
-            return Network.bitcoin
-
-        case "testnet":
-            return Network.testnet
-
-        case "signet":
-            return Network.signet
-
-        case "regtest":
-            return Network.regtest
-
-        default: throw SdkError.Generic(message: "Invalid variant \(network) for enum Network")
+static func asLnUrlWithdrawResultList(arr: [Any]) throws -> [LnUrlWithdrawResult] {
+    var list = [LnUrlWithdrawResult]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var lnUrlWithdrawResult = try asLnUrlWithdrawResult(lnUrlWithdrawResult: val)
+            list.append(lnUrlWithdrawResult)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "LnUrlWithdrawResult"))
         }
     }
+    return list
+}
 
-    static func valueOf(network: Network) -> String {
-        switch network {
-        case .bitcoin:
-            return "bitcoin"
+static func asNetwork(network: String) throws -> Network {
+    switch(network) {
 
-        case .testnet:
-            return "testnet"
+    case "bitcoin":         
+        return Network.bitcoin
 
-        case .signet:
-            return "signet"
+    case "testnet":         
+        return Network.testnet
 
-        case .regtest:
-            return "regtest"
+    case "signet":         
+        return Network.signet
+
+    case "regtest":         
+        return Network.regtest
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(network) for enum Network")
+    }
+}
+
+static func valueOf(network: Network) -> String {
+    switch(network) {
+
+    case .bitcoin:         
+        return "bitcoin"
+
+    case .testnet:         
+        return "testnet"
+
+    case .signet:         
+        return "signet"
+
+    case .regtest:         
+        return "regtest"
+            
+    }
+}
+
+static func arrayOf(`networkList`: [Network]) -> [String] {
+    return `networkList`.map { (v) -> String in return valueOf(network: v) }
+}
+
+static func asNetworkList(arr: [Any]) throws -> [Network] {
+    var list = [Network]()
+    for value in arr {
+        if let val = value as? String {
+            var network = try asNetwork(network: val)
+            list.append(network)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "Network"))
         }
     }
+    return list
+}
 
-    static func arrayOf(networkList: [Network]) -> [String] {
-        return networkList.map { v -> String in return valueOf(network: v) }
-    }
-
-    static func asNetworkList(arr: [Any]) throws -> [Network] {
-        var list = [Network]()
-        for value in arr {
-            if let val = value as? String {
-                var network = try asNetwork(network: val)
-                list.append(network)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "Network"))
-            }
+static func asPayAmount(payAmount: [String: Any?]) throws -> PayAmount {
+    let type = payAmount["type"] as! String
+        if (type == "bitcoin") {
+                guard let _receiverAmountSat = payAmount["receiverAmountSat"] as? UInt64 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "PayAmount"))
+                }            
+            return PayAmount.bitcoin(receiverAmountSat: _receiverAmountSat)       
         }
-        return list
-    }
-
-    static func asPayAmount(payAmount: [String: Any?]) throws -> PayAmount {
-        let type = payAmount["type"] as! String
-        if type == "bitcoin" {
-            guard let _receiverAmountSat = payAmount["receiverAmountSat"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "PayAmount"))
-            }
-            return PayAmount.bitcoin(receiverAmountSat: _receiverAmountSat)
+        if (type == "asset") {
+                guard let _assetId = payAmount["assetId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "PayAmount"))
+                }
+                guard let _receiverAmount = payAmount["receiverAmount"] as? Double else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmount", typeName: "PayAmount"))
+                }            
+            return PayAmount.asset(assetId: _assetId, receiverAmount: _receiverAmount)       
         }
-        if type == "asset" {
-            guard let _assetId = payAmount["assetId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "PayAmount"))
-            }
-            guard let _receiverAmount = payAmount["receiverAmount"] as? Double else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmount", typeName: "PayAmount"))
-            }
-            return PayAmount.asset(assetId: _assetId, receiverAmount: _receiverAmount)
-        }
-        if type == "drain" {
-            return PayAmount.drain
-        }
+        if (type == "drain") {
+            return PayAmount.drain       
+        }    
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum PayAmount")
-    }
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum PayAmount")
+}
 
-    static func dictionaryOf(payAmount: PayAmount) -> [String: Any?] {
-        switch payAmount {
-        case let .bitcoin(
-            receiverAmountSat
-        ):
-            return [
-                "type": "bitcoin",
-                "receiverAmountSat": receiverAmountSat,
-            ]
+static func dictionaryOf(payAmount: PayAmount) -> [String: Any?] {    
+    switch (payAmount) {
+    
+    case let .bitcoin(
+        receiverAmountSat
+    ):
+    return [
+            "type": "bitcoin",
+            "receiverAmountSat": receiverAmountSat,
+        ]
+    
+    case let .asset(
+        assetId, receiverAmount
+    ):
+    return [
+            "type": "asset",
+            "assetId": assetId,
+            "receiverAmount": receiverAmount,
+        ]
+    
+    case .drain:  
+    return [
+            "type": "drain",
+        ]   
+    }    
+}
 
-        case let .asset(
-            assetId, receiverAmount
-        ):
-            return [
-                "type": "asset",
-                "assetId": assetId,
-                "receiverAmount": receiverAmount,
-            ]
+static func arrayOf(`payAmountList`: [PayAmount]) -> [Any] {
+    return `payAmountList`.map { (v) -> [String: Any?] in return dictionaryOf(payAmount: v) }
+}
 
-        case .drain:
-            return [
-                "type": "drain",
-            ]
-        }
-    }
-
-    static func arrayOf(payAmountList: [PayAmount]) -> [Any] {
-        return payAmountList.map { v -> [String: Any?] in return dictionaryOf(payAmount: v) }
-    }
-
-    static func asPayAmountList(arr: [Any]) throws -> [PayAmount] {
-        var list = [PayAmount]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var payAmount = try asPayAmount(payAmount: val)
-                list.append(payAmount)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PayAmount"))
-            }
-        }
-        return list
-    }
-
-    static func asPaymentDetails(paymentDetails: [String: Any?]) throws -> PaymentDetails {
-        let type = paymentDetails["type"] as! String
-        if type == "lightning" {
-            guard let _swapId = paymentDetails["swapId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
-            }
-            guard let _description = paymentDetails["description"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
-            }
-            guard let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidExpirationBlockheight", typeName: "PaymentDetails"))
-            }
-            let _preimage = paymentDetails["preimage"] as? String
-
-            let _invoice = paymentDetails["invoice"] as? String
-
-            let _bolt12Offer = paymentDetails["bolt12Offer"] as? String
-
-            let _paymentHash = paymentDetails["paymentHash"] as? String
-
-            let _destinationPubkey = paymentDetails["destinationPubkey"] as? String
-
-            var _lnurlInfo: LnUrlInfo?
-            if let lnurlInfoTmp = paymentDetails["lnurlInfo"] as? [String: Any?] {
-                _lnurlInfo = try asLnUrlInfo(lnUrlInfo: lnurlInfoTmp)
-            }
-
-            let _bip353Address = paymentDetails["bip353Address"] as? String
-
-            let _claimTxId = paymentDetails["claimTxId"] as? String
-
-            let _refundTxId = paymentDetails["refundTxId"] as? String
-
-            let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
-
-            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, bip353Address: _bip353Address, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
-        }
-        if type == "liquid" {
-            guard let _assetId = paymentDetails["assetId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "PaymentDetails"))
-            }
-            guard let _destination = paymentDetails["destination"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PaymentDetails"))
-            }
-            guard let _description = paymentDetails["description"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
-            }
-            var _assetInfo: AssetInfo?
-            if let assetInfoTmp = paymentDetails["assetInfo"] as? [String: Any?] {
-                _assetInfo = try asAssetInfo(assetInfo: assetInfoTmp)
-            }
-
-            return PaymentDetails.liquid(assetId: _assetId, destination: _destination, description: _description, assetInfo: _assetInfo)
-        }
-        if type == "bitcoin" {
-            guard let _swapId = paymentDetails["swapId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
-            }
-            guard let _description = paymentDetails["description"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
-            }
-            guard let _autoAcceptedFees = paymentDetails["autoAcceptedFees"] as? Bool else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "autoAcceptedFees", typeName: "PaymentDetails"))
-            }
-            let _bitcoinExpirationBlockheight = paymentDetails["bitcoinExpirationBlockheight"] as? UInt32
-
-            let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32
-
-            let _claimTxId = paymentDetails["claimTxId"] as? String
-
-            let _refundTxId = paymentDetails["refundTxId"] as? String
-
-            let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
-
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
-        }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
-    }
-
-    static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {
-        switch paymentDetails {
-        case let .lightning(
-            swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, bip353Address, claimTxId, refundTxId, refundTxAmountSat
-        ):
-            return [
-                "type": "lightning",
-                "swapId": swapId,
-                "description": description,
-                "liquidExpirationBlockheight": liquidExpirationBlockheight,
-                "preimage": preimage == nil ? nil : preimage,
-                "invoice": invoice == nil ? nil : invoice,
-                "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
-                "paymentHash": paymentHash == nil ? nil : paymentHash,
-                "destinationPubkey": destinationPubkey == nil ? nil : destinationPubkey,
-                "lnurlInfo": lnurlInfo == nil ? nil : dictionaryOf(lnUrlInfo: lnurlInfo!),
-                "bip353Address": bip353Address == nil ? nil : bip353Address,
-                "claimTxId": claimTxId == nil ? nil : claimTxId,
-                "refundTxId": refundTxId == nil ? nil : refundTxId,
-                "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
-            ]
-
-        case let .liquid(
-            assetId, destination, description, assetInfo
-        ):
-            return [
-                "type": "liquid",
-                "assetId": assetId,
-                "destination": destination,
-                "description": description,
-                "assetInfo": assetInfo == nil ? nil : dictionaryOf(assetInfo: assetInfo!),
-            ]
-
-        case let .bitcoin(
-            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, claimTxId, refundTxId, refundTxAmountSat
-        ):
-            return [
-                "type": "bitcoin",
-                "swapId": swapId,
-                "description": description,
-                "autoAcceptedFees": autoAcceptedFees,
-                "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,
-                "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
-                "claimTxId": claimTxId == nil ? nil : claimTxId,
-                "refundTxId": refundTxId == nil ? nil : refundTxId,
-                "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
-            ]
+static func asPayAmountList(arr: [Any]) throws -> [PayAmount] {
+    var list = [PayAmount]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var payAmount = try asPayAmount(payAmount: val)
+            list.append(payAmount)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PayAmount"))
         }
     }
+    return list
+}
 
-    static func arrayOf(paymentDetailsList: [PaymentDetails]) -> [Any] {
-        return paymentDetailsList.map { v -> [String: Any?] in return dictionaryOf(paymentDetails: v) }
-    }
-
-    static func asPaymentDetailsList(arr: [Any]) throws -> [PaymentDetails] {
-        var list = [PaymentDetails]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var paymentDetails = try asPaymentDetails(paymentDetails: val)
-                list.append(paymentDetails)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentDetails"))
-            }
+static func asPaymentDetails(paymentDetails: [String: Any?]) throws -> PaymentDetails {
+    let type = paymentDetails["type"] as! String
+        if (type == "lightning") {
+                guard let _swapId = paymentDetails["swapId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
+                }
+                guard let _description = paymentDetails["description"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
+                }
+                guard let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "liquidExpirationBlockheight", typeName: "PaymentDetails"))
+                }
+                    let _preimage = paymentDetails["preimage"] as? String
+                    
+                    let _invoice = paymentDetails["invoice"] as? String
+                    
+                    let _bolt12Offer = paymentDetails["bolt12Offer"] as? String
+                    
+                    let _paymentHash = paymentDetails["paymentHash"] as? String
+                    
+                    let _destinationPubkey = paymentDetails["destinationPubkey"] as? String
+                    
+                    var _lnurlInfo: LnUrlInfo?
+                    if let lnurlInfoTmp = paymentDetails["lnurlInfo"] as? [String: Any?] {
+                        _lnurlInfo = try asLnUrlInfo(lnUrlInfo: lnurlInfoTmp)
+                    }
+                    
+                    let _bip353Address = paymentDetails["bip353Address"] as? String
+                    
+                    let _claimTxId = paymentDetails["claimTxId"] as? String
+                    
+                    let _refundTxId = paymentDetails["refundTxId"] as? String
+                    
+                    let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
+                                
+            return PaymentDetails.lightning(swapId: _swapId, description: _description, liquidExpirationBlockheight: _liquidExpirationBlockheight, preimage: _preimage, invoice: _invoice, bolt12Offer: _bolt12Offer, paymentHash: _paymentHash, destinationPubkey: _destinationPubkey, lnurlInfo: _lnurlInfo, bip353Address: _bip353Address, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)       
         }
-        return list
-    }
-
-    static func asPaymentMethod(paymentMethod: String) throws -> PaymentMethod {
-        switch paymentMethod {
-        case "lightning":
-            return PaymentMethod.lightning
-
-        case "bitcoinAddress":
-            return PaymentMethod.bitcoinAddress
-
-        case "liquidAddress":
-            return PaymentMethod.liquidAddress
-
-        default: throw SdkError.Generic(message: "Invalid variant \(paymentMethod) for enum PaymentMethod")
+        if (type == "liquid") {
+                guard let _assetId = paymentDetails["assetId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "PaymentDetails"))
+                }
+                guard let _destination = paymentDetails["destination"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destination", typeName: "PaymentDetails"))
+                }
+                guard let _description = paymentDetails["description"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
+                }
+                    var _assetInfo: AssetInfo?
+                    if let assetInfoTmp = paymentDetails["assetInfo"] as? [String: Any?] {
+                        _assetInfo = try asAssetInfo(assetInfo: assetInfoTmp)
+                    }
+                                
+            return PaymentDetails.liquid(assetId: _assetId, destination: _destination, description: _description, assetInfo: _assetInfo)       
         }
-    }
+        if (type == "bitcoin") {
+                guard let _swapId = paymentDetails["swapId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
+                }
+                guard let _description = paymentDetails["description"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
+                }
+                guard let _autoAcceptedFees = paymentDetails["autoAcceptedFees"] as? Bool else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "autoAcceptedFees", typeName: "PaymentDetails"))
+                }
+                    let _bitcoinExpirationBlockheight = paymentDetails["bitcoinExpirationBlockheight"] as? UInt32
+                    
+                    let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32
+                    
+                    let _claimTxId = paymentDetails["claimTxId"] as? String
+                    
+                    let _refundTxId = paymentDetails["refundTxId"] as? String
+                    
+                    let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
+                                
+            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)       
+        }    
 
-    static func valueOf(paymentMethod: PaymentMethod) -> String {
-        switch paymentMethod {
-        case .lightning:
-            return "lightning"
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
+}
 
-        case .bitcoinAddress:
-            return "bitcoinAddress"
+static func dictionaryOf(paymentDetails: PaymentDetails) -> [String: Any?] {    
+    switch (paymentDetails) {
+    
+    case let .lightning(
+        swapId, description, liquidExpirationBlockheight, preimage, invoice, bolt12Offer, paymentHash, destinationPubkey, lnurlInfo, bip353Address, claimTxId, refundTxId, refundTxAmountSat
+    ):
+    return [
+            "type": "lightning",
+            "swapId": swapId,
+            "description": description,
+            "liquidExpirationBlockheight": liquidExpirationBlockheight,
+            "preimage": preimage == nil ? nil : preimage,
+            "invoice": invoice == nil ? nil : invoice,
+            "bolt12Offer": bolt12Offer == nil ? nil : bolt12Offer,
+            "paymentHash": paymentHash == nil ? nil : paymentHash,
+            "destinationPubkey": destinationPubkey == nil ? nil : destinationPubkey,
+            "lnurlInfo": lnurlInfo == nil ? nil : dictionaryOf(lnUrlInfo: lnurlInfo!),
+            "bip353Address": bip353Address == nil ? nil : bip353Address,
+            "claimTxId": claimTxId == nil ? nil : claimTxId,
+            "refundTxId": refundTxId == nil ? nil : refundTxId,
+            "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
+        ]
+    
+    case let .liquid(
+        assetId, destination, description, assetInfo
+    ):
+    return [
+            "type": "liquid",
+            "assetId": assetId,
+            "destination": destination,
+            "description": description,
+            "assetInfo": assetInfo == nil ? nil : dictionaryOf(assetInfo: assetInfo!),
+        ]
+    
+    case let .bitcoin(
+        swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, claimTxId, refundTxId, refundTxAmountSat
+    ):
+    return [
+            "type": "bitcoin",
+            "swapId": swapId,
+            "description": description,
+            "autoAcceptedFees": autoAcceptedFees,
+            "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,
+            "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
+            "claimTxId": claimTxId == nil ? nil : claimTxId,
+            "refundTxId": refundTxId == nil ? nil : refundTxId,
+            "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,
+        ]   
+    }    
+}
 
-        case .liquidAddress:
-            return "liquidAddress"
-        }
-    }
+static func arrayOf(`paymentDetailsList`: [PaymentDetails]) -> [Any] {
+    return `paymentDetailsList`.map { (v) -> [String: Any?] in return dictionaryOf(paymentDetails: v) }
+}
 
-    static func arrayOf(paymentMethodList: [PaymentMethod]) -> [String] {
-        return paymentMethodList.map { v -> String in return valueOf(paymentMethod: v) }
-    }
-
-    static func asPaymentMethodList(arr: [Any]) throws -> [PaymentMethod] {
-        var list = [PaymentMethod]()
-        for value in arr {
-            if let val = value as? String {
-                var paymentMethod = try asPaymentMethod(paymentMethod: val)
-                list.append(paymentMethod)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentMethod"))
-            }
-        }
-        return list
-    }
-
-    static func asPaymentState(paymentState: String) throws -> PaymentState {
-        switch paymentState {
-        case "created":
-            return PaymentState.created
-
-        case "pending":
-            return PaymentState.pending
-
-        case "complete":
-            return PaymentState.complete
-
-        case "failed":
-            return PaymentState.failed
-
-        case "timedOut":
-            return PaymentState.timedOut
-
-        case "refundable":
-            return PaymentState.refundable
-
-        case "refundPending":
-            return PaymentState.refundPending
-
-        case "waitingFeeAcceptance":
-            return PaymentState.waitingFeeAcceptance
-
-        default: throw SdkError.Generic(message: "Invalid variant \(paymentState) for enum PaymentState")
-        }
-    }
-
-    static func valueOf(paymentState: PaymentState) -> String {
-        switch paymentState {
-        case .created:
-            return "created"
-
-        case .pending:
-            return "pending"
-
-        case .complete:
-            return "complete"
-
-        case .failed:
-            return "failed"
-
-        case .timedOut:
-            return "timedOut"
-
-        case .refundable:
-            return "refundable"
-
-        case .refundPending:
-            return "refundPending"
-
-        case .waitingFeeAcceptance:
-            return "waitingFeeAcceptance"
-        }
-    }
-
-    static func arrayOf(paymentStateList: [PaymentState]) -> [String] {
-        return paymentStateList.map { v -> String in return valueOf(paymentState: v) }
-    }
-
-    static func asPaymentStateList(arr: [Any]) throws -> [PaymentState] {
-        var list = [PaymentState]()
-        for value in arr {
-            if let val = value as? String {
-                var paymentState = try asPaymentState(paymentState: val)
-                list.append(paymentState)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentState"))
-            }
-        }
-        return list
-    }
-
-    static func asPaymentType(paymentType: String) throws -> PaymentType {
-        switch paymentType {
-        case "receive":
-            return PaymentType.receive
-
-        case "send":
-            return PaymentType.send
-
-        default: throw SdkError.Generic(message: "Invalid variant \(paymentType) for enum PaymentType")
-        }
-    }
-
-    static func valueOf(paymentType: PaymentType) -> String {
-        switch paymentType {
-        case .receive:
-            return "receive"
-
-        case .send:
-            return "send"
+static func asPaymentDetailsList(arr: [Any]) throws -> [PaymentDetails] {
+    var list = [PaymentDetails]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var paymentDetails = try asPaymentDetails(paymentDetails: val)
+            list.append(paymentDetails)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentDetails"))
         }
     }
+    return list
+}
 
-    static func arrayOf(paymentTypeList: [PaymentType]) -> [String] {
-        return paymentTypeList.map { v -> String in return valueOf(paymentType: v) }
+static func asPaymentMethod(paymentMethod: String) throws -> PaymentMethod {
+    switch(paymentMethod) {
+
+    case "lightning":         
+        return PaymentMethod.lightning
+
+    case "bitcoinAddress":         
+        return PaymentMethod.bitcoinAddress
+
+    case "liquidAddress":         
+        return PaymentMethod.liquidAddress
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(paymentMethod) for enum PaymentMethod")
     }
+}
 
-    static func asPaymentTypeList(arr: [Any]) throws -> [PaymentType] {
-        var list = [PaymentType]()
-        for value in arr {
-            if let val = value as? String {
-                var paymentType = try asPaymentType(paymentType: val)
-                list.append(paymentType)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentType"))
-            }
-        }
-        return list
+static func valueOf(paymentMethod: PaymentMethod) -> String {
+    switch(paymentMethod) {
+
+    case .lightning:         
+        return "lightning"
+
+    case .bitcoinAddress:         
+        return "bitcoinAddress"
+
+    case .liquidAddress:         
+        return "liquidAddress"
+            
     }
+}
 
-    static func asReceiveAmount(receiveAmount: [String: Any?]) throws -> ReceiveAmount {
-        let type = receiveAmount["type"] as! String
-        if type == "bitcoin" {
-            guard let _payerAmountSat = receiveAmount["payerAmountSat"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payerAmountSat", typeName: "ReceiveAmount"))
-            }
-            return ReceiveAmount.bitcoin(payerAmountSat: _payerAmountSat)
-        }
-        if type == "asset" {
-            guard let _assetId = receiveAmount["assetId"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "ReceiveAmount"))
-            }
-            let _payerAmount = receiveAmount["payerAmount"] as? Double
+static func arrayOf(`paymentMethodList`: [PaymentMethod]) -> [String] {
+    return `paymentMethodList`.map { (v) -> String in return valueOf(paymentMethod: v) }
+}
 
-            return ReceiveAmount.asset(assetId: _assetId, payerAmount: _payerAmount)
-        }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum ReceiveAmount")
-    }
-
-    static func dictionaryOf(receiveAmount: ReceiveAmount) -> [String: Any?] {
-        switch receiveAmount {
-        case let .bitcoin(
-            payerAmountSat
-        ):
-            return [
-                "type": "bitcoin",
-                "payerAmountSat": payerAmountSat,
-            ]
-
-        case let .asset(
-            assetId, payerAmount
-        ):
-            return [
-                "type": "asset",
-                "assetId": assetId,
-                "payerAmount": payerAmount == nil ? nil : payerAmount,
-            ]
+static func asPaymentMethodList(arr: [Any]) throws -> [PaymentMethod] {
+    var list = [PaymentMethod]()
+    for value in arr {
+        if let val = value as? String {
+            var paymentMethod = try asPaymentMethod(paymentMethod: val)
+            list.append(paymentMethod)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentMethod"))
         }
     }
+    return list
+}
 
-    static func arrayOf(receiveAmountList: [ReceiveAmount]) -> [Any] {
-        return receiveAmountList.map { v -> [String: Any?] in return dictionaryOf(receiveAmount: v) }
+static func asPaymentState(paymentState: String) throws -> PaymentState {
+    switch(paymentState) {
+
+    case "created":         
+        return PaymentState.created
+
+    case "pending":         
+        return PaymentState.pending
+
+    case "complete":         
+        return PaymentState.complete
+
+    case "failed":         
+        return PaymentState.failed
+
+    case "timedOut":         
+        return PaymentState.timedOut
+
+    case "refundable":         
+        return PaymentState.refundable
+
+    case "refundPending":         
+        return PaymentState.refundPending
+
+    case "waitingFeeAcceptance":         
+        return PaymentState.waitingFeeAcceptance
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(paymentState) for enum PaymentState")
     }
+}
 
-    static func asReceiveAmountList(arr: [Any]) throws -> [ReceiveAmount] {
-        var list = [ReceiveAmount]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var receiveAmount = try asReceiveAmount(receiveAmount: val)
-                list.append(receiveAmount)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceiveAmount"))
-            }
+static func valueOf(paymentState: PaymentState) -> String {
+    switch(paymentState) {
+
+    case .created:         
+        return "created"
+
+    case .pending:         
+        return "pending"
+
+    case .complete:         
+        return "complete"
+
+    case .failed:         
+        return "failed"
+
+    case .timedOut:         
+        return "timedOut"
+
+    case .refundable:         
+        return "refundable"
+
+    case .refundPending:         
+        return "refundPending"
+
+    case .waitingFeeAcceptance:         
+        return "waitingFeeAcceptance"
+            
+    }
+}
+
+static func arrayOf(`paymentStateList`: [PaymentState]) -> [String] {
+    return `paymentStateList`.map { (v) -> String in return valueOf(paymentState: v) }
+}
+
+static func asPaymentStateList(arr: [Any]) throws -> [PaymentState] {
+    var list = [PaymentState]()
+    for value in arr {
+        if let val = value as? String {
+            var paymentState = try asPaymentState(paymentState: val)
+            list.append(paymentState)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentState"))
         }
-        return list
     }
+    return list
+}
 
-    static func asSdkEvent(sdkEvent: [String: Any?]) throws -> SdkEvent {
-        let type = sdkEvent["type"] as! String
-        if type == "paymentFailed" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+static func asPaymentType(paymentType: String) throws -> PaymentType {
+    switch(paymentType) {
+
+    case "receive":         
+        return PaymentType.receive
+
+    case "send":         
+        return PaymentType.send
+    
+    default: throw SdkError.Generic(message: "Invalid variant \(paymentType) for enum PaymentType")
+    }
+}
+
+static func valueOf(paymentType: PaymentType) -> String {
+    switch(paymentType) {
+
+    case .receive:         
+        return "receive"
+
+    case .send:         
+        return "send"
+            
+    }
+}
+
+static func arrayOf(`paymentTypeList`: [PaymentType]) -> [String] {
+    return `paymentTypeList`.map { (v) -> String in return valueOf(paymentType: v) }
+}
+
+static func asPaymentTypeList(arr: [Any]) throws -> [PaymentType] {
+    var list = [PaymentType]()
+    for value in arr {
+        if let val = value as? String {
+            var paymentType = try asPaymentType(paymentType: val)
+            list.append(paymentType)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "PaymentType"))
+        }
+    }
+    return list
+}
+
+static func asReceiveAmount(receiveAmount: [String: Any?]) throws -> ReceiveAmount {
+    let type = receiveAmount["type"] as! String
+        if (type == "bitcoin") {
+                guard let _payerAmountSat = receiveAmount["payerAmountSat"] as? UInt64 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "payerAmountSat", typeName: "ReceiveAmount"))
+                }            
+            return ReceiveAmount.bitcoin(payerAmountSat: _payerAmountSat)       
+        }
+        if (type == "asset") {
+                guard let _assetId = receiveAmount["assetId"] as? String else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "assetId", typeName: "ReceiveAmount"))
+                }
+                    let _payerAmount = receiveAmount["payerAmount"] as? Double
+                                
+            return ReceiveAmount.asset(assetId: _assetId, payerAmount: _payerAmount)       
+        }    
+
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum ReceiveAmount")
+}
+
+static func dictionaryOf(receiveAmount: ReceiveAmount) -> [String: Any?] {    
+    switch (receiveAmount) {
+    
+    case let .bitcoin(
+        payerAmountSat
+    ):
+    return [
+            "type": "bitcoin",
+            "payerAmountSat": payerAmountSat,
+        ]
+    
+    case let .asset(
+        assetId, payerAmount
+    ):
+    return [
+            "type": "asset",
+            "assetId": assetId,
+            "payerAmount": payerAmount == nil ? nil : payerAmount,
+        ]   
+    }    
+}
+
+static func arrayOf(`receiveAmountList`: [ReceiveAmount]) -> [Any] {
+    return `receiveAmountList`.map { (v) -> [String: Any?] in return dictionaryOf(receiveAmount: v) }
+}
+
+static func asReceiveAmountList(arr: [Any]) throws -> [ReceiveAmount] {
+    var list = [ReceiveAmount]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var receiveAmount = try asReceiveAmount(receiveAmount: val)
+            list.append(receiveAmount)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "ReceiveAmount"))
+        }
+    }
+    return list
+}
+
+static func asSdkEvent(sdkEvent: [String: Any?]) throws -> SdkEvent {
+    let type = sdkEvent["type"] as! String
+        if (type == "paymentFailed") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentFailed(details: _details)
+                        
+            return SdkEvent.paymentFailed(details: _details)       
         }
-        if type == "paymentPending" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentPending") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentPending(details: _details)
+                        
+            return SdkEvent.paymentPending(details: _details)       
         }
-        if type == "paymentRefundable" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentRefundable") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentRefundable(details: _details)
+                        
+            return SdkEvent.paymentRefundable(details: _details)       
         }
-        if type == "paymentRefunded" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentRefunded") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentRefunded(details: _details)
+                        
+            return SdkEvent.paymentRefunded(details: _details)       
         }
-        if type == "paymentRefundPending" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentRefundPending") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentRefundPending(details: _details)
+                        
+            return SdkEvent.paymentRefundPending(details: _details)       
         }
-        if type == "paymentSucceeded" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentSucceeded") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentSucceeded(details: _details)
+                        
+            return SdkEvent.paymentSucceeded(details: _details)       
         }
-        if type == "paymentWaitingConfirmation" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentWaitingConfirmation") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentWaitingConfirmation(details: _details)
+                        
+            return SdkEvent.paymentWaitingConfirmation(details: _details)       
         }
-        if type == "paymentWaitingFeeAcceptance" {
-            guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
-            }
+        if (type == "paymentWaitingFeeAcceptance") {
+                guard let detailsTmp = sdkEvent["details"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "SdkEvent"))
+                }
             let _details = try asPayment(payment: detailsTmp)
-
-            return SdkEvent.paymentWaitingFeeAcceptance(details: _details)
+                        
+            return SdkEvent.paymentWaitingFeeAcceptance(details: _details)       
         }
-        if type == "synced" {
-            return SdkEvent.synced
-        }
+        if (type == "synced") {
+            return SdkEvent.synced       
+        }    
 
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum SdkEvent")
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum SdkEvent")
+}
+
+static func dictionaryOf(sdkEvent: SdkEvent) -> [String: Any?] {    
+    switch (sdkEvent) {
+    
+    case let .paymentFailed(
+        details
+    ):
+    return [
+            "type": "paymentFailed",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentPending(
+        details
+    ):
+    return [
+            "type": "paymentPending",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentRefundable(
+        details
+    ):
+    return [
+            "type": "paymentRefundable",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentRefunded(
+        details
+    ):
+    return [
+            "type": "paymentRefunded",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentRefundPending(
+        details
+    ):
+    return [
+            "type": "paymentRefundPending",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentSucceeded(
+        details
+    ):
+    return [
+            "type": "paymentSucceeded",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentWaitingConfirmation(
+        details
+    ):
+    return [
+            "type": "paymentWaitingConfirmation",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case let .paymentWaitingFeeAcceptance(
+        details
+    ):
+    return [
+            "type": "paymentWaitingFeeAcceptance",
+            "details": dictionaryOf(payment: details),
+        ]
+    
+    case .synced:  
+    return [
+            "type": "synced",
+        ]   
+    }    
+}
+
+static func arrayOf(`sdkEventList`: [SdkEvent]) -> [Any] {
+    return `sdkEventList`.map { (v) -> [String: Any?] in return dictionaryOf(sdkEvent: v) }
+}
+
+static func asSdkEventList(arr: [Any]) throws -> [SdkEvent] {
+    var list = [SdkEvent]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var sdkEvent = try asSdkEvent(sdkEvent: val)
+            list.append(sdkEvent)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SdkEvent"))
+        }
     }
+    return list
+}
 
-    static func dictionaryOf(sdkEvent: SdkEvent) -> [String: Any?] {
-        switch sdkEvent {
-        case let .paymentFailed(
-            details
-        ):
-            return [
-                "type": "paymentFailed",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentPending(
-            details
-        ):
-            return [
-                "type": "paymentPending",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentRefundable(
-            details
-        ):
-            return [
-                "type": "paymentRefundable",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentRefunded(
-            details
-        ):
-            return [
-                "type": "paymentRefunded",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentRefundPending(
-            details
-        ):
-            return [
-                "type": "paymentRefundPending",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentSucceeded(
-            details
-        ):
-            return [
-                "type": "paymentSucceeded",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentWaitingConfirmation(
-            details
-        ):
-            return [
-                "type": "paymentWaitingConfirmation",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case let .paymentWaitingFeeAcceptance(
-            details
-        ):
-            return [
-                "type": "paymentWaitingFeeAcceptance",
-                "details": dictionaryOf(payment: details),
-            ]
-
-        case .synced:
-            return [
-                "type": "synced",
-            ]
-        }
-    }
-
-    static func arrayOf(sdkEventList: [SdkEvent]) -> [Any] {
-        return sdkEventList.map { v -> [String: Any?] in return dictionaryOf(sdkEvent: v) }
-    }
-
-    static func asSdkEventList(arr: [Any]) throws -> [SdkEvent] {
-        var list = [SdkEvent]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sdkEvent = try asSdkEvent(sdkEvent: val)
-                list.append(sdkEvent)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SdkEvent"))
-            }
-        }
-        return list
-    }
-
-    static func asSendDestination(sendDestination: [String: Any?]) throws -> SendDestination {
-        let type = sendDestination["type"] as! String
-        if type == "liquidAddress" {
-            guard let addressDataTmp = sendDestination["addressData"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "addressData", typeName: "SendDestination"))
-            }
+static func asSendDestination(sendDestination: [String: Any?]) throws -> SendDestination {
+    let type = sendDestination["type"] as! String
+        if (type == "liquidAddress") {
+                guard let addressDataTmp = sendDestination["addressData"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "addressData", typeName: "SendDestination"))
+                }
             let _addressData = try asLiquidAddressData(liquidAddressData: addressDataTmp)
-
-            return SendDestination.liquidAddress(addressData: _addressData)
+                        
+            return SendDestination.liquidAddress(addressData: _addressData)       
         }
-        if type == "bolt11" {
-            guard let invoiceTmp = sendDestination["invoice"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "SendDestination"))
-            }
+        if (type == "bolt11") {
+                guard let invoiceTmp = sendDestination["invoice"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "invoice", typeName: "SendDestination"))
+                }
             let _invoice = try asLnInvoice(lnInvoice: invoiceTmp)
-
-            let _bip353Address = sendDestination["bip353Address"] as? String
-
-            return SendDestination.bolt11(invoice: _invoice, bip353Address: _bip353Address)
+            
+                    let _bip353Address = sendDestination["bip353Address"] as? String
+                                
+            return SendDestination.bolt11(invoice: _invoice, bip353Address: _bip353Address)       
         }
-        if type == "bolt12" {
-            guard let offerTmp = sendDestination["offer"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "SendDestination"))
-            }
+        if (type == "bolt12") {
+                guard let offerTmp = sendDestination["offer"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "offer", typeName: "SendDestination"))
+                }
             let _offer = try asLnOffer(lnOffer: offerTmp)
+            
+                guard let _receiverAmountSat = sendDestination["receiverAmountSat"] as? UInt64 else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "SendDestination"))
+                }
+                    let _bip353Address = sendDestination["bip353Address"] as? String
+                                
+            return SendDestination.bolt12(offer: _offer, receiverAmountSat: _receiverAmountSat, bip353Address: _bip353Address)       
+        }    
 
-            guard let _receiverAmountSat = sendDestination["receiverAmountSat"] as? UInt64 else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "receiverAmountSat", typeName: "SendDestination"))
-            }
-            let _bip353Address = sendDestination["bip353Address"] as? String
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum SendDestination")
+}
 
-            return SendDestination.bolt12(offer: _offer, receiverAmountSat: _receiverAmountSat, bip353Address: _bip353Address)
+static func dictionaryOf(sendDestination: SendDestination) -> [String: Any?] {    
+    switch (sendDestination) {
+    
+    case let .liquidAddress(
+        addressData
+    ):
+    return [
+            "type": "liquidAddress",
+            "addressData": dictionaryOf(liquidAddressData: addressData),
+        ]
+    
+    case let .bolt11(
+        invoice, bip353Address
+    ):
+    return [
+            "type": "bolt11",
+            "invoice": dictionaryOf(lnInvoice: invoice),
+            "bip353Address": bip353Address == nil ? nil : bip353Address,
+        ]
+    
+    case let .bolt12(
+        offer, receiverAmountSat, bip353Address
+    ):
+    return [
+            "type": "bolt12",
+            "offer": dictionaryOf(lnOffer: offer),
+            "receiverAmountSat": receiverAmountSat,
+            "bip353Address": bip353Address == nil ? nil : bip353Address,
+        ]   
+    }    
+}
+
+static func arrayOf(`sendDestinationList`: [SendDestination]) -> [Any] {
+    return `sendDestinationList`.map { (v) -> [String: Any?] in return dictionaryOf(sendDestination: v) }
+}
+
+static func asSendDestinationList(arr: [Any]) throws -> [SendDestination] {
+    var list = [SendDestination]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var sendDestination = try asSendDestination(sendDestination: val)
+            list.append(sendDestination)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SendDestination"))
         }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum SendDestination")
     }
+    return list
+}
 
-    static func dictionaryOf(sendDestination: SendDestination) -> [String: Any?] {
-        switch sendDestination {
-        case let .liquidAddress(
-            addressData
-        ):
-            return [
-                "type": "liquidAddress",
-                "addressData": dictionaryOf(liquidAddressData: addressData),
-            ]
-
-        case let .bolt11(
-            invoice, bip353Address
-        ):
-            return [
-                "type": "bolt11",
-                "invoice": dictionaryOf(lnInvoice: invoice),
-                "bip353Address": bip353Address == nil ? nil : bip353Address,
-            ]
-
-        case let .bolt12(
-            offer, receiverAmountSat, bip353Address
-        ):
-            return [
-                "type": "bolt12",
-                "offer": dictionaryOf(lnOffer: offer),
-                "receiverAmountSat": receiverAmountSat,
-                "bip353Address": bip353Address == nil ? nil : bip353Address,
-            ]
-        }
-    }
-
-    static func arrayOf(sendDestinationList: [SendDestination]) -> [Any] {
-        return sendDestinationList.map { v -> [String: Any?] in return dictionaryOf(sendDestination: v) }
-    }
-
-    static func asSendDestinationList(arr: [Any]) throws -> [SendDestination] {
-        var list = [SendDestination]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sendDestination = try asSendDestination(sendDestination: val)
-                list.append(sendDestination)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendDestination"))
-            }
-        }
-        return list
-    }
-
-    static func asSuccessAction(successAction: [String: Any?]) throws -> SuccessAction {
-        let type = successAction["type"] as! String
-        if type == "aes" {
-            guard let dataTmp = successAction["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
-            }
+static func asSuccessAction(successAction: [String: Any?]) throws -> SuccessAction {
+    let type = successAction["type"] as! String
+        if (type == "aes") {
+                guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+                }
             let _data = try asAesSuccessActionData(aesSuccessActionData: dataTmp)
-
-            return SuccessAction.aes(data: _data)
+                        
+            return SuccessAction.aes(data: _data)       
         }
-        if type == "message" {
-            guard let dataTmp = successAction["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
-            }
+        if (type == "message") {
+                guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+                }
             let _data = try asMessageSuccessActionData(messageSuccessActionData: dataTmp)
-
-            return SuccessAction.message(data: _data)
+                        
+            return SuccessAction.message(data: _data)       
         }
-        if type == "url" {
-            guard let dataTmp = successAction["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
-            }
+        if (type == "url") {
+                guard let dataTmp = successAction["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessAction"))
+                }
             let _data = try asUrlSuccessActionData(urlSuccessActionData: dataTmp)
+                        
+            return SuccessAction.url(data: _data)       
+        }    
 
-            return SuccessAction.url(data: _data)
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessAction")
+}
+
+static func dictionaryOf(successAction: SuccessAction) -> [String: Any?] {    
+    switch (successAction) {
+    
+    case let .aes(
+        data
+    ):
+    return [
+            "type": "aes",
+            "data": dictionaryOf(aesSuccessActionData: data),
+        ]
+    
+    case let .message(
+        data
+    ):
+    return [
+            "type": "message",
+            "data": dictionaryOf(messageSuccessActionData: data),
+        ]
+    
+    case let .url(
+        data
+    ):
+    return [
+            "type": "url",
+            "data": dictionaryOf(urlSuccessActionData: data),
+        ]   
+    }    
+}
+
+static func arrayOf(`successActionList`: [SuccessAction]) -> [Any] {
+    return `successActionList`.map { (v) -> [String: Any?] in return dictionaryOf(successAction: v) }
+}
+
+static func asSuccessActionList(arr: [Any]) throws -> [SuccessAction] {
+    var list = [SuccessAction]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var successAction = try asSuccessAction(successAction: val)
+            list.append(successAction)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessAction"))
         }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessAction")
     }
+    return list
+}
 
-    static func dictionaryOf(successAction: SuccessAction) -> [String: Any?] {
-        switch successAction {
-        case let .aes(
-            data
-        ):
-            return [
-                "type": "aes",
-                "data": dictionaryOf(aesSuccessActionData: data),
-            ]
-
-        case let .message(
-            data
-        ):
-            return [
-                "type": "message",
-                "data": dictionaryOf(messageSuccessActionData: data),
-            ]
-
-        case let .url(
-            data
-        ):
-            return [
-                "type": "url",
-                "data": dictionaryOf(urlSuccessActionData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(successActionList: [SuccessAction]) -> [Any] {
-        return successActionList.map { v -> [String: Any?] in return dictionaryOf(successAction: v) }
-    }
-
-    static func asSuccessActionList(arr: [Any]) throws -> [SuccessAction] {
-        var list = [SuccessAction]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var successAction = try asSuccessAction(successAction: val)
-                list.append(successAction)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessAction"))
-            }
-        }
-        return list
-    }
-
-    static func asSuccessActionProcessed(successActionProcessed: [String: Any?]) throws -> SuccessActionProcessed {
-        let type = successActionProcessed["type"] as! String
-        if type == "aes" {
-            guard let resultTmp = successActionProcessed["result"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "result", typeName: "SuccessActionProcessed"))
-            }
+static func asSuccessActionProcessed(successActionProcessed: [String: Any?]) throws -> SuccessActionProcessed {
+    let type = successActionProcessed["type"] as! String
+        if (type == "aes") {
+                guard let resultTmp = successActionProcessed["result"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "result", typeName: "SuccessActionProcessed"))
+                }
             let _result = try asAesSuccessActionDataResult(aesSuccessActionDataResult: resultTmp)
-
-            return SuccessActionProcessed.aes(result: _result)
+                        
+            return SuccessActionProcessed.aes(result: _result)       
         }
-        if type == "message" {
-            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
-            }
+        if (type == "message") {
+                guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
+                }
             let _data = try asMessageSuccessActionData(messageSuccessActionData: dataTmp)
-
-            return SuccessActionProcessed.message(data: _data)
+                        
+            return SuccessActionProcessed.message(data: _data)       
         }
-        if type == "url" {
-            guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
-            }
+        if (type == "url") {
+                guard let dataTmp = successActionProcessed["data"] as? [String: Any?] else {
+                    throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "data", typeName: "SuccessActionProcessed"))
+                }
             let _data = try asUrlSuccessActionData(urlSuccessActionData: dataTmp)
+                        
+            return SuccessActionProcessed.url(data: _data)       
+        }    
 
-            return SuccessActionProcessed.url(data: _data)
+    throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessActionProcessed")
+}
+
+static func dictionaryOf(successActionProcessed: SuccessActionProcessed) -> [String: Any?] {    
+    switch (successActionProcessed) {
+    
+    case let .aes(
+        result
+    ):
+    return [
+            "type": "aes",
+            "result": dictionaryOf(aesSuccessActionDataResult: result),
+        ]
+    
+    case let .message(
+        data
+    ):
+    return [
+            "type": "message",
+            "data": dictionaryOf(messageSuccessActionData: data),
+        ]
+    
+    case let .url(
+        data
+    ):
+    return [
+            "type": "url",
+            "data": dictionaryOf(urlSuccessActionData: data),
+        ]   
+    }    
+}
+
+static func arrayOf(`successActionProcessedList`: [SuccessActionProcessed]) -> [Any] {
+    return `successActionProcessedList`.map { (v) -> [String: Any?] in return dictionaryOf(successActionProcessed: v) }
+}
+
+static func asSuccessActionProcessedList(arr: [Any]) throws -> [SuccessActionProcessed] {
+    var list = [SuccessActionProcessed]()
+    for value in arr {
+        if let val = value as? [String: Any?] {
+            var successActionProcessed = try asSuccessActionProcessed(successActionProcessed: val)
+            list.append(successActionProcessed)
+        } else { 
+            throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessActionProcessed"))
         }
-
-        throw SdkError.Generic(message: "Unexpected type \(type) for enum SuccessActionProcessed")
     }
-
-    static func dictionaryOf(successActionProcessed: SuccessActionProcessed) -> [String: Any?] {
-        switch successActionProcessed {
-        case let .aes(
-            result
-        ):
-            return [
-                "type": "aes",
-                "result": dictionaryOf(aesSuccessActionDataResult: result),
-            ]
-
-        case let .message(
-            data
-        ):
-            return [
-                "type": "message",
-                "data": dictionaryOf(messageSuccessActionData: data),
-            ]
-
-        case let .url(
-            data
-        ):
-            return [
-                "type": "url",
-                "data": dictionaryOf(urlSuccessActionData: data),
-            ]
-        }
-    }
-
-    static func arrayOf(successActionProcessedList: [SuccessActionProcessed]) -> [Any] {
-        return successActionProcessedList.map { v -> [String: Any?] in return dictionaryOf(successActionProcessed: v) }
-    }
-
-    static func asSuccessActionProcessedList(arr: [Any]) throws -> [SuccessActionProcessed] {
-        var list = [SuccessActionProcessed]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var successActionProcessed = try asSuccessActionProcessed(successActionProcessed: val)
-                list.append(successActionProcessed)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SuccessActionProcessed"))
-            }
-        }
-        return list
-    }
-
+    return list
+}    
     static func hasNonNilKey(data: [String: Any?], key: String) -> Bool {
         if let val = data[key] {
             return !(val == nil || val is NSNull)
@@ -4962,4 +5001,5 @@ enum BreezSDKLiquidMapper {
     static func errUnexpectedValue(fieldName: String) -> String {
         return "Unexpected value for optional field \(fieldName)"
     }
+
 }

--- a/packages/react-native/ios/RNBreezSDKLiquid.swift
+++ b/packages/react-native/ios/RNBreezSDKLiquid.swift
@@ -1,27 +1,28 @@
-import BreezSDKLiquid
 import Foundation
+import BreezSDKLiquid
 
 @objc(RNBreezSDKLiquid)
 class RNBreezSDKLiquid: RCTEventEmitter {
     static let TAG: String = "BreezSDKLiquid"
-
+    
     public static var emitter: RCTEventEmitter!
     public static var hasListeners: Bool = false
     public static var supportedEvents: [String] = ["breezSdkLiquidLog"]
 
     private var bindingLiquidSdk: BindingLiquidSdk!
 
+
     static var breezSdkLiquidDirectory: URL {
         let applicationDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let breezSdkLiquidDirectory = applicationDirectory.appendingPathComponent("breezSdkLiquid", isDirectory: true)
-
+        
         if !FileManager.default.fileExists(atPath: breezSdkLiquidDirectory.path) {
             try! FileManager.default.createDirectory(atPath: breezSdkLiquidDirectory.path, withIntermediateDirectories: true)
         }
-
+        
         return breezSdkLiquidDirectory
     }
-
+    
     override init() {
         super.init()
         RNBreezSDKLiquid.emitter = self
@@ -35,32 +36,32 @@ class RNBreezSDKLiquid: RCTEventEmitter {
     static func addSupportedEvent(name: String) {
         RNBreezSDKLiquid.supportedEvents.append(name)
     }
-
+    
     override func supportedEvents() -> [String]! {
         return RNBreezSDKLiquid.supportedEvents
     }
-
+    
     override func startObserving() {
         RNBreezSDKLiquid.hasListeners = true
     }
-
+    
     override func stopObserving() {
         RNBreezSDKLiquid.hasListeners = false
     }
-
+    
     @objc
     override static func requiresMainQueueSetup() -> Bool {
         return false
     }
-
+    
     func getBindingLiquidSdk() throws -> BindingLiquidSdk {
         if bindingLiquidSdk != nil {
             return bindingLiquidSdk
         }
-
+        
         throw SdkError.Generic(message: "Not initialized")
     }
-
+        
     private func ensureWorkingDir(workingDir: String) throws {
         do {
             if !FileManager.default.fileExists(atPath: workingDir) {
@@ -71,31 +72,32 @@ class RNBreezSDKLiquid: RCTEventEmitter {
         }
     }
 
+        
     @objc(defaultConfig:breezApiKey:resolve:reject:)
-    func defaultConfig(_ network: String, breezApiKey: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func defaultConfig(_ network: String, breezApiKey: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let networkTmp = try BreezSDKLiquidMapper.asLiquidNetwork(liquidNetwork: network)
             let breezApiKeyTmp = breezApiKey.isEmpty ? nil : breezApiKey
-            var res = try BreezSDKLiquid.defaultConfig(network: networkTmp, breezApiKey: breezApiKeyTmp)
+            var res =try BreezSDKLiquid.defaultConfig(network: networkTmp, breezApiKey: breezApiKeyTmp)
             res.workingDir = RNBreezSDKLiquid.breezSdkLiquidDirectory.path
             resolve(BreezSDKLiquidMapper.dictionaryOf(config: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+        
     @objc(parseInvoice:resolve:reject:)
-    func parseInvoice(_ input: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func parseInvoice(_ input: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try BreezSDKLiquid.parseInvoice(input: input)
+            var res =try BreezSDKLiquid.parseInvoice(input: input)
             resolve(BreezSDKLiquidMapper.dictionaryOf(lnInvoice: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+      
     @objc(setLogger:reject:)
-    func setLogger(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func setLogger(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try BreezSDKLiquid.setLogger(logger: BreezSDKLiquidLogger())
             resolve(["status": "ok"])
@@ -105,7 +107,7 @@ class RNBreezSDKLiquid: RCTEventEmitter {
     }
 
     @objc(connect:resolve:reject:)
-    func connect(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func connect(_ req:[String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         if bindingLiquidSdk != nil {
             reject("Generic", "Already initialized", nil)
             return
@@ -121,7 +123,7 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+ 
     @objc(addEventListener:reject:)
     func addEventListener(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
@@ -135,8 +137,9 @@ class RNBreezSDKLiquid: RCTEventEmitter {
         }
     }
 
+    
     @objc(removeEventListener:resolve:reject:)
-    func removeEventListener(_ id: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func removeEventListener(_ id: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().removeEventListener(id: id)
             resolve(["status": "ok"])
@@ -144,173 +147,173 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(getInfo:reject:)
-    func getInfo(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func getInfo(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().getInfo()
+            var res =try getBindingLiquidSdk().getInfo()
             resolve(BreezSDKLiquidMapper.dictionaryOf(getInfoResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(signMessage:resolve:reject:)
-    func signMessage(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func signMessage(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let signMessageRequest = try BreezSDKLiquidMapper.asSignMessageRequest(signMessageRequest: req)
-            var res = try getBindingLiquidSdk().signMessage(req: signMessageRequest)
+            var res =try getBindingLiquidSdk().signMessage(req: signMessageRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(signMessageResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(checkMessage:resolve:reject:)
-    func checkMessage(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func checkMessage(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let checkMessageRequest = try BreezSDKLiquidMapper.asCheckMessageRequest(checkMessageRequest: req)
-            var res = try getBindingLiquidSdk().checkMessage(req: checkMessageRequest)
+            var res =try getBindingLiquidSdk().checkMessage(req: checkMessageRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(checkMessageResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(parse:resolve:reject:)
-    func parse(_ input: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func parse(_ input: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().parse(input: input)
+            var res =try getBindingLiquidSdk().parse(input: input)
             resolve(BreezSDKLiquidMapper.dictionaryOf(inputType: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(prepareSendPayment:resolve:reject:)
-    func prepareSendPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func prepareSendPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let prepareSendRequest = try BreezSDKLiquidMapper.asPrepareSendRequest(prepareSendRequest: req)
-            var res = try getBindingLiquidSdk().prepareSendPayment(req: prepareSendRequest)
+            var res =try getBindingLiquidSdk().prepareSendPayment(req: prepareSendRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(prepareSendResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(sendPayment:resolve:reject:)
-    func sendPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func sendPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let sendPaymentRequest = try BreezSDKLiquidMapper.asSendPaymentRequest(sendPaymentRequest: req)
-            var res = try getBindingLiquidSdk().sendPayment(req: sendPaymentRequest)
+            var res =try getBindingLiquidSdk().sendPayment(req: sendPaymentRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(sendPaymentResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(prepareReceivePayment:resolve:reject:)
-    func prepareReceivePayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func prepareReceivePayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let prepareReceiveRequest = try BreezSDKLiquidMapper.asPrepareReceiveRequest(prepareReceiveRequest: req)
-            var res = try getBindingLiquidSdk().prepareReceivePayment(req: prepareReceiveRequest)
+            var res =try getBindingLiquidSdk().prepareReceivePayment(req: prepareReceiveRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(prepareReceiveResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(receivePayment:resolve:reject:)
-    func receivePayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func receivePayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let receivePaymentRequest = try BreezSDKLiquidMapper.asReceivePaymentRequest(receivePaymentRequest: req)
-            var res = try getBindingLiquidSdk().receivePayment(req: receivePaymentRequest)
+            var res =try getBindingLiquidSdk().receivePayment(req: receivePaymentRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(receivePaymentResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(fetchLightningLimits:reject:)
-    func fetchLightningLimits(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func fetchLightningLimits(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().fetchLightningLimits()
+            var res =try getBindingLiquidSdk().fetchLightningLimits()
             resolve(BreezSDKLiquidMapper.dictionaryOf(lightningPaymentLimitsResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(fetchOnchainLimits:reject:)
-    func fetchOnchainLimits(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func fetchOnchainLimits(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().fetchOnchainLimits()
+            var res =try getBindingLiquidSdk().fetchOnchainLimits()
             resolve(BreezSDKLiquidMapper.dictionaryOf(onchainPaymentLimitsResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(preparePayOnchain:resolve:reject:)
-    func preparePayOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func preparePayOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let preparePayOnchainRequest = try BreezSDKLiquidMapper.asPreparePayOnchainRequest(preparePayOnchainRequest: req)
-            var res = try getBindingLiquidSdk().preparePayOnchain(req: preparePayOnchainRequest)
+            var res =try getBindingLiquidSdk().preparePayOnchain(req: preparePayOnchainRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(preparePayOnchainResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(payOnchain:resolve:reject:)
-    func payOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func payOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let payOnchainRequest = try BreezSDKLiquidMapper.asPayOnchainRequest(payOnchainRequest: req)
-            var res = try getBindingLiquidSdk().payOnchain(req: payOnchainRequest)
+            var res =try getBindingLiquidSdk().payOnchain(req: payOnchainRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(sendPaymentResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(prepareBuyBitcoin:resolve:reject:)
-    func prepareBuyBitcoin(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func prepareBuyBitcoin(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let prepareBuyBitcoinRequest = try BreezSDKLiquidMapper.asPrepareBuyBitcoinRequest(prepareBuyBitcoinRequest: req)
-            var res = try getBindingLiquidSdk().prepareBuyBitcoin(req: prepareBuyBitcoinRequest)
+            var res =try getBindingLiquidSdk().prepareBuyBitcoin(req: prepareBuyBitcoinRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(prepareBuyBitcoinResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(buyBitcoin:resolve:reject:)
-    func buyBitcoin(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func buyBitcoin(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let buyBitcoinRequest = try BreezSDKLiquidMapper.asBuyBitcoinRequest(buyBitcoinRequest: req)
-            var res = try getBindingLiquidSdk().buyBitcoin(req: buyBitcoinRequest)
+            var res =try getBindingLiquidSdk().buyBitcoin(req: buyBitcoinRequest)
             resolve(res)
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(listPayments:resolve:reject:)
-    func listPayments(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func listPayments(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let listPaymentsRequest = try BreezSDKLiquidMapper.asListPaymentsRequest(listPaymentsRequest: req)
-            var res = try getBindingLiquidSdk().listPayments(req: listPaymentsRequest)
+            var res =try getBindingLiquidSdk().listPayments(req: listPaymentsRequest)
             resolve(BreezSDKLiquidMapper.arrayOf(paymentList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(getPayment:resolve:reject:)
-    func getPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func getPayment(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let reqTmp = try BreezSDKLiquidMapper.asGetPaymentRequest(getPaymentRequest: req)
-            var res = try getBindingLiquidSdk().getPayment(req: reqTmp)
+            var res =try getBindingLiquidSdk().getPayment(req: reqTmp)
             if res != nil {
                 resolve(BreezSDKLiquidMapper.dictionaryOf(payment: res!))
             } else {
@@ -320,20 +323,20 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(fetchPaymentProposedFees:resolve:reject:)
-    func fetchPaymentProposedFees(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func fetchPaymentProposedFees(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let fetchPaymentProposedFeesRequest = try BreezSDKLiquidMapper.asFetchPaymentProposedFeesRequest(fetchPaymentProposedFeesRequest: req)
-            var res = try getBindingLiquidSdk().fetchPaymentProposedFees(req: fetchPaymentProposedFeesRequest)
+            var res =try getBindingLiquidSdk().fetchPaymentProposedFees(req: fetchPaymentProposedFeesRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(fetchPaymentProposedFeesResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(acceptPaymentProposedFees:resolve:reject:)
-    func acceptPaymentProposedFees(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func acceptPaymentProposedFees(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let acceptPaymentProposedFeesRequest = try BreezSDKLiquidMapper.asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: req)
             try getBindingLiquidSdk().acceptPaymentProposedFees(req: acceptPaymentProposedFeesRequest)
@@ -342,41 +345,41 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(listRefundables:reject:)
-    func listRefundables(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func listRefundables(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().listRefundables()
+            var res =try getBindingLiquidSdk().listRefundables()
             resolve(BreezSDKLiquidMapper.arrayOf(refundableSwapList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(prepareRefund:resolve:reject:)
-    func prepareRefund(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func prepareRefund(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let prepareRefundRequest = try BreezSDKLiquidMapper.asPrepareRefundRequest(prepareRefundRequest: req)
-            var res = try getBindingLiquidSdk().prepareRefund(req: prepareRefundRequest)
+            var res =try getBindingLiquidSdk().prepareRefund(req: prepareRefundRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(prepareRefundResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(refund:resolve:reject:)
-    func refund(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func refund(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let refundRequest = try BreezSDKLiquidMapper.asRefundRequest(refundRequest: req)
-            var res = try getBindingLiquidSdk().refund(req: refundRequest)
+            var res =try getBindingLiquidSdk().refund(req: refundRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(refundResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(rescanOnchainSwaps:reject:)
-    func rescanOnchainSwaps(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func rescanOnchainSwaps(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().rescanOnchainSwaps()
             resolve(["status": "ok"])
@@ -384,9 +387,9 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(sync:reject:)
-    func sync(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func sync(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().sync()
             resolve(["status": "ok"])
@@ -394,19 +397,19 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(recommendedFees:reject:)
-    func recommendedFees(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func recommendedFees(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().recommendedFees()
+            var res =try getBindingLiquidSdk().recommendedFees()
             resolve(BreezSDKLiquidMapper.dictionaryOf(recommendedFees: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(backup:resolve:reject:)
-    func backup(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func backup(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let backupRequest = try BreezSDKLiquidMapper.asBackupRequest(backupRequest: req)
             try getBindingLiquidSdk().backup(req: backupRequest)
@@ -415,9 +418,9 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(restore:resolve:reject:)
-    func restore(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func restore(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let restoreRequest = try BreezSDKLiquidMapper.asRestoreRequest(restoreRequest: req)
             try getBindingLiquidSdk().restore(req: restoreRequest)
@@ -426,9 +429,9 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(disconnect:reject:)
-    func disconnect(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func disconnect(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().disconnect()
             bindingLiquidSdk = nil
@@ -437,53 +440,53 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(prepareLnurlPay:resolve:reject:)
-    func prepareLnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func prepareLnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let prepareLnUrlPayRequest = try BreezSDKLiquidMapper.asPrepareLnUrlPayRequest(prepareLnUrlPayRequest: req)
-            var res = try getBindingLiquidSdk().prepareLnurlPay(req: prepareLnUrlPayRequest)
+            var res =try getBindingLiquidSdk().prepareLnurlPay(req: prepareLnUrlPayRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(prepareLnUrlPayResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(lnurlPay:resolve:reject:)
-    func lnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func lnurlPay(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let lnUrlPayRequest = try BreezSDKLiquidMapper.asLnUrlPayRequest(lnUrlPayRequest: req)
-            var res = try getBindingLiquidSdk().lnurlPay(req: lnUrlPayRequest)
+            var res =try getBindingLiquidSdk().lnurlPay(req: lnUrlPayRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(lnUrlPayResult: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(lnurlWithdraw:resolve:reject:)
-    func lnurlWithdraw(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func lnurlWithdraw(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let lnUrlWithdrawRequest = try BreezSDKLiquidMapper.asLnUrlWithdrawRequest(lnUrlWithdrawRequest: req)
-            var res = try getBindingLiquidSdk().lnurlWithdraw(req: lnUrlWithdrawRequest)
+            var res =try getBindingLiquidSdk().lnurlWithdraw(req: lnUrlWithdrawRequest)
             resolve(BreezSDKLiquidMapper.dictionaryOf(lnUrlWithdrawResult: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(lnurlAuth:resolve:reject:)
-    func lnurlAuth(_ reqData: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func lnurlAuth(_ reqData: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             let lnUrlAuthRequestData = try BreezSDKLiquidMapper.asLnUrlAuthRequestData(lnUrlAuthRequestData: reqData)
-            var res = try getBindingLiquidSdk().lnurlAuth(reqData: lnUrlAuthRequestData)
+            var res =try getBindingLiquidSdk().lnurlAuth(reqData: lnUrlAuthRequestData)
             resolve(BreezSDKLiquidMapper.dictionaryOf(lnUrlCallbackStatus: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(registerWebhook:resolve:reject:)
-    func registerWebhook(_ webhookUrl: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func registerWebhook(_ webhookUrl: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().registerWebhook(webhookUrl: webhookUrl)
             resolve(["status": "ok"])
@@ -491,9 +494,9 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(unregisterWebhook:reject:)
-    func unregisterWebhook(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func unregisterWebhook(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
             try getBindingLiquidSdk().unregisterWebhook()
             resolve(["status": "ok"])
@@ -501,27 +504,28 @@ class RNBreezSDKLiquid: RCTEventEmitter {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(fetchFiatRates:reject:)
-    func fetchFiatRates(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func fetchFiatRates(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().fetchFiatRates()
+            var res =try getBindingLiquidSdk().fetchFiatRates()
             resolve(BreezSDKLiquidMapper.arrayOf(rateList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
-
+    
     @objc(listFiatCurrencies:reject:)
-    func listFiatCurrencies(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func listFiatCurrencies(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         do {
-            var res = try getBindingLiquidSdk().listFiatCurrencies()
+            var res =try getBindingLiquidSdk().listFiatCurrencies()
             resolve(BreezSDKLiquidMapper.arrayOf(fiatCurrencyList: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }
     }
 
+    
     func rejectErr(err: Error, reject: @escaping RCTPromiseRejectBlock) {
         var errorName = "Generic"
         var message = "\(err)"
@@ -534,3 +538,4 @@ class RNBreezSDKLiquid: RCTEventEmitter {
         reject(errorName, message, err)
     }
 }
+

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -88,9 +88,8 @@ export interface CheckMessageResponse {
 }
 
 export interface Config {
-    liquidElectrumUrl: string
-    bitcoinElectrumUrl: string
-    mempoolspaceUrl: string
+    liquidExplorers: BlockchainExplorer[]
+    bitcoinExplorers: BlockchainExplorer[]
     workingDir: string
     network: LiquidNetwork
     paymentTimeoutSec: number
@@ -517,6 +516,20 @@ export type Amount = {
     type: AmountVariant.CURRENCY,
     iso4217Code: string
     fractionalAmount: number
+}
+
+export enum BlockchainExplorerVariant {
+    ELECTRUM = "electrum",
+    ESPLORA = "esplora"
+}
+
+export type BlockchainExplorer = {
+    type: BlockchainExplorerVariant.ELECTRUM,
+    url: string
+} | {
+    type: BlockchainExplorerVariant.ESPLORA,
+    url: string
+    useWaterfalls: boolean
 }
 
 export enum BuyBitcoinProvider {


### PR DESCRIPTION
## Overview

This PR adds the ability for the wallet to switch between available Electrum/Esplora clients when performing a full sync. In case its current client is not available, the sync iterates cyclically over the available clients, ultimately failing if none succeed. Once an available client is found, it will be reused on the next iteration.

## Todo

## Notes