### PR TITLE
Set Swift framework CFBundleShortVersionString

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -85,6 +85,14 @@ jobs:
           cp ios-universal-sim/libbreez_sdk_liquid_bindings.a build/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/breez_sdk_liquidFFI
           cp darwin-universal/libbreez_sdk_liquid_bindings.a build/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/macos-arm64_x86_64/breez_sdk_liquidFFI.framework/breez_sdk_liquidFFI
 
+      - name: Set plist versions
+        working-directory: build/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework
+        run: |
+          SHORT_VERSION=$(echo "${{ inputs.package-version }}" | grep -Eo '^(\d.\d.\d)')
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios-arm64/breez_sdk_liquidFFI.framework/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" macos-arm64_x86_64/breez_sdk_liquidFFI.framework/Info.plist
+
       - name: Compress XCFramework
         working-directory: build/lib/bindings/langs/swift
         run: |

--- a/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64/breez_sdk_liquidFFI.framework/Info.plist
+++ b/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64/breez_sdk_liquidFFI.framework/Info.plist
@@ -18,6 +18,8 @@
 	</array>
     <key>CFBundleSignature</key>
     <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>MinimumOSVersion</key>

--- a/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/Info.plist
+++ b/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_liquidFFI.framework/Info.plist
@@ -18,6 +18,8 @@
 	</array>
     <key>CFBundleSignature</key>
     <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>MinimumOSVersion</key>

--- a/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/macos-arm64_x86_64/breez_sdk_liquidFFI.framework/Info.plist
+++ b/lib/bindings/langs/swift/breez_sdk_liquidFFI.xcframework/macos-arm64_x86_64/breez_sdk_liquidFFI.framework/Info.plist
@@ -18,6 +18,8 @@
     </array>
     <key>CFBundleSignature</key>
     <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>MinimumOSVersion</key>


### PR DESCRIPTION
The lack of a `CFBundleShortVersionString` key in the framework Info.plist files are causing issues in newer Xcode versions. This PR sets the version from the publishing package version

Dummy [breez_sdk_liquidFFI.xcframework](https://github.com/breez/breez-sdk-liquid/actions/runs/14123021249/artifacts/2836876495) from CI run

Fixes #825 