### PR TITLE
WASM: end-to-end-test support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -359,6 +359,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install Wasm target
         run: rustup target add wasm32-unknown-unknown
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "regtest/boltz"]
 	path = regtest/boltz
 	url = https://github.com/BoltzExchange/regtest.git
+[submodule "regtest/waterfalls-service/waterfalls"]
+	path = regtest/waterfalls-service/waterfalls
+	url = https://github.com/RCasatta/waterfalls.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/BoltzExchange/regtest.git
 [submodule "regtest/waterfalls-service/waterfalls"]
 	path = regtest/waterfalls-service/waterfalls
-	url = https://github.com/RCasatta/waterfalls.git
+	url = https://github.com/breez/waterfalls.git

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -123,6 +123,7 @@ getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-futures = "0.4.50"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 futures = "0.3.31"
+console_log = "1.0.0"
 
 [build-dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }

--- a/lib/core/DEVELOPMENT.md
+++ b/lib/core/DEVELOPMENT.md
@@ -32,11 +32,17 @@ make regtest-start
 make regtest-stop
 ```
 
-To run the end-to-end tests:
+To run the end-to-end tests (see [Makefile](./Makefile) for all targets):
 ```bash
-make regtest-test
-```
-This comprises the following make tasks:
-```bash
-make cargo-regtest-test wasm-regtest-test
+make regtest-test # all tests on all targets
+
+make cargo-regtest-test # run natively
+
+make wasm-regtest-test # run on all Wasm runtimes (browser + node)
+
+make wasm-regtest-test-browser # run on the browser (headless)
+make wasm-regtest-test-browser NO_HEADLESS=1 # run on the browser (not headless)
+# To run just a specific test or a subset of all tests the variable:
+make wasm-regtest-test-browser REGTEST_TESTS=partial_test_name
+make wasm-regtest-test-node # run on node.js
 ```

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -61,10 +61,10 @@ test-safari:
 wasm-regtest-test: wasm-regtest-test-browser wasm-regtest-test-node
 
 wasm-regtest-test-node: check-regtest
-	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test --node --features regtest -- $(REGTEST_TESTS)
+	$(CLANG_PREFIX) $(REGTEST_PREFIX) wasm-pack test --node --features regtest -- $(REGTEST_TESTS) --nocapture
 
 wasm-regtest-test-browser: check-regtest
-	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test --headless --$(BROWSER) --features regtest,browser-tests -- $(REGTEST_TESTS)
+	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test $(if $(NO_HEADLESS), ,--headless) --$(BROWSER) --features regtest,browser-tests -- $(REGTEST_TESTS)
 
 wasm-regtest-test-chrome:
 	BROWSER=chrome $(MAKE) wasm-regtest-test-browser

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -192,7 +192,7 @@ pub mod test_utils;
 #[cfg(not(feature = "test-utils"))]
 pub(crate) mod test_utils;
 #[allow(hidden_glob_reexports)]
-pub mod utils;
+pub(crate) mod utils;
 pub mod wallet;
 
 pub use lwk_wollet::bitcoin;
@@ -206,4 +206,5 @@ pub mod prelude {
     pub use crate::model::*;
     pub use crate::sdk::*;
     pub use crate::signer::SdkSigner;
+    pub use sdk_common::utils::Arc;
 }

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -192,7 +192,7 @@ pub mod test_utils;
 #[cfg(not(feature = "test-utils"))]
 pub(crate) mod test_utils;
 #[allow(hidden_glob_reexports)]
-pub(crate) mod utils;
+pub mod utils;
 pub mod wallet;
 
 pub use lwk_wollet::bitcoin;

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -227,8 +227,8 @@ impl Config {
     pub fn regtest_esplora() -> Self {
         Config {
             liquid_explorer: BlockchainExplorer::Esplora {
-                url: "http://localhost:4003/api".to_string(),
-                use_waterfalls: false,
+                url: "http://localhost:3120/api".to_string(),
+                use_waterfalls: true,
             },
             bitcoin_explorer: BlockchainExplorer::Esplora {
                 url: "http://localhost:4002/api".to_string(),
@@ -238,7 +238,7 @@ impl Config {
             cache_dir: None,
             network: LiquidNetwork::Regtest,
             payment_timeout_sec: 15,
-            sync_service_url: Some("http://localhost:8088".to_string()),
+            sync_service_url: Some("http://localhost:8089".to_string()),
             zero_conf_max_amount_sat: None,
             breez_api_key: None,
             external_input_parsers: None,

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -22,6 +22,8 @@ use sdk_common::lightning_invoice::Bolt11Invoice;
 use sdk_common::lightning_with_bolt12::offers::invoice::Bolt12Invoice;
 use web_time::{SystemTime, UNIX_EPOCH};
 
+pub use sdk_common::utils::Arc;
+
 lazy_static! {
     static ref LBTC_TESTNET_ASSET_ID: AssetId =
         AssetId::from_str("144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49")

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -22,8 +22,6 @@ use sdk_common::lightning_invoice::Bolt11Invoice;
 use sdk_common::lightning_with_bolt12::offers::invoice::Bolt12Invoice;
 use web_time::{SystemTime, UNIX_EPOCH};
 
-pub use sdk_common::utils::Arc;
-
 lazy_static! {
     static ref LBTC_TESTNET_ASSET_ID: AssetId =
         AssetId::from_str("144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49")

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -5,21 +5,24 @@ mod bolt11;
 mod liquid;
 mod utils;
 
-use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use std::{fs, path::PathBuf, time::Duration};
 
 use anyhow::Result;
+use breez_sdk_liquid::model::Config;
 use breez_sdk_liquid::{
     model::{
-        ConnectRequest, EventListener, LiquidNetwork, ListPaymentsRequest, PayOnchainRequest,
-        Payment, PreparePayOnchainRequest, PreparePayOnchainResponse, PrepareReceiveRequest,
+        ConnectRequest, EventListener, ListPaymentsRequest, PayOnchainRequest, Payment,
+        PreparePayOnchainRequest, PreparePayOnchainResponse, PrepareReceiveRequest,
         PrepareReceiveResponse, PrepareSendRequest, PrepareSendResponse, ReceivePaymentRequest,
         ReceivePaymentResponse, SdkEvent, SendPaymentRequest, SendPaymentResponse,
     },
     sdk::LiquidSdk,
+    utils::Arc,
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio_with_wasm::alias as tokio;
 
-pub const TIMEOUT: Duration = Duration::from_secs(30);
+pub const TIMEOUT: Duration = Duration::from_secs(40);
 
 struct ForwardingEventListener {
     sender: Sender<SdkEvent>,
@@ -36,8 +39,17 @@ pub struct SdkNodeHandle {
     receiver: Receiver<SdkEvent>,
 }
 
+pub enum ChainBackend {
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    Electrum,
+    Esplora,
+}
+
 impl SdkNodeHandle {
-    pub async fn init_node() -> Result<Self> {
+    pub async fn init_node(backend: ChainBackend) -> Result<Self> {
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        let _ = console_log::init_with_level(log::Level::Debug);
+
         let data_dir = PathBuf::from(format!("/tmp/{}", uuid::Uuid::new_v4()));
         if data_dir.exists() {
             fs::remove_dir_all(&data_dir)?;
@@ -45,9 +57,53 @@ impl SdkNodeHandle {
 
         let mnemonic = bip39::Mnemonic::generate_in(bip39::Language::English, 12)?;
 
-        let mut config = LiquidSdk::default_config(LiquidNetwork::Regtest, None)?;
+        let mut config = match backend {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+            ChainBackend::Electrum => Config::regtest(),
+            ChainBackend::Esplora => Config::regtest_esplora(),
+        };
         config.working_dir = data_dir.to_str().unwrap().to_string();
 
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        let sdk = {
+            let connect_req = ConnectRequest {
+                config: config.clone(),
+                mnemonic: Some(mnemonic.to_string()),
+                passphrase: None,
+                seed: None,
+            };
+            let signer: Arc<Box<dyn breez_sdk_liquid::model::Signer>> =
+                Arc::new(Box::new(LiquidSdk::default_signer(&connect_req)?));
+            let mut sdk_builder = breez_sdk_liquid::sdk::LiquidSdkBuilder::new(
+                config.clone(),
+                sdk_common::prelude::PRODUCTION_BREEZSERVER_URL.to_string(),
+                signer.clone(),
+            )?;
+            let persister = Arc::new(breez_sdk_liquid::persist::Persister::new_in_memory(
+                &config.working_dir,
+                config.network,
+                config.sync_enabled(),
+                config.asset_metadata.clone(),
+                None,
+            )?);
+
+            let onchain_wallet = Arc::new(
+                breez_sdk_liquid::wallet::LiquidOnchainWallet::new_in_memory(
+                    config,
+                    Arc::clone(&persister),
+                    signer,
+                )
+                .await?,
+            );
+
+            sdk_builder.persister(persister);
+            sdk_builder.onchain_wallet(onchain_wallet);
+
+            let sdk = sdk_builder.build().await?;
+            sdk.start().await?;
+            sdk
+        };
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
         let sdk = LiquidSdk::connect(ConnectRequest {
             config,
             mnemonic: Some(mnemonic.to_string()),

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -16,8 +16,8 @@ use breez_sdk_liquid::{
         PrepareReceiveResponse, PrepareSendRequest, PrepareSendResponse, ReceivePaymentRequest,
         ReceivePaymentResponse, SdkEvent, SendPaymentRequest, SendPaymentResponse,
     },
+    prelude::Arc,
     sdk::LiquidSdk,
-    utils::Arc,
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio_with_wasm::alias as tokio;

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -1,6 +1,4 @@
 use base64::Engine;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use futures::FutureExt;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::error::Error;
@@ -140,28 +138,6 @@ pub async fn pay_invoice_lnd(invoice: &str) -> Result<(), Box<dyn Error>> {
     )
     .await?;
     Ok(())
-}
-
-pub fn start_pay_invoice_lnd(invoice: String) {
-    let task = async move {
-        pay_invoice_lnd(&invoice).await.unwrap();
-    };
-
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    {
-        tokio::spawn(task);
-    }
-
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    {
-        wasm_bindgen_futures::spawn_local(async {
-            let timeout_future = gloo_timers::future::TimeoutFuture::new(5000);
-            let _ = futures::select! {
-                _ = task.fuse() => {},
-                _ = timeout_future.fuse() => {},
-            };
-        });
-    }
 }
 
 pub async fn mine_blocks(n_blocks: u64) -> Result<(), Box<dyn Error>> {

--- a/regtest/docker-compose.yml
+++ b/regtest/docker-compose.yml
@@ -7,8 +7,27 @@ services:
     restart: on-failure
     ports:
       - 8088:8080
+      - 8089:8081
     volumes:
       - rt-sync-data:/app/db
+
+  waterfalls:
+    build: ./waterfalls-service
+    environment:
+      - RPC_USER_PASSWORD=regtest:regtest
+    command: waterfalls --network elements-regtest --esplora-url http://esplora:4003/api --use-esplora --listen 0.0.0.0:3102 --add-cors
+    ports:
+      - 3102:3102
+
+  nginx:
+    image: nginx:stable-alpine
+    ports:
+      - "3120:3120"
+    volumes:
+      - ./waterfalls-service/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - waterfalls
+    restart: on-failure
 
   ssl-proxy:
     network_mode: "host"

--- a/regtest/waterfalls-service/Dockerfile
+++ b/regtest/waterfalls-service/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust:slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    librocksdb-dev \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/waterfalls
+
+COPY waterfalls/Cargo.toml waterfalls/Cargo.lock ./
+COPY waterfalls/src ./src
+COPY waterfalls/benches ./benches
+
+RUN cargo build --locked --release
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    librocksdb-dev \
+    ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/waterfalls/target/release/waterfalls /usr/local/bin/waterfalls
+
+CMD ["waterfalls"]

--- a/regtest/waterfalls-service/nginx.conf
+++ b/regtest/waterfalls-service/nginx.conf
@@ -1,0 +1,49 @@
+events {}
+
+http {
+    upstream waterfalls_backend {
+        server waterfalls:3102;
+    }
+    upstream esplora_backend {
+        server esplora:4003;
+    }
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    server {
+        listen 3120;
+        server_name localhost;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        location /api/v1/ {
+            proxy_pass http://waterfalls_backend/v1/;
+        }
+
+        location /api/v2/ {
+            proxy_pass http://waterfalls_backend/v2/;
+        }
+
+        location /api/v3/ {
+            proxy_pass http://waterfalls_backend/v3/;
+        }
+
+        location /api/ {
+            proxy_pass http://esplora_backend/api/;
+        }
+
+        location = / {
+            return 200 'Nginx Proxy OK';
+            add_header Content-Type text/plain;
+        }
+    }
+} 


### PR DESCRIPTION
Resolves #635 

This PR adds support for WASM to the end-to-end test suite. Changelist:

- Splits up tests into electrum and esplora variants and runs only the esplora ones on Wasm.
- Upgrades the data-sync regtest instance to include https://github.com/breez/data-sync/pull/22
- Sets up waterfalls + nginx on regtest
- Drops `start_pay_invoice_lnd` (it was unnecessary)


Known issues / potential improvements:
- There are some issues with events missing, which I propose to deal with in a later PR (#847)
- The waterfalls instance is built from scratch on every CI run. It would be nice to avoid this to reduce jobs times. #892 
