### PR TITLE
WASM: async sleep

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "js-sys",
  "lazy_static",
  "log",
  "lwk_common",
@@ -764,6 +765,8 @@ dependencies = [
  "tonic-build 0.12.3",
  "url",
  "uuid",
+ "wasm-bindgen-futures",
+ "web-sys",
  "x509-parser",
  "zbase32",
 ]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "js-sys",
  "lazy_static",
  "log",
  "lwk_common",
@@ -861,7 +862,9 @@ dependencies = [
  "tonic-build 0.12.3",
  "url",
  "uuid",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
  "x509-parser",
  "zbase32",
 ]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -80,6 +80,9 @@ lwk_wollet = { version = "0.9.0", default-features = false, features = [
 ] }
 maybe-sync = "0.1.1"
 uuid = { version = "1.8.0", features = ["v4", "js"] }
+wasm-bindgen-futures = "0.4.50"
+js-sys = "0.3.77"
+web-sys = "0.3.77"
 
 [dev-dependencies]
 sdk-common = { workspace = true, features = ["test-utils"] }

--- a/lib/core/src/chain/bitcoin.rs
+++ b/lib/core/src/chain/bitcoin.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, OnceLock},
-    time::Duration,
 };
 
 use anyhow::{anyhow, Result};
@@ -20,6 +19,7 @@ use sdk_common::{
     prelude::{get_and_check_success, parse_json, RestClient},
 };
 
+use crate::utils::async_sleep;
 use crate::{
     model::{Config, LiquidNetwork, RecommendedFees},
     prelude::Utxo,
@@ -203,7 +203,7 @@ impl BitcoinChainService for HybridBitcoinChainService {
                         "Script history for {} got zero transactions, retrying in {} seconds...",
                         script_hash, retry
                     );
-                    tokio::time::sleep(Duration::from_secs(retry)).await;
+                    async_sleep(retry as i32 * 1_000).await;
                 }
                 false => break,
             }
@@ -320,7 +320,7 @@ impl BitcoinChainService for HybridBitcoinChainService {
                         "Got zero balance for script {}, retrying in {} seconds...",
                         script_hash, retry
                     );
-                    tokio::time::sleep(Duration::from_secs(retry)).await;
+                    async_sleep(retry as i32 * 1_000).await;
                 }
                 _ => break,
             }

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -1,5 +1,4 @@
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use boltz_client::ToHex;
@@ -17,6 +16,7 @@ use mockall::automock;
 
 use crate::model::LiquidNetwork;
 use crate::prelude::Utxo;
+use crate::utils::async_sleep;
 use crate::{model::Config, utils};
 
 #[automock]
@@ -204,7 +204,7 @@ impl LiquidChainService for HybridLiquidChainService {
                     retry += 1;
                     info!("Script history for {script_hash} is empty, retrying in 1 second... ({retry} of {retries})");
                     // Waiting 1s between retries, so we detect the new tx as soon as possible
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    async_sleep(1_000).await;
                 }
                 false => break,
             }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -45,6 +45,7 @@ use crate::swapper::SubscriptionHandler;
 use crate::swapper::{
     boltz::BoltzSwapper, Swapper, SwapperStatusStream, SwapperSubscriptionHandler,
 };
+use crate::utils::async_sleep;
 use crate::wallet::{LiquidOnchainWallet, OnchainWallet};
 use crate::{
     error::{PaymentError, SdkResult},
@@ -2114,7 +2115,7 @@ impl LiquidSdk {
         swap: Swap,
         accept_zero_conf: bool,
     ) -> Result<Payment, PaymentError> {
-        let timeout_fut = tokio::time::sleep(Duration::from_secs(self.config.payment_timeout_sec));
+        let timeout_fut = async_sleep(self.config.payment_timeout_sec as i32 * 1_000);
         tokio::pin!(timeout_fut);
 
         let expected_swap_id = swap.id();

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use log::{info, trace, warn};
 use tokio::sync::{broadcast, watch};
-use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
 use tonic::Streaming;
 
@@ -20,6 +18,7 @@ use crate::sync::model::data::{
 use crate::sync::model::DecryptionInfo;
 use crate::sync::model::{Record, SetRecordRequest, SetRecordStatus};
 use crate::utils;
+use crate::utils::async_sleep;
 use crate::{
     persist::{cache::KEY_LAST_DERIVATION_INDEX, Persister},
     prelude::Signer,
@@ -140,7 +139,7 @@ impl SyncService {
                             "realtime-sync: new_listener returned error: {:?} waiting 3 seconds",
                             e
                         );
-                        sleep(Duration::from_secs(3)).await;
+                        async_sleep(3_000).await;
                         continue;
                     }
                 };


### PR DESCRIPTION
This PR proposes using [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout) to implement async sleep on WASM builds.

This approach does have issues, such as [this](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#timeouts_in_inactive_tabs), and serves just a first step. Once we have a WASM-compatible build, we'll need to test it, and we'll figure out then if we to improve it.

