### PR TITLE
Prevent concurrent claim attempts

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
 dependencies = [
  "async-trait",
  "bip39",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a#9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a"
 dependencies = [
  "async-trait",
  "bip39",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a#9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a#9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a"
 dependencies = [
  "async-trait",
  "bip39",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a#9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
 dependencies = [
  "async-trait",
  "bip39",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/hydra-yse/boltz-rust?rev=b54f181e218d#b54f181e218d6c7d44d7bfd3eabda3681006fbc0"
+source = "git+https://github.com/danielgranhao/boltz-rust?rev=3397e792759d5772c9909890b322d6d6725516a5#3397e792759d5772c9909890b322d6d6725516a5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -77,7 +77,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "3397e792759d5772c9909890b322d6d6725516a5", features = [
+boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a", features = [
     "electrum",
 ] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
@@ -98,7 +98,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "3397e792759d5772c9909890b322d6d6725516a5" }
+boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "9c703b20a86cb8a4d9a0d3d6dc2f610a0389fe7a" }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -77,7 +77,9 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "b54f181e218d", features = ["electrum"] }
+boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "3397e792759d5772c9909890b322d6d6725516a5", features = [
+    "electrum",
+] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",
@@ -96,7 +98,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/hydra-yse/boltz-rust", rev = "b54f181e218d" }
+boltz-client = { git = "https://github.com/danielgranhao/boltz-rust", rev = "3397e792759d5772c9909890b322d6d6725516a5" }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",

--- a/lib/core/src/swapper/boltz/bitcoin.rs
+++ b/lib/core/src/swapper/boltz/bitcoin.rs
@@ -31,7 +31,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
                         swap_script.as_bitcoin_script()?,
                         refund_address,
                         bitcoin_client,
-                        self.get_url().await?,
+                        &self.get_boltz_client().await?.inner,
                         swap.id.clone(),
                     )
                     .await
@@ -121,7 +121,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
             claim_swap_script,
             claim_address,
             bitcoin_client,
-            self.get_url().await?,
+            &self.get_boltz_client().await?.inner,
             swap.id.clone(),
         )
         .await?;

--- a/lib/core/src/swapper/boltz/client.rs
+++ b/lib/core/src/swapper/boltz/client.rs
@@ -1,3 +1,4 @@
+use crate::swapper::boltz::CONNECTION_TIMEOUT;
 use crate::{
     bitcoin, elements,
     model::{BlockchainExplorer, Config, BREEZ_LIQUID_ESPLORA_URL},
@@ -13,8 +14,6 @@ use boltz_client::{
 };
 use log::error;
 use sdk_macros::async_trait;
-
-const BOLTZ_CONNECTION_TIMEOUT: u8 = 100;
 
 pub(crate) enum LiquidClient {
     #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -34,7 +33,7 @@ impl LiquidClient {
                         url,
                         tls,
                         validate_domain,
-                        BOLTZ_CONNECTION_TIMEOUT,
+                        CONNECTION_TIMEOUT.as_secs() as u8,
                     )?,
                 ))
             }
@@ -65,7 +64,7 @@ impl LiquidClient {
                     client,
                     config.network.into(),
                     url,
-                    BOLTZ_CONNECTION_TIMEOUT as u64,
+                    CONNECTION_TIMEOUT.as_secs(),
                 )))
             }
         })
@@ -128,7 +127,7 @@ impl BitcoinClient {
                         url,
                         tls,
                         validate_domain,
-                        BOLTZ_CONNECTION_TIMEOUT,
+                        CONNECTION_TIMEOUT.as_secs() as u8,
                     )?,
                 ))
             }
@@ -136,7 +135,7 @@ impl BitcoinClient {
                 Self::Esplora(Box::new(EsploraBitcoinClient::new(
                     config.network.as_bitcoin_chain(),
                     url,
-                    BOLTZ_CONNECTION_TIMEOUT as u64,
+                    CONNECTION_TIMEOUT.as_secs(),
                 )))
             }
         })

