### PR TITLE
Downgrade to ubuntu 22.04 for built binaries

### DIFF
--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -44,7 +44,7 @@ jobs:
 
   build:
     if: ${{ !inputs.use-dummy-binaries }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: build ${{ matrix.target }}${{ matrix.uniffi }}
     needs: setup
     strategy:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -81,7 +81,7 @@ jobs:
           path: lib/bindings/langs/python/dist/*.whl
 
   build-linux-wheels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [x86_64, aarch64]


### PR DESCRIPTION
aljaz TG: https://t.me/breezsdk/2535
> any particular reason why are the libs compiled with such a new glibc requirement? its a big pain in the ass 
>
> /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/lib/python3.12/site-packages/breez_sdk_liquid/libbreez_sdk_liquid_bindings.so) 
> 
> this is using python bindings
>
> no official docker images of anything have glibc that is fresh enough