### PR TITLE
Handle send swap minimal_batched

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "async-trait",
  "bip39",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_REGTEST, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, SubmarinePair, BOLTZ_MAINNET_URL_V2, BOLTZ_REGTEST, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -1341,6 +1341,12 @@ impl SendSwap {
             blinding_key: internal_create_response.blinding_key.clone(),
         };
         Ok(res)
+    }
+
+    pub(crate) fn get_boltz_pair(&self) -> Result<SubmarinePair> {
+        let pair: SubmarinePair = serde_json::from_str(&self.pair_fees_json)
+            .map_err(|e| anyhow!("Failed to deserialize SubmarinePair: {e:?}"))?;
+        Ok(pair)
     }
 
     pub(crate) fn get_swap_script(&self) -> Result<LBtcSwapScript, SdkError> {

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, SubmarinePair, BOLTZ_MAINNET_URL_V2, BOLTZ_REGTEST, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_REGTEST, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -1341,12 +1341,6 @@ impl SendSwap {
             blinding_key: internal_create_response.blinding_key.clone(),
         };
         Ok(res)
-    }
-
-    pub(crate) fn get_boltz_pair(&self) -> Result<SubmarinePair> {
-        let pair: SubmarinePair = serde_json::from_str(&self.pair_fees_json)
-            .map_err(|e| anyhow!("Failed to deserialize SubmarinePair: {e:?}"))?;
-        Ok(pair)
     }
 
     pub(crate) fn get_swap_script(&self) -> Result<LBtcSwapScript, SdkError> {

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -62,13 +62,10 @@ impl SendSwapHandler {
 
         // Recover preimage if needed
         if recovered_data.lockup_tx_id.is_some() && send_swap.preimage.is_none() {
-            let pair_limits = send_swap.get_boltz_pair()?.limits;
-            // If the swap is batched or we have a claim tx id, we can attempt
-            // to recover the preimage cooperatively. If we cannot recover it
-            // cooperatively, we can try to recover it from the claim tx.
-            if send_swap.receiver_amount_sat < pair_limits.minimal
-                || recovered_data.claim_tx_id.is_some()
-            {
+            // We can attempt to recover the preimage cooperatively after we know the
+            // lockup tx was broadcast. If we cannot recover it cooperatively,
+            // we can try to recover it from the claim tx.
+            if recovered_data.claim_tx_id.is_some() {
                 match Self::recover_preimage(
                     context,
                     recovered_data.claim_tx_id.clone(),

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -65,26 +65,24 @@ impl SendSwapHandler {
             // We can attempt to recover the preimage cooperatively after we know the
             // lockup tx was broadcast. If we cannot recover it cooperatively,
             // we can try to recover it from the claim tx.
-            if recovered_data.claim_tx_id.is_some() {
-                match Self::recover_preimage(
-                    context,
-                    recovered_data.claim_tx_id.clone(),
-                    &swap_id,
-                    context.swapper.clone(),
-                )
-                .await
-                {
-                    Ok(Some(preimage)) => {
-                        recovered_data.preimage = Some(preimage);
-                    }
-                    Ok(None) => {
-                        warn!("No preimage found for Send Swap {swap_id}");
-                        recovered_data.claim_tx_id = None;
-                    }
-                    Err(e) => {
-                        error!("Failed to recover preimage for swap {swap_id}: {e}");
-                        recovered_data.claim_tx_id = None
-                    }
+            match Self::recover_preimage(
+                context,
+                recovered_data.claim_tx_id.clone(),
+                &swap_id,
+                context.swapper.clone(),
+            )
+            .await
+            {
+                Ok(Some(preimage)) => {
+                    recovered_data.preimage = Some(preimage);
+                }
+                Ok(None) => {
+                    warn!("No preimage found for Send Swap {swap_id}");
+                    recovered_data.claim_tx_id = None;
+                }
+                Err(e) => {
+                    error!("Failed to recover preimage for swap {swap_id}: {e}");
+                    recovered_data.claim_tx_id = None
                 }
             }
         }
@@ -197,7 +195,7 @@ impl SendSwapHandler {
     ) -> Result<Option<String>> {
         // Try cooperative first
         if let Ok(preimage) = swapper.get_submarine_preimage(swap_id).await {
-            log::debug!("Found Send Swap {swap_id} preimage cooperatively: {preimage}");
+            log::debug!("Fetched Send Swap {swap_id} preimage cooperatively: {preimage}");
             return Ok(Some(preimage));
         }
         warn!("Could not recover Send swap {swap_id} preimage cooperatively");

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod test {
+    use boltz_client::boltz::SubmarinePairLimits;
+
     use crate::{
         model::PaymentState,
         recover::handlers::{
@@ -10,8 +12,20 @@ mod test {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+    fn default_pair_limits() -> SubmarinePairLimits {
+        SubmarinePairLimits {
+            maximal: 25_000_000,
+            minimal: 1_000,
+            maximal_zero_conf: 25_000,
+            minimal_batched: Some(21),
+        }
+    }
+
     #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_claim() {
+        let batch_receiver_amount_sat = 100;
+        let receiver_amount_sat = 1_000;
+        let pair_limits = default_pair_limits();
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_lbtc_history_txid("1111", 100)),
             claim_tx_id: Some(create_lbtc_history_txid("2222", 101)),
@@ -21,11 +35,23 @@ mod test {
 
         // When there's a lockup and claim tx, it should always be Complete, regardless of timeout
         assert_eq!(
-            recovered_data.derive_partial_state(false),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
             Some(PaymentState::Complete)
         );
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(
+                batch_receiver_amount_sat,
+                pair_limits.clone(),
+                false
+            ),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), true),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(batch_receiver_amount_sat, pair_limits, true),
             Some(PaymentState::Complete)
         );
     }
@@ -33,6 +59,8 @@ mod test {
     #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_and_refund() {
         // Test with confirmed refund
+        let receiver_amount_sat = 1_000;
+        let pair_limits = default_pair_limits();
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_lbtc_history_txid("1111", 100)),
             claim_tx_id: None,
@@ -42,11 +70,11 @@ mod test {
 
         // When there's a lockup and confirmed refund tx, it should be Failed
         assert_eq!(
-            recovered_data.derive_partial_state(false),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
             Some(PaymentState::Failed)
         );
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), true),
             Some(PaymentState::Failed)
         );
 
@@ -60,17 +88,20 @@ mod test {
 
         // When there's a lockup and unconfirmed refund tx, it should be RefundPending
         assert_eq!(
-            recovered_data.derive_partial_state(false),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
             Some(PaymentState::RefundPending)
         );
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits, true),
             Some(PaymentState::RefundPending)
         );
     }
 
     #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_only() {
+        let batch_receiver_amount_sat = 100;
+        let receiver_amount_sat = 1_000;
+        let pair_limits = default_pair_limits();
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_lbtc_history_txid("1111", 100)),
             claim_tx_id: None,
@@ -80,19 +111,36 @@ mod test {
 
         // Not expired yet - should be Pending
         assert_eq!(
-            recovered_data.derive_partial_state(false),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
             Some(PaymentState::Pending)
+        );
+        // Not expired yet - should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(
+                batch_receiver_amount_sat,
+                pair_limits.clone(),
+                false
+            ),
+            Some(PaymentState::Complete)
         );
 
         // Expired - should be RefundPending
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), true),
             Some(PaymentState::RefundPending)
+        );
+        // Expired - should be Complete
+        assert_eq!(
+            recovered_data.derive_partial_state(batch_receiver_amount_sat, pair_limits, true),
+            Some(PaymentState::Complete)
         );
     }
 
     #[sdk_macros::test_all]
     fn test_derive_partial_state_with_no_txs() {
+        let batch_receiver_amount_sat = 100;
+        let receiver_amount_sat = 1_000;
+        let pair_limits = default_pair_limits();
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: None,
             claim_tx_id: None,
@@ -101,11 +149,26 @@ mod test {
         };
 
         // Not expired yet - should return None because we can't determine the state
-        assert_eq!(recovered_data.derive_partial_state(false), None);
+        assert_eq!(
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
+            None
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(
+                batch_receiver_amount_sat,
+                pair_limits.clone(),
+                false
+            ),
+            None
+        );
 
         // Expired - should be Failed
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), true),
+            Some(PaymentState::Failed)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(batch_receiver_amount_sat, pair_limits, true),
             Some(PaymentState::Failed)
         );
     }
