### PR TITLE
Move `mockall` dependency

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3106,7 +3106,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -30,6 +30,7 @@ flutter_rust_bridge = { version = "=2.8.0", features = [
 log = { workspace = true }
 lwk_common = "0.8.0"
 lwk_signer = { version = "0.8.0", default-features = false }
+mockall = "0.13.1"
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",
@@ -70,7 +71,6 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = { version = "0.12.3", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-mockall = "0.13.1"
 
 # WASM dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]


### PR DESCRIPTION
Move to be used by all targets including WASM