### PR TITLE
Fixes the reference to the dart repo tag

### DIFF
--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -74,7 +74,6 @@ jobs:
           cp -r ../build/lib/bindings/langs/flutter/breez_sdk_liquidFFI/include/breez_sdk_liquidFFI.h macos/Classes
           cp ../build/packages/flutter/analysis_options.yaml .
           cp ../build/packages/flutter/pubspec.yaml .
-          cp ../build/packages/flutter/pubspec_overrides.yaml .
 
       - name: Copy docs
         working-directory: dist
@@ -103,12 +102,10 @@ jobs:
         working-directory: dist
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
-          sed -i.bak -e 's/path:.*/git:\n      url: git@github.com:breez\/breez-sdk-liquid-dart.git\n      ref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
           sed -i.bak -e "s/^version = .*/version = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           sed -i.bak -e "s/^version = .*/version = '${{ inputs.package-version }}'/" macos/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
-          rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak
           rm ios/flutter_breez_liquid.podspec.bak
           rm macos/flutter_breez_liquid.podspec.bak

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -4,7 +4,7 @@ ROOT="$SCRIPT_DIR/../../../../.."
 TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 
 # Update Flutter plugin to use the same Dart plugin version
-sed -i.bak -E "/breez_liquid:/,/ref:/s|(ref: ).*|\1$TAG_NAME|" "$ROOT/packages/flutter/pubspec.yaml"
+sed -i.bak -E "/breez_liquid:/,/ref:/s|(ref: ).*|\1v$TAG_NAME|" "$ROOT/packages/flutter/pubspec.yaml"
 rm "$ROOT/packages/flutter/pubspec.yaml.bak"
 
 # iOS & macOS

--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -1,4 +1,4 @@
-version '0.7.2-dev1' // generated; do not edit
+version '0.8.0' // generated; do not edit
 group 'technology.breez.flutter_breez_liquid'
 
 buildscript {

--- a/packages/flutter/android/build.gradle.production
+++ b/packages/flutter/android/build.gradle.production
@@ -1,4 +1,4 @@
-version '0.7.2-dev1' // generated; do not edit
+version '0.8.0' // generated; do not edit
 group 'technology.breez.flutter_breez_liquid'
 
 buildscript {

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint flutter_breez_liquid.podspec` to validate before publishing.

--- a/packages/flutter/ios/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.

--- a/packages/flutter/macos/flutter_breez_liquid.podspec
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint flutter_breez_liquid.podspec` to validate before publishing.

--- a/packages/flutter/macos/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-dart
-      ref: 0.8.0
+      ref: v0.8.0
   ffigen: ^18.0.0
 
 dev_dependencies:


### PR DESCRIPTION
The `ref` for the breez_liquid dependency was missing the "v" of the repo tag causing:
```
Because every version of flutter_breez_liquid from git depends on breez_liquid from git which doesn't exist (Could not find git ref '0.8.0' (fatal: ambiguous argument '0.8.0')
```