### PR TITLE
Reintroduce 32bit builds

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -52,6 +52,8 @@ jobs:
         uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
+          armv7-linux-androideabi,
+          i686-linux-android,
           x86_64-linux-android,
         ]
     steps:
@@ -95,6 +97,11 @@ jobs:
         cp lib/target/${{ matrix.target }}/release/libbreez_sdk_liquid_bindings.so dist
 
     - name: Copy libc++_shared
+      if: ${{ matrix.target == 'armv7-linux-androideabi'}}
+      run: cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so dist
+
+    - name: Copy libc++_shared
+      if: ${{ matrix.target != 'armv7-linux-androideabi'}}
       run: cp $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/${{ matrix.target }}/libc++_shared.so dist
 
     - name: Archive release
@@ -120,6 +127,16 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: bindings-armv7-linux-androideabi${{ matrix.uniffi }}
+          path: armeabi-v7a
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-i686-linux-android${{ matrix.uniffi }}
+          path: x86
+
+      - uses: actions/download-artifact@v4
+        with:
           name: bindings-x86_64-linux-android${{ matrix.uniffi }}
           path: x86_64
       
@@ -139,6 +156,8 @@ jobs:
         uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
+          armv7-linux-androideabi,
+          i686-linux-android,
           x86_64-linux-android,
         ]
     steps:
@@ -167,6 +186,16 @@ jobs:
         with:
           name: bindings-aarch64-linux-android${{ matrix.uniffi }}
           path: arm64-v8a
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-armv7-linux-androideabi${{ matrix.uniffi }}
+          path: armeabi-v7a
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-i686-linux-android${{ matrix.uniffi }}
+          path: x86
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -51,6 +51,7 @@ jobs:
       matrix:
         uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
+          i686-pc-windows-msvc,
           x86_64-pc-windows-msvc,
         ]
     steps:
@@ -102,6 +103,7 @@ jobs:
       matrix:
         uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
+          i686-pc-windows-msvc,
           x86_64-pc-windows-msvc,
         ]
     steps:

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -66,6 +66,11 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: bindings-i686-pc-windows-msvc-uniffi-25
+          path: lib/bindings/langs/csharp/src/runtimes/win-x86/native
+
+      - uses: actions/download-artifact@v4
+        with:
           name: bindings-x86_64-pc-windows-msvc-uniffi-25
           path: lib/bindings/langs/csharp/src/runtimes/win-x64/native
 

--- a/.github/workflows/publish-golang.yml
+++ b/.github/workflows/publish-golang.yml
@@ -43,6 +43,16 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: bindings-i686-linux-android-uniffi-25
+          path: breez_sdk_liquid/lib/android-386
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-armv7-linux-androideabi-uniffi-25
+          path: breez_sdk_liquid/lib/android-aarch
+
+      - uses: actions/download-artifact@v4
+        with:
           name: bindings-x86_64-linux-android-uniffi-25
           path: breez_sdk_liquid/lib/android-amd64
 

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -151,6 +151,12 @@ jobs:
           path: lib/bindings/langs/python/src/breez_sdk_liquid
 
       - uses: actions/download-artifact@v4
+        if: matrix.arch == 'win32'
+        with:
+          name: bindings-i686-pc-windows-msvc
+          path: lib/bindings/langs/python/src/breez_sdk_liquid
+
+      - uses: actions/download-artifact@v4
         with:
           name: bindings-python
           path: lib/bindings/langs/python/src/breez_sdk_liquid

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1147,6 +1147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96487aad690d45a83f2b9876828ba856c5430bbb143cb5730d8a5d04a4805179"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1702,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2436,6 +2448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "libsecp256k1"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,14 +2519,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+version = "0.1.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
 dependencies = [
- "bech32 0.9.1",
+ "bech32 0.11.0",
  "bitcoin 0.32.5",
- "lightning-invoice 0.32.0",
- "lightning-types",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice 0.33.1",
+ "lightning-types 0.2.0",
+ "musig2",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -2533,7 +2555,17 @@ checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.32.5",
- "lightning-types",
+ "lightning-types 0.1.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.33.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "bech32 0.11.0",
+ "bitcoin 0.32.5",
+ "lightning-types 0.2.0",
 ]
 
 [[package]]
@@ -2545,6 +2577,14 @@ dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.32.5",
  "hex-conservative 0.2.1",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "bitcoin 0.32.5",
 ]
 
 [[package]]
