### PR TITLE
Strip input prefix before bip353 lookup

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=2a077be8bf07ac3d07d611b8bce91babdda3ecde#2a077be8bf07ac3d07d611b8bce91babdda3ecde"
+source = "git+https://github.com/breez/breez-sdk?rev=223002e47a3b1be8306f68e9b8094ee2884c9568#223002e47a3b1be8306f68e9b8094ee2884c9568"
 dependencies = [
  "aes",
  "anyhow",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=2a077be8bf07ac3d07d611b8bce91babdda3ecde#2a077be8bf07ac3d07d611b8bce91babdda3ecde"
+source = "git+https://github.com/breez/breez-sdk?rev=223002e47a3b1be8306f68e9b8094ee2884c9568#223002e47a3b1be8306f68e9b8094ee2884c9568"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "async-trait",
  "bip39",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f78e159fe72e1c357e7830bc08d2b9e42a65362c#f78e159fe72e1c357e7830bc08d2b9e42a65362c"
+source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4686,7 +4686,7 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=2a077be8bf07ac3d07d611b8bce91babdda3ecde#2a077be8bf07ac3d07d611b8bce91babdda3ecde"
+source = "git+https://github.com/breez/breez-sdk?rev=223002e47a3b1be8306f68e9b8094ee2884c9568#223002e47a3b1be8306f68e9b8094ee2884c9568"
 dependencies = [
  "aes",
  "anyhow",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=2a077be8bf07ac3d07d611b8bce91babdda3ecde#2a077be8bf07ac3d07d611b8bce91babdda3ecde"
+source = "git+https://github.com/breez/breez-sdk?rev=223002e47a3b1be8306f68e9b8094ee2884c9568#223002e47a3b1be8306f68e9b8094ee2884c9568"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "2a077be8bf07ac3d07d611b8bce91babdda3ecde", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "2a077be8bf07ac3d07d611b8bce91babdda3ecde" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "223002e47a3b1be8306f68e9b8094ee2884c9568", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "223002e47a3b1be8306f68e9b8094ee2884c9568" }
 thiserror = "1.0"
 
 [patch.crates-io]


### PR DESCRIPTION
Strip ₿ prefix from input before BIP353 lookup

@erdemyerebasmaz do you want this cherry picking to the `misty-release` branch?