### PR TITLE
BOLT12 receive updates

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -177,7 +177,7 @@ jobs:
     - setup
     - build-dummies
     runs-on: ubuntu-latest
-    name: build jniLibs dummy ${{ matrix.target }}${{ matrix.uniffi }}
+    name: build jniLibs dummy ${{ matrix.uniffi }}
     strategy:
       matrix:
         uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
+source = "git+https://github.com/breez/boltz-rust?rev=d44295fa20da9c665a1f5580d16e387ff7245339#d44295fa20da9c665a1f5580d16e387ff7245339"
 dependencies = [
  "async-trait",
  "bip39",
@@ -648,7 +648,7 @@ dependencies = [
  "getrandom 0.2.14",
  "hex",
  "js-sys",
- "lightning 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-invoice 0.32.0",
  "log",
  "macros",
  "reqwest 0.12.12",
@@ -2568,34 +2568,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3225b37b2081fec068c481bbc80bd153bec905ada13379f58d462c00da9158"
+checksum = "ad202bfb8960e3043d167d507693b0ca853e727cf93ad0ba4b3663cc08b54eda"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin 0.32.5",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lightning-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "possiblyrandom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lightning"
-version = "0.1.2"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
-dependencies = [
- "bech32 0.11.0",
- "bitcoin 0.32.5",
- "dnssec-prover",
- "hashbrown 0.13.2",
- "libm",
- "lightning-invoice 0.33.2 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
- "lightning-types 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
- "musig2",
- "possiblyrandom 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "lightning-invoice 0.33.2",
+ "lightning-types 0.2.0",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -2614,23 +2598,35 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.5",
+ "lightning-types 0.1.0",
+]
+
+[[package]]
+name = "lightning-invoice"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin 0.32.5",
- "lightning-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-types 0.2.0",
 ]
 
 [[package]]
-name = "lightning-invoice"
-version = "0.33.2"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
 dependencies = [
- "bech32 0.11.0",
+ "bech32 0.9.1",
  "bitcoin 0.32.5",
- "lightning-types 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -2638,14 +2634,6 @@ name = "lightning-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin 0.32.5",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.2.0"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
 dependencies = [
  "bitcoin 0.32.5",
 ]
@@ -2770,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
+source = "git+https://github.com/breez/boltz-rust?rev=d44295fa20da9c665a1f5580d16e387ff7245339#d44295fa20da9c665a1f5580d16e387ff7245339"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2905,14 +2893,6 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "musig2"
-version = "0.1.0"
-source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
-dependencies = [
- "bitcoin 0.32.5",
-]
 
 [[package]]
 name = "native-tls"
@@ -3274,14 +3254,6 @@ name = "possiblyrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
-dependencies = [
- "getrandom 0.2.14",
-]
-
-[[package]]
-name = "possiblyrandom"
-version = "0.2.0"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
 dependencies = [
  "getrandom 0.2.14",
 ]
@@ -4190,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=4e1165bd0f78af6c716c52ab8ba401cfaac76f55#4e1165bd0f78af6c716c52ab8ba401cfaac76f55"
+source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
 dependencies = [
  "aes",
  "anyhow",
@@ -4206,7 +4178,7 @@ dependencies = [
  "hickory-resolver",
  "lazy_static",
  "lightning 0.0.118",
- "lightning 0.1.2 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "lightning 0.1.3",
  "lightning-invoice 0.26.0",
  "log",
  "maybe-sync",
@@ -4235,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=4e1165bd0f78af6c716c52ab8ba401cfaac76f55#4e1165bd0f78af6c716c52ab8ba401cfaac76f55"
+source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
+source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
 dependencies = [
  "aes",
  "anyhow",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
+source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/breez/boltz-rust?rev=0ffdc77b3db6a14484b1a948b78d506a6aebbafe#0ffdc77b3db6a14484b1a948b78d506a6aebbafe"
+source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
 dependencies = [
  "async-trait",
  "bip39",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/breez/boltz-rust?rev=0ffdc77b3db6a14484b1a948b78d506a6aebbafe#0ffdc77b3db6a14484b1a948b78d506a6aebbafe"
+source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/breez/boltz-rust?rev=0ffdc77b3db6a14484b1a948b78d506a6aebbafe#0ffdc77b3db6a14484b1a948b78d506a6aebbafe"
+source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
 dependencies = [
  "async-trait",
  "bip39",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/breez/boltz-rust?rev=0ffdc77b3db6a14484b1a948b78d506a6aebbafe#0ffdc77b3db6a14484b1a948b78d506a6aebbafe"
+source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
+source = "git+https://github.com/breez/boltz-rust?rev=d44295fa20da9c665a1f5580d16e387ff7245339#d44295fa20da9c665a1f5580d16e387ff7245339"
 dependencies = [
  "async-trait",
  "bip39",
@@ -771,7 +771,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hex",
  "js-sys",
- "lightning 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-invoice 0.32.0",
  "log",
  "macros",
  "reqwest 0.12.12",
@@ -2946,34 +2946,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3225b37b2081fec068c481bbc80bd153bec905ada13379f58d462c00da9158"
+checksum = "ad202bfb8960e3043d167d507693b0ca853e727cf93ad0ba4b3663cc08b54eda"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin 0.32.5",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lightning-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "possiblyrandom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lightning"
-version = "0.1.2"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
-dependencies = [
- "bech32 0.11.0",
- "bitcoin 0.32.5",
- "dnssec-prover",
- "hashbrown 0.13.2",
- "libm",
- "lightning-invoice 0.33.2 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
- "lightning-types 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
- "musig2",
- "possiblyrandom 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "lightning-invoice 0.33.2",
+ "lightning-types 0.2.0",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -2992,23 +2976,35 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.5",
+ "lightning-types 0.1.0",
+]
+
+[[package]]
+name = "lightning-invoice"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin 0.32.5",
- "lightning-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-types 0.2.0",
 ]
 
 [[package]]
-name = "lightning-invoice"
-version = "0.33.2"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
 dependencies = [
- "bech32 0.11.0",
+ "bech32 0.9.1",
  "bitcoin 0.32.5",
- "lightning-types 0.2.0 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -3016,14 +3012,6 @@ name = "lightning-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin 0.32.5",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.2.0"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
 dependencies = [
  "bitcoin 0.32.5",
 ]
@@ -3196,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/breez/boltz-rust?rev=84246f0e677e3f5b06553e379750a24869250789#84246f0e677e3f5b06553e379750a24869250789"
+source = "git+https://github.com/breez/boltz-rust?rev=d44295fa20da9c665a1f5580d16e387ff7245339#d44295fa20da9c665a1f5580d16e387ff7245339"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3345,14 +3333,6 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "musig2"
-version = "0.1.0"
-source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
-dependencies = [
- "bitcoin 0.32.5",
-]
 
 [[package]]
 name = "native-tls"
@@ -3718,14 +3698,6 @@ name = "possiblyrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
-dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "possiblyrandom"
-version = "0.2.0"
-source = "git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6#1ed173a39d4a415bab8171c3348b459f51f3b5e6"
 dependencies = [
  "getrandom 0.2.15",
 ]
@@ -4716,7 +4688,7 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=4e1165bd0f78af6c716c52ab8ba401cfaac76f55#4e1165bd0f78af6c716c52ab8ba401cfaac76f55"
+source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
 dependencies = [
  "aes",
  "anyhow",
@@ -4732,7 +4704,7 @@ dependencies = [
  "hickory-resolver",
  "lazy_static",
  "lightning 0.0.118",
- "lightning 0.1.2 (git+https://github.com/breez/rust-lightning?rev=1ed173a39d4a415bab8171c3348b459f51f3b5e6)",
+ "lightning 0.1.3",
  "lightning-invoice 0.26.0",
  "log",
  "maybe-sync",
@@ -4761,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=4e1165bd0f78af6c716c52ab8ba401cfaac76f55#4e1165bd0f78af6c716c52ab8ba401cfaac76f55"
+source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4688,7 +4688,7 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 [[package]]
 name = "sdk-common"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
+source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
 dependencies = [
  "aes",
  "anyhow",
@@ -4733,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=62584ee885581d65e2bcb797772fe79765239129#62584ee885581d65e2bcb797772fe79765239129"
+source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "4e1165bd0f78af6c716c52ab8ba401cfaac76f55", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "4e1165bd0f78af6c716c52ab8ba401cfaac76f55" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "62584ee885581d65e2bcb797772fe79765239129", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "62584ee885581d65e2bcb797772fe79765239129" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "62584ee885581d65e2bcb797772fe79765239129", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "62584ee885581d65e2bcb797772fe79765239129" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "247343395d02563087bade9aeb319ee6d9cdd549", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "247343395d02563087bade9aeb319ee6d9cdd549" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -1126,6 +1126,11 @@ typedef struct wire_cst_onchain_payment_limits_response {
   struct wire_cst_limits receive;
 } wire_cst_onchain_payment_limits_response;
 
+typedef struct wire_cst_PaymentError_AmountOutOfRange {
+  uint64_t min;
+  uint64_t max;
+} wire_cst_PaymentError_AmountOutOfRange;
+
 typedef struct wire_cst_PaymentError_AmountMissing {
   struct wire_cst_list_prim_u_8_strict *err;
 } wire_cst_PaymentError_AmountMissing;
@@ -1168,6 +1173,7 @@ typedef struct wire_cst_PaymentError_SignerError {
 } wire_cst_PaymentError_SignerError;
 
 typedef union PaymentErrorKind {
+  struct wire_cst_PaymentError_AmountOutOfRange AmountOutOfRange;
   struct wire_cst_PaymentError_AmountMissing AmountMissing;
   struct wire_cst_PaymentError_AssetError AssetError;
   struct wire_cst_PaymentError_InvalidNetwork InvalidNetwork;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -973,6 +973,10 @@ typedef struct wire_cst_LnUrlPayError_Generic {
   struct wire_cst_list_prim_u_8_strict *err;
 } wire_cst_LnUrlPayError_Generic;
 
+typedef struct wire_cst_LnUrlPayError_InsufficientBalance {
+  struct wire_cst_list_prim_u_8_strict *err;
+} wire_cst_LnUrlPayError_InsufficientBalance;
+
 typedef struct wire_cst_LnUrlPayError_InvalidAmount {
   struct wire_cst_list_prim_u_8_strict *err;
 } wire_cst_LnUrlPayError_InvalidAmount;
@@ -1015,6 +1019,7 @@ typedef struct wire_cst_LnUrlPayError_ServiceConnectivity {
 
 typedef union LnUrlPayErrorKind {
   struct wire_cst_LnUrlPayError_Generic Generic;
+  struct wire_cst_LnUrlPayError_InsufficientBalance InsufficientBalance;
   struct wire_cst_LnUrlPayError_InvalidAmount InvalidAmount;
   struct wire_cst_LnUrlPayError_InvalidInvoice InvalidInvoice;
   struct wire_cst_LnUrlPayError_InvalidNetwork InvalidNetwork;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/InvoiceRequest.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/InvoiceRequest.swift
@@ -45,19 +45,20 @@ class InvoiceRequestTask : ReplyableTask {
         do {
             let createBolt12InvoiceRes = try liquidSDK.createBolt12Invoice(req: CreateBolt12InvoiceRequest(offer: request!.offer, invoiceRequest: request!.invoice_request))
             self.replyServer(encodable: InvoiceRequestResponse(invoice: createBolt12InvoiceRes.invoice), replyURL: request!.reply_url)
+        } catch let e as PaymentError {
+            self.logger.log(tag: TAG, line: "failed to process invoice request: \(e)", level: "ERROR")
+            let error = e.localizedDescription
+            self.notifyError(request: request, error: error)
         } catch let e {
             self.logger.log(tag: TAG, line: "failed to process invoice request: \(e)", level: "ERROR")
-            let error: String
-            switch e {
-                case PaymentError.AmountOutOfRange(let message):
-                    error = message
-                case PaymentError.AmountMissing(let message):
-                    error = "Amount missing in invoice request"
-                default:
-                    error = "Failed to create invoice"
-            }
+            self.notifyError(request: request, error: "Failed to process invoice request")
+        } 
+    }
+
+    func notifyError(request: InvoiceRequestRequest?, error: String) {
+        if request != nil {
             self.replyServer(encodable: InvoiceErrorResponse(error: error), replyURL: request!.reply_url)
-            self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_REPLACEABLE)
         }
+        self.displayPushNotification(title: self.failNotificationTitle, logger: self.logger, threadIdentifier: Constants.NOTIFICATION_THREAD_REPLACEABLE)
     }
 }

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -172,6 +172,7 @@ dictionary LnUrlPayErrorData {
 interface LnUrlPayError {
     AlreadyPaid();
     Generic(string err);
+    InsufficientBalance(string err);
     InvalidAmount(string err);
     InvalidInvoice(string err);
     InvalidNetwork(string err);

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -77,7 +77,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "0ffdc77b3db6a14484b1a948b78d506a6aebbafe", features = [
+boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "84246f0e677e3f5b06553e379750a24869250789", features = [
     "electrum",
 ] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
@@ -98,7 +98,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "0ffdc77b3db6a14484b1a948b78d506a6aebbafe" }
+boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "84246f0e677e3f5b06553e379750a24869250789" }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -77,7 +77,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "84246f0e677e3f5b06553e379750a24869250789", features = [
+boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "d44295fa20da9c665a1f5580d16e387ff7245339", features = [
     "electrum",
 ] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
@@ -98,7 +98,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "84246f0e677e3f5b06553e379750a24869250789" }
+boltz-client = { git = "https://github.com/breez/boltz-rust", rev = "d44295fa20da9c665a1f5580d16e387ff7245339" }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [
     "backup",
     "bundled",

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -595,6 +595,10 @@ pub mod duplicates {
         #[error("Generic: {err}")]
         Generic { err: String },
 
+        /// This error is raised when the node does not have enough funds to make the payment.
+        #[error("Insufficient balance: {err}")]
+        InsufficientBalance { err: String },
+
         /// This error is raised when the amount from the parsed invoice is not set.
         #[error("Invalid amount: {err}")]
         InvalidAmount { err: String },
@@ -642,6 +646,9 @@ pub mod duplicates {
             match value {
                 sdk_common::prelude::LnUrlPayError::AlreadyPaid => Self::AlreadyPaid,
                 sdk_common::prelude::LnUrlPayError::Generic { err } => Self::Generic { err },
+                sdk_common::prelude::LnUrlPayError::InsufficientBalance { err } => {
+                    Self::InsufficientBalance { err }
+                }
                 sdk_common::prelude::LnUrlPayError::InvalidAmount { err } => {
                     Self::InvalidAmount { err }
                 }

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -75,8 +75,8 @@ pub enum PaymentError {
     #[error("The payment is already in progress")]
     PaymentInProgress,
 
-    #[error("Amount is out of range")]
-    AmountOutOfRange,
+    #[error("Amount must be between {min} and {max}")]
+    AmountOutOfRange { min: u64, max: u64 },
 
     #[error("Amount is missing: {err}")]
     AmountMissing { err: String },

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4115,7 +4115,12 @@ impl SseDecode for crate::error::PaymentError {
                 return crate::error::PaymentError::PaymentInProgress;
             }
             3 => {
-                return crate::error::PaymentError::AmountOutOfRange;
+                let mut var_min = <u64>::sse_decode(deserializer);
+                let mut var_max = <u64>::sse_decode(deserializer);
+                return crate::error::PaymentError::AmountOutOfRange {
+                    min: var_min,
+                    max: var_max,
+                };
             }
             4 => {
                 let mut var_err = <String>::sse_decode(deserializer);
@@ -6534,7 +6539,12 @@ impl flutter_rust_bridge::IntoDart for crate::error::PaymentError {
             crate::error::PaymentError::AlreadyClaimed => [0.into_dart()].into_dart(),
             crate::error::PaymentError::AlreadyPaid => [1.into_dart()].into_dart(),
             crate::error::PaymentError::PaymentInProgress => [2.into_dart()].into_dart(),
-            crate::error::PaymentError::AmountOutOfRange => [3.into_dart()].into_dart(),
+            crate::error::PaymentError::AmountOutOfRange { min, max } => [
+                3.into_dart(),
+                min.into_into_dart().into_dart(),
+                max.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
             crate::error::PaymentError::AmountMissing { err } => {
                 [4.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
@@ -8891,8 +8901,10 @@ impl SseEncode for crate::error::PaymentError {
             crate::error::PaymentError::PaymentInProgress => {
                 <i32>::sse_encode(2, serializer);
             }
-            crate::error::PaymentError::AmountOutOfRange => {
+            crate::error::PaymentError::AmountOutOfRange { min, max } => {
                 <i32>::sse_encode(3, serializer);
+                <u64>::sse_encode(min, serializer);
+                <u64>::sse_encode(max, serializer);
             }
             crate::error::PaymentError::AmountMissing { err } => {
                 <i32>::sse_encode(4, serializer);
@@ -11169,7 +11181,13 @@ mod io {
                 0 => crate::error::PaymentError::AlreadyClaimed,
                 1 => crate::error::PaymentError::AlreadyPaid,
                 2 => crate::error::PaymentError::PaymentInProgress,
-                3 => crate::error::PaymentError::AmountOutOfRange,
+                3 => {
+                    let ans = unsafe { self.kind.AmountOutOfRange };
+                    crate::error::PaymentError::AmountOutOfRange {
+                        min: ans.min.cst_decode(),
+                        max: ans.max.cst_decode(),
+                    }
+                }
                 4 => {
                     let ans = unsafe { self.kind.AmountMissing };
                     crate::error::PaymentError::AmountMissing {
@@ -15064,6 +15082,7 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub union PaymentErrorKind {
+        AmountOutOfRange: wire_cst_PaymentError_AmountOutOfRange,
         AmountMissing: wire_cst_PaymentError_AmountMissing,
         AssetError: wire_cst_PaymentError_AssetError,
         InvalidNetwork: wire_cst_PaymentError_InvalidNetwork,
@@ -15075,6 +15094,12 @@ mod io {
         SendError: wire_cst_PaymentError_SendError,
         SignerError: wire_cst_PaymentError_SignerError,
         nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_PaymentError_AmountOutOfRange {
+        min: u64,
+        max: u64,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -3384,43 +3384,49 @@ impl SseDecode for crate::bindings::duplicates::LnUrlPayError {
             }
             2 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InsufficientBalance {
+                    err: var_err,
+                };
             }
             3 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err: var_err };
             }
             4 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err: var_err };
             }
             5 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::InvalidUri { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err: var_err };
             }
             6 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InvalidUri { err: var_err };
             }
             7 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err: var_err };
             }
             8 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err: var_err };
             }
             9 => {
                 let mut var_err = <String>::sse_decode(deserializer);
-                return crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err: var_err };
+                return crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err: var_err };
             }
             10 => {
+                let mut var_err = <String>::sse_decode(deserializer);
+                return crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err: var_err };
+            }
+            11 => {
                 let mut var_err = <String>::sse_decode(deserializer);
                 return crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive {
                     err: var_err,
                 };
             }
-            11 => {
+            12 => {
                 let mut var_err = <String>::sse_decode(deserializer);
                 return crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity {
                     err: var_err,
@@ -5955,35 +5961,38 @@ impl flutter_rust_bridge::IntoDart for crate::bindings::duplicates::LnUrlPayErro
             crate::bindings::duplicates::LnUrlPayError::Generic { err } => {
                 [1.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InsufficientBalance { err } => {
                 [2.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err } => {
                 [3.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err } => {
                 [4.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidUri { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err } => {
                 [5.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidUri { err } => {
                 [6.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err } => {
                 [7.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err } => {
+            crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err } => {
                 [8.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err } => {
+            crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err } => {
                 [9.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive { err } => {
+            crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err } => {
                 [10.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
-            crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity { err } => {
+            crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive { err } => {
                 [11.into_dart(), err.into_into_dart().into_dart()].into_dart()
+            }
+            crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity { err } => {
+                [12.into_dart(), err.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -8289,44 +8298,48 @@ impl SseEncode for crate::bindings::duplicates::LnUrlPayError {
                 <i32>::sse_encode(1, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InsufficientBalance { err } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidAmount { err } => {
                 <i32>::sse_encode(3, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidInvoice { err } => {
                 <i32>::sse_encode(4, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::InvalidUri { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidNetwork { err } => {
                 <i32>::sse_encode(5, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvalidUri { err } => {
                 <i32>::sse_encode(6, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err } => {
+            crate::bindings::duplicates::LnUrlPayError::InvoiceExpired { err } => {
                 <i32>::sse_encode(7, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err } => {
+            crate::bindings::duplicates::LnUrlPayError::PaymentFailed { err } => {
                 <i32>::sse_encode(8, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err } => {
+            crate::bindings::duplicates::LnUrlPayError::PaymentTimeout { err } => {
                 <i32>::sse_encode(9, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive { err } => {
+            crate::bindings::duplicates::LnUrlPayError::RouteNotFound { err } => {
                 <i32>::sse_encode(10, serializer);
                 <String>::sse_encode(err, serializer);
             }
-            crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity { err } => {
+            crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive { err } => {
                 <i32>::sse_encode(11, serializer);
+                <String>::sse_encode(err, serializer);
+            }
+            crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity { err } => {
+                <i32>::sse_encode(12, serializer);
                 <String>::sse_encode(err, serializer);
             }
             _ => {
@@ -10785,60 +10798,66 @@ mod io {
                     }
                 }
                 2 => {
+                    let ans = unsafe { self.kind.InsufficientBalance };
+                    crate::bindings::duplicates::LnUrlPayError::InsufficientBalance {
+                        err: ans.err.cst_decode(),
+                    }
+                }
+                3 => {
                     let ans = unsafe { self.kind.InvalidAmount };
                     crate::bindings::duplicates::LnUrlPayError::InvalidAmount {
                         err: ans.err.cst_decode(),
                     }
                 }
-                3 => {
+                4 => {
                     let ans = unsafe { self.kind.InvalidInvoice };
                     crate::bindings::duplicates::LnUrlPayError::InvalidInvoice {
                         err: ans.err.cst_decode(),
                     }
                 }
-                4 => {
+                5 => {
                     let ans = unsafe { self.kind.InvalidNetwork };
                     crate::bindings::duplicates::LnUrlPayError::InvalidNetwork {
                         err: ans.err.cst_decode(),
                     }
                 }
-                5 => {
+                6 => {
                     let ans = unsafe { self.kind.InvalidUri };
                     crate::bindings::duplicates::LnUrlPayError::InvalidUri {
                         err: ans.err.cst_decode(),
                     }
                 }
-                6 => {
+                7 => {
                     let ans = unsafe { self.kind.InvoiceExpired };
                     crate::bindings::duplicates::LnUrlPayError::InvoiceExpired {
                         err: ans.err.cst_decode(),
                     }
                 }
-                7 => {
+                8 => {
                     let ans = unsafe { self.kind.PaymentFailed };
                     crate::bindings::duplicates::LnUrlPayError::PaymentFailed {
                         err: ans.err.cst_decode(),
                     }
                 }
-                8 => {
+                9 => {
                     let ans = unsafe { self.kind.PaymentTimeout };
                     crate::bindings::duplicates::LnUrlPayError::PaymentTimeout {
                         err: ans.err.cst_decode(),
                     }
                 }
-                9 => {
+                10 => {
                     let ans = unsafe { self.kind.RouteNotFound };
                     crate::bindings::duplicates::LnUrlPayError::RouteNotFound {
                         err: ans.err.cst_decode(),
                     }
                 }
-                10 => {
+                11 => {
                     let ans = unsafe { self.kind.RouteTooExpensive };
                     crate::bindings::duplicates::LnUrlPayError::RouteTooExpensive {
                         err: ans.err.cst_decode(),
                     }
                 }
-                11 => {
+                12 => {
                     let ans = unsafe { self.kind.ServiceConnectivity };
                     crate::bindings::duplicates::LnUrlPayError::ServiceConnectivity {
                         err: ans.err.cst_decode(),
@@ -14722,6 +14741,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub union LnUrlPayErrorKind {
         Generic: wire_cst_LnUrlPayError_Generic,
+        InsufficientBalance: wire_cst_LnUrlPayError_InsufficientBalance,
         InvalidAmount: wire_cst_LnUrlPayError_InvalidAmount,
         InvalidInvoice: wire_cst_LnUrlPayError_InvalidInvoice,
         InvalidNetwork: wire_cst_LnUrlPayError_InvalidNetwork,
@@ -14737,6 +14757,11 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_LnUrlPayError_Generic {
+        err: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_LnUrlPayError_InsufficientBalance {
         err: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1743,11 +1743,11 @@ impl LiquidSdk {
                     "Found MRH for L-BTC address {bip21}, invoice amount_sat {receiver_amount_sat}"
                 );
                 let signing_pubkey = invoice.signing_pubkey().to_string();
-                verify_mrh_signature(&bip21, &signing_pubkey, &signature)?;
+                let (_, address, _, _) = verify_mrh_signature(&bip21, &signing_pubkey, &signature)?;
 
                 self.pay_liquid(
                     LiquidAddressData {
-                        address: bip21,
+                        address,
                         network: self.config.network.into(),
                         asset_id: None,
                         amount: None,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -4337,29 +4337,28 @@ impl LiquidSdk {
     /// the new correct `webhook_url`. To unregister a webhook call [LiquidSdk::unregister_webhook].
     pub async fn register_webhook(&self, webhook_url: String) -> SdkResult<()> {
         info!("Registering for webhook notifications");
-        let maybe_old_webhook_url = self.persister.get_webhook_url()?;
-
         self.persister.set_webhook_url(webhook_url.clone())?;
 
-        // If the webhook URL has changed, update all bolt12 offers
-        if let Some(old_webhook_url) = maybe_old_webhook_url {
-            if old_webhook_url != webhook_url {
-                let bolt12_offers = self.persister.list_bolt12_offers()?;
-
-                for mut bolt12_offer in bolt12_offers {
-                    let keypair = bolt12_offer.get_keypair()?;
-                    let webhook_url_hash_sig = utils::sign_message_hash(&webhook_url, &keypair)?;
-                    self.swapper
-                        .update_bolt12_offer(UpdateBolt12OfferRequest {
-                            offer: bolt12_offer.id.clone(),
-                            url: Some(webhook_url.clone()),
-                            signature: webhook_url_hash_sig.to_hex(),
-                        })
-                        .await?;
-                    bolt12_offer.webhook_url = Some(webhook_url.clone());
-                    self.persister
-                        .insert_or_update_bolt12_offer(&bolt12_offer)?;
-                }
+        // Update all BOLT12 offers where the webhook URL is different
+        let bolt12_offers = self.persister.list_bolt12_offers()?;
+        for mut bolt12_offer in bolt12_offers {
+            if bolt12_offer
+                .webhook_url
+                .clone()
+                .is_none_or(|url| url != webhook_url)
+            {
+                let keypair = bolt12_offer.get_keypair()?;
+                let webhook_url_hash_sig = utils::sign_message_hash(&webhook_url, &keypair)?;
+                self.swapper
+                    .update_bolt12_offer(UpdateBolt12OfferRequest {
+                        offer: bolt12_offer.id.clone(),
+                        url: Some(webhook_url.clone()),
+                        signature: webhook_url_hash_sig.to_hex(),
+                    })
+                    .await?;
+                bolt12_offer.webhook_url = Some(webhook_url.clone());
+                self.persister
+                    .insert_or_update_bolt12_offer(&bolt12_offer)?;
             }
         }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1618,7 +1618,7 @@ impl LiquidSdk {
                 let fees_sat = fees_sat.ok_or(PaymentError::InsufficientFunds)?;
                 let bolt12_info = self
                     .swapper
-                    .get_bolt12_invoice(&offer.offer, *receiver_amount_sat)
+                    .get_bolt12_info(&offer.offer, *receiver_amount_sat)
                     .await?;
                 let mut response = self
                     .pay_bolt12_invoice(offer, *receiver_amount_sat, bolt12_info, fees_sat)
@@ -2871,6 +2871,7 @@ impl LiquidSdk {
         &self,
         req: &CreateBolt12InvoiceRequest,
     ) -> Result<CreateBolt12InvoiceResponse, PaymentError> {
+        debug!("Started create BOLT12 invoice");
         let bolt12_offer =
             self.persister
                 .fetch_bolt12_offer_by_id(&req.offer)?
@@ -3021,6 +3022,7 @@ impl LiquidSdk {
 
         let swap_id = create_response.id.clone();
         let destination_pubkey = cln_node_public_key.to_hex();
+        debug!("Created receive swap: {swap_id}");
 
         let create_response_json =
             ReceiveSwap::from_boltz_struct_to_json(&create_response, &swap_id, None)?;
@@ -3055,6 +3057,7 @@ impl LiquidSdk {
             })
             .map_err(|_| PaymentError::PersistError)?;
         self.status_stream.track_swap_id(&swap_id)?;
+        debug!("Finished create BOLT12 invoice");
 
         Ok(CreateBolt12InvoiceResponse {
             invoice: invoice_str,

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -553,7 +553,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
         Ok(())
     }
 
-    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, SdkError> {
+    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, PaymentError> {
         let res = self
             .get_boltz_client()
             .await?

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -10,8 +10,9 @@ use boltz_client::{
     boltz::{
         self, BoltzApiClientV2, ChainPair, Cooperative, CreateBolt12OfferRequest,
         CreateChainRequest, CreateChainResponse, CreateReverseRequest, CreateReverseResponse,
-        CreateSubmarineRequest, CreateSubmarineResponse, GetBolt12ParamsResponse, GetNodesResponse,
-        ReversePair, SubmarineClaimTxResponse, SubmarinePair, UpdateBolt12OfferRequest, WsRequest,
+        CreateSubmarineRequest, CreateSubmarineResponse, GetBolt12FetchResponse,
+        GetBolt12ParamsResponse, GetNodesResponse, ReversePair, SubmarineClaimTxResponse,
+        SubmarinePair, UpdateBolt12OfferRequest, WsRequest,
     },
     elements::secp256k1_zkp::{MusigPartialSignature, MusigPubNonce},
     network::Chain,
@@ -514,7 +515,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
         &self,
         offer: &str,
         amount_sat: u64,
-    ) -> Result<String, PaymentError> {
+    ) -> Result<GetBolt12FetchResponse, PaymentError> {
         let invoice_res = self
             .get_boltz_client()
             .await?
@@ -522,7 +523,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
             .get_bolt12_invoice(offer, amount_sat)
             .await?;
         info!("Received BOLT12 invoice response: {invoice_res:?}");
-        Ok(invoice_res.invoice)
+        Ok(invoice_res)
     }
 
     async fn create_bolt12_offer(&self, req: CreateBolt12OfferRequest) -> Result<(), SdkError> {

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -511,7 +511,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
         .map_err(Into::into)
     }
 
-    async fn get_bolt12_invoice(
+    async fn get_bolt12_info(
         &self,
         offer: &str,
         amount_sat: u64,

--- a/lib/core/src/swapper/boltz/status_stream.rs
+++ b/lib/core/src/swapper/boltz/status_stream.rs
@@ -46,6 +46,7 @@ impl<P: ProxyUrlFetcher> SwapperStatusStream for BoltzSwapper<P> {
         tokio::spawn(async move {
             loop {
                 debug!("Start of ws stream loop");
+                let mut request_stream = self.request_notifier.subscribe();
                 let client = match swapper.get_boltz_client().await {
                     Ok(client) => client,
                     Err(e) => {
@@ -57,9 +58,7 @@ impl<P: ProxyUrlFetcher> SwapperStatusStream for BoltzSwapper<P> {
                 match client.inner.connect_ws().await {
                     Ok(ws_stream) => {
                         let (mut sender, mut receiver) = ws_stream.split();
-
                         let mut tracked_ids: HashSet<String> = HashSet::new();
-                        let mut request_stream = self.request_notifier.subscribe();
 
                         callback.track_subscriptions().await;
 

--- a/lib/core/src/swapper/boltz/status_stream.rs
+++ b/lib/core/src/swapper/boltz/status_stream.rs
@@ -195,6 +195,16 @@ impl<P: ProxyUrlFetcher> SwapperStatusStream for BoltzSwapper<P> {
         Ok(())
     }
 
+    fn send_invoice_error(&self, id: &str, error: &str) -> Result<()> {
+        let _ = self
+            .request_notifier
+            .send(WsRequest::InvoiceError(boltz::InvoiceError {
+                id: id.to_string(),
+                error: error.to_string(),
+            }));
+        Ok(())
+    }
+
     fn subscribe_swap_updates(&self) -> broadcast::Receiver<boltz::SwapStatus> {
         self.update_notifier.subscribe()
     }

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -3,8 +3,8 @@ use boltz_client::{
     boltz::{
         ChainPair, CreateBolt12OfferRequest, CreateChainRequest, CreateChainResponse,
         CreateReverseRequest, CreateReverseResponse, CreateSubmarineRequest,
-        CreateSubmarineResponse, GetBolt12ParamsResponse, GetNodesResponse, ReversePair,
-        SubmarineClaimTxResponse, SubmarinePair, UpdateBolt12OfferRequest,
+        CreateSubmarineResponse, GetBolt12FetchResponse, GetBolt12ParamsResponse, GetNodesResponse,
+        ReversePair, SubmarineClaimTxResponse, SubmarinePair, UpdateBolt12OfferRequest,
     },
     network::Chain,
     Amount,
@@ -129,7 +129,7 @@ pub trait Swapper: MaybeSend + MaybeSync {
         &self,
         offer: &str,
         amount_sat: u64,
-    ) -> Result<String, PaymentError>;
+    ) -> Result<GetBolt12FetchResponse, PaymentError>;
 
     async fn create_bolt12_offer(&self, req: CreateBolt12OfferRequest) -> Result<(), SdkError>;
 

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -137,7 +137,7 @@ pub trait Swapper: MaybeSend + MaybeSync {
 
     async fn delete_bolt12_offer(&self, offer: &str, signature: &str) -> Result<(), SdkError>;
 
-    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, SdkError>;
+    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, PaymentError>;
 
     async fn get_nodes(&self) -> Result<GetNodesResponse, SdkError>;
 }

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -153,6 +153,7 @@ pub trait SwapperStatusStream: MaybeSend + MaybeSync {
     fn track_offer(&self, offer: &str, signature: &str) -> Result<()>;
 
     fn send_invoice_created(&self, id: &str, invoice: &str) -> Result<()>;
+    fn send_invoice_error(&self, id: &str, error: &str) -> Result<()>;
 
     fn subscribe_swap_updates(&self) -> broadcast::Receiver<boltz_client::boltz::SwapStatus>;
     fn subscribe_invoice_requests(

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -125,7 +125,7 @@ pub trait Swapper: MaybeSend + MaybeSync {
         invoice: &str,
     ) -> Result<Option<(String, boltz_client::bitcoin::Amount)>, PaymentError>;
 
-    async fn get_bolt12_invoice(
+    async fn get_bolt12_info(
         &self,
         offer: &str,
         amount_sat: u64,

--- a/lib/core/src/test_utils/status_stream.rs
+++ b/lib/core/src/test_utils/status_stream.rs
@@ -52,6 +52,10 @@ impl SwapperStatusStream for MockStatusStream {
         Ok(())
     }
 
+    fn send_invoice_error(&self, _id: &str, _error: &str) -> Result<()> {
+        Ok(())
+    }
+
     fn subscribe_swap_updates(&self) -> broadcast::Receiver<boltz::SwapStatus> {
         self.update_notifier.subscribe()
     }

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -3,7 +3,7 @@ use boltz_client::{
     boltz::{
         ChainFees, ChainMinerFees, ChainPair, ChainSwapDetails, CreateBolt12OfferRequest,
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse,
-        GetBolt12ParamsResponse, GetNodesResponse, Leaf, MagicRoutingHint, Node, PairLimits,
+        GetBolt12FetchResponse, GetBolt12ParamsResponse, GetNodesResponse, Leaf, Node, PairLimits,
         PairMinerFees, ReverseFees, ReverseLimits, ReversePair, SubmarineClaimTxResponse,
         SubmarineFees, SubmarinePair, SubmarinePairLimits, SwapTree, UpdateBolt12OfferRequest,
     },
@@ -349,7 +349,7 @@ impl Swapper for MockSwapper {
         &self,
         _offer: &str,
         _amount_sat: u64,
-    ) -> Result<String, PaymentError> {
+    ) -> Result<GetBolt12FetchResponse, PaymentError> {
         unimplemented!()
     }
 
@@ -366,12 +366,7 @@ impl Swapper for MockSwapper {
     }
 
     async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, SdkError> {
-        Ok(GetBolt12ParamsResponse {
-            min_cltv: 180,
-            magic_routing_hint: MagicRoutingHint {
-                channel_id: "596385002596073472".to_string(),
-            },
-        })
+        Ok(GetBolt12ParamsResponse { min_cltv: 180 })
     }
 
     async fn get_nodes(&self) -> Result<GetNodesResponse, SdkError> {

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -365,7 +365,7 @@ impl Swapper for MockSwapper {
         Ok(())
     }
 
-    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, SdkError> {
+    async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, PaymentError> {
         Ok(GetBolt12ParamsResponse { min_cltv: 180 })
     }
 

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -345,7 +345,7 @@ impl Swapper for MockSwapper {
         unimplemented!()
     }
 
-    async fn get_bolt12_invoice(
+    async fn get_bolt12_info(
         &self,
         _offer: &str,
         _amount_sat: u64,

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -54,7 +54,7 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     let (prepare_response, receive_response) = handle_alice
         .receive_payment(&PrepareReceiveRequest {
-            payment_method: breez_sdk_liquid::model::PaymentMethod::Lightning,
+            payment_method: breez_sdk_liquid::model::PaymentMethod::Bolt11Invoice,
             amount: Some(breez_sdk_liquid::model::ReceiveAmount::Bitcoin { payer_amount_sat }),
         })
         .await
@@ -169,7 +169,7 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     let (_, receive_response) = handle_bob
         .receive_payment(&PrepareReceiveRequest {
-            payment_method: breez_sdk_liquid::model::PaymentMethod::Lightning,
+            payment_method: breez_sdk_liquid::model::PaymentMethod::Bolt11Invoice,
             amount: Some(breez_sdk_liquid::model::ReceiveAmount::Bitcoin {
                 payer_amount_sat: receiver_amount_sat,
             }),

--- a/packages/dart/lib/src/bindings/duplicates.dart
+++ b/packages/dart/lib/src/bindings/duplicates.dart
@@ -50,6 +50,9 @@ sealed class LnUrlPayError with _$LnUrlPayError implements FrbException {
   /// in this enum.
   const factory LnUrlPayError.generic({required String err}) = LnUrlPayError_Generic;
 
+  /// This error is raised when the node does not have enough funds to make the payment.
+  const factory LnUrlPayError.insufficientBalance({required String err}) = LnUrlPayError_InsufficientBalance;
+
   /// This error is raised when the amount from the parsed invoice is not set.
   const factory LnUrlPayError.invalidAmount({required String err}) = LnUrlPayError_InvalidAmount;
 

--- a/packages/dart/lib/src/bindings/duplicates.freezed.dart
+++ b/packages/dart/lib/src/bindings/duplicates.freezed.dart
@@ -530,6 +530,72 @@ as String,
 /// @nodoc
 
 
+class LnUrlPayError_InsufficientBalance extends LnUrlPayError {
+  const LnUrlPayError_InsufficientBalance({required this.err}): super._();
+  
+
+ final  String err;
+
+/// Create a copy of LnUrlPayError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LnUrlPayError_InsufficientBalanceCopyWith<LnUrlPayError_InsufficientBalance> get copyWith => _$LnUrlPayError_InsufficientBalanceCopyWithImpl<LnUrlPayError_InsufficientBalance>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LnUrlPayError_InsufficientBalance&&(identical(other.err, err) || other.err == err));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,err);
+
+@override
+String toString() {
+  return 'LnUrlPayError.insufficientBalance(err: $err)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LnUrlPayError_InsufficientBalanceCopyWith<$Res> implements $LnUrlPayErrorCopyWith<$Res> {
+  factory $LnUrlPayError_InsufficientBalanceCopyWith(LnUrlPayError_InsufficientBalance value, $Res Function(LnUrlPayError_InsufficientBalance) _then) = _$LnUrlPayError_InsufficientBalanceCopyWithImpl;
+@useResult
+$Res call({
+ String err
+});
+
+
+
+
+}
+/// @nodoc
+class _$LnUrlPayError_InsufficientBalanceCopyWithImpl<$Res>
+    implements $LnUrlPayError_InsufficientBalanceCopyWith<$Res> {
+  _$LnUrlPayError_InsufficientBalanceCopyWithImpl(this._self, this._then);
+
+  final LnUrlPayError_InsufficientBalance _self;
+  final $Res Function(LnUrlPayError_InsufficientBalance) _then;
+
+/// Create a copy of LnUrlPayError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? err = null,}) {
+  return _then(LnUrlPayError_InsufficientBalance(
+err: null == err ? _self.err : err // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
 class LnUrlPayError_InvalidAmount extends LnUrlPayError {
   const LnUrlPayError_InvalidAmount({required this.err}): super._();
   

--- a/packages/dart/lib/src/error.dart
+++ b/packages/dart/lib/src/error.dart
@@ -15,7 +15,8 @@ sealed class PaymentError with _$PaymentError implements FrbException {
   const factory PaymentError.alreadyClaimed() = PaymentError_AlreadyClaimed;
   const factory PaymentError.alreadyPaid() = PaymentError_AlreadyPaid;
   const factory PaymentError.paymentInProgress() = PaymentError_PaymentInProgress;
-  const factory PaymentError.amountOutOfRange() = PaymentError_AmountOutOfRange;
+  const factory PaymentError.amountOutOfRange({required BigInt min, required BigInt max}) =
+      PaymentError_AmountOutOfRange;
   const factory PaymentError.amountMissing({required String err}) = PaymentError_AmountMissing;
   const factory PaymentError.assetError({required String err}) = PaymentError_AssetError;
   const factory PaymentError.invalidNetwork({required String err}) = PaymentError_InvalidNetwork;

--- a/packages/dart/lib/src/error.freezed.dart
+++ b/packages/dart/lib/src/error.freezed.dart
@@ -142,33 +142,69 @@ String toString() {
 
 
 class PaymentError_AmountOutOfRange extends PaymentError {
-  const PaymentError_AmountOutOfRange(): super._();
+  const PaymentError_AmountOutOfRange({required this.min, required this.max}): super._();
   
 
+ final  BigInt min;
+ final  BigInt max;
 
-
+/// Create a copy of PaymentError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PaymentError_AmountOutOfRangeCopyWith<PaymentError_AmountOutOfRange> get copyWith => _$PaymentError_AmountOutOfRangeCopyWithImpl<PaymentError_AmountOutOfRange>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentError_AmountOutOfRange);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentError_AmountOutOfRange&&(identical(other.min, min) || other.min == min)&&(identical(other.max, max) || other.max == max));
 }
 
 
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,min,max);
 
 @override
 String toString() {
-  return 'PaymentError.amountOutOfRange()';
+  return 'PaymentError.amountOutOfRange(min: $min, max: $max)';
 }
 
 
 }
 
+/// @nodoc
+abstract mixin class $PaymentError_AmountOutOfRangeCopyWith<$Res> implements $PaymentErrorCopyWith<$Res> {
+  factory $PaymentError_AmountOutOfRangeCopyWith(PaymentError_AmountOutOfRange value, $Res Function(PaymentError_AmountOutOfRange) _then) = _$PaymentError_AmountOutOfRangeCopyWithImpl;
+@useResult
+$Res call({
+ BigInt min, BigInt max
+});
 
 
+
+
+}
+/// @nodoc
+class _$PaymentError_AmountOutOfRangeCopyWithImpl<$Res>
+    implements $PaymentError_AmountOutOfRangeCopyWith<$Res> {
+  _$PaymentError_AmountOutOfRangeCopyWithImpl(this._self, this._then);
+
+  final PaymentError_AmountOutOfRange _self;
+  final $Res Function(PaymentError_AmountOutOfRange) _then;
+
+/// Create a copy of PaymentError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? min = null,Object? max = null,}) {
+  return _then(PaymentError_AmountOutOfRange(
+min: null == min ? _self.min : min // ignore: cast_nullable_to_non_nullable
+as BigInt,max: null == max ? _self.max : max // ignore: cast_nullable_to_non_nullable
+as BigInt,
+  ));
+}
+
+
+}
 
 /// @nodoc
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2449,24 +2449,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 1:
         return LnUrlPayError_Generic(err: dco_decode_String(raw[1]));
       case 2:
-        return LnUrlPayError_InvalidAmount(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InsufficientBalance(err: dco_decode_String(raw[1]));
       case 3:
-        return LnUrlPayError_InvalidInvoice(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InvalidAmount(err: dco_decode_String(raw[1]));
       case 4:
-        return LnUrlPayError_InvalidNetwork(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InvalidInvoice(err: dco_decode_String(raw[1]));
       case 5:
-        return LnUrlPayError_InvalidUri(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InvalidNetwork(err: dco_decode_String(raw[1]));
       case 6:
-        return LnUrlPayError_InvoiceExpired(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InvalidUri(err: dco_decode_String(raw[1]));
       case 7:
-        return LnUrlPayError_PaymentFailed(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_InvoiceExpired(err: dco_decode_String(raw[1]));
       case 8:
-        return LnUrlPayError_PaymentTimeout(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_PaymentFailed(err: dco_decode_String(raw[1]));
       case 9:
-        return LnUrlPayError_RouteNotFound(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_PaymentTimeout(err: dco_decode_String(raw[1]));
       case 10:
-        return LnUrlPayError_RouteTooExpensive(err: dco_decode_String(raw[1]));
+        return LnUrlPayError_RouteNotFound(err: dco_decode_String(raw[1]));
       case 11:
+        return LnUrlPayError_RouteTooExpensive(err: dco_decode_String(raw[1]));
+      case 12:
         return LnUrlPayError_ServiceConnectivity(err: dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
@@ -4674,32 +4676,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return LnUrlPayError_Generic(err: var_err);
       case 2:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_InvalidAmount(err: var_err);
+        return LnUrlPayError_InsufficientBalance(err: var_err);
       case 3:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_InvalidInvoice(err: var_err);
+        return LnUrlPayError_InvalidAmount(err: var_err);
       case 4:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_InvalidNetwork(err: var_err);
+        return LnUrlPayError_InvalidInvoice(err: var_err);
       case 5:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_InvalidUri(err: var_err);
+        return LnUrlPayError_InvalidNetwork(err: var_err);
       case 6:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_InvoiceExpired(err: var_err);
+        return LnUrlPayError_InvalidUri(err: var_err);
       case 7:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_PaymentFailed(err: var_err);
+        return LnUrlPayError_InvoiceExpired(err: var_err);
       case 8:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_PaymentTimeout(err: var_err);
+        return LnUrlPayError_PaymentFailed(err: var_err);
       case 9:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_RouteNotFound(err: var_err);
+        return LnUrlPayError_PaymentTimeout(err: var_err);
       case 10:
         var var_err = sse_decode_String(deserializer);
-        return LnUrlPayError_RouteTooExpensive(err: var_err);
+        return LnUrlPayError_RouteNotFound(err: var_err);
       case 11:
+        var var_err = sse_decode_String(deserializer);
+        return LnUrlPayError_RouteTooExpensive(err: var_err);
+      case 12:
         var var_err = sse_decode_String(deserializer);
         return LnUrlPayError_ServiceConnectivity(err: var_err);
       default:
@@ -7041,35 +7046,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case LnUrlPayError_Generic(err: final err):
         sse_encode_i_32(1, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_InvalidAmount(err: final err):
+      case LnUrlPayError_InsufficientBalance(err: final err):
         sse_encode_i_32(2, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_InvalidInvoice(err: final err):
+      case LnUrlPayError_InvalidAmount(err: final err):
         sse_encode_i_32(3, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_InvalidNetwork(err: final err):
+      case LnUrlPayError_InvalidInvoice(err: final err):
         sse_encode_i_32(4, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_InvalidUri(err: final err):
+      case LnUrlPayError_InvalidNetwork(err: final err):
         sse_encode_i_32(5, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_InvoiceExpired(err: final err):
+      case LnUrlPayError_InvalidUri(err: final err):
         sse_encode_i_32(6, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_PaymentFailed(err: final err):
+      case LnUrlPayError_InvoiceExpired(err: final err):
         sse_encode_i_32(7, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_PaymentTimeout(err: final err):
+      case LnUrlPayError_PaymentFailed(err: final err):
         sse_encode_i_32(8, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_RouteNotFound(err: final err):
+      case LnUrlPayError_PaymentTimeout(err: final err):
         sse_encode_i_32(9, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_RouteTooExpensive(err: final err):
+      case LnUrlPayError_RouteNotFound(err: final err):
         sse_encode_i_32(10, serializer);
         sse_encode_String(err, serializer);
-      case LnUrlPayError_ServiceConnectivity(err: final err):
+      case LnUrlPayError_RouteTooExpensive(err: final err):
         sse_encode_i_32(11, serializer);
+        sse_encode_String(err, serializer);
+      case LnUrlPayError_ServiceConnectivity(err: final err):
+        sse_encode_i_32(12, serializer);
         sse_encode_String(err, serializer);
     }
   }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2884,7 +2884,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return PaymentError_PaymentInProgress();
       case 3:
-        return PaymentError_AmountOutOfRange();
+        return PaymentError_AmountOutOfRange(min: dco_decode_u_64(raw[1]), max: dco_decode_u_64(raw[2]));
       case 4:
         return PaymentError_AmountMissing(err: dco_decode_String(raw[1]));
       case 5:
@@ -5282,7 +5282,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return PaymentError_PaymentInProgress();
       case 3:
-        return PaymentError_AmountOutOfRange();
+        var var_min = sse_decode_u_64(deserializer);
+        var var_max = sse_decode_u_64(deserializer);
+        return PaymentError_AmountOutOfRange(min: var_min, max: var_max);
       case 4:
         var var_err = sse_decode_String(deserializer);
         return PaymentError_AmountMissing(err: var_err);
@@ -7567,8 +7569,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(1, serializer);
       case PaymentError_PaymentInProgress():
         sse_encode_i_32(2, serializer);
-      case PaymentError_AmountOutOfRange():
+      case PaymentError_AmountOutOfRange(min: final min, max: final max):
         sse_encode_i_32(3, serializer);
+        sse_encode_u_64(min, serializer);
+        sse_encode_u_64(max, serializer);
       case PaymentError_AmountMissing(err: final err):
         sse_encode_i_32(4, serializer);
         sse_encode_String(err, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3508,7 +3508,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       return;
     }
     if (apiObj is PaymentError_AmountOutOfRange) {
+      var pre_min = cst_encode_u_64(apiObj.min);
+      var pre_max = cst_encode_u_64(apiObj.max);
       wireObj.tag = 3;
+      wireObj.kind.AmountOutOfRange.min = pre_min;
+      wireObj.kind.AmountOutOfRange.max = pre_max;
       return;
     }
     if (apiObj is PaymentError_AmountMissing) {
@@ -7822,6 +7826,14 @@ final class wire_cst_onchain_payment_limits_response extends ffi.Struct {
   external wire_cst_limits receive;
 }
 
+final class wire_cst_PaymentError_AmountOutOfRange extends ffi.Struct {
+  @ffi.Uint64()
+  external int min;
+
+  @ffi.Uint64()
+  external int max;
+}
+
 final class wire_cst_PaymentError_AmountMissing extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
@@ -7865,6 +7877,8 @@ final class wire_cst_PaymentError_SignerError extends ffi.Struct {
 }
 
 final class PaymentErrorKind extends ffi.Union {
+  external wire_cst_PaymentError_AmountOutOfRange AmountOutOfRange;
+
   external wire_cst_PaymentError_AmountMissing AmountMissing;
 
   external wire_cst_PaymentError_AssetError AssetError;

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3115,63 +3115,69 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Generic.err = pre_err;
       return;
     }
-    if (apiObj is LnUrlPayError_InvalidAmount) {
+    if (apiObj is LnUrlPayError_InsufficientBalance) {
       var pre_err = cst_encode_String(apiObj.err);
       wireObj.tag = 2;
+      wireObj.kind.InsufficientBalance.err = pre_err;
+      return;
+    }
+    if (apiObj is LnUrlPayError_InvalidAmount) {
+      var pre_err = cst_encode_String(apiObj.err);
+      wireObj.tag = 3;
       wireObj.kind.InvalidAmount.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_InvalidInvoice) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 3;
+      wireObj.tag = 4;
       wireObj.kind.InvalidInvoice.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_InvalidNetwork) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 4;
+      wireObj.tag = 5;
       wireObj.kind.InvalidNetwork.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_InvalidUri) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 5;
+      wireObj.tag = 6;
       wireObj.kind.InvalidUri.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_InvoiceExpired) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 6;
+      wireObj.tag = 7;
       wireObj.kind.InvoiceExpired.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_PaymentFailed) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 7;
+      wireObj.tag = 8;
       wireObj.kind.PaymentFailed.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_PaymentTimeout) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 8;
+      wireObj.tag = 9;
       wireObj.kind.PaymentTimeout.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_RouteNotFound) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 9;
+      wireObj.tag = 10;
       wireObj.kind.RouteNotFound.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_RouteTooExpensive) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 10;
+      wireObj.tag = 11;
       wireObj.kind.RouteTooExpensive.err = pre_err;
       return;
     }
     if (apiObj is LnUrlPayError_ServiceConnectivity) {
       var pre_err = cst_encode_String(apiObj.err);
-      wireObj.tag = 11;
+      wireObj.tag = 12;
       wireObj.kind.ServiceConnectivity.err = pre_err;
       return;
     }
@@ -7644,6 +7650,10 @@ final class wire_cst_LnUrlPayError_Generic extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
 
+final class wire_cst_LnUrlPayError_InsufficientBalance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
+}
+
 final class wire_cst_LnUrlPayError_InvalidAmount extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
@@ -7686,6 +7696,8 @@ final class wire_cst_LnUrlPayError_ServiceConnectivity extends ffi.Struct {
 
 final class LnUrlPayErrorKind extends ffi.Union {
   external wire_cst_LnUrlPayError_Generic Generic;
+
+  external wire_cst_LnUrlPayError_InsufficientBalance InsufficientBalance;
 
   external wire_cst_LnUrlPayError_InvalidAmount InvalidAmount;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5501,6 +5501,10 @@ final class wire_cst_LnUrlPayError_Generic extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
 
+final class wire_cst_LnUrlPayError_InsufficientBalance extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
+}
+
 final class wire_cst_LnUrlPayError_InvalidAmount extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
@@ -5543,6 +5547,8 @@ final class wire_cst_LnUrlPayError_ServiceConnectivity extends ffi.Struct {
 
 final class LnUrlPayErrorKind extends ffi.Union {
   external wire_cst_LnUrlPayError_Generic Generic;
+
+  external wire_cst_LnUrlPayError_InsufficientBalance InsufficientBalance;
 
   external wire_cst_LnUrlPayError_InvalidAmount InvalidAmount;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5683,6 +5683,14 @@ final class wire_cst_onchain_payment_limits_response extends ffi.Struct {
   external wire_cst_limits receive;
 }
 
+final class wire_cst_PaymentError_AmountOutOfRange extends ffi.Struct {
+  @ffi.Uint64()
+  external int min;
+
+  @ffi.Uint64()
+  external int max;
+}
+
 final class wire_cst_PaymentError_AmountMissing extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> err;
 }
@@ -5726,6 +5734,8 @@ final class wire_cst_PaymentError_SignerError extends ffi.Struct {
 }
 
 final class PaymentErrorKind extends ffi.Union {
+  external wire_cst_PaymentError_AmountOutOfRange AmountOutOfRange;
+
   external wire_cst_PaymentError_AmountMissing AmountMissing;
 
   external wire_cst_PaymentError_AssetError AssetError;


### PR DESCRIPTION
This PR:
- Sends the BOLT12 invoice request error immediately back via websocket or webhook response
- Removes setting the BOLT12 invoice blinded payment path to the MRH short channel id
- Uses the MRH returned alongside fetching the BOLT12 invoice to send directly via Liquid tx
- Optimizes requests to Boltz during invoice creation (remove request to get CLN node public key, parellelize requests to get BOLT12 params and reverse swap pairs)

**Testing notes:**
- When paying under the minimum receive amount (< 100sat) from Phoenix, you should receive a payment failure error faster. Test Misty when both in foreground and background

Builds:
- Android 432: https://github.com/breez/misty-breez/actions/runs/14836581663
- iOS TestFlight 6418.1: https://github.com/breez/misty-breez/actions/runs/14836943107