### PR TITLE
WASM: spawn task

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio_with_wasm",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "url",
@@ -4705,6 +4706,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42d20f41cbfe26740d0c2fb320d44ce7dfa716be135cb663e99a48248a0e897"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80eb7e23abaa636caa9afe6042c6d8a8c0686165b8165f4fbf2988f0dd347f"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -857,6 +857,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio_with_wasm",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "url",
@@ -5098,6 +5099,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42d20f41cbfe26740d0c2fb320d44ce7dfa716be135cb663e99a48248a0e897"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80eb7e23abaa636caa9afe6042c6d8a8c0686165b8165f4fbf2988f0dd347f"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -36,6 +36,7 @@ rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7e
     "bundled",
 ] }
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
+tokio_with_wasm = { version = "0.8.2", features = ["rt", "macros"] }
 sdk-common = { workspace = true }
 sdk-macros = { workspace = true }
 rusqlite_migration = { git = "https://github.com/hydra-yse/rusqlite_migration", branch = "rusqlite-v0.33.0" }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -29,6 +29,7 @@ use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
 use tokio::time::MissedTickBehavior;
 use tokio_stream::wrappers::BroadcastStream;
+use tokio_with_wasm::alias as tokio;
 use web_time::Instant;
 use x509_parser::parse_x509_certificate;
 

--- a/lib/core/src/swapper/boltz/status_stream.rs
+++ b/lib/core/src/swapper/boltz/status_stream.rs
@@ -15,6 +15,7 @@ use futures_util::{stream::SplitSink, SinkExt, StreamExt};
 use log::{debug, error, info, warn};
 use tokio::sync::{broadcast, watch};
 use tokio::time::MissedTickBehavior;
+use tokio_with_wasm::alias as tokio;
 
 impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
     async fn send_subscription(

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -7,6 +7,7 @@ use log::{info, trace, warn};
 use tokio::sync::{broadcast, watch};
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
+use tokio_with_wasm::alias as tokio;
 use tonic::Streaming;
 
 use self::client::SyncerClient;

--- a/lib/core/src/test_utils/status_stream.rs
+++ b/lib/core/src/test_utils/status_stream.rs
@@ -5,6 +5,7 @@ use boltz_client::boltz;
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, watch};
+use tokio_with_wasm::alias as tokio;
 
 use crate::swapper::{SubscriptionHandler, SwapperStatusStream};
 


### PR DESCRIPTION
This PR proposes using [`tokio_with_wasm`](https://crates.io/crates/tokio_with_wasm) to spawn async tasks on wasm. 

Something to keep in mind is https://crates.io/crates/tokio_with_wasm#caution. The most obvious and immediate effect is that our tests that rely on spawning a task ( the update tracking tests on `sdk.rs`), if they fail on WASM, they do with a very non-descriptive error. A failing assert in just one of the tests causes the following output. We don't even get to see which test failed. We might deem this fine if we think it's unlikely for wasm tests to fail differently from native tests.

```
Failed to detect test as having been run. It might have timed out.
output div contained:
    running 38 tests
    test sdk::tests::test_zero_amount_chain_swap_with_leeway ... ok
    test sdk::tests::test_zero_amount_chain_swap_zero_leeway ... ok

driver status: signal: 9 (SIGKILL)                
driver stdout:
    1742562140558       geckodriver     INFO    Listening on 127.0.0.1:56493
    1742562140658       mozrunner::runner       INFO    Running command: MOZ_CRASHREPORTER="1" MOZ_CRASHREPORTER_NO_REPORT="1" MOZ_CRASHREPORTER_SHUTDOWN="1" "/Applications/Firefox. ... e" "-headless" "-foreground" "-no-remote" "-profile" "/var/folders/j7/9m9jk4bs61s_r3vcrdtkjdyh0000gn/T/rust_mozprofileDqrTcJ"
    console.warn: services.settings: Ignoring preference override of remote settings server
    console.warn: services.settings: Allow by setting MOZ_REMOTE_SETTINGS_DEVTOOLS=1 in the environment
    1742562143312       Marionette      INFO    Marionette enabled
    1742562144188       Marionette      INFO    Listening on port 56503
    [GFX1-]: RenderCompositorSWGL failed mapping default framebuffer, no dt
    1742562166332       Marionette      INFO    Stopped listening on port 56503

driver stderr:
    *** You are running in headless mode.
    JavaScript error: http://127.0.0.1:56492/wasm-bindgen-test_bg.wasm, line 27874641: RuntimeError: unreachable executed

```