### PR TITLE
Add failsafe mechanism for real-time sync

### DIFF
--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -89,7 +89,7 @@ impl SyncService {
     async fn run_event_loop(&self, failed_sync_counter: &mut u8) {
         info!("realtime-sync: Running sync event loop");
 
-        if *failed_sync_counter >= 5 {
+        if *failed_sync_counter > 4 {
             warn!("realtime-sync: Consecutive failed sync counter reached, wiping database and retrying.");
             if let Err(err) = self.persister.reset_sync() {
                 warn!("realtime-sync: Could not wipe sync database: {err:?}");

--- a/lib/core/src/sync/model/client.rs
+++ b/lib/core/src/sync/model/client.rs
@@ -24,7 +24,10 @@ fn sign_message(msg: &[u8], signer: Arc<Box<dyn Signer>>) -> Result<String, Sign
 }
 
 impl ListChangesRequest {
-    pub(crate) fn new(since_revision: u64, signer: Arc<Box<dyn Signer>>) -> Result<Self> {
+    pub(crate) fn new(
+        since_revision: u64,
+        signer: Arc<Box<dyn Signer>>,
+    ) -> Result<Self, SignerError> {
         let request_time = utils::now();
         let msg = format!("{}-{}", since_revision, request_time);
         let signature = sign_message(msg.as_bytes(), signer)?;

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -127,6 +127,34 @@ pub(crate) struct DecryptionInfo {
     pub(crate) last_commit_time: Option<u32>,
 }
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum PushError {
+    #[error("Received conflict status from remote")]
+    RecordConflict,
+
+    #[error("Could not encrypt payload with signer: {err}")]
+    InvalidPayload { err: String },
+
+    #[error("Generic error: {err}")]
+    Generic { err: String },
+}
+
+impl From<anyhow::Error> for PushError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Generic {
+            err: value.to_string(),
+        }
+    }
+}
+
+impl From<crate::model::SignerError> for PushError {
+    fn from(value: crate::model::SignerError) -> Self {
+        Self::InvalidPayload {
+            err: value.to_string(),
+        }
+    }
+}
+
 impl Record {
     pub(crate) fn new(
         data: SyncData,

--- a/lib/core/src/sync/model/mod.rs
+++ b/lib/core/src/sync/model/mod.rs
@@ -1,7 +1,7 @@
 tonic::include_proto!("sync");
 
 use self::data::SyncData;
-use crate::prelude::Signer;
+use crate::prelude::{Signer, SignerError};
 use anyhow::Result;
 use lazy_static::lazy_static;
 use log::trace;
@@ -81,46 +81,6 @@ pub(crate) struct DecryptedRecord {
     pub(crate) data: SyncData,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum DecryptionError {
-    #[error("Record is not applicable: schema_version too high")]
-    SchemaNotApplicable,
-
-    #[error("Remote record revision is lower or equal to the persisted one. Skipping update.")]
-    AlreadyPersisted,
-
-    #[error("Could not decrypt payload with signer: {err}")]
-    InvalidPayload { err: String },
-
-    #[error("Could not deserialize JSON bytes: {err}")]
-    DeserializeError { err: String },
-
-    #[error("Generic error: {err}")]
-    Generic { err: String },
-}
-
-impl DecryptionError {
-    pub(crate) fn invalid_payload(err: crate::model::SignerError) -> Self {
-        Self::InvalidPayload {
-            err: err.to_string(),
-        }
-    }
-
-    pub(crate) fn deserialize_error(err: serde_json::Error) -> Self {
-        Self::DeserializeError {
-            err: err.to_string(),
-        }
-    }
-}
-
-impl From<anyhow::Error> for DecryptionError {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Generic {
-            err: value.to_string(),
-        }
-    }
-}
-
 pub(crate) struct DecryptionInfo {
     pub(crate) new_sync_state: SyncState,
     pub(crate) record: DecryptedRecord,
@@ -128,29 +88,144 @@ pub(crate) struct DecryptionInfo {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum PushError {
-    #[error("Received conflict status from remote")]
-    RecordConflict,
+pub(crate) enum PullError {
+    #[error("Record is not applicable: schema_version too high")]
+    SchemaNotApplicable,
 
-    #[error("Could not encrypt payload with signer: {err}")]
-    InvalidPayload { err: String },
+    #[error("Remote record revision is lower or equal to the persisted one. Skipping update.")]
+    AlreadyPersisted,
 
-    #[error("Generic error: {err}")]
-    Generic { err: String },
+    #[error("Could not sign outgoing payload: {err}")]
+    Signing { err: String },
+
+    #[error("Could not decrypt incoming record: {err}")]
+    Decryption { err: String },
+
+    #[error("Could not deserialize record data: {err}")]
+    Deserialization { err: String },
+
+    #[error("Remote record version could not be parsed: {err}")]
+    InvalidRecordVersion { err: String },
+
+    #[error("Could not contact remote: {err}")]
+    Network { err: String },
+
+    #[error("Could not call the persister: {err}")]
+    Persister { err: String },
+
+    #[error("Could not merge record with updated fields: {err}")]
+    Merge { err: String },
+
+    #[error("Could not recover record data from onchain: {err}")]
+    Recovery { err: String },
 }
 
-impl From<anyhow::Error> for PushError {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Generic {
-            err: value.to_string(),
+impl PullError {
+    pub(crate) fn signing(err: SignerError) -> Self {
+        Self::Signing {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn decryption(err: SignerError) -> Self {
+        Self::Decryption {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn deserialization(err: serde_json::Error) -> Self {
+        Self::Deserialization {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn invalid_record_version(err: semver::Error) -> Self {
+        Self::InvalidRecordVersion {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn network(err: anyhow::Error) -> Self {
+        Self::Network {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn persister(err: anyhow::Error) -> Self {
+        Self::Persister {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn merge(err: anyhow::Error) -> Self {
+        Self::Merge {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn recovery(err: anyhow::Error) -> Self {
+        Self::Recovery {
+            err: err.to_string(),
         }
     }
 }
 
-impl From<crate::model::SignerError> for PushError {
-    fn from(value: crate::model::SignerError) -> Self {
-        Self::InvalidPayload {
-            err: value.to_string(),
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum PushError {
+    #[error("Received conflict status from remote")]
+    RecordConflict,
+
+    #[error("Could not sign outgoing payload: {err}")]
+    Signing { err: String },
+
+    #[error("Could not encrypt outgoing record: {err}")]
+    Encryption { err: String },
+
+    #[error("Could not serialize record data: {err}")]
+    Serialization { err: String },
+
+    #[error("Could not contact remote: {err}")]
+    Network { err: String },
+
+    #[error("Could not call the persister: {err}")]
+    Persister { err: String },
+
+    #[error("Push completed with too many failed records: succeded {succeded} total {total} recoverable {recoverable}")]
+    ExcessiveRecordConflicts {
+        succeded: usize,
+        total: usize,
+        recoverable: usize,
+    },
+}
+
+impl PushError {
+    pub(crate) fn signing(err: SignerError) -> Self {
+        Self::Signing {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn encryption(err: SignerError) -> Self {
+        Self::Encryption {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn serialization(err: serde_json::Error) -> Self {
+        Self::Serialization {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn network(err: anyhow::Error) -> Self {
+        Self::Network {
+            err: err.to_string(),
+        }
+    }
+
+    pub(crate) fn persister(err: anyhow::Error) -> Self {
+        Self::Persister {
+            err: err.to_string(),
         }
     }
 }
@@ -160,13 +235,11 @@ impl Record {
         data: SyncData,
         revision: u64,
         signer: Arc<Box<dyn Signer>>,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, PushError> {
         let id = Self::get_id_from_sync_data(&data);
-        let data = data.to_bytes()?;
+        let data = data.to_bytes().map_err(PushError::serialization)?;
         trace!("About to encrypt sync data: {data:?}");
-        let data = signer
-            .ecies_encrypt(data)
-            .map_err(|err| anyhow::anyhow!("Could not encrypt sync data: {err:?}"))?;
+        let data = signer.ecies_encrypt(data).map_err(PushError::encryption)?;
         trace!("Got encrypted sync data: {data:?}");
         let schema_version = CURRENT_SCHEMA_VERSION.to_string();
         Ok(Self {
@@ -205,7 +278,7 @@ impl Record {
         Self::id(prefix, data_id)
     }
 
-    pub(crate) fn is_applicable(&self) -> Result<bool> {
+    pub(crate) fn is_applicable(&self) -> Result<bool, semver::Error> {
         let record_version = Version::parse(&self.schema_version)?;
         Ok(CURRENT_SCHEMA_VERSION.major >= record_version.major)
     }
@@ -213,11 +286,11 @@ impl Record {
     pub(crate) fn decrypt(
         self,
         signer: Arc<Box<dyn Signer>>,
-    ) -> Result<DecryptedRecord, DecryptionError> {
+    ) -> Result<DecryptedRecord, PullError> {
         let dec_data = signer
             .ecies_decrypt(self.data)
-            .map_err(DecryptionError::invalid_payload)?;
-        let data = serde_json::from_slice(&dec_data).map_err(DecryptionError::deserialize_error)?;
+            .map_err(PullError::decryption)?;
+        let data = serde_json::from_slice(&dec_data).map_err(PullError::deserialization)?;
         Ok(DecryptedRecord {
             id: self.id,
             revision: self.revision,


### PR DESCRIPTION
This PR:
- Improves logging for the real-time sync service (prefixing, log level and messages)
- Adds a failsafe mechanism in case of consecutive errors while running the event loop (> 5). After too many failed attempts, it will wipe the sync tables (incoming, outgoing and state) and re-enqueue all local swaps for push.
- Improves error handling with new `PushError` and `PullError` variants (reflected in logs)