### PR TITLE
Adds Logger interface for Wasm

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -686,7 +686,6 @@ dependencies = [
  "bip39",
  "boltz-client",
  "chrono",
- "console_log",
  "derivative",
  "ecies",
  "electrum-client",
@@ -919,16 +918,6 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
 ]
 
 [[package]]
@@ -2440,9 +2429,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
 dependencies = [
  "jiff-static",
  "log",
@@ -2453,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -781,7 +781,6 @@ dependencies = [
  "bip39",
  "boltz-client",
  "chrono",
- "console_log",
  "derivative",
  "ecies",
  "electrum-client",
@@ -2928,8 +2927,10 @@ dependencies = [
 [[package]]
 name = "log"
 version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+source = "git+https://github.com/breez/log?rev=d34efde73c8dfdf3ef938b8ad4dcc83e9801aab0#d34efde73c8dfdf3ef938b8ad4dcc83e9801aab0"
+dependencies = [
+ "maybe-sync",
+]
 
 [[package]]
 name = "lru-cache"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -44,3 +44,6 @@ thiserror = "1.0"
 [patch.crates-io]
 # https://github.com/BlockstreamResearch/rust-secp256k1-zkp/pull/48/commits and rebased on secp256k1-zkp 0.11.0
 secp256k1-zkp = { git = "https://github.com/breez/rust-secp256k1-zkp.git", rev = "eac2e479255a6e32b5588bc25ee53c642fdd8395" }
+# Patches log to allow non Send + Sync in Wasm and applies the patch to dependencies
+log = { git = "https://github.com/breez/log", rev = "d34efde73c8dfdf3ef938b8ad4dcc83e9801aab0", features = ["std"] }
+

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -77,7 +77,6 @@ boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f78
 
 # Wasm dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-console_log = "1"
 lwk_wollet = { git = "https://github.com/breez/lwk", rev = "0b18e777d496", default-features = false, features = [
     "esplora",
 ] }

--- a/lib/core/src/logger.rs
+++ b/lib/core/src/logger.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use anyhow::{anyhow, Result};
 use chrono::Local;
 use log::{LevelFilter, Metadata, Record};
+use maybe_sync::{MaybeSend, MaybeSync};
 
 use crate::model::LogEntry;
 
@@ -81,6 +82,6 @@ pub(super) fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>)
     Ok(())
 }
 
-pub trait Logger: Send + Sync {
+pub trait Logger: MaybeSend + MaybeSync {
     fn log(&self, l: LogEntry);
 }

--- a/lib/wasm/src/logger.rs
+++ b/lib/wasm/src/logger.rs
@@ -1,0 +1,36 @@
+use log::{Level, Log, Metadata, Record};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::model::LogEntry;
+
+pub struct WasmLogger {
+    pub logger: Logger,
+}
+
+impl Log for WasmLogger {
+    fn enabled(&self, m: &Metadata) -> bool {
+        m.level() <= Level::Trace
+    }
+
+    fn log(&self, record: &Record) {
+        self.logger.log(LogEntry {
+            line: record.args().to_string(),
+            level: record.level().as_str().to_string(),
+        });
+    }
+    fn flush(&self) {}
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const LOGGER: &'static str = r#"export interface Logger {
+    log: (l: LogEntry) => void;
+}"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "Logger")]
+    pub type Logger;
+
+    #[wasm_bindgen(structural, method, js_name = log)]
+    pub fn log(this: &Logger, l: LogEntry);
+}


### PR DESCRIPTION
**_This might be a controversial and long-winded way of doing this.
So please let be know if there is a simpler way._**

This PR uses a forked [log repo](https://github.com/rust-lang/log/compare/master...breez:log:savage-wasm-log) to implement the Logger interface in Wasm. The fork changes the Log trait to use `MaybeSend + MaybeSync` to allow received log records to be emitted through the javascript `Logger` callback interface.

We use the forked log to patch the other dependences so we receive the log records from them also.

Fixes: #831 

**Error when not using the log fork:**
```bash
error[E0277]: `*mut u8` cannot be sent between threads safely
    --> wasm/src/logger.rs:10:14
     |
10   | impl Log for WasmLogger {
     |              ^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
     |
     = help: within `logger::WasmLogger`, the trait `std::marker::Send` is not implemented for `*mut u8`
note: required because it appears within the type `std::marker::PhantomData<*mut u8>`
    --> /Users/rosssavage/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/marker.rs:757:12
     |
757  | pub struct PhantomData<T: ?Sized>;
     |            ^^^^^^^^^^^
note: required because it appears within the type `wasm_bindgen::JsValue`
    --> /Users/rosssavage/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-0.2.100/src/lib.rs:135:12
     |
135  | pub struct JsValue {
     |            ^^^^^^^
note: required because it appears within the type `logger::Logger`
    --> wasm/src/logger.rs:32:14
     |
32   |     pub type Logger;
     |              ^^^^^^
note: required because it appears within the type `logger::WasmLogger`
    --> wasm/src/logger.rs:6:12
     |
6    | pub struct WasmLogger {
     |            ^^^^^^^^^^
note: required by a bound in `log::Log`
    --> /Users/rosssavage/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.27/src/lib.rs:1174:23
     |
1174 | pub trait Log: Sync + Send {
     |                       ^^^^ required by this bound in `Log`

error[E0277]: `*mut u8` cannot be shared between threads safely
    --> wasm/src/logger.rs:10:14
     |
10   | impl Log for WasmLogger {
     |              ^^^^^^^^^^ `*mut u8` cannot be shared between threads safely
     |
     = help: within `logger::WasmLogger`, the trait `std::marker::Sync` is not implemented for `*mut u8`
note: required because it appears within the type `std::marker::PhantomData<*mut u8>`
    --> /Users/rosssavage/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/marker.rs:757:12
     |
757  | pub struct PhantomData<T: ?Sized>;
     |            ^^^^^^^^^^^
note: required because it appears within the type `wasm_bindgen::JsValue`
    --> /Users/rosssavage/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-0.2.100/src/lib.rs:135:12
     |
135  | pub struct JsValue {
     |            ^^^^^^^
note: required because it appears within the type `logger::Logger`
    --> wasm/src/logger.rs:32:14
     |
32   |     pub type Logger;
     |              ^^^^^^
note: required because it appears within the type `logger::WasmLogger`
    --> wasm/src/logger.rs:6:12
     |
6    | pub struct WasmLogger {
     |            ^^^^^^^^^^
note: required by a bound in `log::Log`
    --> /Users/rosssavage/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.27/src/lib.rs:1174:16
     |
1174 | pub trait Log: Sync + Send {
     |                ^^^^ required by this bound in `Log`
```