@@ -113,6 +176,9 @@ mod test {
     #[sdk_macros::test_all]
     fn test_derive_partial_state_with_lockup_claim_refund() {
         // This is an edge case where both claim and refund txs exist
+        let batch_receiver_amount_sat = 100;
+        let receiver_amount_sat = 1_000;
+        let pair_limits = default_pair_limits();
         let recovered_data = RecoveredOnchainDataSend {
             lockup_tx_id: Some(create_lbtc_history_txid("1111", 100)),
             claim_tx_id: Some(create_lbtc_history_txid("2222", 101)),
@@ -122,11 +188,23 @@ mod test {
 
         // Complete state should take precedence over refund
         assert_eq!(
-            recovered_data.derive_partial_state(false),
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), false),
             Some(PaymentState::Complete)
         );
         assert_eq!(
-            recovered_data.derive_partial_state(true),
+            recovered_data.derive_partial_state(
+                batch_receiver_amount_sat,
+                pair_limits.clone(),
+                false
+            ),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(receiver_amount_sat, pair_limits.clone(), true),
+            Some(PaymentState::Complete)
+        );
+        assert_eq!(
+            recovered_data.derive_partial_state(batch_receiver_amount_sat, pair_limits, true),
             Some(PaymentState::Complete)
         );
     }

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -300,7 +300,7 @@ mod test {
             preimage: None,
             payer_amount_sat: 100000,
             receiver_amount_sat: 95000,
-            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000, "mininalBatched":21},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
             create_response_json: r#"{"accept_zero_conf":true,"address":"lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv","bip21":"liquidnetwork:lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv?amount=0.00001015&label=Send%20to%20BTC%20lightning&assetid=6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d","claim_public_key":"0381b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123","expected_amount":1015,"referral_id":"breez-sdk","swap_tree":{"claim_leaf":{"output":"a914cea2d1aa5af00fb688727b0054de58ecf45e948f882081b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123ac","version":196},"refund_leaf":{"output":"20a668381222ff9076ca6d5f5b098b501331f07d5065f1dc0e0f217cc493359e69ad03b12432b1","version":196}},"timeout_block_height":3286193,"blinding_key":"73332603e5d438ddb3b12c16c7271c9f98658c77257cbb06639d05773aa1fec3"}"#.to_string(),
             lockup_tx_id: None,
             refund_address: None,

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -300,7 +300,7 @@ mod test {
             preimage: None,
             payer_amount_sat: 100000,
             receiver_amount_sat: 95000,
-            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000, "minimalBatched":21},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            pair_fees_json: r#"{"hash":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000,"minimalBatched":21},"fees":{"percentage":0.5,"minerFees":200}}"#.to_string(),
             create_response_json: r#"{"accept_zero_conf":true,"address":"lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv","bip21":"liquidnetwork:lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv?amount=0.00001015&label=Send%20to%20BTC%20lightning&assetid=6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d","claim_public_key":"0381b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123","expected_amount":1015,"referral_id":"breez-sdk","swap_tree":{"claim_leaf":{"output":"a914cea2d1aa5af00fb688727b0054de58ecf45e948f882081b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123ac","version":196},"refund_leaf":{"output":"20a668381222ff9076ca6d5f5b098b501331f07d5065f1dc0e0f217cc493359e69ad03b12432b1","version":196}},"timeout_block_height":3286193,"blinding_key":"73332603e5d438ddb3b12c16c7271c9f98658c77257cbb06639d05773aa1fec3"}"#.to_string(),
             lockup_tx_id: None,
             refund_address: None,

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::chain::liquid::MockLiquidChainService;
+    use crate::error::PaymentError;
     use crate::prelude::*;
     use crate::recover::handlers::tests::{
         create_empty_lbtc_transaction, create_mock_lbtc_wallet_tx,
@@ -84,7 +85,14 @@ mod test {
     #[sdk_macros::async_test_all]
     async fn test_recover_with_refund_tx() {
         // Setup mock data
-        let (mut send_swap, recovery_context) = setup_test_data();
+        let (mut send_swap, mut recovery_context) = setup_test_data();
+
+        // Setup mock swapper
+        let mut swapper = MockSwapper::new();
+        swapper
+            .expect_get_submarine_preimage()
+            .returning(move |_| Err(PaymentError::generic("No preimage available")));
+        recovery_context.swapper = Arc::new(swapper);
 
         // Create a lockup tx
         let swap_script = send_swap.get_swap_script().unwrap();
@@ -127,7 +135,15 @@ mod test {
     #[sdk_macros::async_test_all]
     async fn test_recover_with_lockup_only() {
         // Setup mock data
-        let (mut send_swap, recovery_context) = setup_test_data();
+        let (mut send_swap, mut recovery_context) = setup_test_data();
+
+        // Setup mock swapper
+        let preimage = "49666c97f6cea07fa5780c22ece1f0c9957caf1e3c37b9037b4f64dc6d09be7f"; // base64 of "somepreimage1234567890"
+        let mut swapper = MockSwapper::new();
+        swapper
+            .expect_get_submarine_preimage()
+            .returning(move |_| Ok(preimage.to_string()));
+        recovery_context.swapper = Arc::new(swapper);
 
         // Create a lockup tx
         let swap_script = send_swap.get_swap_script().unwrap();
@@ -151,7 +167,7 @@ mod test {
 
         // Verify results
         assert!(result.is_ok());
-        assert_eq!(send_swap.state, PaymentState::Pending); // Not expired -> Pending
+        assert_eq!(send_swap.state, PaymentState::Complete); // Not expired -> Complete
         assert_eq!(send_swap.lockup_tx_id, Some(lockup_tx_id.to_string()));
         assert_eq!(send_swap.refund_tx_id, None);
     }
@@ -161,6 +177,13 @@ mod test {
     async fn test_recover_with_lockup_expired() {
         // Setup mock data
         let (mut send_swap, mut recovery_context) = setup_test_data();
+
+        // Setup mock swapper
+        let mut swapper = MockSwapper::new();
+        swapper
+            .expect_get_submarine_preimage()
+            .returning(move |_| Err(PaymentError::generic("Swap expired")));
+        recovery_context.swapper = Arc::new(swapper);
 
         // Set tip height to make swap expired
         recovery_context.liquid_tip_height = send_swap.timeout_block_height as u32 + 10;
@@ -196,7 +219,14 @@ mod test {
     #[sdk_macros::async_test_all]
     async fn test_recover_with_unconfirmed_refund() {
         // Setup mock data
-        let (mut send_swap, recovery_context) = setup_test_data();
+        let (mut send_swap, mut recovery_context) = setup_test_data();
+
+        // Setup mock swapper
+        let mut swapper = MockSwapper::new();
+        swapper
+            .expect_get_submarine_preimage()
+            .returning(move |_| Err(PaymentError::generic("No preimage available")));
+        recovery_context.swapper = Arc::new(swapper);
 
         // Create a lockup tx
         let swap_script = send_swap.get_swap_script().unwrap();

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -300,7 +300,7 @@ mod test {
             preimage: None,
             payer_amount_sat: 100000,
             receiver_amount_sat: 95000,
-            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000, "mininalBatched":21},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
+            pair_fees_json: r#"{"id":"BTC/BTC","rate":0.997,"limits":{"maximal":2000000,"minimal":10000,"maximalZeroConf":50000, "minimalBatched":21},"fees":{"percentage":0.5,"miner":200}}"#.to_string(),
             create_response_json: r#"{"accept_zero_conf":true,"address":"lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv","bip21":"liquidnetwork:lq1pqg8hsjkptr8u7l35ctx5yn4dpwufkjxt7d24zuj5ddahnn7jaduh8r6celry8kn9xrkgwchrrx2madlemf0u27pnmjar4d4k5wvtem8kfl7ru56w94sv?amount=0.00001015&label=Send%20to%20BTC%20lightning&assetid=6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d","claim_public_key":"0381b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123","expected_amount":1015,"referral_id":"breez-sdk","swap_tree":{"claim_leaf":{"output":"a914cea2d1aa5af00fb688727b0054de58ecf45e948f882081b8583fe95488b961d12836102b1869b241972e571bd44a933d273b12a0d123ac","version":196},"refund_leaf":{"output":"20a668381222ff9076ca6d5f5b098b501331f07d5065f1dc0e0f217cc493359e69ad03b12432b1","version":196}},"timeout_block_height":3286193,"blinding_key":"73332603e5d438ddb3b12c16c7271c9f98658c77257cbb06639d05773aa1fec3"}"#.to_string(),
             lockup_tx_id: None,
             refund_address: None,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2000,7 +2000,7 @@ impl LiquidSdk {
 
         Ok(LightningPaymentLimitsResponse {
             send: Limits {
-                min_sat: send_limits.minimal,
+                min_sat: send_limits.minimal_batched.unwrap_or(send_limits.minimal),
                 max_sat: send_limits.maximal,
                 max_zero_conf_sat: send_limits.maximal_zero_conf,
             },

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -304,8 +304,6 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
             .new_lbtc_refund_wrapper(&Swap::Send(swap.clone()), refund_address)
             .await?;
 
-        self.validate_send_swap_preimage(swap_id, &swap.invoice, &claim_tx_response.preimage)?;
-
         let (partial_sig, pub_nonce) = refund_tx_wrapper.partial_sign(
             &keypair,
             &claim_tx_response.pub_nonce,

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -315,7 +315,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
             .inner
             .post_submarine_claim_tx_details(&swap_id.to_string(), pub_nonce, partial_sig)
             .await?;
-        info!("Successfully sent claim details for swap-in {swap_id}");
+        info!("Successfully cooperatively claimed Send Swap {swap_id}");
         Ok(())
     }
 

--- a/lib/core/src/test_utils/persist.rs
+++ b/lib/core/src/test_utils/persist.rs
@@ -57,7 +57,8 @@ pub fn new_send_swap(
             "limits": {
                 "maximal": 25000000,
                 "minimal": 1000,
-                "maximalZeroConf": 100000
+                "maximalZeroConf": 100000,
+                "minimalBatched": 21
             },
             "fees": {
                 "percentage": 0.1,

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -191,7 +191,7 @@ impl Swapper for MockSwapper {
                 maximal: 25_000_000,
                 minimal: 1_000,
                 maximal_zero_conf: 250_000,
-                minimal_batched: None,
+                minimal_batched: Some(21),
             },
             fees: SubmarineFees {
                 percentage: 0.1,


### PR DESCRIPTION
This PR incorporates the [minimal_batched submarine pair limit](https://github.com/SatoshiPortal/boltz-rust/pull/99) to allow batched send swap payments, where in the case of a batched payment there is no need to cooperatively claim.

**Testing notes:**
This lowers the minimum send payment amount to around 21 sats. 
- Pay invoices (from non-SDK apps) between 21 - 999 sats. Should complete and have a valid preimage.
- Pay invoices (from non-SDK apps) 1000 + sats. Should complete and have a valid preimage.
