### PR TITLE
Fix recommended fees calculation

### DIFF
--- a/lib/core/src/chain/bitcoin/electrum.rs
+++ b/lib/core/src/chain/bitcoin/electrum.rs
@@ -318,7 +318,7 @@ impl BitcoinChainService for ElectrumBitcoinChainService {
             .get_client()?
             .batch_estimate_fee([1, 3, 6, 25, 1008])?
             .into_iter()
-            .map(|v| v.ceil() as u64)
+            .map(|v| (v * 100_000.0).ceil() as u64)
             .collect();
         Ok(RecommendedFees {
             fastest_fee: fees[0],


### PR DESCRIPTION
```

blockchain.estimatefee

Return the estimated transaction fee per kilobyte for a transaction to be confirmed within a certain number of blocks.

Result

    The estimated transaction fee in coin units per kilobyte, as a floating point number. If the daemon does not have enough information to make an estimate, the integer -1 is returned.

Example Result

0.00001

```