### PR TITLE
Lock cargo-expand install

### DIFF
--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -21,7 +21,8 @@ clean:
 
 # Install flutter_rust_bridge_codegen dependencies
 frb:
-	cargo install cargo-expand
+	# This is locked plist PR https://github.com/ebarnard/rust-plist/pull/152 is merged/released
+	cargo install cargo-expand --locked
 	cargo install flutter_rust_bridge_codegen --version 2.9.0
 	dart pub global activate ffigen
 	dart pub global activate ffi


### PR DESCRIPTION
Locks the installation of `cargo-expand` until an update to `plist` is released. See https://github.com/ebarnard/rust-plist/pull/152

Fixes #802 