### PR TITLE
WASM: run core crate tests on wasm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,17 +80,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clippy
-        working-directory: lib/wasm 
-        run: cargo clippy --target=wasm32-unknown-unknown -- -D warnings
+        run: make wasm-clippy
 
   build:
     name: Cargo Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        
-      - name: Install WASM target
-        run: rustup target add wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -300,8 +296,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WASM
-        working-directory: lib/wasm
-        run: wasm-pack test --headless --firefox
+        run: make wasm-test
 
   notification-plugin:
     name: Check notification plugin

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ cargo-clippy:
 	cd cli && cargo clippy -- -D warnings
 
 wasm-clippy:
+	make -C ./lib/core wasm-clippy
 	make -C ./lib/wasm clippy
 
 test: cargo-test wasm-test
@@ -23,6 +24,7 @@ cargo-test:
 	cd lib/core && cargo test
 
 wasm-test:
+	make -C ./lib/core wasm-test
 	make -C ./lib/wasm test
 
 codegen: flutter-codegen react-native-codegen

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -1,0 +1,30 @@
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+	CLANG_PREFIX += AR=$(shell brew --prefix llvm)/bin/llvm-ar CC=$(shell brew --prefix llvm)/bin/clang
+endif
+
+init:
+	cargo install wasm-pack
+
+clippy: cargo-clippy wasm-clippy
+
+test: cargo-test wasm-test
+
+cargo-clippy:
+	cargo clippy -- -D warnings
+
+cargo-test:
+	cargo test
+
+wasm-clippy:
+	$(CLANG_PREFIX) cargo clippy --target=wasm32-unknown-unknown -- -D warnings
+
+wasm-test:
+	$(CLANG_PREFIX) wasm-pack test --headless --firefox
+
+test-chrome:
+	$(CLANG_PREFIX) wasm-pack test --headless --chrome
+
+test-safari:
+	$(CLANG_PREFIX) wasm-pack test --headless --safari


### PR DESCRIPTION
This adds a makefile to the `core` crate with helper targets for running clippy and tests. We already have something similar on the wasm crate, but running tests there won't run the tests in the core crate. I also adjusted the main makefile to run wasm clippy and tests on both crates.