### PR TITLE
Fix missing 0.8.0 version bump

### DIFF
--- a/packages/flutter/android/build.gradle
+++ b/packages/flutter/android/build.gradle
@@ -1,4 +1,4 @@
-version '0.7.2-dev1' // generated; do not edit
+version '0.8.0' // generated; do not edit
 group 'technology.breez.flutter_breez_liquid'
 
 buildscript {

--- a/packages/flutter/android/build.gradle.production
+++ b/packages/flutter/android/build.gradle.production
@@ -1,4 +1,4 @@
-version '0.7.2-dev1' // generated; do not edit
+version '0.8.0' // generated; do not edit
 group 'technology.breez.flutter_breez_liquid'
 
 buildscript {

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint flutter_breez_liquid.podspec` to validate before publishing.

--- a/packages/flutter/ios/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.

--- a/packages/flutter/macos/flutter_breez_liquid.podspec
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint flutter_breez_liquid.podspec` to validate before publishing.

--- a/packages/flutter/macos/flutter_breez_liquid.podspec.production
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec.production
@@ -1,4 +1,4 @@
-version = '0.7.2-dev1' # generated; do not edit
+version = '0.8.0' # generated; do not edit
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.


### PR DESCRIPTION
The recent commit bumping to 0.8.0 missed updating the flutter package versions and CI was complaining.