### PR TITLE
fix: Interval not compatible with node.js

### DIFF
--- a/lib/core/src/test_utils/sync.rs
+++ b/lib/core/src/test_utils/sync.rs
@@ -42,7 +42,7 @@ impl MockSyncerClient {
 #[sdk_macros::async_trait]
 impl SyncerClient for MockSyncerClient {
     async fn connect(&self, _connect_url: String) -> Result<()> {
-        todo!()
+        Ok(())
     }
 
     async fn push(&self, req: SetRecordRequest) -> Result<SetRecordReply> {
@@ -68,7 +68,7 @@ impl SyncerClient for MockSyncerClient {
             });
         }
 
-        return Err(anyhow::anyhow!("No record was sent"));
+        Err(anyhow::anyhow!("No record was sent"))
     }
 
     async fn pull(&self, _req: ListChangesRequest) -> Result<ListChangesReply> {
@@ -79,11 +79,11 @@ impl SyncerClient for MockSyncerClient {
     }
 
     async fn listen(&self, _req: ListenChangesRequest) -> Result<Streaming<Notification>> {
-        todo!()
+        Err(anyhow::anyhow!("Not implemented"))
     }
 
     async fn disconnect(&self) -> Result<()> {
-        todo!()
+        Ok(())
     }
 }
 

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -16,6 +16,11 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 async fn bitcoin() {
     let mut handle = SdkNodeHandle::init_node().await.unwrap();
 
+    handle
+        .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
+        .await
+        .unwrap();
+
     // --------------RECEIVE--------------
     let payer_amount_sat = 100_000;
 
@@ -258,12 +263,6 @@ async fn bitcoin() {
     assert_eq!(payments.len(), 3);
     let payment = &payments[0];
     assert_eq!(payment.status, PaymentState::Failed);
-    println!("Payment details: {:?}", payment.details);
-    println!("Lockup amount sat: {}", lockup_amount_sat);
-    println!(
-        "Prepare refund rbf response: {:?}",
-        prepare_refund_rbf_response
-    );
     // The following fails because the payment's refund_tx_amount_sat is None. Related issue: https://github.com/breez/breez-sdk-liquid/issues/773
     // TODO: uncomment once the issue is fixed
     /*assert!(matches!(

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -17,6 +17,16 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[serial]
 async fn bolt11() {
     let mut handle_alice = SdkNodeHandle::init_node().await.unwrap();
+    let mut handle_bob = SdkNodeHandle::init_node().await.unwrap();
+
+    handle_alice
+        .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
+        .await
+        .unwrap();
+    handle_bob
+        .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
+        .await
+        .unwrap();
 
     // -------------------RECEIVE SWAP-------------------
     let payer_amount_sat = 200_000;
@@ -136,8 +146,6 @@ async fn bolt11() {
     assert!(matches!(payment.details, PaymentDetails::Lightning { .. }));
 
     // -------------------MRH-------------------
-    let mut handle_bob = SdkNodeHandle::init_node().await.unwrap();
-
     let receiver_amount_sat = 50_000;
 
     let (_, receive_response) = handle_bob

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -14,6 +14,11 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 async fn liquid() {
     let mut handle = SdkNodeHandle::init_node().await.unwrap();
 
+    handle
+        .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
+        .await
+        .unwrap();
+
     // --------------RECEIVE--------------
 
     let (prepare_response, receive_response) = handle

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -19,7 +19,7 @@ use breez_sdk_liquid::{
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
-pub const TIMEOUT: Duration = Duration::from_secs(15);
+pub const TIMEOUT: Duration = Duration::from_secs(30);
 
 struct ForwardingEventListener {
     sender: Sender<SdkEvent>,


### PR DESCRIPTION
The `Interval` from [`tokio_with_wasm`](https://docs.rs/tokio_with_wasm/latest/tokio_with_wasm/) causes a panic on node.js. 

This PR proposes fixing it by simply not using Interval and using sleep instead. I did try [`wasmtimer`](https://github.com/whizsid/wasmtimer-rs), which at first seemed like it provided a good Interval implementation, but I later realized it was buggy: using it prevented the shutdown branches from ever being picked up.

I'm of course open to ideas/alternatives where tasks are still started at regular intervals