### PR TITLE
Switch Esplora client url to Breez server instance

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "async-trait",
  "bip39",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -76,7 +76,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f78e159fe72e1c357e7830bc08d2b9e42a65362c", features = ["electrum"] }
+boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "b54f181e218d", features = ["electrum"] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",
@@ -95,7 +95,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f78e159fe72e1c357e7830bc08d2b9e42a65362c" }
+boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "b54f181e218d" }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",

--- a/lib/core/src/chain/bitcoin/esplora.rs
+++ b/lib/core/src/chain/bitcoin/esplora.rs
@@ -52,7 +52,6 @@ impl EsploraBitcoinChainService {
             .timeout(3)
             .max_retries(10)
             .build_async()?;
-
         let client = self.client.get_or_init(|| client);
         Ok(client)
     }

--- a/lib/core/src/chain/liquid/esplora.rs
+++ b/lib/core/src/chain/liquid/esplora.rs
@@ -10,7 +10,7 @@ use crate::{
     utils,
 };
 
-use log::{info, warn};
+use log::{error, info};
 use lwk_wollet::{
     asyncr::EsploraClientBuilder, clients::asyncr::EsploraClient, elements::hex::FromHex as _,
 };
@@ -50,7 +50,7 @@ impl EsploraLiquidChainService {
                         }
                         None => {
                             let err = "Cannot start Breez Esplora client: Breez API key is not set";
-                            warn!("{err}");
+                            error!("{err}");
                             bail!(err)
                         }
                     };

--- a/lib/core/src/chain/liquid/esplora.rs
+++ b/lib/core/src/chain/liquid/esplora.rs
@@ -1,16 +1,16 @@
 use std::{sync::OnceLock, time::Duration};
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{anyhow, bail, Context as _, Result};
 use tokio::sync::RwLock;
 use tokio_with_wasm::alias as tokio;
 
 use crate::{
     elements::{Address, OutPoint, Script, Transaction, Txid},
-    model::{BlockchainExplorer, Config, Utxo},
+    model::{BlockchainExplorer, Config, Utxo, BREEZ_LIQUID_ESPLORA_URL},
     utils,
 };
 
-use log::info;
+use log::{info, warn};
 use lwk_wollet::{
     asyncr::EsploraClientBuilder, clients::asyncr::EsploraClient, elements::hex::FromHex as _,
 };
@@ -40,10 +40,23 @@ impl EsploraLiquidChainService {
             BlockchainExplorer::Esplora {
                 url,
                 use_waterfalls,
-            } => EsploraClientBuilder::new(url, self.config.network.into())
-                .timeout(3)
-                .waterfalls(*use_waterfalls)
-                .build(),
+            } => {
+                let mut builder = EsploraClientBuilder::new(url, self.config.network.into());
+                if url == BREEZ_LIQUID_ESPLORA_URL {
+                    match &self.config.breez_api_key {
+                        Some(api_key) => {
+                            builder = builder
+                                .header("authorization".to_string(), format!("Bearer {api_key}"));
+                        }
+                        None => {
+                            let err = "Cannot start Breez Esplora client: Breez API key is not set";
+                            warn!("{err}");
+                            bail!(err)
+                        }
+                    };
+                }
+                builder.timeout(3).waterfalls(*use_waterfalls).build()
+            }
             #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
             BlockchainExplorer::Electrum { .. } => {
                 anyhow::bail!("Cannot start Liquid Esplora chain service without an Esplora url")

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -221,7 +221,7 @@ impl LiquidSdkBuilder {
         let liquid_chain_service: Arc<dyn LiquidChainService> =
             match self.liquid_chain_service.clone() {
                 Some(liquid_chain_service) => liquid_chain_service,
-                None => self.config.liquid_chain_service(),
+                None => self.config.liquid_chain_service()?,
             };
 
         let onchain_wallet: Arc<dyn OnchainWallet> = match self.onchain_wallet.clone() {

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -4,7 +4,7 @@ use boltz_client::{
         ChainFees, ChainMinerFees, ChainPair, ChainSwapDetails, CreateChainResponse,
         CreateReverseResponse, CreateSubmarineResponse, Leaf, PairLimits, PairMinerFees,
         ReverseFees, ReverseLimits, ReversePair, SubmarineClaimTxResponse, SubmarineFees,
-        SubmarinePair, SwapTree,
+        SubmarinePair, SubmarinePairLimits, SwapTree,
     },
     util::secrets::Preimage,
     Amount, PublicKey,
@@ -187,10 +187,11 @@ impl Swapper for MockSwapper {
         Ok(Some(SubmarinePair {
             hash: generate_random_string(10),
             rate: 0.0,
-            limits: PairLimits {
+            limits: SubmarinePairLimits {
                 maximal: 25_000_000,
                 minimal: 1_000,
                 maximal_zero_conf: 250_000,
+                minimal_batched: None,
             },
             fees: SubmarineFees {
                 percentage: 0.1,


### PR DESCRIPTION
~Waiting for breez/server#67~
This PR:
- Adds API key check for Breez waterfalls url on all client types (chain, wallet, swapper)
- Changes the main Esplora url to Breez instance

## Notes
- Switching to [custom branch](https://github.com/hydra-yse/boltz-rust/tree/esplora-custom-client) until SatoshiPortal/boltz-rust#100 is merged