### PR TITLE
Update README: Add Breez API Key Instructions

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,21 @@ A simple cli tool that sends commands to the sdk. It is intended to demonstrate 
 
 ## Run
 
-Start the CLI with
+Before running the CLI, you need to set your Breez API key. You can request an API key [here](https://breez.technology/request-api-key/#contact-us-form-sdk).
+
+Set the API key in your environment:
+
+#### **Linux/macOS**
+```bash
+export BREEZ_API_KEY="your-api-key-here"
+```
+#### **Windows (PowerShell)**
+```bash
+$env:BREEZ_API_KEY="your-api-key-here"
+```
+
+
+Then start the CLI with
 
 ```bash
 cargo run

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 A simple cli tool that sends commands to the sdk. It is intended to demonstrate the usage and investigate issues that are hard to debug on mobile platforms.
 
-## Run
+## Prerequisites
 
 Before running the CLI, you need to set your Breez API key. You can request an API key [here](https://breez.technology/request-api-key/#contact-us-form-sdk).
 
@@ -17,7 +17,7 @@ export BREEZ_API_KEY="your-api-key-here"
 $env:BREEZ_API_KEY="your-api-key-here"
 ```
 
-
+## Run
 Then start the CLI with
 
 ```bash


### PR DESCRIPTION
This PR improves the `README` by adding instructions on setting the `BREEZ_API_KEY` before running cargo run. This ensures users know they need an API key and how to set it up properly.

**Changes Implemented**:
✅ Added instructions on setting `BREEZ_API_KEY` for Linux, macOS, and Windows.
✅ Included a link to request an API key from Breez.
✅ Clarified that the API key is required before running the CLI.