### PR TITLE
Remove frb from default features in Cargo.toml #793

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -8,8 +8,8 @@ name = "breez_sdk_liquid"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = ["frb"]
-frb = ["dep:flutter_rust_bridge"]
+default = []  # Removed "frb" from default features
+frb = ["dep:flutter_rust_bridge"]  # Kept as an optional feature
 # Uniffi features required to build using cargo-lipo
 uniffi-25 = []
 uniffi-28 = []


### PR DESCRIPTION
### Remove `frb` from default features in `Cargo.toml`

#### Changes:
- Removed `frb` from the `default` feature list in `Cargo.toml`.
- Ensured that `frb` remains optional by keeping it under `[features]`.

#### Reason:
- `frb` should not be enabled by default to provide more flexibility in feature selection.
- This change allows users to explicitly enable `frb` only when needed.

#### Impact:
- The build process will no longer include `flutter_rust_bridge` by default.
- Users who require `frb` need to enable it manually.

solves #793 
@danielgranhao 
