### PR TITLE
WASM: getting the current time

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "tonic-build 0.12.3",
  "url",
  "uuid",
+ "web-time",
  "x509-parser",
  "zbase32",
 ]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-bindgen-test",
+ "web-time",
  "x509-parser",
  "zbase32",
 ]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -49,6 +49,7 @@ futures-util = { version = "0.3.28", default-features = false, features = [
     "sink",
     "std",
 ] }
+web-time = "1.1.0"
 async-trait = "0.1.86"
 hex = "0.4"
 reqwest = { version = "0.12", features = ["json"] }

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -222,7 +222,7 @@ impl Recoverer {
         &self,
         swap_lbtc_scripts: Vec<LBtcScript>,
     ) -> Result<HashMap<LBtcScript, Vec<HistoryTxId>>> {
-        let t0 = std::time::Instant::now();
+        let t0 = web_time::Instant::now();
         let lbtc_script_histories = self
             .liquid_chain_service
             .get_scripts_history(&swap_lbtc_scripts.to_vec())
@@ -261,7 +261,7 @@ impl Recoverer {
             .map(|x| x.as_script())
             .collect::<Vec<&lwk_wollet::bitcoin::Script>>();
 
-        let t0 = std::time::Instant::now();
+        let t0 = web_time::Instant::now();
         let btc_script_histories = self
             .bitcoin_chain_service
             .get_scripts_history(&swap_btc_scripts)?;
@@ -292,7 +292,7 @@ impl Recoverer {
             .map(|(k, v)| (k, v.iter().map(HistoryTxId::from).collect()))
             .collect();
 
-        let t0 = std::time::Instant::now();
+        let t0 = web_time::Instant::now();
         let btc_script_txs = self
             .bitcoin_chain_service
             .get_transactions(&btx_script_tx_ids)?;
@@ -302,7 +302,7 @@ impl Recoverer {
             t0.elapsed().as_millis()
         );
 
-        let t0 = std::time::Instant::now();
+        let t0 = web_time::Instant::now();
         let btc_script_balances = self
             .bitcoin_chain_service
             .scripts_get_balance(&swap_btc_scripts)?;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Not as _;
-use std::time::Instant;
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, ensure, Result};
@@ -30,6 +29,7 @@ use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
 use tokio::time::MissedTickBehavior;
 use tokio_stream::wrappers::BroadcastStream;
+use web_time::Instant;
 use x509_parser::parse_x509_certificate;
 
 use crate::chain::bitcoin::BitcoinChainService;

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use std::{str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, Result};
@@ -10,6 +10,7 @@ use lwk_wollet::elements::{LockTime, Transaction};
 use lwk_wollet::hashes::{sha256, Hash};
 use sdk_common::prelude::{AesSuccessActionDataResult, SuccessAction, SuccessActionProcessed};
 use tokio::sync::broadcast;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use crate::chain::liquid::LiquidChainService;
 use crate::model::{

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use crate::ensure_sdk;
 use crate::error::{PaymentError, SdkResult};
@@ -20,6 +20,7 @@ use sdk_common::bitcoin::bech32;
 use sdk_common::bitcoin::bech32::FromBase32;
 use sdk_common::lightning_125::offers::invoice::Bolt12Invoice;
 use sdk_common::lightning_invoice::Bolt11Invoice;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 lazy_static! {
     static ref LBTC_TESTNET_ASSET_ID: AssetId =

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fs::{self, create_dir_all};
 use std::io::Write;
 use std::path::PathBuf;
-use std::time::Instant;
 use std::{path::Path, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, Result};
@@ -20,6 +19,7 @@ use sdk_common::bitcoin::hashes::{sha256, Hash};
 use sdk_common::bitcoin::secp256k1::PublicKey;
 use sdk_common::lightning::util::message_signing::verify;
 use tokio::sync::Mutex;
+use web_time::Instant;
 
 use crate::model::Signer;
 use crate::persist::Persister;


### PR DESCRIPTION
This PR introduces the `web-time` crate for getting the current time in a wasm-compatible way. It's essentially a wrapper that on native builds just re-exports `std::time::{Instant, SystemTime}` but on wasm replaces those with implementations that rely on browser APIs. 