### PR TITLE
Side-Swap: Add base communication layer and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ Contributions are always welcome. Please read our [contribution guide](CONTRIBUT
 - [x]  WebAssembly
 - [x]  Bolt12 receive
 - [x]  Add fees via a dedicated portal
-- [ ]  USDT <-> LBTC swaps
+- [x]  USDT <-> LBTC swaps
 - [ ]  WebLN
 - [ ]  NWC

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sideswap_api",
  "strum",
  "strum_macros",
  "tempfile",
@@ -875,7 +876,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1030,6 +1031,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2193,7 +2229,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.101",
  "unic-langid",
 ]
@@ -2320,6 +2356,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4515,6 +4557,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,6 +4615,31 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sideswap_api"
+version = "0.1.2"
+source = "git+https://github.com/breez/sideswap_rust?rev=2c3c4312d8fe#2c3c4312d8fe9f2766d96320994145ba7287cc28"
+dependencies = [
+ "elements",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sideswap_types",
+]
+
+[[package]]
+name = "sideswap_types"
+version = "0.1.2"
+source = "git+https://github.com/breez/sideswap_rust?rev=2c3c4312d8fe#2c3c4312d8fe9f2766d96320994145ba7287cc28"
+dependencies = [
+ "elements",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "slab"
@@ -4606,6 +4695,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -6462,7 +6462,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sideswap_api",
  "strum",
  "strum_macros",
  "tempdir",
@@ -1238,6 +1239,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2555,6 +2591,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4857,6 +4899,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,6 +4972,31 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sideswap_api"
+version = "0.1.2"
+source = "git+https://github.com/breez/sideswap_rust?rev=2c3c4312d8fe#2c3c4312d8fe9f2766d96320994145ba7287cc28"
+dependencies = [
+ "elements",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sideswap_types",
+]
+
+[[package]]
+name = "sideswap_types"
+version = "0.1.2"
+source = "git+https://github.com/breez/sideswap_rust?rev=2c3c4312d8fe#2c3c4312d8fe9f2766d96320994145ba7287cc28"
+dependencies = [
+ "elements",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -293,6 +293,7 @@ typedef struct wire_cst_PayAmount_Asset {
   struct wire_cst_list_prim_u_8_strict *asset_id;
   double receiver_amount;
   bool *estimate_asset_fees;
+  bool *pay_with_bitcoin;
 } wire_cst_PayAmount_Asset;
 
 typedef union PayAmountKind {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -527,7 +527,7 @@ dictionary OnchainPaymentLimitsResponse {
 [Enum]
 interface PayAmount {
     Bitcoin(u64 receiver_amount_sat);
-    Asset(string asset_id, f64 receiver_amount, boolean? estimate_asset_fees);
+    Asset(string asset_id, f64 receiver_amount, boolean? estimate_asset_fees, boolean? pay_with_bitcoin);
     Drain();
 };
 

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -64,6 +64,7 @@ lazy_static = "1.5.0"
 esplora-client = { git = "https://github.com/hydra-yse/rust-esplora-client", branch = "scripthash-utxo", features = [
     "async-https-rustls",
 ] }
+sideswap_api = { git = "https://github.com/breez/sideswap_rust", rev = "2c3c4312d8fe" }
 
 # Non-Wasm dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -23,9 +23,7 @@ bip39 = "2.0.0"
 chrono = "0.4"
 derivative = "2.2.0"
 env_logger = "0.11"
-flutter_rust_bridge = { version = "=2.9.0", features = [
-    "chrono",
-], optional = true }
+flutter_rust_bridge = { version = "=2.9.0", features = ["chrono"], optional = true }
 log = { workspace = true }
 lwk_common = { git = "https://github.com/breez/lwk", rev = "b19e0eadecf4" }
 lwk_signer = { git = "https://github.com/breez/lwk", rev = "b19e0eadecf4", default-features = false }

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3969,10 +3969,12 @@ impl SseDecode for crate::model::PayAmount {
                 let mut var_assetId = <String>::sse_decode(deserializer);
                 let mut var_receiverAmount = <f64>::sse_decode(deserializer);
                 let mut var_estimateAssetFees = <Option<bool>>::sse_decode(deserializer);
+                let mut var_payWithBitcoin = <Option<bool>>::sse_decode(deserializer);
                 return crate::model::PayAmount::Asset {
                     asset_id: var_assetId,
                     receiver_amount: var_receiverAmount,
                     estimate_asset_fees: var_estimateAssetFees,
+                    pay_with_bitcoin: var_payWithBitcoin,
                 };
             }
             2 => {
@@ -6402,11 +6404,13 @@ impl flutter_rust_bridge::IntoDart for crate::model::PayAmount {
                 asset_id,
                 receiver_amount,
                 estimate_asset_fees,
+                pay_with_bitcoin,
             } => [
                 1.into_dart(),
                 asset_id.into_into_dart().into_dart(),
                 receiver_amount.into_into_dart().into_dart(),
                 estimate_asset_fees.into_into_dart().into_dart(),
+                pay_with_bitcoin.into_into_dart().into_dart(),
             ]
             .into_dart(),
             crate::model::PayAmount::Drain => [2.into_dart()].into_dart(),
@@ -8808,11 +8812,13 @@ impl SseEncode for crate::model::PayAmount {
                 asset_id,
                 receiver_amount,
                 estimate_asset_fees,
+                pay_with_bitcoin,
             } => {
                 <i32>::sse_encode(1, serializer);
                 <String>::sse_encode(asset_id, serializer);
                 <f64>::sse_encode(receiver_amount, serializer);
                 <Option<bool>>::sse_encode(estimate_asset_fees, serializer);
+                <Option<bool>>::sse_encode(pay_with_bitcoin, serializer);
             }
             crate::model::PayAmount::Drain => {
                 <i32>::sse_encode(2, serializer);
@@ -11137,6 +11143,7 @@ mod io {
                         asset_id: ans.asset_id.cst_decode(),
                         receiver_amount: ans.receiver_amount.cst_decode(),
                         estimate_asset_fees: ans.estimate_asset_fees.cst_decode(),
+                        pay_with_bitcoin: ans.pay_with_bitcoin.cst_decode(),
                     }
                 }
                 2 => crate::model::PayAmount::Drain,
@@ -15067,6 +15074,7 @@ mod io {
         asset_id: *mut wire_cst_list_prim_u_8_strict,
         receiver_amount: f64,
         estimate_asset_fees: *mut bool,
+        pay_with_bitcoin: *mut bool,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -186,6 +186,7 @@ pub mod receive_swap;
 pub(crate) mod recover;
 pub mod sdk;
 pub(crate) mod send_swap;
+pub(crate) mod side_swap;
 pub mod signer;
 pub(crate) mod swapper;
 pub(crate) mod sync;

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -787,6 +787,9 @@ pub enum PayAmount {
         asset_id: String,
         receiver_amount: f64,
         estimate_asset_fees: Option<bool>,
+        /// Specifies whether or not to always use the wallet's L-BTC to execute the payment.
+        /// If true, it will try swapping the asset via the [Side Swap Service](crate::side_swap::api::SideSwapService)
+        pay_with_bitcoin: Option<bool>,
     },
 
     /// Indicates that all available Bitcoin funds should be sent

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -23,18 +23,19 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
-use crate::utils;
 use crate::{
     bitcoin,
+    chain::bitcoin::esplora::EsploraBitcoinChainService,
+    chain::liquid::esplora::EsploraLiquidChainService,
     chain::{bitcoin::BitcoinChainService, liquid::LiquidChainService},
     elements,
     error::{PaymentError, SdkError, SdkResult},
+    persist::model::PaymentTxBalance,
+    prelude::DEFAULT_EXTERNAL_INPUT_PARSERS,
+    receive_swap::DEFAULT_ZERO_CONF_MAX_SAT,
+    side_swap::api::{SIDESWAP_MAINNET_URL, SIDESWAP_TESTNET_URL},
+    utils,
 };
-use crate::{
-    chain::bitcoin::esplora::EsploraBitcoinChainService,
-    chain::liquid::esplora::EsploraLiquidChainService, prelude::DEFAULT_EXTERNAL_INPUT_PARSERS,
-};
-use crate::{persist::model::PaymentTxBalance, receive_swap::DEFAULT_ZERO_CONF_MAX_SAT};
 
 // Uses f64 for the maximum precision when converting between units
 pub const LIQUID_FEE_RATE_SAT_PER_VBYTE: f64 = 0.1;
@@ -350,6 +351,14 @@ impl Config {
             &electrum_url,
             lwk_wollet::ElectrumOptions { timeout: Some(3) },
         )
+    }
+
+    pub(crate) fn sideswap_url(&self) -> &'static str {
+        match self.network {
+            LiquidNetwork::Mainnet => SIDESWAP_MAINNET_URL,
+            LiquidNetwork::Testnet => SIDESWAP_TESTNET_URL,
+            LiquidNetwork::Regtest => unimplemented!(),
+        }
     }
 }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Not as _;
 use std::{path::PathBuf, str::FromStr, time::Duration};
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, ensure, Context as _, Result};
 use boltz_client::swaps::magic_routing::verify_mrh_signature;
 use boltz_client::Secp256k1;
 use boltz_client::{swaps::boltz::*, util::secrets::Preimage};
@@ -40,6 +40,7 @@ use sdk_common::lightning_with_bolt12::util::string::UntrustedString;
 use sdk_common::liquid::LiquidAddressData;
 use sdk_common::prelude::{FiatAPI, FiatCurrency, LnUrlPayError, LnUrlWithdrawError, Rate};
 use sdk_common::utils::Arc;
+use side_swap::api::SideSwapService;
 use signer::SdkSigner;
 use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
@@ -1215,6 +1216,7 @@ impl LiquidSdk {
         let receiver_amount_sat;
         let asset_id;
         let payment_destination;
+        let mut validate_funds = true;
 
         match self.parse(&req.destination).await {
             Ok(InputType::LiquidAddress {
@@ -1236,6 +1238,7 @@ impl LiquidSdk {
                                 asset_id,
                                 receiver_amount: amount,
                                 estimate_asset_fees: None,
+                                pay_with_bitcoin: None,
                             }
                         }
                     }
@@ -1305,6 +1308,7 @@ impl LiquidSdk {
                         asset_id,
                         receiver_amount,
                         estimate_asset_fees,
+                        pay_with_bitcoin,
                     } => {
                         let estimate_asset_fees = estimate_asset_fees.unwrap_or(false);
                         let asset_metadata = self.persister.get_asset_metadata(&asset_id)?.ok_or(
@@ -1313,33 +1317,60 @@ impl LiquidSdk {
                             },
                         )?;
                         let receiver_amount_sat = asset_metadata.amount_to_sat(receiver_amount);
-                        let fees_sat_res = self
-                            .estimate_onchain_tx_or_drain_tx_fee(
-                                receiver_amount_sat,
-                                &liquid_address_data.address,
-                                &asset_id,
-                            )
-                            .await;
-                        let asset_fees = if estimate_asset_fees {
-                            self.payjoin_service
-                                .estimate_payjoin_tx_fee(&asset_id, receiver_amount_sat)
-                                .await
-                                .inspect_err(|e| debug!("Error estimating payjoin tx: {e}"))
-                                .ok()
-                        } else {
-                            None
-                        };
-                        let (fees_sat, asset_fees) = match (fees_sat_res, asset_fees) {
-                            (Ok(fees_sat), _) => (Some(fees_sat), asset_fees),
-                            (Err(e), Some(asset_fees)) => {
-                                debug!(
-                                    "Error estimating onchain tx, but returning payjoin fees: {e}"
-                                );
-                                (None, Some(asset_fees))
+
+                        match pay_with_bitcoin.unwrap_or(false) {
+                            false => {
+                                let fees_sat_res = self
+                                    .estimate_onchain_tx_or_drain_tx_fee(
+                                        receiver_amount_sat,
+                                        &liquid_address_data.address,
+                                        &asset_id,
+                                    )
+                                    .await;
+                                let asset_fees = if estimate_asset_fees {
+                                    self.payjoin_service
+                                        .estimate_payjoin_tx_fee(&asset_id, receiver_amount_sat)
+                                        .await
+                                        .inspect_err(|e| debug!("Error estimating payjoin tx: {e}"))
+                                        .ok()
+                                } else {
+                                    None
+                                };
+                                let (fees_sat, asset_fees) = match (fees_sat_res, asset_fees) {
+                                    (Ok(fees_sat), _) => (Some(fees_sat), asset_fees),
+                                    (Err(e), Some(asset_fees)) => {
+                                        debug!(
+                                            "Error estimating onchain tx, but returning payjoin fees: {e}"
+                                        );
+                                        (None, Some(asset_fees))
+                                    }
+                                    (Err(e), None) => return Err(e),
+                                };
+                                (asset_id, receiver_amount_sat, fees_sat, asset_fees)
                             }
-                            (Err(e), None) => return Err(e),
-                        };
-                        (asset_id, receiver_amount_sat, fees_sat, asset_fees)
+                            true => {
+                                let asset_id = AssetId::from_str(&asset_id)?;
+                                let sideswap_service = SideSwapService::from_sdk(self);
+
+                                let swap = sideswap_service
+                                    .get_asset_swap(asset_id, receiver_amount_sat)
+                                    .await?;
+
+                                ensure_sdk!(
+                                    get_info_res.wallet_info.balance_sat
+                                        >= swap.payer_amount_sat + swap.fees_sat,
+                                    PaymentError::InsufficientFunds
+                                );
+
+                                validate_funds = false;
+                                (
+                                    swap.asset_id,
+                                    receiver_amount_sat,
+                                    Some(swap.fees_sat),
+                                    None,
+                                )
+                            }
+                        }
                     }
                 };
 
@@ -1501,12 +1532,14 @@ impl LiquidSdk {
             }
         };
 
-        get_info_res.wallet_info.validate_sufficient_funds(
-            self.config.network,
-            receiver_amount_sat,
-            fees_sat,
-            &asset_id,
-        )?;
+        if validate_funds {
+            get_info_res.wallet_info.validate_sufficient_funds(
+                self.config.network,
+                receiver_amount_sat,
+                fees_sat,
+                &asset_id,
+            )?;
+        }
 
         Ok(PrepareSendResponse {
             destination: payment_destination,
@@ -1560,9 +1593,10 @@ impl LiquidSdk {
                 bip353_address,
             } => {
                 let asset_pay_fees = req.use_asset_fees.unwrap_or_default();
-                let Some(amount_sat) = liquid_address_data.amount_sat else {
+                let Some(receiver_amount_sat) = liquid_address_data.amount_sat else {
                     return Err(PaymentError::AmountMissing {
-                        err: "Amount must be set when paying to a Liquid address".to_string(),
+                        err: "Receiver amount must be set when paying to a Liquid address"
+                            .to_string(),
                     });
                 };
                 let Some(ref asset_id) = liquid_address_data.asset_id else {
@@ -1582,23 +1616,52 @@ impl LiquidSdk {
                     }
                 );
 
-                self.get_info()
-                    .await?
-                    .wallet_info
-                    .validate_sufficient_funds(
+                let get_info_res = self.get_info().await?;
+                let validate_sufficient_funds = || {
+                    get_info_res.wallet_info.validate_sufficient_funds(
                         self.config.network,
-                        amount_sat,
+                        receiver_amount_sat,
                         *fees_sat,
                         asset_id,
-                    )?;
+                    )
+                };
 
                 let mut response = if asset_pay_fees {
-                    self.pay_liquid_payjoin(liquid_address_data.clone(), amount_sat)
+                    validate_sufficient_funds()?;
+                    self.pay_liquid_payjoin(liquid_address_data.clone(), receiver_amount_sat)
                         .await?
                 } else {
                     let fees_sat = fees_sat.ok_or(PaymentError::InsufficientFunds)?;
-                    self.pay_liquid(liquid_address_data.clone(), amount_sat, fees_sat, true)
+
+                    let is_liquid_payment = *asset_id == self.config.lbtc_asset_id();
+                    let pay_with_bitcoin = match req.prepare_response.amount {
+                        Some(PayAmount::Asset {
+                            pay_with_bitcoin, ..
+                        }) => pay_with_bitcoin.unwrap_or(false),
+                        _ => false,
+                    };
+
+                    if is_liquid_payment || !pay_with_bitcoin {
+                        validate_sufficient_funds()?;
+                        self.pay_liquid(
+                            liquid_address_data.clone(),
+                            receiver_amount_sat,
+                            fees_sat,
+                            true,
+                        )
                         .await?
+                    } else {
+                        let sideswap_service = SideSwapService::from_sdk(self);
+                        let res = self
+                            .pay_sideswap(
+                                &sideswap_service,
+                                liquid_address_data.clone(),
+                                receiver_amount_sat,
+                                fees_sat,
+                            )
+                            .await;
+                        res?
+                    }
                 };
 
                 self.insert_payment_details(&None, bip353_address, &mut response)?;
@@ -1911,6 +1974,69 @@ impl LiquidSdk {
         Ok(SendPaymentResponse {
             payment: Payment::from_tx_data(tx_data, tx_balance, None, payment_details),
         })
+    }
+
+    /// Performs a Liquid send payment via SideSwap
+    async fn pay_sideswap(
+        &self,
+        sideswap_service: &SideSwapService,
+        address_data: LiquidAddressData,
+        receiver_amount_sat: u64,
+        fees_sat: u64,
+    ) -> Result<SendPaymentResponse, PaymentError> {
+        let receiver_address =
+            elements::Address::from_str(&address_data.address).map_err(|err| {
+                PaymentError::generic(format!("Could not convert destination address: {err}"))
+            })?;
+        let asset_id = address_data.asset_id.clone().context("Expected asset id")?;
+        let swap = sideswap_service
+            .get_asset_swap(AssetId::from_str(&asset_id)?, receiver_amount_sat)
+            .await?;
+
+        ensure_sdk!(
+            swap.fees_sat <= fees_sat,
+            PaymentError::InvalidOrExpiredFees
+        );
+
+        ensure_sdk!(
+            self.get_info().await?.wallet_info.balance_sat >= swap.payer_amount_sat,
+            PaymentError::InsufficientFunds
+        );
+
+        let tx_id = sideswap_service
+            .execute_swap(receiver_address, &swap)
+            .await?;
+
+        // We insert a pseudo-tx in case LWK fails to pick up the new mempool tx for a while
+        // This makes the tx known to the SDK (get_info, list_payments) instantly
+        self.persister.insert_or_update_payment(
+            PaymentTxData {
+                tx_id: tx_id.clone(),
+                timestamp: Some(utils::now()),
+                fees_sat: swap.fees_sat,
+                is_confirmed: false,
+                unblinding_data: None,
+            },
+            &[PaymentTxBalance {
+                asset_id: utils::lbtc_asset_id(self.config.network).to_string(),
+                amount: swap.payer_amount_sat,
+                payment_type: PaymentType::Send,
+            }],
+            Some(PaymentTxDetails {
+                tx_id: tx_id.clone(),
+                destination: address_data.address,
+                description: address_data.message,
+                ..Default::default()
+            }),
+            false,
+        )?;
+        self.emit_payment_updated(Some(tx_id.clone())).await?; // Emit Pending event
+
+        let payment = self
+            .persister
+            .get_payment(&tx_id)?
+            .context("Payment not found")?;
+        Ok(SendPaymentResponse { payment })
     }
 
     /// Performs a Send Payment by doing a payjoin tx to a Liquid address

--- a/lib/core/src/side_swap/api/mod.rs
+++ b/lib/core/src/side_swap/api/mod.rs
@@ -1,0 +1,338 @@
+use anyhow::{anyhow, bail, Result};
+use base64::Engine;
+use futures_util::{SinkExt as _, StreamExt};
+use log::{debug, error, info, warn};
+use request_handler::SideSwapRequestHandler;
+use response_handler::SideSwapResponseHandler;
+use sdk_common::bitcoin::hashes::hex::ToHex as _;
+use sdk_common::prelude::{parse_json, RestClient};
+use sdk_common::utils::Arc;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sideswap_api::http_rpc::{SwapSignRequest, SwapStartRequest};
+use sideswap_api::{StartSwapWebRequest, SubscribePriceStreamRequest, Utxo};
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::sync::{watch, OnceCell};
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+use tokio_with_wasm::alias as tokio;
+
+use boltz_client::boltz::tokio_tungstenite_wasm;
+use tokio_tungstenite_wasm::{connect, Message};
+
+use model::*;
+
+use crate::bitcoin::base64;
+use crate::elements::{self, pset::PartiallySignedTransaction, Address, AssetId};
+use crate::error::PaymentError;
+use crate::model::Config;
+use crate::wallet::OnchainWallet;
+use crate::{ensure_sdk, utils};
+
+pub(crate) mod model;
+mod request_handler;
+mod response_handler;
+
+pub const SIDESWAP_MAINNET_URL: &str = "wss://api.sideswap.io/json-rpc-ws";
+pub const SIDESWAP_TESTNET_URL: &str = "wss://api-testnet.sideswap.io/json-rpc-ws";
+
+pub(crate) struct SideSwapService {
+    config: Config,
+    rest_client: Arc<dyn RestClient>,
+    onchain_wallet: Arc<dyn OnchainWallet>,
+    request_handler: SideSwapRequestHandler,
+    response_handler: SideSwapResponseHandler,
+    event_loop_handle: OnceCell<JoinHandle<()>>,
+}
+
+impl SideSwapService {
+    pub(crate) fn from_sdk(sdk: &crate::sdk::LiquidSdk) -> Arc<Self> {
+        Self::new(
+            sdk.config.clone(),
+            sdk.rest_client.clone(),
+            sdk.onchain_wallet.clone(),
+            sdk.shutdown_receiver.clone(),
+        )
+    }
+
+    pub(crate) fn new(
+        config: Config,
+        rest_client: Arc<dyn RestClient>,
+        onchain_wallet: Arc<dyn OnchainWallet>,
+        mut shutdown_rx: watch::Receiver<()>,
+    ) -> Arc<Self> {
+        let service = Arc::new(Self {
+            config,
+            request_handler: SideSwapRequestHandler::new(),
+            response_handler: SideSwapResponseHandler::new(),
+            rest_client,
+            onchain_wallet,
+            event_loop_handle: OnceCell::new(),
+        });
+        let cloned = service.clone();
+
+        let handle = tokio::spawn(async move {
+            info!("Starting SideSwap service event loop");
+            loop {
+                if shutdown_rx.has_changed().unwrap_or(true) {
+                    return;
+                }
+
+                let ws = match connect(cloned.config.sideswap_url()).await {
+                    Ok(ws) => ws,
+                    Err(err) => {
+                        error!("Could not connect to SideSwap websocket: {err}");
+                        sleep(Duration::from_secs(3)).await;
+                        continue;
+                    }
+                };
+
+                let (mut ws_sender, mut ws_receiver) = ws.split();
+                let keep_alive_ping_interval = Duration::from_secs(15);
+                loop {
+                    tokio::select! {
+                        _ = shutdown_rx.changed() => {
+                            info!("Received shutdown signal from SDK, exiting SideSwap service loop");
+                            return;
+                        }
+
+                        _ = tokio::time::sleep(keep_alive_ping_interval) => {
+                            if let Err(err) = cloned.request_handler.send(Request::Ping(None)).await {
+                                warn!("Could not send ping message to SideSwap server: {err:?}");
+                            };
+                        },
+
+                        maybe_req_msg = cloned.request_handler.recv() => match maybe_req_msg {
+                            Some(req_msg) => cloned.request_handler.send_ws(&mut ws_sender, req_msg).await,
+                            None => {
+                                warn!("Request channel has been closed, exiting socket loop");
+                                break;
+                            }
+                        },
+
+                        maybe_next = ws_receiver.next() => match maybe_next {
+                            Some(msg) => match msg {
+                                Ok(Message::Close(_)) => {
+                                    warn!("Received close msg, exiting socket loop");
+                                    break; // break the inner loop which will start the main loop by reconnecting
+                                },
+                                Ok(Message::Text(payload)) => cloned.handle_message(payload.as_str()).await,
+                                Ok(msg) => warn!("Unhandled msg: {msg:?}"),
+                                Err(e) => {
+                                    error!("Received stream error: {e:?}");
+                                    let _ = ws_sender.close().await;
+                                    break; // break the inner loop which will start the main loop by reconnecting
+                                }
+                            }
+                            None => {
+                                warn!("Received nothing from the stream");
+                                let _ = ws_sender.close().await;
+                                break; // break the inner loop which will start the main loop by reconnecting
+                            },
+                        }
+                    }
+                }
+            }
+        });
+        let _ = service.event_loop_handle.set(handle);
+        service
+    }
+
+    async fn post_request<I: Serialize, O: DeserializeOwned>(
+        &self,
+        url: &str,
+        body: &I,
+    ) -> Result<O> {
+        let headers = HashMap::from([("Content-Type".to_string(), "application/json".to_string())]);
+        let body = serde_json::to_string(body)?;
+        debug!("Posting request to SideSwap API: {body}");
+        let (response, status_code) = self
+            .rest_client
+            .post(url, Some(headers), Some(body))
+            .await?;
+        if status_code != 200 {
+            error!("Received status code {status_code} response from SideSwap API");
+            bail!("Failed to post request to SideSwap API: {response}")
+        }
+        debug!("Received response from SideSwap API: {response}");
+        Ok(parse_json(&response)?)
+    }
+
+    pub(crate) fn stop(&self) {
+        if let Some(handle) = self.event_loop_handle.get() {
+            handle.abort();
+        }
+    }
+
+    async fn handle_message(&self, msg: &str) {
+        info!("Received text message: {msg}");
+        match serde_json::from_str::<WrappedResponse>(msg) {
+            Ok(WrappedResponse::Response { id, response, .. }) => {
+                self.response_handler.handle_response(id, response).await;
+            }
+            Ok(WrappedResponse::Notification { notification, .. }) => {
+                debug!("Received unhandled notification from SideSwap service: {notification:?}");
+            }
+            // Either an error or an invalid response
+            Ok(WrappedResponse::Error { error, .. }) => {
+                error!("Received error response from the server: {error:?}")
+            }
+            Err(e) => error!("Failed to parse websocket response: {e:?} - response: {msg}"),
+        }
+    }
+
+    fn invalid_response(res: Response) -> anyhow::Error {
+        anyhow!("Received invalid response from the server: {res:?}")
+    }
+
+    pub(crate) async fn get_asset_swap(
+        &self,
+        asset_id: AssetId,
+        receiver_amount_sat: u64,
+    ) -> Result<AssetSwap> {
+        let req = Request::SubscribePriceStream(SubscribePriceStreamRequest {
+            subscribe_id: None,
+            asset: asset_id,
+            send_bitcoins: true,
+            send_amount: None,
+            recv_amount: Some(receiver_amount_sat as i64),
+        });
+        let request_id = self.request_handler.send(req).await?;
+        let res = match self.response_handler.recv(request_id).await? {
+            Response::SubscribePriceStream(res) => res,
+            res => {
+                return Err(Self::invalid_response(res));
+            }
+        };
+
+        res.try_into()
+    }
+
+    pub(crate) async fn execute_swap(
+        &self,
+        receiver_address: Address,
+        asset_swap: &AssetSwap,
+    ) -> Result<String> {
+        let req = Request::StartSwapWeb(StartSwapWebRequest {
+            asset: AssetId::from_str(&asset_swap.asset_id)?,
+            price: asset_swap.exchange_rate,
+            send_amount: asset_swap.payer_amount_sat as i64,
+            recv_amount: asset_swap.receiver_amount_sat as i64,
+            send_bitcoins: true,
+        });
+        let request_id = self.request_handler.send(req).await?;
+        let start_res = match self.response_handler.recv(request_id).await? {
+            Response::StartSwapWeb(res) => Ok(res),
+            res => Err(Self::invalid_response(res)),
+        }?;
+
+        let change_addr = self.onchain_wallet.next_unused_change_address().await?;
+
+        let wallet_utxos = self
+            .onchain_wallet
+            .asset_utxos(&utils::lbtc_asset_id(self.config.network))
+            .await?;
+
+        ensure_sdk!(
+            !wallet_utxos.is_empty(),
+            PaymentError::InsufficientFunds.into()
+        );
+
+        let mut inputs = vec![];
+        let mut send_value = 0i64;
+        for wallet_utxo in wallet_utxos {
+            if wallet_utxo.is_spent {
+                continue;
+            }
+            send_value += wallet_utxo.unblinded.value as i64;
+            inputs.push(Utxo {
+                txid: wallet_utxo.outpoint.txid,
+                vout: wallet_utxo.outpoint.vout,
+                asset: wallet_utxo.unblinded.asset,
+                asset_bf: wallet_utxo.unblinded.asset_bf,
+                value: wallet_utxo.unblinded.value,
+                value_bf: wallet_utxo.unblinded.value_bf,
+                redeem_script: None,
+            });
+            if send_value >= start_res.send_amount {
+                break;
+            }
+        }
+        ensure_sdk!(
+            send_value >= start_res.send_amount,
+            PaymentError::InsufficientFunds.into()
+        );
+
+        let body = HttpRequest::SwapStart(SwapStartRequest {
+            order_id: start_res.order_id,
+            inputs,
+            recv_addr: receiver_address.clone(),
+            change_addr: change_addr.clone(),
+            send_asset: start_res.send_asset,
+            send_amount: start_res.send_amount,
+            recv_asset: start_res.recv_asset,
+            recv_amount: start_res.recv_amount,
+        });
+        let HttpResponse::SwapStart(response) =
+            self.post_request(&start_res.upload_url, &body).await?
+        else {
+            bail!("Received unexpected response from SideSwap API.");
+        };
+
+        let mut pset = PartiallySignedTransaction::from_str(&response.pset)?;
+        let Some(recv_output) = pset
+            .outputs()
+            .iter()
+            .find(|o| o.script_pubkey == receiver_address.script_pubkey())
+        else {
+            bail!("PSET verification error: Could not find receive address script pubkey among outputs");
+        };
+
+        ensure_sdk!(
+            recv_output.amount.is_some_and(|a| a == start_res.recv_amount as u64) &&
+            recv_output.asset.is_some_and(|a| a == start_res.recv_asset),
+            anyhow!(
+                "PSET verification error: (receive output) expected amount: {}, asset: {} / received: amount: {:?}, asset: {:?}",
+                start_res.recv_amount, start_res.recv_asset,
+                recv_output.amount, recv_output.asset,
+            )
+        );
+
+        let Some(change_output) = pset
+            .outputs()
+            .iter()
+            .find(|o| o.script_pubkey == change_addr.script_pubkey())
+        else {
+            bail!("PSET verification error: Could not find change address script pubkey among outputs");
+        };
+        let change_amount = (send_value - start_res.send_amount) as u64;
+        let change_asset = utils::lbtc_asset_id(self.config.network);
+        ensure_sdk!(
+            change_output.amount.is_some_and(|a| a == change_amount) &&
+            change_output.asset.is_some_and(|a| a == change_asset),
+            anyhow!(
+                "PSET verification error: (change output) expected amount: {}, asset: {} / received: amount: {:?}, asset: {:?}",
+                change_amount, change_asset,
+                change_output.amount, change_output.asset,
+            )
+        );
+
+        self.onchain_wallet.sign_pset(&mut pset).await?;
+        let pset = elements::encode::serialize(&pset);
+        let body = HttpRequest::SwapSign(SwapSignRequest {
+            order_id: start_res.order_id,
+            submit_id: response.submit_id,
+            pset: base64::engine::general_purpose::STANDARD.encode(&pset),
+        });
+
+        let HttpResponse::SwapSign(response) =
+            self.post_request(&start_res.upload_url, &body).await?
+        else {
+            bail!("Received unexpected response from SideSwap API.");
+        };
+
+        Ok(response.txid.to_hex())
+    }
+}

--- a/lib/core/src/side_swap/api/model.rs
+++ b/lib/core/src/side_swap/api/model.rs
@@ -1,0 +1,110 @@
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+pub(crate) use sideswap_api::http_rpc::{Request as HttpRequest, Response as HttpResponse};
+use sideswap_api::{
+    Empty, StartSwapWebRequest, StartSwapWebResponse, SubscribePriceStreamRequest,
+    SubscribePriceStreamResponse, SwapDoneNotification, UnsubscribePriceStreamRequest,
+    UnsubscribePriceStreamResponse,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub(crate) enum RequestId {
+    String(String),
+    Int(i64),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+pub(crate) enum Request {
+    Ping(Empty),
+    SubscribePriceStream(SubscribePriceStreamRequest),
+    UnsubscribePriceStream(UnsubscribePriceStreamRequest),
+    StartSwapWeb(StartSwapWebRequest),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct WrappedRequest {
+    pub id: RequestId,
+    #[serde(flatten)]
+    pub request: Request,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "method", content = "result", rename_all = "snake_case")]
+pub(crate) enum Response {
+    Ping(Empty),
+    SubscribePriceStream(SubscribePriceStreamResponse),
+    UnsubscribePriceStream(UnsubscribePriceStreamResponse),
+    StartSwapWeb(StartSwapWebResponse),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub(crate) enum WrappedResponse {
+    Notification {
+        #[serde(flatten)]
+        notification: Notification,
+    },
+    Response {
+        id: RequestId,
+        #[serde(flatten)]
+        response: Response,
+    },
+    Error {
+        id: Option<RequestId>,
+        error: sideswap_api::Error,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+pub(crate) enum Notification {
+    UpdatePriceStream(SubscribePriceStreamResponse),
+    SwapDone(SwapDoneNotification),
+}
+
+/// The current state of a swap via the SideSwap service
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AssetSwap {
+    /// The asset we are currently trading for
+    pub(crate) asset_id: String,
+    /// The exchange rate of the asset (the amount that can be traded for one L-BTC)
+    pub(crate) exchange_rate: f64,
+    /// The service fees for the swap (in satoshi)
+    pub(crate) fees_sat: u64,
+    /// The asset amount which will be received after swapping (in satoshi precision)
+    pub(crate) receiver_amount_sat: u64,
+    /// The amount of L-BTC (in satoshi) to execute the swap
+    pub(crate) payer_amount_sat: u64,
+}
+
+impl TryFrom<SubscribePriceStreamResponse> for AssetSwap {
+    type Error = anyhow::Error;
+
+    fn try_from(value: SubscribePriceStreamResponse) -> Result<Self, Self::Error> {
+        if let Some(err) = &value.error_msg {
+            anyhow::bail!(
+                "Could not convert SideSwap price - received error message from stream: {err}"
+            );
+        }
+
+        Ok(Self {
+            asset_id: value.asset.to_string(),
+            payer_amount_sat: value
+                .send_amount
+                .context("Expected send amount when creating side swap")?
+                as u64,
+            receiver_amount_sat: value
+                .recv_amount
+                .context("Expected receive amount when creating side swap")?
+                as u64,
+            fees_sat: value
+                .fixed_fee
+                .context("Expected fees when creating side swap")? as u64,
+            exchange_rate: value
+                .price
+                .context("Expected price when creating side swap")?,
+        })
+    }
+}

--- a/lib/core/src/side_swap/api/request_handler.rs
+++ b/lib/core/src/side_swap/api/request_handler.rs
@@ -1,0 +1,65 @@
+use anyhow::{anyhow, Result};
+use boltz_client::boltz::tokio_tungstenite_wasm::{Message, WebSocketStream};
+use futures_util::{stream::SplitSink, SinkExt as _};
+use log::{debug, error, warn};
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    Mutex,
+};
+
+use super::model::{Request, RequestId, WrappedRequest};
+
+pub(crate) struct SideSwapRequestHandler {
+    latest_request_id: Mutex<i64>,
+    sender: UnboundedSender<WrappedRequest>,
+    receiver: Mutex<UnboundedReceiver<WrappedRequest>>,
+}
+
+impl SideSwapRequestHandler {
+    pub(crate) fn new() -> Self {
+        let (sender, receiver) = unbounded_channel::<WrappedRequest>();
+        Self {
+            sender,
+            latest_request_id: Mutex::new(0),
+            receiver: Mutex::new(receiver),
+        }
+    }
+
+    pub(crate) async fn next_request_id(&self) -> i64 {
+        let mut request_id = self.latest_request_id.lock().await;
+        *request_id += 1;
+        *request_id
+    }
+
+    pub(crate) async fn send_ws(
+        &self,
+        ws_sender: &mut SplitSink<WebSocketStream, Message>,
+        msg: WrappedRequest,
+    ) {
+        match serde_json::to_string(&msg) {
+            Ok(msg) => match ws_sender.send(Message::Text(msg.clone().into())).await {
+                Ok(_) => debug!("Sent message to SideSwap service: {msg:?}"),
+                Err(e) => warn!("Failed to send message: {e:?}"),
+            },
+            Err(e) => error!("Failed to serialize message: {e:?}"),
+        }
+    }
+
+    pub(crate) async fn send(&self, request: Request) -> Result<i64> {
+        let request_id = self.next_request_id().await;
+        let msg = WrappedRequest {
+            id: RequestId::Int(request_id),
+            request,
+        };
+
+        self.sender
+            .send(msg)
+            .map_err(|err| anyhow!("Could not forward message to SideSwap service: {err}"))?;
+        Ok(request_id)
+    }
+
+    pub(crate) async fn recv(&self) -> Option<WrappedRequest> {
+        let mut receiver = self.receiver.lock().await;
+        receiver.recv().await
+    }
+}

--- a/lib/core/src/side_swap/api/response_handler.rs
+++ b/lib/core/src/side_swap/api/response_handler.rs
@@ -1,0 +1,61 @@
+use std::{collections::HashMap, time::Duration};
+
+use super::model::{RequestId, Response};
+use anyhow::{bail, Result};
+use log::warn;
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    Mutex,
+};
+
+const RECV_TIMEOUT_SECS: u64 = 10;
+
+pub(crate) struct SideSwapResponseHandler {
+    sender: UnboundedSender<i64>,
+    receiver: Mutex<UnboundedReceiver<i64>>,
+    received: Mutex<HashMap<i64, Response>>,
+}
+
+impl SideSwapResponseHandler {
+    pub(crate) fn new() -> Self {
+        let (sender, receiver) = unbounded_channel::<i64>();
+        Self {
+            sender,
+            receiver: Mutex::new(receiver),
+            received: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) async fn handle_response(&self, res_id: RequestId, res: Response) {
+        let RequestId::Int(res_id) = res_id else {
+            warn!("Could not handle response - invalid id received from server: {res_id:?}");
+            return;
+        };
+        self.received.lock().await.insert(res_id, res);
+        let _ = self.sender.send(res_id);
+    }
+
+    pub(crate) async fn recv(&self, res_id: i64) -> Result<Response> {
+        let mut received = self.received.lock().await;
+        if let Some(maybe_res) = received.remove(&res_id) {
+            return Ok(maybe_res);
+        }
+        drop(received);
+
+        tokio::time::timeout(Duration::from_secs(RECV_TIMEOUT_SECS), async {
+            let mut receiver = self.receiver.lock().await;
+            while let Some(new_id) = receiver.recv().await {
+                if new_id != res_id {
+                    continue;
+                }
+                let mut received = self.received.lock().await;
+                match received.remove(&res_id) {
+                    Some(maybe_res) => return Ok(maybe_res),
+                    None => bail!("Expected response from the server"),
+                }
+            }
+            bail!("Receive channel has been closed")
+        })
+        .await?
+    }
+}

--- a/lib/core/src/side_swap/mod.rs
+++ b/lib/core/src/side_swap/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod api;

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -92,11 +92,8 @@ impl OnchainWallet for MockWallet {
         Ok(TEST_LIQUID_TX.clone())
     }
 
-    async fn sign_pset(
-        &self,
-        _pset: PartiallySignedTransaction,
-    ) -> Result<Transaction, PaymentError> {
-        Ok(TEST_LIQUID_TX.clone())
+    async fn sign_pset(&self, _pset: &mut PartiallySignedTransaction) -> Result<(), PaymentError> {
+        Ok(())
     }
 
     async fn next_unused_address(&self) -> Result<Address, PaymentError> {

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -483,6 +483,7 @@ pub enum PayAmount {
         asset_id: String,
         receiver_amount: f64,
         estimate_asset_fees: Option<bool>,
+        pay_with_bitcoin: Option<bool>,
     },
     Drain,
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2791,6 +2791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           assetId: dco_decode_String(raw[1]),
           receiverAmount: dco_decode_f_64(raw[2]),
           estimateAssetFees: dco_decode_opt_box_autoadd_bool(raw[3]),
+          payWithBitcoin: dco_decode_opt_box_autoadd_bool(raw[4]),
         );
       case 2:
         return PayAmount_Drain();
@@ -5158,10 +5159,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_assetId = sse_decode_String(deserializer);
         var var_receiverAmount = sse_decode_f_64(deserializer);
         var var_estimateAssetFees = sse_decode_opt_box_autoadd_bool(deserializer);
+        var var_payWithBitcoin = sse_decode_opt_box_autoadd_bool(deserializer);
         return PayAmount_Asset(
           assetId: var_assetId,
           receiverAmount: var_receiverAmount,
           estimateAssetFees: var_estimateAssetFees,
+          payWithBitcoin: var_payWithBitcoin,
         );
       case 2:
         return PayAmount_Drain();
@@ -7488,11 +7491,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         assetId: final assetId,
         receiverAmount: final receiverAmount,
         estimateAssetFees: final estimateAssetFees,
+        payWithBitcoin: final payWithBitcoin,
       ):
         sse_encode_i_32(1, serializer);
         sse_encode_String(assetId, serializer);
         sse_encode_f_64(receiverAmount, serializer);
         sse_encode_opt_box_autoadd_bool(estimateAssetFees, serializer);
+        sse_encode_opt_box_autoadd_bool(payWithBitcoin, serializer);
       case PayAmount_Drain():
         sse_encode_i_32(2, serializer);
     }

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3387,10 +3387,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_asset_id = cst_encode_String(apiObj.assetId);
       var pre_receiver_amount = cst_encode_f_64(apiObj.receiverAmount);
       var pre_estimate_asset_fees = cst_encode_opt_box_autoadd_bool(apiObj.estimateAssetFees);
+      var pre_pay_with_bitcoin = cst_encode_opt_box_autoadd_bool(apiObj.payWithBitcoin);
       wireObj.tag = 1;
       wireObj.kind.Asset.asset_id = pre_asset_id;
       wireObj.kind.Asset.receiver_amount = pre_receiver_amount;
       wireObj.kind.Asset.estimate_asset_fees = pre_estimate_asset_fees;
+      wireObj.kind.Asset.pay_with_bitcoin = pre_pay_with_bitcoin;
       return;
     }
     if (apiObj is PayAmount_Drain) {
@@ -6720,6 +6722,8 @@ final class wire_cst_PayAmount_Asset extends ffi.Struct {
   external double receiver_amount;
 
   external ffi.Pointer<ffi.Bool> estimate_asset_fees;
+
+  external ffi.Pointer<ffi.Bool> pay_with_bitcoin;
 }
 
 final class PayAmountKind extends ffi.Union {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -772,6 +772,10 @@ sealed class PayAmount with _$PayAmount {
     required String assetId,
     required double receiverAmount,
     bool? estimateAssetFees,
+
+    /// Specifies whether or not to always use the wallet's L-BTC to execute the payment.
+    /// If true, it will try swapping the asset via the [Side Swap Service](crate::side_swap::api::SideSwapService)
+    bool? payWithBitcoin,
   }) = PayAmount_Asset;
 
   /// Indicates that all available Bitcoin funds should be sent

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -869,12 +869,15 @@ as BigInt,
 
 
 class PayAmount_Asset extends PayAmount {
-  const PayAmount_Asset({required this.assetId, required this.receiverAmount, this.estimateAssetFees}): super._();
+  const PayAmount_Asset({required this.assetId, required this.receiverAmount, this.estimateAssetFees, this.payWithBitcoin}): super._();
   
 
  final  String assetId;
  final  double receiverAmount;
  final  bool? estimateAssetFees;
+/// Specifies whether or not to always use the wallet's L-BTC to execute the payment.
+/// If true, it will try swapping the asset via the [Side Swap Service](crate::side_swap::api::SideSwapService)
+ final  bool? payWithBitcoin;
 
 /// Create a copy of PayAmount
 /// with the given fields replaced by the non-null parameter values.
@@ -886,16 +889,16 @@ $PayAmount_AssetCopyWith<PayAmount_Asset> get copyWith => _$PayAmount_AssetCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PayAmount_Asset&&(identical(other.assetId, assetId) || other.assetId == assetId)&&(identical(other.receiverAmount, receiverAmount) || other.receiverAmount == receiverAmount)&&(identical(other.estimateAssetFees, estimateAssetFees) || other.estimateAssetFees == estimateAssetFees));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PayAmount_Asset&&(identical(other.assetId, assetId) || other.assetId == assetId)&&(identical(other.receiverAmount, receiverAmount) || other.receiverAmount == receiverAmount)&&(identical(other.estimateAssetFees, estimateAssetFees) || other.estimateAssetFees == estimateAssetFees)&&(identical(other.payWithBitcoin, payWithBitcoin) || other.payWithBitcoin == payWithBitcoin));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,assetId,receiverAmount,estimateAssetFees);
+int get hashCode => Object.hash(runtimeType,assetId,receiverAmount,estimateAssetFees,payWithBitcoin);
 
 @override
 String toString() {
-  return 'PayAmount.asset(assetId: $assetId, receiverAmount: $receiverAmount, estimateAssetFees: $estimateAssetFees)';
+  return 'PayAmount.asset(assetId: $assetId, receiverAmount: $receiverAmount, estimateAssetFees: $estimateAssetFees, payWithBitcoin: $payWithBitcoin)';
 }
 
 
@@ -906,7 +909,7 @@ abstract mixin class $PayAmount_AssetCopyWith<$Res> implements $PayAmountCopyWit
   factory $PayAmount_AssetCopyWith(PayAmount_Asset value, $Res Function(PayAmount_Asset) _then) = _$PayAmount_AssetCopyWithImpl;
 @useResult
 $Res call({
- String assetId, double receiverAmount, bool? estimateAssetFees
+ String assetId, double receiverAmount, bool? estimateAssetFees, bool? payWithBitcoin
 });
 
 
@@ -923,11 +926,12 @@ class _$PayAmount_AssetCopyWithImpl<$Res>
 
 /// Create a copy of PayAmount
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? assetId = null,Object? receiverAmount = null,Object? estimateAssetFees = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? assetId = null,Object? receiverAmount = null,Object? estimateAssetFees = freezed,Object? payWithBitcoin = freezed,}) {
   return _then(PayAmount_Asset(
 assetId: null == assetId ? _self.assetId : assetId // ignore: cast_nullable_to_non_nullable
 as String,receiverAmount: null == receiverAmount ? _self.receiverAmount : receiverAmount // ignore: cast_nullable_to_non_nullable
 as double,estimateAssetFees: freezed == estimateAssetFees ? _self.estimateAssetFees : estimateAssetFees // ignore: cast_nullable_to_non_nullable
+as bool?,payWithBitcoin: freezed == payWithBitcoin ? _self.payWithBitcoin : payWithBitcoin // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
 
 dependencies:
   ffi: ^2.1.4
-  flutter_rust_bridge: ">=2.4.0 <=2.9.0"
+  flutter_rust_bridge: 2.9.0
   freezed_annotation: ^3.0.0
   logging: ^1.3.0
   meta: ^1.16.0

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4562,6 +4562,8 @@ final class wire_cst_PayAmount_Asset extends ffi.Struct {
   external double receiver_amount;
 
   external ffi.Pointer<ffi.Bool> estimate_asset_fees;
+
+  external ffi.Pointer<ffi.Bool> pay_with_bitcoin;
 }
 
 final class PayAmountKind extends ffi.Union {

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -1,7 +1,11 @@
 package com.breezsdkliquid
 import breez_sdk_liquid.*
 import com.facebook.react.bridge.*
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
+import java.io.File
 import java.util.*
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 fun asAcceptPaymentProposedFeesRequest(acceptPaymentProposedFeesRequest: ReadableMap): AcceptPaymentProposedFeesRequest? {
     if (!validateMandatoryFields(
@@ -3494,7 +3498,8 @@ fun asPayAmount(payAmount: ReadableMap): PayAmount? {
         val assetId = payAmount.getString("assetId")!!
         val receiverAmount = payAmount.getDouble("receiverAmount")
         val estimateAssetFees = if (hasNonNullKey(payAmount, "estimateAssetFees")) payAmount.getBoolean("estimateAssetFees") else null
-        return PayAmount.Asset(assetId, receiverAmount, estimateAssetFees)
+        val payWithBitcoin = if (hasNonNullKey(payAmount, "payWithBitcoin")) payAmount.getBoolean("payWithBitcoin") else null
+        return PayAmount.Asset(assetId, receiverAmount, estimateAssetFees, payWithBitcoin)
     }
     if (type == "drain") {
         return PayAmount.Drain
@@ -3514,6 +3519,7 @@ fun readableMapOf(payAmount: PayAmount): ReadableMap? {
             pushToMap(map, "assetId", payAmount.assetId)
             pushToMap(map, "receiverAmount", payAmount.receiverAmount)
             pushToMap(map, "estimateAssetFees", payAmount.estimateAssetFees)
+            pushToMap(map, "payWithBitcoin", payAmount.payWithBitcoin)
         }
         is PayAmount.Drain -> {
             pushToMap(map, "type", "drain")

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4322,7 +4322,9 @@ enum BreezSDKLiquidMapper {
             }
             let _estimateAssetFees = payAmount["estimateAssetFees"] as? Bool
 
-            return PayAmount.asset(assetId: _assetId, receiverAmount: _receiverAmount, estimateAssetFees: _estimateAssetFees)
+            let _payWithBitcoin = payAmount["payWithBitcoin"] as? Bool
+
+            return PayAmount.asset(assetId: _assetId, receiverAmount: _receiverAmount, estimateAssetFees: _estimateAssetFees, payWithBitcoin: _payWithBitcoin)
         }
         if type == "drain" {
             return PayAmount.drain
@@ -4342,13 +4344,14 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .asset(
-            assetId, receiverAmount, estimateAssetFees
+            assetId, receiverAmount, estimateAssetFees, payWithBitcoin
         ):
             return [
                 "type": "asset",
                 "assetId": assetId,
                 "receiverAmount": receiverAmount,
                 "estimateAssetFees": estimateAssetFees == nil ? nil : estimateAssetFees,
+                "payWithBitcoin": payWithBitcoin == nil ? nil : payWithBitcoin,
             ]
 
         case .drain:

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -700,6 +700,7 @@ export type PayAmount = {
     assetId: string
     receiverAmount: number
     estimateAssetFees?: boolean
+    payWithBitcoin?: boolean
 } | {
     type: PayAmountVariant.DRAIN
 }


### PR DESCRIPTION
This PR:
- Adds a base WebSocket layer to allow connections and exchange messages with the SideSwap API
- Adds `sideswap_api` as a dependency for the API types (currently pointing to local crate)

## To-dos
- [X] Add WebSocket start on-demand (swap lifetime only)
- [x] Fix WASM incompatibilities
- [x] Address `sideswap_api` crate issues or switch to custom branch