### PR TITLE
WASM: fix various minor issues

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -37,6 +37,7 @@ rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7e
 ] }
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 tokio_with_wasm = { version = "0.8.2", features = ["macros", "rt", "sync", "time"] }
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 sdk-common = { workspace = true }
 sdk-macros = { workspace = true }
 rusqlite_migration = { git = "https://github.com/hydra-yse/rusqlite_migration", branch = "rusqlite-v0.33.0" }
@@ -70,7 +71,6 @@ electrum-client = { version = "0.21.0", default-features = false, features = [
 lwk_wollet = { version = "0.9.0" }
 maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
-tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
 

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -194,6 +194,7 @@ impl From<lwk_wollet::Error> for PaymentError {
     }
 }
 
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 impl From<lwk_wollet::UrlError> for PaymentError {
     fn from(err: lwk_wollet::UrlError) -> Self {
         PaymentError::Generic {

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -818,7 +818,7 @@ pub enum GetPaymentRequest {
 
 /// Trait that can be used to react to new blocks from Bitcoin and Liquid chains
 #[sdk_macros::async_trait]
-pub(crate) trait BlockListener: Send + Sync {
+pub(crate) trait BlockListener: MaybeSend + MaybeSync {
     async fn on_bitcoin_block(&self, height: u32);
     async fn on_liquid_block(&self, height: u32);
 }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -17,7 +17,6 @@ use lwk_wollet::elements::AssetId;
 use lwk_wollet::elements_miniscript::elements::bitcoin::bip32::Xpub;
 use lwk_wollet::hashes::{sha256, Hash};
 use lwk_wollet::secp256k1::Message;
-use lwk_wollet::ElementsNetwork;
 use persist::model::PaymentTxDetails;
 use recover::recoverer::Recoverer;
 use sdk_common::bitcoin::hashes::hex::ToHex;
@@ -3313,7 +3312,7 @@ impl LiquidSdk {
     #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub fn empty_wallet_cache(&self) -> Result<()> {
         let mut path = PathBuf::from(self.config.working_dir.clone());
-        path.push(Into::<ElementsNetwork>::into(self.config.network).as_str());
+        path.push(Into::<lwk_wollet::ElementsNetwork>::into(self.config.network).as_str());
         path.push("enc_cache");
 
         std::fs::remove_dir_all(&path)?;

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -28,11 +28,12 @@ use crate::{
     model::{Config, LiquidNetwork},
 };
 use lwk_wollet::secp256k1::Message;
+use maybe_sync::{MaybeSend, MaybeSync};
 
 static LN_MESSAGE_PREFIX: &[u8] = b"Lightning Signed Message:";
 
 #[sdk_macros::async_trait]
-pub trait OnchainWallet: Send + Sync {
+pub trait OnchainWallet: MaybeSend + MaybeSync {
     /// List all transactions in the wallet
     async fn transactions(&self) -> Result<Vec<WalletTx>, PaymentError>;
 


### PR DESCRIPTION
This PR:

- Adds tokio-stream to the wasm dependencies (previously was only available on non-wasm)
- Replaces Send + Sync with MaybeSend + MaybeSync where needed
- Fixes an unused warning 
- Excludes the implementation of `From<UrlError>` on Wasm