### PR TITLE
WASM: Fix minor compilation issues

### DIFF
--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 pub(crate) fn new_chain_swap_handler(persister: Arc<Persister>) -> Result<ChainSwapHandler> {
-    let config = Config::testnet(None);
+    let config = Config::testnet_esplora(None);
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(BoltzSwapper::new(

--- a/lib/core/src/test_utils/receive_swap.rs
+++ b/lib/core/src/test_utils/receive_swap.rs
@@ -16,7 +16,7 @@ use super::{
 };
 
 pub(crate) fn new_receive_swap_handler(persister: Arc<Persister>) -> Result<ReceiveSwapHandler> {
-    let config = Config::testnet(None);
+    let config = Config::testnet_esplora(None);
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer)?);
     let swapper = Arc::new(MockSwapper::default());

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -45,7 +45,7 @@ pub(crate) fn new_liquid_sdk_with_chain_services(
     bitcoin_chain_service: Arc<MockBitcoinChainService>,
     onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
 ) -> Result<Arc<LiquidSdk>> {
-    let mut config = Config::testnet(None);
+    let mut config = Config::testnet_esplora(None);
     config.working_dir = persister
         .get_database_dir()
         .to_str()

--- a/lib/core/src/test_utils/send_swap.rs
+++ b/lib/core/src/test_utils/send_swap.rs
@@ -17,7 +17,7 @@ use super::{
 };
 
 pub(crate) fn new_send_swap_handler(persister: Arc<Persister>) -> Result<SendSwapHandler> {
-    let config = Config::testnet(None);
+    let config = Config::testnet_esplora(None);
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
     let swapper = Arc::new(MockSwapper::default());

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -483,7 +483,7 @@ mod tests {
         let sdk_signer: Box<dyn Signer> = Box::new(SdkSigner::new(mnemonic, "", false).unwrap());
         let sdk_signer = Arc::new(sdk_signer);
 
-        let config = Config::testnet(None);
+        let config = Config::testnet_esplora(None);
 
         create_persister!(storage);
 

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -74,7 +74,12 @@ async fn connect_inner(
 
 #[wasm_bindgen(js_name = "defaultConfig")]
 pub fn default_config(network: LiquidNetwork, breez_api_key: Option<String>) -> WasmResult<Config> {
-    Ok(LiquidSdk::default_config(network.into(), breez_api_key)?.into())
+    let config = match network {
+        LiquidNetwork::Mainnet => breez_sdk_liquid::model::Config::mainnet_esplora(breez_api_key),
+        LiquidNetwork::Testnet => breez_sdk_liquid::model::Config::testnet_esplora(breez_api_key),
+        LiquidNetwork::Regtest => breez_sdk_liquid::model::Config::regtest_esplora(),
+    };
+    Ok(config.into())
 }
 
 #[wasm_bindgen(js_name = "parseInvoice")]

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -293,9 +293,9 @@ pub struct Symbol {
     pub position: Option<u32>,
 }
 
+#[derive(Clone)]
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::BlockchainExplorer)]
 pub enum BlockchainExplorer {
-    Electrum { url: String },
     Esplora { url: String, use_waterfalls: bool },
 }
 
@@ -336,6 +336,7 @@ pub enum SdkEvent {
     PaymentWaitingConfirmation { details: Payment },
     PaymentWaitingFeeAcceptance { details: Payment },
     Synced,
+    DataSynced { did_pull_new_records: bool },
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This PR:
- Manually maps the `default_config` method (which is now feature-locked on sdk-core) to use the config's esplora branch
- Adds the `DataSynced` event to `SdkEvents`
- Removes `BlockchainExplorer::Electrum` from pattern matches