### PR TITLE
Set the BOLT12 Offer min amount

### DIFF
--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -563,7 +563,7 @@ impl<P: ProxyUrlFetcher> Swapper for BoltzSwapper<P> {
         Ok(res)
     }
 
-    async fn get_nodes(&self) -> Result<GetNodesResponse, SdkError> {
+    async fn get_nodes(&self) -> Result<GetNodesResponse, PaymentError> {
         let res = self.get_boltz_client().await?.inner.get_nodes().await?;
         Ok(res)
     }

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -139,7 +139,7 @@ pub trait Swapper: MaybeSend + MaybeSync {
 
     async fn get_bolt12_params(&self) -> Result<GetBolt12ParamsResponse, PaymentError>;
 
-    async fn get_nodes(&self) -> Result<GetNodesResponse, SdkError>;
+    async fn get_nodes(&self) -> Result<GetNodesResponse, PaymentError>;
 }
 
 pub trait SwapperStatusStream: MaybeSend + MaybeSync {

--- a/lib/core/src/test_utils/bolt12_offer.rs
+++ b/lib/core/src/test_utils/bolt12_offer.rs
@@ -3,7 +3,7 @@ use crate::{model::Bolt12Offer, test_utils::generate_random_string, utils};
 pub fn new_bolt12_offer(description: Option<String>, webhook_url: Option<String>) -> Bolt12Offer {
     Bolt12Offer {
         id: generate_random_string(32),
-        description: description.unwrap_or("default".to_string()),
+        description: description.unwrap_or("".to_string()),
         private_key: "945affeef55f12227f1d4a3f80a17062a05b229ddc5a01591eb5ddf882df92e3".to_string(),
         webhook_url,
         created_at: utils::now(),

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -369,7 +369,7 @@ impl Swapper for MockSwapper {
         Ok(GetBolt12ParamsResponse { min_cltv: 180 })
     }
 
-    async fn get_nodes(&self) -> Result<GetNodesResponse, SdkError> {
+    async fn get_nodes(&self) -> Result<GetNodesResponse, PaymentError> {
         Ok(GetNodesResponse {
             btc: HashMap::from([(
                 "CLN".to_string(),


### PR DESCRIPTION
This PR sets the BOLT12 offer minimum amount to the receive payment minimum limit (currently 100sat). When setting the minimum a description needs to be set also, which can be done using the `description` param of `ReceivePaymentRequest`

Misty PR: https://github.com/breez/misty-breez/pull/537

**Testing notes:**
- Using either the BOLT12 offer or BIP353 address, send a payment using the **latest** Phoenix. Edit the amount (set default to the minimum amount). Check the description is set (in Misty it's "Pay to Misty Breez")

**Builds:**
- Android: https://github.com/breez/misty-breez/actions/runs/15036725919
- iOS 6426.1: https://github.com/breez/misty-breez/actions/runs/15036727917