### PR TITLE
Downgrade android release to Uniffi 0.25

### DIFF
--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -60,7 +60,7 @@ on:
 jobs:
   build-language-bindings:
     runs-on: ubuntu-latest
-    if: ${{ inputs.kotlin || inputs.swift || inputs.python }}
+    if: ${{ inputs.swift || inputs.python }}
     steps:
       - name: Checkout breez-sdk-liquid repo
         uses: actions/checkout@v4
@@ -82,19 +82,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: lib
-
-      - name: Build Kotlin binding
-        if: ${{ inputs.kotlin }}
-        working-directory: lib/bindings
-        run: |
-          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language kotlin -o ffi/kotlin
-  
-      - name: Archive Kotlin binding
-        if: ${{ inputs.kotlin }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-kotlin
-          path: lib/bindings/ffi/kotlin/breez_sdk_liquid/breez_sdk_liquid.kt
       
       - name: Build Swift binding
         if: ${{ inputs.swift }}
@@ -154,6 +141,13 @@ jobs:
         working-directory: lib/bindings
         run: |
           cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --language kotlin -o ffi/kotlin
+  
+      - name: Archive Kotlin binding
+        if: ${{ inputs.kotlin }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-kotlin
+          path: lib/bindings/ffi/kotlin/breez_sdk_liquid/breez_sdk_liquid.kt
 
       - name: Archive Kotlin multiplatform binding
         if: ${{ inputs.kotlin }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,8 +217,8 @@ jobs:
 
       - name: Run bindings tests
         run: |
-          curl -o jna-5.12.1.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
-          export CLASSPATH=$(pwd)/jna-5.12.1.jar;
+          curl -o jna-5.14.0.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.14.0/jna-5.14.0.jar
+          export CLASSPATH=$(pwd)/jna-5.14.0.jar;
           cd lib/bindings
           cargo test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Build Android bindings
         working-directory: lib/bindings       
         run: |
-          cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o langs/android/lib/src/main/kotlin
+          cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o langs/android/lib/src/main/kotlin
 
       - name: Run Android build
         working-directory: lib/bindings/langs/android  

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -121,7 +121,7 @@ jobs:
       swift-package-version: ${{ needs.pre-setup.outputs.swift-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
       use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
-      uniffi-25: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version }}
+      uniffi-25: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version }}
     steps:
       - run: echo "set setup output variables"
 

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: bindings-android-jniLibs
+          name: bindings-android-jniLibs-uniffi-25
           path: lib/bindings/langs/android/lib/src/main/jniLibs
 
       - uses: actions/download-artifact@v4

--- a/lib/bindings/langs/android/lib/build.gradle.kts
+++ b/lib/bindings/langs/android/lib/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 33
+        minSdk = 24
         consumerProguardFiles("consumer-rules.pro")
     }
     

--- a/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/build.gradle.kts
+++ b/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/build.gradle.kts
@@ -83,7 +83,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/lib/bindings/makefile
+++ b/lib/bindings/makefile
@@ -58,7 +58,7 @@ x86_64-linux-android-uniffi-25: $(SOURCES) ndk-home
 	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
 
-bindings-android: android
+bindings-android: android-uniffi-25
 	cp -r ffi/kotlin/jniLibs langs/android/lib/src/main
 	cp -r ffi/kotlin/breez_sdk_liquid langs/android/lib/src/main/kotlin/
 	cd langs/android && ./gradlew assemble

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -18,11 +18,11 @@
 
 ## Requirements
 
-- Flutter >=3.10.0
-- Dart >=3.4.0 <4.0.0
-- iOS >=12.0
-- MacOS >=10.11
-- Android `compileSDK` 31
+- Flutter >=3.27.0
+- Dart >=3.6.0 <4.0.0
+- iOS >=13.0
+- MacOS >=15.0
+- Android `compileSDK` 35
 - Java 1.8
 - Android Gradle Plugin >=7.1.2
 - Gradle wrapper >=7.4

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 33
+        minSdkVersion 24
     }
 }
 

--- a/packages/flutter/android/build.gradle.production
+++ b/packages/flutter/android/build.gradle.production
@@ -51,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 33
+        minSdkVersion 24
     }
 }
 

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 34
     defaultConfig {
-        minSdkVersion 33
+        minSdkVersion 24
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/packages/react-native/example/android/build.gradle
+++ b/packages/react-native/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 33
+        minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlin_version = "1.8.0"


### PR DESCRIPTION
This PR reverts UniFFI upgrade to 28.0 for Android builds introduced on  #766.

- [Downgrade android release to Uniffi 0.25](https://github.com/breez/breez-sdk-liquid/pull/786/commits/2e339df97cc0b5c7db79c985a8d8e4b75cf0ccfa)

#### Other changes:
- Bump JNA used on bindings tests to 5.14.0
- Bump package requirements on `flutter_breez_liquid` `README.md`