### PR TITLE
Wasm: Run tests on node.js

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -13,7 +13,8 @@ frb = ["dep:flutter_rust_bridge"]
 # Uniffi features required to build using cargo-lipo
 uniffi-25 = []
 uniffi-28 = []
-regtest = []   # Enable regtest tests
+regtest = []        # Enable regtest tests
+browser-tests = []  # Enable browser wasm-pack tests
 test-utils = ["sdk-common/test-utils"]
 
 [lints]

--- a/lib/core/Makefile
+++ b/lib/core/Makefile
@@ -37,27 +37,37 @@ regtest-stop:
 
 REGTEST_TESTS ?= regtest
 cargo-regtest-test: check-regtest
-	$(REGTEST_PREFIX) cargo test $(REGTEST_TESTS) --features "regtest"
+	$(REGTEST_PREFIX) cargo test $(REGTEST_TESTS) --features regtest
 
 wasm-clippy:
 	$(CLANG_PREFIX) cargo clippy --all-targets --target=wasm32-unknown-unknown -- -D warnings
 
 BROWSER ?= firefox
 
-wasm-test:
-	$(CLANG_PREFIX) wasm-pack test --headless --$(BROWSER)
+wasm-test: test-browser test-node
+
+test-node:
+	$(CLANG_PREFIX) wasm-pack test --node
+
+test-browser:
+	$(CLANG_PREFIX) wasm-pack test --headless --$(BROWSER) --features browser-tests
 
 test-chrome:
-	BROWSER=chrome $(MAKE) wasm-test
+	BROWSER=chrome $(MAKE) test-browser
 
 test-safari:
-	BROWSER=safari $(MAKE) wasm-test
+	BROWSER=safari $(MAKE) test-browser
 
-wasm-regtest-test: check-regtest
-	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test --headless --$(BROWSER) --features regtest -- $(REGTEST_TESTS)
+wasm-regtest-test: wasm-regtest-test-browser wasm-regtest-test-node
+
+wasm-regtest-test-node: check-regtest
+	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test --node --features regtest -- $(REGTEST_TESTS)
+
+wasm-regtest-test-browser: check-regtest
+	$(CLANG_PREFIX) $(REGTEST_PREFIX) WASM_BINDGEN_TEST_TIMEOUT=500 wasm-pack test --headless --$(BROWSER) --features regtest,browser-tests -- $(REGTEST_TESTS)
 
 wasm-regtest-test-chrome:
-	BROWSER=chrome $(MAKE) wasm-regtest-test
+	BROWSER=chrome $(MAKE) wasm-regtest-test-browser
 
 wasm-regtest-test-safari:
-	BROWSER=safari $(MAKE) wasm-regtest-test
+	BROWSER=safari $(MAKE) wasm-regtest-test-browser

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -1520,7 +1520,7 @@ mod tests {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/payjoin/network_fee.rs
+++ b/lib/core/src/payjoin/network_fee.rs
@@ -47,7 +47,7 @@ impl TxFee {
 mod tests {
     use super::*;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/payjoin/pset/tests.rs
+++ b/lib/core/src/payjoin/pset/tests.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 use crate::payjoin::pset::{construct_pset, ConstructPsetRequest, PsetInput, PsetOutput};
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(feature = "browser-tests")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn create_test_secret_key() -> SecretKey {

--- a/lib/core/src/payjoin/side_swap.rs
+++ b/lib/core/src/payjoin/side_swap.rs
@@ -487,7 +487,7 @@ mod tests {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     fn create_sideswap_payjoin_service(

--- a/lib/core/src/payjoin/utxo_select/tests.rs
+++ b/lib/core/src/payjoin/utxo_select/tests.rs
@@ -11,7 +11,7 @@ use crate::payjoin::{
     },
 };
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(feature = "browser-tests")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[sdk_macros::test_all]

--- a/lib/core/src/persist/address.rs
+++ b/lib/core/src/persist/address.rs
@@ -102,7 +102,7 @@ mod tests {
 
     use crate::test_utils::persist::create_persister;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/persist/cache.rs
+++ b/lib/core/src/persist/cache.rs
@@ -208,7 +208,7 @@ mod tests {
 
     use crate::test_utils::persist::create_persister;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -534,7 +534,7 @@ mod tests {
     use crate::test_utils::persist::create_persister;
     use anyhow::Result;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -1133,7 +1133,7 @@ mod tests {
 
     use super::{PaymentState, PaymentType};
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -418,7 +418,7 @@ mod tests {
 
     use super::PaymentState;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -429,7 +429,7 @@ mod tests {
 
     use super::PaymentState;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -562,7 +562,7 @@ mod tests {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests.rs
@@ -9,7 +9,7 @@ mod test {
     };
     use boltz_client::boltz::PairLimits;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_receive_swap_tests_integration.rs
@@ -16,7 +16,7 @@ mod test {
     use sdk_common::utils::Arc;
     use std::{collections::HashMap, str::FromStr};
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests.rs
@@ -8,7 +8,7 @@ mod test {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_chain_send_swap_tests_integration.rs
@@ -19,7 +19,7 @@ mod test {
 
     use std::{collections::HashMap, str::FromStr};
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests.rs
@@ -7,7 +7,7 @@ mod test {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -15,7 +15,7 @@ mod test {
     use sdk_common::utils::Arc;
     use std::{collections::HashMap, str::FromStr};
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests.rs
@@ -7,7 +7,7 @@ mod test {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -18,7 +18,7 @@ mod test {
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     /// Test recovery with a claim transaction and preimage

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -4061,7 +4061,7 @@ mod tests {
     };
     use paste::paste;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     struct NewSwapArgs {

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -593,7 +593,7 @@ mod tests {
         },
     };
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/signer.rs
+++ b/lib/core/src/signer.rs
@@ -298,7 +298,7 @@ mod tests {
     };
     use std::collections::BTreeMap;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     fn get_descriptor<S: LwkSigner>(

--- a/lib/core/src/sync/mod.rs
+++ b/lib/core/src/sync/mod.rs
@@ -569,7 +569,7 @@ mod tests {
 
     use super::model::{data::SyncData, Record, RecordType};
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/src/utils.rs
+++ b/lib/core/src/utils.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::error::PaymentError;
     use crate::utils::verify_payment_hash;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::test_all]

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -637,7 +637,7 @@ mod tests {
     use crate::wallet::LiquidOnchainWallet;
     use anyhow::Result;
 
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sdk_macros::async_test_all]

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -8,7 +8,7 @@ use serial_test::serial;
 
 use crate::regtest::{utils, SdkNodeHandle, TIMEOUT};
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(feature = "browser-tests")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[sdk_macros::async_test_all]

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -10,7 +10,7 @@ use crate::regtest::{
     SdkNodeHandle, TIMEOUT,
 };
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(feature = "browser-tests")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[sdk_macros::async_test_all]

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -6,7 +6,7 @@ use serial_test::serial;
 
 use crate::regtest::{utils, SdkNodeHandle, TIMEOUT};
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(feature = "browser-tests")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[sdk_macros::async_test_all]


### PR DESCRIPTION
Resolves #859 

This PR sets up Wasm tests to run on node.js (in addition to the existing ones running in a headless browser)