### PR TITLE
WASM: fix clippy and tests

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
+source = "git+https://github.com/breez/breez-sdk?rev=cc331f34102abda3a39a51524307688a74458050#cc331f34102abda3a39a51524307688a74458050"
 dependencies = [
  "aes",
  "anyhow",
@@ -4186,6 +4186,7 @@ dependencies = [
  "lightning 0.1.1",
  "lightning-invoice 0.26.0",
  "log",
+ "maybe-sync",
  "percent-encoding",
  "prost 0.11.9",
  "prost 0.13.5",
@@ -4211,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
+source = "git+https://github.com/breez/breez-sdk?rev=cc331f34102abda3a39a51524307688a74458050#cc331f34102abda3a39a51524307688a74458050"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
+source = "git+https://github.com/breez/breez-sdk?rev=cc331f34102abda3a39a51524307688a74458050#cc331f34102abda3a39a51524307688a74458050"
 dependencies = [
  "aes",
  "anyhow",
@@ -4517,6 +4517,7 @@ dependencies = [
  "lightning 0.1.1",
  "lightning-invoice 0.26.0",
  "log",
+ "maybe-sync",
  "percent-encoding",
  "prost 0.11.9",
  "prost 0.13.5",
@@ -4542,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=34b589583e040ccf773d5b368326856994d005f0#34b589583e040ccf773d5b368326856994d005f0"
+source = "git+https://github.com/breez/breez-sdk?rev=cc331f34102abda3a39a51524307688a74458050#cc331f34102abda3a39a51524307688a74458050"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "34b589583e040ccf773d5b368326856994d005f0", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "34b589583e040ccf773d5b368326856994d005f0" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "cc331f34102abda3a39a51524307688a74458050", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "cc331f34102abda3a39a51524307688a74458050" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/core/src/buy.rs
+++ b/lib/core/src/buy.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use anyhow::{anyhow, Result};
 use maybe_sync::{MaybeSend, MaybeSync};
-use sdk_common::prelude::{BreezServer, BuyBitcoinProviderApi, MoonpayProvider};
+use sdk_common::prelude::{utils::Arc, BreezServer, BuyBitcoinProviderApi, MoonpayProvider};
 
 use crate::{
     model::{BuyBitcoinProvider, ChainSwap, Config},

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Context, Result};
 use boltz_client::{
@@ -10,6 +10,7 @@ use elements::{hex::FromHex, Script, Transaction};
 use futures_util::TryFutureExt;
 use log::{debug, error, info, warn};
 use lwk_wollet::hashes::hex::DisplayHex;
+use sdk_common::utils::Arc;
 use tokio::sync::broadcast;
 
 use crate::{

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -186,6 +186,7 @@ pub(crate) mod signer;
 pub(crate) mod swapper;
 pub(crate) mod sync;
 pub(crate) mod test_utils;
+#[allow(hidden_glob_reexports)]
 pub(crate) mod utils;
 pub mod wallet;
 

--- a/lib/core/src/lnurl/auth.rs
+++ b/lib/core/src/lnurl/auth.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
-
 use sdk_common::{
     bitcoin::util::bip32::{ChildNumber, DerivationPath},
     prelude::{LnUrlResult, LnurlAuthSigner},
+    utils::Arc,
 };
 
 use crate::model::Signer;

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -16,10 +16,11 @@ use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRe
 use rusqlite::ToSql;
 use sdk_common::bitcoin::hashes::hex::ToHex as _;
 use sdk_common::prelude::*;
+use sdk_common::utils::Arc;
 use serde::{Deserialize, Serialize};
+use std::cmp::PartialEq;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{cmp::PartialEq, sync::Arc};
 use strum_macros::{Display, EnumString};
 
 use crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT;

--- a/lib/core/src/persist/backup.rs
+++ b/lib/core/src/persist/backup.rs
@@ -36,6 +36,7 @@ impl Persister {
 }
 
 #[cfg(test)]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 mod tests {
     use anyhow::Result;
 

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 use boltz_client::swaps::boltz::RevSwapStates;
@@ -8,6 +8,7 @@ use lwk_wollet::elements::secp256k1_zkp::Secp256k1;
 use lwk_wollet::elements::{Transaction, Txid};
 use lwk_wollet::hashes::hex::DisplayHex;
 use lwk_wollet::secp256k1::SecretKey;
+use sdk_common::utils::Arc;
 use tokio::sync::broadcast;
 
 use crate::chain::liquid::LiquidChainService;

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use boltz_client::ToHex;
 use log::{debug, error, warn};
 use lwk_wollet::elements::Txid;
+use sdk_common::utils::Arc;
 
 use crate::prelude::*;
 use crate::recover::model::*;

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
@@ -13,7 +13,8 @@ mod test {
     use bitcoin::{transaction::Version, Sequence};
     use boltz_client::{Amount, LockTime};
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
-    use std::{collections::HashMap, str::FromStr, sync::Arc};
+    use sdk_common::utils::Arc;
+    use std::{collections::HashMap, str::FromStr};
 
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -15,8 +15,9 @@ mod test {
     use bitcoin::{transaction::Version, ScriptBuf, Sequence};
     use boltz_client::{Amount, LockTime};
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
+    use sdk_common::utils::Arc;
 
-    use std::{collections::HashMap, str::FromStr, sync::Arc};
+    use std::{collections::HashMap, str::FromStr};
 
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -12,7 +12,8 @@ mod test {
     };
     use elements::{Address as ElementsAddress, Script, Txid};
     use lwk_wollet::{elements_miniscript::slip77::MasterBlindingKey, WalletTx};
-    use std::{collections::HashMap, str::FromStr, sync::Arc};
+    use sdk_common::utils::Arc;
+    use std::{collections::HashMap, str::FromStr};
 
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -13,9 +13,9 @@ mod test {
     use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
     use lwk_wollet::WalletTx;
     use mockall::predicate::*;
+    use sdk_common::utils::Arc;
     use std::collections::HashMap;
     use std::str::FromStr;
-    use std::sync::Arc;
 
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
 use lwk_wollet::WalletTx;
+use sdk_common::utils::Arc;
 
 use crate::chain::liquid::LiquidChainService;
 use crate::prelude::*;

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use anyhow::{anyhow, ensure, Result};
 use log::{debug, info, warn};
@@ -15,6 +15,7 @@ use lwk_wollet::{
     hashes::hex::{DisplayHex, FromHex},
     WalletTx,
 };
+use sdk_common::utils::Arc;
 
 use crate::sdk::NETWORK_PROPAGATION_GRACE_PERIOD;
 use crate::swapper::Swapper;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Not as _;
-use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{anyhow, ensure, Result};
 use boltz_client::{swaps::boltz::*, util::secrets::Preimage};
@@ -22,6 +22,7 @@ use sdk_common::bitcoin::hashes::hex::ToHex;
 use sdk_common::input_parser::InputType;
 use sdk_common::liquid::LiquidAddressData;
 use sdk_common::prelude::{FiatAPI, FiatCurrency, LnUrlPayError, LnUrlWithdrawError, Rate};
+use sdk_common::utils::Arc;
 use signer::SdkSigner;
 use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
@@ -3850,7 +3851,7 @@ fn extract_description_from_metadata(request_data: &LnUrlPayRequestData) -> Opti
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::str::FromStr;
 
     use anyhow::{anyhow, Result};
     use boltz_client::{
@@ -3858,6 +3859,8 @@ mod tests {
         swaps::boltz::{ChainSwapStates, RevSwapStates, SubSwapStates},
     };
     use lwk_wollet::hashes::hex::DisplayHex as _;
+    use sdk_common::utils::Arc;
+    use tokio_with_wasm::alias as tokio;
 
     use crate::chain_swap::ESTIMATED_BTC_LOCKUP_TX_VSIZE;
     use crate::test_utils::chain_swap::{

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -1,5 +1,5 @@
+use std::str::FromStr;
 use std::time::Duration;
-use std::{str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use boltz_client::swaps::boltz;
@@ -9,6 +9,7 @@ use log::{debug, error, info, warn};
 use lwk_wollet::elements::{LockTime, Transaction};
 use lwk_wollet::hashes::{sha256, Hash};
 use sdk_common::prelude::{AesSuccessActionDataResult, SuccessAction, SuccessActionProcessed};
+use sdk_common::utils::Arc;
 use tokio::sync::broadcast;
 use web_time::{SystemTime, UNIX_EPOCH};
 

--- a/lib/core/src/signer.rs
+++ b/lib/core/src/signer.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::anyhow;
 use bip39::Mnemonic;
 use boltz_client::PublicKey;
@@ -23,6 +21,7 @@ use lwk_wollet::elements_miniscript::{
 use lwk_wollet::hashes::{sha256, HashEngine, Hmac, HmacEngine};
 use lwk_wollet::secp256k1::ecdsa::Signature;
 use lwk_wollet::secp256k1::Message;
+use sdk_common::utils::Arc;
 
 use crate::model::{Signer, SignerError};
 

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use crate::{
     error::{PaymentError, SdkError},
@@ -19,6 +19,7 @@ use boltz_client::{
 use client::{BitcoinClient, LiquidClient};
 use log::info;
 use proxy::split_proxy_url;
+use sdk_common::utils::Arc;
 use tokio::sync::broadcast;
 
 use super::{ProxyUrlFetcher, Swapper};

--- a/lib/core/src/swapper/boltz/proxy.rs
+++ b/lib/core/src/swapper/boltz/proxy.rs
@@ -1,7 +1,8 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use sdk_common::prelude::BreezServer;
+use sdk_common::utils::Arc;
 use url::Url;
 
 use crate::{persist::Persister, swapper::ProxyUrlFetcher};

--- a/lib/core/src/swapper/boltz/status_stream.rs
+++ b/lib/core/src/swapper/boltz/status_stream.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::swapper::{
@@ -13,6 +12,7 @@ use boltz_client::boltz::{
 };
 use futures_util::{stream::SplitSink, SinkExt, StreamExt};
 use log::{debug, error, info, warn};
+use sdk_common::utils::Arc;
 use tokio::sync::{broadcast, watch};
 use tokio_with_wasm::alias as tokio;
 

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use boltz_client::{
     boltz::{
@@ -12,6 +10,7 @@ use boltz_client::{
 };
 use maybe_sync::{MaybeSend, MaybeSync};
 use mockall::automock;
+use sdk_common::utils::Arc;
 use tokio::sync::{broadcast, watch};
 
 use crate::{

--- a/lib/core/src/swapper/subscription_handler.rs
+++ b/lib/core/src/swapper/subscription_handler.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
-
 use log::{error, info};
 use maybe_sync::{MaybeSend, MaybeSync};
 
 use crate::persist::Persister;
+
+use sdk_common::utils::Arc;
 
 use super::SwapperStatusStream;
 

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use log::{info, trace, warn};
+use sdk_common::utils::Arc;
 use tokio::sync::{broadcast, watch};
 use tokio::time::sleep;
 use tokio_stream::StreamExt as _;
@@ -548,7 +548,8 @@ impl SyncService {
 #[cfg(test)]
 mod tests {
     use anyhow::{anyhow, Result};
-    use std::{collections::HashMap, sync::Arc};
+    use sdk_common::utils::Arc;
+    use std::collections::HashMap;
 
     use crate::{
         persist::{cache::KEY_LAST_DERIVATION_INDEX, Persister},

--- a/lib/core/src/sync/model/client.rs
+++ b/lib/core/src/sync/model/client.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use log::trace;
 use lwk_wollet::hashes::hex::DisplayHex as _;
 use sdk_common::bitcoin::hashes::{sha256, Hash};
-use std::sync::Arc;
+use sdk_common::utils::Arc;
 
 use super::{
     ListChangesRequest, ListenChangesRequest, Record, SetRecordRequest, CURRENT_SCHEMA_VERSION,

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 tonic::include_proto!("sync");
 
 use self::data::SyncData;
@@ -13,6 +11,7 @@ use rusqlite::{
     ToSql,
 };
 use sdk_common::bitcoin::hashes::{sha256, Hash};
+use sdk_common::utils::Arc;
 use semver::Version;
 
 pub(crate) mod client;

--- a/lib/core/src/test_utils/chain_swap.rs
+++ b/lib/core/src/test_utils/chain_swap.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use hex::FromHex;
 use lazy_static::lazy_static;
 use sdk_common::bitcoin::{consensus::deserialize, Transaction};
-use std::sync::Arc;
+use sdk_common::utils::Arc;
 
 use crate::{
     chain_swap::ChainSwapHandler,

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -10,6 +10,7 @@ use sdk_common::{
     lightning_invoice::{Currency, InvoiceBuilder},
     prelude::invoice_pubkey,
 };
+use std::time::SystemTime;
 
 use crate::{
     model::{LiquidNetwork, PaymentState, PaymentTxData, PaymentType, ReceiveSwap, SendSwap},
@@ -35,7 +36,7 @@ pub(crate) fn new_send_swap(
         .description("Test invoice".into())
         .payment_hash(payment_hash)
         .payment_secret(PaymentSecret([42u8; 32]))
-        .current_timestamp()
+        .timestamp(SystemTime::UNIX_EPOCH)
         .min_final_cltv_expiry_delta(144)
         .build_signed(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
         .expect("Expected valid invoice");
@@ -134,7 +135,7 @@ macro_rules! create_persister {
                     .collect();
                 res
             };
-            std::sync::Arc::new(crate::persist::Persister::new_in_memory(
+            sdk_common::utils::Arc::new(crate::persist::Persister::new_in_memory(
                 &db_id,
                 crate::model::LiquidNetwork::Testnet,
                 true,
@@ -148,7 +149,7 @@ macro_rules! create_persister {
                 .to_str()
                 .ok_or(anyhow::anyhow!("Could not create temporary directory"))?
                 .to_string();
-            std::sync::Arc::new(crate::persist::Persister::new_using_fs(
+            sdk_common::utils::Arc::new(crate::persist::Persister::new_using_fs(
                 &temp_dir_path,
                 crate::model::LiquidNetwork::Testnet,
                 true,

--- a/lib/core/src/test_utils/receive_swap.rs
+++ b/lib/core/src/test_utils/receive_swap.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use anyhow::Result;
-use std::sync::Arc;
+use sdk_common::utils::Arc;
 
 use crate::{
     model::{Config, Signer},

--- a/lib/core/src/test_utils/recover.rs
+++ b/lib/core/src/test_utils/recover.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
-
 use anyhow::Result;
+use sdk_common::utils::Arc;
 
 use super::chain::{MockBitcoinChainService, MockLiquidChainService};
 use crate::persist::Persister;

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Result};
 use sdk_common::prelude::{MockRestClient, RestClient, STAGING_BREEZSERVER_URL};
-use std::sync::Arc;
+use sdk_common::utils::Arc;
 
 use crate::{
     model::{Config, Signer},

--- a/lib/core/src/test_utils/send_swap.rs
+++ b/lib/core/src/test_utils/send_swap.rs
@@ -1,7 +1,5 @@
 #![cfg(test)]
 
-use std::sync::Arc;
-
 use crate::{
     model::{Config, Signer},
     persist::Persister,
@@ -9,6 +7,7 @@ use crate::{
     send_swap::SendSwapHandler,
 };
 use anyhow::Result;
+use sdk_common::utils::Arc;
 
 use super::{
     chain::{MockBitcoinChainService, MockLiquidChainService},

--- a/lib/core/src/test_utils/status_stream.rs
+++ b/lib/core/src/test_utils/status_stream.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use boltz_client::boltz;
-use std::sync::Arc;
+use sdk_common::utils::Arc;
 
 use tokio::sync::{broadcast, watch};
 use tokio_with_wasm::alias as tokio;

--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use crate::{
     persist::Persister,
@@ -17,6 +17,7 @@ use crate::{
     },
 };
 use anyhow::Result;
+use sdk_common::utils::Arc;
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     Mutex,

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr};
 
 use crate::{
     error::PaymentError,
@@ -23,6 +23,7 @@ use lwk_wollet::{
     secp256k1::{All, Message},
     WalletTx,
 };
+use sdk_common::utils::Arc;
 
 pub(crate) struct MockWallet {
     signer: SdkLwkSigner,

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -3,8 +3,8 @@ mod event;
 pub mod model;
 mod signer;
 
+use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use crate::event::{EventListener, WasmEventListener};
 use crate::model::*;
@@ -19,7 +19,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub struct BindingLiquidSdk {
-    sdk: Arc<LiquidSdk>,
+    sdk: Rc<LiquidSdk>,
 }
 
 #[wasm_bindgen(js_name = "connect")]
@@ -42,24 +42,24 @@ async fn connect_inner(
     signer: Box<dyn breez_sdk_liquid::model::Signer>,
 ) -> WasmResult<BindingLiquidSdk> {
     let config: breez_sdk_liquid::model::Config = config.into();
-    let signer = Arc::new(signer);
+    let signer = Rc::new(signer);
 
     let mut sdk_builder = LiquidSdkBuilder::new(
         config.clone(),
         PRODUCTION_BREEZSERVER_URL.to_string(),
-        Arc::clone(&signer),
+        Rc::clone(&signer),
     )?;
 
-    let persister = Arc::new(Persister::new_in_memory(
+    let persister = Rc::new(Persister::new_in_memory(
         &config.working_dir,
         config.network,
         config.sync_enabled(),
         config.asset_metadata.clone(),
     )?);
 
-    let onchain_wallet = Arc::new(LiquidOnchainWallet::new_in_memory(
+    let onchain_wallet = Rc::new(LiquidOnchainWallet::new_in_memory(
         config,
-        Arc::clone(&persister),
+        Rc::clone(&persister),
         signer,
     )?);
 


### PR DESCRIPTION
This PR fixes the last things missing to clean up the Wasm clippy and tests.

On Wasm there were some clippy errors due to having non send and sync `Arc`s. Fixed by creating an Arc alias for Rc in sdk-common: https://github.com/breez/breez-sdk-greenlight/pull/1189