--- a/lib/core/src/swapper/boltz/liquid.rs
+++ b/lib/core/src/swapper/boltz/liquid.rs
@@ -39,7 +39,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
             swap_script,
             claim_address,
             liquid_client,
-            self.get_url().await?,
+            &self.get_boltz_client().await?.inner,
             swap.id.clone(),
         )
         .await?;
@@ -70,7 +70,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
             swap_script,
             claim_address,
             liquid_client,
-            self.get_url().await?,
+            &self.get_boltz_client().await?.inner,
             swap.id.clone(),
         )
         .await?;
@@ -115,7 +115,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
                         swap_script.as_liquid_script()?,
                         refund_address,
                         liquid_client,
-                        self.get_url().await?,
+                        &self.get_boltz_client().await?.inner,
                         swap.id.clone(),
                     )
                     .await
@@ -127,7 +127,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
                     swap_script,
                     refund_address,
                     liquid_client,
-                    self.get_url().await?,
+                    &self.get_boltz_client().await?.inner,
                     swap.id.clone(),
                 )
                 .await

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -79,7 +79,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
         let boltz_url = boltz_api_base_url.unwrap_or(self.config.default_boltz_url().to_string());
 
         let boltz_client = self.boltz_client.get_or_init(|| BoltzClient {
-            inner: BoltzApiClientV2::new(boltz_url, CONNECTION_TIMEOUT),
+            inner: BoltzApiClientV2::new(boltz_url, Some(CONNECTION_TIMEOUT)),
             referral_id,
         });
         Ok(boltz_client)

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -30,6 +30,8 @@ pub(crate) mod liquid;
 pub(crate) mod proxy;
 pub mod status_stream;
 
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub(crate) struct BoltzClient {
     referral_id: Option<String>,
     inner: BoltzApiClientV2,
@@ -77,7 +79,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
         let boltz_url = boltz_api_base_url.unwrap_or(self.config.default_boltz_url().to_string());
 
         let boltz_client = self.boltz_client.get_or_init(|| BoltzClient {
-            inner: BoltzApiClientV2::new(boltz_url, Duration::from_secs(20)),
+            inner: BoltzApiClientV2::new(boltz_url, CONNECTION_TIMEOUT),
             referral_id,
         });
         Ok(boltz_client)

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::{sync::OnceLock, time::Duration};
 
 use crate::{
     error::{PaymentError, SdkError},
@@ -31,7 +31,6 @@ pub(crate) mod proxy;
 pub mod status_stream;
 
 pub(crate) struct BoltzClient {
-    url: String,
     referral_id: Option<String>,
     inner: BoltzApiClientV2,
 }
@@ -78,8 +77,7 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
         let boltz_url = boltz_api_base_url.unwrap_or(self.config.default_boltz_url().to_string());
 
         let boltz_client = self.boltz_client.get_or_init(|| BoltzClient {
-            inner: BoltzApiClientV2::new(&boltz_url),
-            url: boltz_url,
+            inner: BoltzApiClientV2::new(boltz_url, Duration::from_secs(20)),
             referral_id,
         });
         Ok(boltz_client)
@@ -103,10 +101,6 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
             .map_err(|err| anyhow!("Could not create Boltz Bitcoin client: {err:?}"))?;
         let bitcoin_client = self.bitcoin_client.get_or_init(|| bitcoin_client);
         Ok(bitcoin_client)
-    }
-
-    async fn get_url(&self) -> Result<String> {
-        Ok(self.get_boltz_client().await?.url.clone())
     }
 
     async fn get_claim_partial_sig(


### PR DESCRIPTION
This PR addresses a race condition where concurrent attempts to claim the same swap (both Chain Swaps and Receive Swaps) could lead to failures when interacting with the Boltz backend. The server initiates a session when each claim is started, so when a second claim is initiated in quick succession (before the signature is submitted), the first session is dropped, causing the submitted partial signature to be considered invalid.

The proposed fix is to introduce in-memory locking. There is an edge case where a panic may cause a lock to be held until restart, but this is unlikely (a panic on either the sync or the status stream tasks would be a big issue itself), so IMO it's acceptable.