### PR TITLE
Notification Plugin: Dismiss replaceable notifications on service shutdown

### DIFF
--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
@@ -15,9 +15,11 @@ import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INFO
 import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE
 import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_SWAP_UPDATED
 import breez_sdk_liquid_notification.Constants.NOTIFICATION_ID_FOREGROUND_SERVICE
+import breez_sdk_liquid_notification.Constants.NOTIFICATION_ID_REPLACEABLE
 import breez_sdk_liquid_notification.Constants.SERVICE_TIMEOUT_MS
 import breez_sdk_liquid_notification.Constants.SHUTDOWN_DELAY_MS
 import breez_sdk_liquid_notification.NotificationHelper.Companion.notifyForegroundService
+import breez_sdk_liquid_notification.NotificationHelper.Companion.cancelNotification
 import breez_sdk_liquid_notification.job.Job
 import breez_sdk_liquid_notification.job.LnurlPayInfoJob
 import breez_sdk_liquid_notification.job.LnurlPayInvoiceJob
@@ -97,6 +99,7 @@ abstract class ForegroundService :
 
     open fun shutdown() {
         logger.log(TAG, "Shutting down foreground service", "DEBUG")
+        cancelNotification(applicationContext, NOTIFICATION_ID_REPLACEABLE)
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }


### PR DESCRIPTION
This PR dismisses on Android the replaceable notifications when the background task / service is shutdown

Fixes #767 

**Testing notes:**
- When receiving via LNURL/lightning address, the "Receiving payment information" / "Fetching invoice" should be dismissed automatically once the background task is closed. This can be tested by sending via lightning address between two Misty devices (receiving on Android).