### PR TITLE
WASM: Add missing lnurl_info/bip353_address to wasm PaymentDetails

### DIFF
--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -677,6 +677,8 @@ pub enum PaymentDetails {
         description: String,
         asset_id: String,
         asset_info: Option<AssetInfo>,
+        lnurl_info: Option<LnUrlInfo>,
+        bip353_address: Option<String>,
     },
     Bitcoin {
         swap_id: String,


### PR DESCRIPTION
This PR adds the missing lnurl_info & bip353_address fields to the wasm PaymentDetails::Liquid enum