### PR TITLE
fix: missing wallet cache dir creation after deletion

### DIFF
--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -14,7 +14,7 @@ use lwk_wollet::elements::hex::ToHex;
 use lwk_wollet::elements::pset::PartiallySignedTransaction;
 use lwk_wollet::elements::{Address, AssetId, OutPoint, Transaction, TxOut, Txid};
 use lwk_wollet::secp256k1::Message;
-use lwk_wollet::{ElementsNetwork, FsPersister, WalletTx, WalletTxOut, Wollet, WolletDescriptor};
+use lwk_wollet::{ElementsNetwork, WalletTx, WalletTxOut, Wollet, WolletDescriptor};
 use maybe_sync::{MaybeSend, MaybeSync};
 use sdk_common::bitcoin::hashes::{sha256, Hash};
 use sdk_common::bitcoin::secp256k1::PublicKey;
@@ -202,11 +202,7 @@ impl LiquidOnchainWallet {
         let wallet_cache_persister: Arc<dyn WalletCachePersister> =
             Arc::new(FsWalletCachePersister::new(
                 working_dir.clone(),
-                FsPersister::new(
-                    &working_dir,
-                    config.network.into(),
-                    &get_descriptor(&signer, config.network)?,
-                )?,
+                get_descriptor(&signer, config.network)?,
                 config.network.into(),
             )?);
 
@@ -274,7 +270,7 @@ impl LiquidOnchainWallet {
         let descriptor = get_descriptor(signer, config.network)?;
         let wollet_res = Wollet::new(
             elements_network,
-            wallet_cache_persister.get_lwk_persister(),
+            wallet_cache_persister.get_lwk_persister()?,
             descriptor.clone(),
         );
         match wollet_res {
@@ -288,7 +284,7 @@ impl LiquidOnchainWallet {
                 wallet_cache_persister.clear_cache().await?;
                 Ok(Wollet::new(
                     elements_network,
-                    wallet_cache_persister.get_lwk_persister(),
+                    wallet_cache_persister.get_lwk_persister()?,
                     descriptor.clone(),
                 )?)
             }

--- a/lib/wasm/src/platform/browser/wallet_persister.rs
+++ b/lib/wasm/src/platform/browser/wallet_persister.rs
@@ -42,9 +42,9 @@ impl<S: AsyncWalletStorage> AsyncWalletCachePersister<S> {
 
 #[sdk_macros::async_trait]
 impl<S: AsyncWalletStorage> WalletCachePersister for AsyncWalletCachePersister<S> {
-    fn get_lwk_persister(&self) -> LwkPersister {
+    fn get_lwk_persister(&self) -> anyhow::Result<LwkPersister> {
         let persister = std::sync::Arc::clone(&self.lwk_persister);
-        persister as LwkPersister
+        Ok(persister as LwkPersister)
     }
 
     async fn clear_cache(&self) -> anyhow::Result<()> {

--- a/lib/wasm/src/platform/node_js/wallet_persister.rs
+++ b/lib/wasm/src/platform/node_js/wallet_persister.rs
@@ -42,9 +42,9 @@ impl NodeFsWalletCachePersister {
 
 #[sdk_macros::async_trait]
 impl WalletCachePersister for NodeFsWalletCachePersister {
-    fn get_lwk_persister(&self) -> LwkPersister {
+    fn get_lwk_persister(&self) -> anyhow::Result<LwkPersister> {
         let persister = Arc::clone(&self.lwk_persister);
-        persister as LwkPersister
+        Ok(persister as LwkPersister)
     }
 
     async fn clear_cache(&self) -> anyhow::Result<()> {

--- a/lib/wasm/src/platform/wallet_persister_common.rs
+++ b/lib/wasm/src/platform/wallet_persister_common.rs
@@ -60,7 +60,7 @@ pub(crate) mod tests {
         let working_dir = format!("/tmp/{}", uuid::Uuid::new_v4());
 
         let persister = build_persister(&working_dir).await?;
-        let lwk_persister = persister.get_lwk_persister();
+        let lwk_persister = persister.get_lwk_persister()?;
 
         assert!(lwk_persister.get(0)?.is_none());
 
@@ -86,7 +86,7 @@ pub(crate) mod tests {
 
         // Reload persister
         let persister = build_persister(&working_dir).await?;
-        let lwk_persister = persister.get_lwk_persister();
+        let lwk_persister = persister.get_lwk_persister()?;
 
         assert_eq!(lwk_persister.get(0)?.unwrap().tip.height, 5);
         assert_eq!(lwk_persister.get(1)?.unwrap().tip.height, 15);


### PR DESCRIPTION
This fixes a bug introduced in #868, where on native builds clearing the cache would be followed by:
```
ERROR breez_sdk_liquid::sdk:429] Failed to connect: No such file or directory (os error 2)
```

The `clear_cache` implementation of `FsWalletCachePersister` deleted the cache directory and it was never created again. Given that the cache directory is defined and created by the constructor of lwk's `FsPersister`, I propose we construct that struct again instead of trying to create the dir ourselves.