@@ -2802,6 +2842,14 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "musig2"
+version = "0.1.0"
+source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
+dependencies = [
+ "bitcoin 0.32.5",
+]
 
 [[package]]
 name = "native-tls"
@@ -3156,6 +3204,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -3995,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=3a46e2acdf935884c7d1a3f6296b20973c9e4cce#3a46e2acdf935884c7d1a3f6296b20973c9e4cce"
+source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
 dependencies = [
  "aes",
  "anyhow",
@@ -4011,7 +4067,7 @@ dependencies = [
  "hickory-resolver",
  "lazy_static",
  "lightning 0.0.118",
- "lightning 0.0.125",
+ "lightning 0.1.1",
  "lightning-invoice 0.26.0",
  "log",
  "percent-encoding",
@@ -4039,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=3a46e2acdf935884c7d1a3f6296b20973c9e4cce#3a46e2acdf935884c7d1a3f6296b20973c9e4cce"
+source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -1344,6 +1344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96487aad690d45a83f2b9876828ba856c5430bbb143cb5730d8a5d04a4805179"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +1928,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2682,6 +2694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "libsecp256k1"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,14 +2765,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+version = "0.1.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
 dependencies = [
- "bech32 0.9.1",
+ "bech32 0.11.0",
  "bitcoin 0.32.5",
- "lightning-invoice 0.32.0",
- "lightning-types",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice 0.33.1",
+ "lightning-types 0.2.0",
+ "musig2",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -2779,7 +2801,17 @@ checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.32.5",
- "lightning-types",
+ "lightning-types 0.1.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.33.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "bech32 0.11.0",
+ "bitcoin 0.32.5",
+ "lightning-types 0.2.0",
 ]
 
 [[package]]
@@ -2791,6 +2823,14 @@ dependencies = [
  "bech32 0.9.1",
  "bitcoin 0.32.5",
  "hex-conservative 0.2.1",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "bitcoin 0.32.5",
 ]
 
 [[package]]
@@ -3062,6 +3102,14 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "musig2"
+version = "0.1.0"
+source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
+dependencies = [
+ "bitcoin 0.32.5",
+]
 
 [[package]]
 name = "native-tls"
@@ -3420,6 +3468,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -4326,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=3a46e2acdf935884c7d1a3f6296b20973c9e4cce#3a46e2acdf935884c7d1a3f6296b20973c9e4cce"
+source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
 dependencies = [
  "aes",
  "anyhow",
@@ -4342,7 +4398,7 @@ dependencies = [
  "hickory-resolver",
  "lazy_static",
  "lightning 0.0.118",
- "lightning 0.0.125",
+ "lightning 0.1.1",
  "lightning-invoice 0.26.0",
  "log",
  "percent-encoding",
@@ -4370,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=3a46e2acdf935884c7d1a3f6296b20973c9e4cce#3a46e2acdf935884c7d1a3f6296b20973c9e4cce"
+source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "3a46e2acdf935884c7d1a3f6296b20973c9e4cce", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "3a46e2acdf935884c7d1a3f6296b20973c9e4cce" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "34b589583e040ccf773d5b368326856994d005f0", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "34b589583e040ccf773d5b368326856994d005f0" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/bindings/langs/csharp/src/Breez.Sdk.Liquid.csproj
+++ b/lib/bindings/langs/csharp/src/Breez.Sdk.Liquid.csproj
@@ -29,5 +29,6 @@
     <Content Include="runtimes/linux-arm64/native/libbreez_sdk_liquid_bindings.so" Link="runtimes/linux-arm64/native/libbreez_sdk_liquid_bindings.so" Pack="true" PackagePath="runtimes/linux-arm64/native/libbreez_sdk_liquid_bindings.so" />
     <Content Include="runtimes/linux-x64/native/libbreez_sdk_liquid_bindings.so" Link="runtimes/linux-x64/native/libbreez_sdk_liquid_bindings.so" Pack="true" PackagePath="runtimes/linux-x64/native/libbreez_sdk_liquid_bindings.so" />
     <Content Include="runtimes/win-x64/native/breez_sdk_liquid_bindings.dll" Link="runtimes/win-x64/native/breez_sdk_liquid_bindings.dll" Pack="true" PackagePath="runtimes/win-x64/native/breez_sdk_liquid_bindings.dll" />
+    <Content Include="runtimes/win-x86/native/breez_sdk_liquid_bindings.dll" Link="runtimes/win-x86/native/breez_sdk_liquid_bindings.dll" Pack="true" PackagePath="runtimes/win-x86/native/breez_sdk_liquid_bindings.dll" />
   </ItemGroup>
 </Project>

--- a/lib/bindings/makefile
+++ b/lib/bindings/makefile
@@ -9,7 +9,7 @@ init:
 	rustup target add aarch64-apple-ios x86_64-apple-ios
 	rustup target add aarch64-apple-darwin x86_64-apple-darwin
 	rustup target add aarch64-apple-ios-sim
-	rustup target add aarch64-linux-android x86_64-linux-android
+	rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 	rustup target add aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 	@if [ $$(uname) == "Darwin" ] ; then cargo install cargo-lipo ; fi
 	cargo install cbindgen
@@ -36,23 +36,39 @@ all: bindings-swift bindings-android python-darwin react-native
 
 ## Android 
 .PHONY: android
-android: aarch64-linux-android x86_64-linux-android
+android: aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 	cargo run --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
-
-android-uniffi-25: aarch64-linux-android-uniffi-25 x86_64-linux-android-uniffi-25
-	cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
 
 aarch64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --release	
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
 
-aarch64-linux-android-uniffi-25: $(SOURCES) ndk-home
-	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release	
-	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
+armv7-linux-androideabi: $(SOURCES) ndk-home
+	cargo ndk -t armv7-linux-androideabi -o ffi/kotlin/jniLibs build --release
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so ffi/kotlin/jniLibs/armeabi-v7a/
+
+i686-linux-android: $(SOURCES) ndk-home
+	cargo ndk -t i686-linux-android -o ffi/kotlin/jniLibs build --release
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/i686-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86/
 
 x86_64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --release
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
+
+android-uniffi-25: aarch64-linux-android-uniffi-25 armv7-linux-androideabi-uniffi-25 i686-linux-android-uniffi-25 x86_64-linux-android-uniffi-25
+	cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk_liquid.udl --no-format --language kotlin -o ffi/kotlin
+
+aarch64-linux-android-uniffi-25: $(SOURCES) ndk-home
+	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release	
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
+
+armv7-linux-androideabi-uniffi-25: $(SOURCES) ndk-home
+	cargo ndk -t armv7-linux-androideabi -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so ffi/kotlin/jniLibs/armeabi-v7a/
+
+i686-linux-android-uniffi-25: $(SOURCES) ndk-home
+	cargo ndk -t i686-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
+	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/i686-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86/
 
 x86_64-linux-android-uniffi-25: $(SOURCES) ndk-home
 	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -54,7 +54,7 @@ use crate::{
     persist::Persister,
     utils, *,
 };
-use sdk_common::lightning_125::offers::invoice::Bolt12Invoice;
+use sdk_common::lightning_with_bolt12::offers::invoice::Bolt12Invoice;
 
 use self::sync::client::BreezSyncerClient;
 use self::sync::SyncService;

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -18,8 +18,8 @@ use lwk_wollet::elements::{
 };
 use sdk_common::bitcoin::bech32;
 use sdk_common::bitcoin::bech32::FromBase32;
-use sdk_common::lightning_125::offers::invoice::Bolt12Invoice;
 use sdk_common::lightning_invoice::Bolt11Invoice;
+use sdk_common::lightning_with_bolt12::offers::invoice::Bolt12Invoice;
 use web_time::{SystemTime, UNIX_EPOCH};
 
 lazy_static! {
@@ -80,7 +80,7 @@ pub(crate) fn parse_bolt12_invoice(invoice: &str) -> Result<Bolt12Invoice> {
 
     let data = Vec::<u8>::from_base32(&data)?;
 
-    sdk_common::lightning_125::offers::invoice::Bolt12Invoice::try_from(data)
+    sdk_common::lightning_with_bolt12::offers::invoice::Bolt12Invoice::try_from(data)
         .map_err(|e| anyhow!("Failed to parse BOLT12: {e:?}"))
 }
 


### PR DESCRIPTION
Uses the updated `rust-lightning` dependency in https://github.com/breez/breez-sdk-greenlight/pull/1186 to build for 32bit targets

CI publish test: https://github.com/breez/breez-sdk-liquid/actions/runs/14045179367