### PR TITLE
Waterfalls script history

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.9.0"
-source = "git+https://github.com/breez/lwk?rev=f56909c67be069dd99876a0a72de342d1dd7e334#f56909c67be069dd99876a0a72de342d1dd7e334"
+source = "git+https://github.com/breez/lwk?rev=21082d6a1b99a4030f47386bff9d352410bcdc1a#21082d6a1b99a4030f47386bff9d352410bcdc1a"
 dependencies = [
  "aes-gcm-siv",
  "age",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.9.0"
-source = "git+https://github.com/breez/lwk?rev=f56909c67be069dd99876a0a72de342d1dd7e334#f56909c67be069dd99876a0a72de342d1dd7e334"
+source = "git+https://github.com/breez/lwk?rev=21082d6a1b99a4030f47386bff9d352410bcdc1a#21082d6a1b99a4030f47386bff9d352410bcdc1a"
 dependencies = [
  "aes-gcm-siv",
  "age",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -71,7 +71,7 @@ electrum-client = { version = "0.21.0", default-features = false, features = [
     "use-rustls-ring",
     "proxy",
 ] }
-lwk_wollet = { git = "https://github.com/breez/lwk", rev = "f56909c67be069dd99876a0a72de342d1dd7e334" }
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "21082d6a1b99a4030f47386bff9d352410bcdc1a" }
 maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
@@ -85,7 +85,7 @@ rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7e
 # Wasm dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 console_log = "1"
-lwk_wollet = { git = "https://github.com/breez/lwk", rev = "f56909c67be069dd99876a0a72de342d1dd7e334", default-features = false, features = [
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "21082d6a1b99a4030f47386bff9d352410bcdc1a", default-features = false, features = [
     "esplora",
 ] }
 maybe-sync = "0.1.1"


### PR DESCRIPTION
Updates LWK to use wateralls to fetch scripts history (See PR https://github.com/Blockstream/lwk/pull/80).

~Calling `/v2/waterfalls?addresses=` suffers the same issue as calling `/address/<addr>/txs` in waterfalls, in that it only returns a subset of the results esplora does (missing txs in script history). So setting this PR to draft while we determine if that is the intended behavior.~

Fixes #855 