### PR TITLE
Side-Swap: SDK Integration

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sideswap_api",
  "strum",
  "strum_macros",
  "tempfile",
@@ -866,7 +867,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1027,6 +1028,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2155,7 +2191,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.100",
  "unic-langid",
 ]
@@ -2313,6 +2349,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4373,6 +4415,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,6 +4463,30 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sideswap_api"
+version = "0.1.2"
+source = "git+https://github.com/hydra-yse/sideswap_rust?rev=83313c970825#83313c970825faf5b77e702a307f344d4f5e667f"
+dependencies = [
+ "elements",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sideswap_types",
+]
+
+[[package]]
+name = "sideswap_types"
+version = "0.1.2"
+source = "git+https://github.com/hydra-yse/sideswap_rust?rev=83313c970825#83313c970825faf5b77e702a307f344d4f5e667f"
+dependencies = [
+ "elements",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "slab"
@@ -4454,6 +4542,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -746,6 +746,14 @@ dictionary PrepareAssetSwapResponse {
     AssetSwap asset_swap;
 };
 
+dictionary ExecuteAssetSwapRequest {
+    PrepareAssetSwapResponse prepare_response;
+};
+
+dictionary ExecuteAssetSwapResponse {
+    Payment payment;
+};
+
 namespace breez_sdk_liquid {
     [Throws=SdkError]
     BindingLiquidSdk connect(ConnectRequest req);

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -737,6 +737,15 @@ dictionary AssetSwap {
     u64 fees_sat;
 };
 
+dictionary PrepareAssetSwapRequest {
+    string asset_id;
+    u64 send_amount_sat;
+};
+
+dictionary PrepareAssetSwapResponse {
+    AssetSwap asset_swap;
+};
+
 namespace breez_sdk_liquid {
     [Throws=SdkError]
     BindingLiquidSdk connect(ConnectRequest req);

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -24,7 +24,6 @@ use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
 use crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT;
-use crate::utils;
 use crate::{
     bitcoin,
     chain::{bitcoin::BitcoinChainService, liquid::LiquidChainService},
@@ -34,6 +33,10 @@ use crate::{
 use crate::{
     chain::bitcoin::esplora::EsploraBitcoinChainService,
     chain::liquid::esplora::EsploraLiquidChainService, prelude::DEFAULT_EXTERNAL_INPUT_PARSERS,
+};
+use crate::{
+    side_swap::api::{SIDESWAP_MAINNET_URL, SIDESWAP_REGTEST_URL, SIDESWAP_TESTNET_URL},
+    utils,
 };
 
 // Uses f64 for the maximum precision when converting between units
@@ -349,6 +352,14 @@ impl Config {
             &electrum_url,
             lwk_wollet::ElectrumOptions { timeout: Some(3) },
         )
+    }
+
+    pub(crate) fn sideswap_url(&self) -> &'static str {
+        match self.network {
+            LiquidNetwork::Mainnet => SIDESWAP_MAINNET_URL,
+            LiquidNetwork::Testnet => SIDESWAP_TESTNET_URL,
+            LiquidNetwork::Regtest => SIDESWAP_REGTEST_URL,
+        }
     }
 }
 
@@ -2445,6 +2456,19 @@ impl TryFrom<&sideswap_api::SubscribePriceStreamResponse> for AssetSwap {
                 .context("Expected price when creating side swap")?,
         })
     }
+}
+
+/// An argument when calling [crate::sdk::LiquidSdk::prepare_asset_swap_request].
+#[derive(Debug, Clone, Serialize)]
+pub struct PrepareAssetSwapRequest {
+    pub asset_id: String,
+    pub send_amount_sat: u64,
+}
+
+/// Returned when calling [crate::sdk::LiquidSdk::prepare_asset_swap_request].
+#[derive(Debug, Clone, Serialize)]
+pub struct PrepareAssetSwapResponse {
+    pub asset_swap: AssetSwap,
 }
 
 #[derive(Clone, Debug)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -2471,6 +2471,18 @@ pub struct PrepareAssetSwapResponse {
     pub asset_swap: AssetSwap,
 }
 
+/// An argument when calling [crate::sdk::LiquidSdk::execute_asset_swap_request].
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteAssetSwapRequest {
+    pub prepare_response: PrepareAssetSwapResponse,
+}
+
+/// Returned when calling [crate::sdk::LiquidSdk::execute_asset_swap_request].
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteAssetSwapResponse {
+    pub payment: Payment,
+}
+
 #[derive(Clone, Debug)]
 pub struct BtcScriptBalance {
     /// Confirmed balance in Satoshis for the address.

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -23,6 +23,7 @@ use sdk_common::input_parser::InputType;
 use sdk_common::liquid::LiquidAddressData;
 use sdk_common::prelude::{FiatAPI, FiatCurrency, LnUrlPayError, LnUrlWithdrawError, Rate};
 use sdk_common::utils::Arc;
+use side_swap::api::{HybridSideSwapService, SideSwapService};
 use signer::SdkSigner;
 use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
@@ -79,6 +80,7 @@ pub struct LiquidSdkBuilder {
     liquid_chain_service: Option<Arc<dyn LiquidChainService>>,
     onchain_wallet: Option<Arc<dyn OnchainWallet>>,
     payjoin_service: Option<Arc<dyn PayjoinService>>,
+    sideswap_service: Option<Arc<dyn SideSwapService>>,
     persister: Option<Arc<Persister>>,
     recoverer: Option<Arc<Recoverer>>,
     rest_client: Option<Arc<dyn RestClient>>,
@@ -103,6 +105,7 @@ impl LiquidSdkBuilder {
             liquid_chain_service: None,
             onchain_wallet: None,
             payjoin_service: None,
+            sideswap_service: None,
             persister: None,
             recoverer: None,
             rest_client: None,
@@ -140,6 +143,11 @@ impl LiquidSdkBuilder {
 
     pub fn payjoin_service(&mut self, payjoin_service: Arc<dyn PayjoinService>) -> &mut Self {
         self.payjoin_service = Some(payjoin_service.clone());
+        self
+    }
+
+    pub fn sideswap_service(&mut self, sideswap_service: Arc<dyn SideSwapService>) -> &mut Self {
+        self.sideswap_service = Some(sideswap_service.clone());
         self
     }
 
@@ -329,6 +337,15 @@ impl LiquidSdkBuilder {
             )),
         };
 
+        let sideswap_service = match self.sideswap_service.clone() {
+            Some(sideswap_service) => sideswap_service,
+            None => Arc::new(HybridSideSwapService::new(
+                self.config.sideswap_url().to_string(),
+                rest_client.clone(),
+                onchain_wallet.clone(),
+            )),
+        };
+
         let buy_bitcoin_service = Arc::new(BuyBitcoinService::new(
             self.config.clone(),
             self.breez_server.clone(),
@@ -357,6 +374,7 @@ impl LiquidSdkBuilder {
             sync_service,
             chain_swap_handler,
             payjoin_service,
+            sideswap_service,
             buy_bitcoin_service,
             external_input_parsers,
         });
@@ -385,6 +403,7 @@ pub struct LiquidSdk {
     pub(crate) receive_swap_handler: ReceiveSwapHandler,
     pub(crate) chain_swap_handler: Arc<ChainSwapHandler>,
     pub(crate) payjoin_service: Arc<dyn PayjoinService>,
+    pub(crate) sideswap_service: Arc<dyn SideSwapService>,
     pub(crate) buy_bitcoin_service: Arc<dyn BuyBitcoinApi>,
     pub(crate) external_input_parsers: Vec<ExternalInputParser>,
 }
@@ -4030,6 +4049,26 @@ impl LiquidSdk {
     #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>) -> Result<()> {
         crate::logger::init_logging(log_dir, app_logger)
+    }
+
+    pub async fn prepare_asset_swap(
+        &self,
+        req: &PrepareAssetSwapRequest,
+    ) -> Result<PrepareAssetSwapResponse, PaymentError> {
+        self.sideswap_service.clone().start().await?;
+
+        ensure_sdk!(
+            self.get_info().await?.wallet_info.balance_sat > req.send_amount_sat,
+            PaymentError::InsufficientFunds
+        );
+
+        let asset_id = AssetId::from_str(&req.asset_id)
+            .map_err(|err| PaymentError::generic(&format!("Invalid asset: {err}")))?;
+        let asset_swap = self
+            .sideswap_service
+            .subscribe_price_stream(asset_id, req.send_amount_sat)
+            .await?;
+        Ok(PrepareAssetSwapResponse { asset_swap })
     }
 }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -23,7 +23,7 @@ use sdk_common::input_parser::InputType;
 use sdk_common::liquid::LiquidAddressData;
 use sdk_common::prelude::{FiatAPI, FiatCurrency, LnUrlPayError, LnUrlWithdrawError, Rate};
 use sdk_common::utils::Arc;
-use side_swap::api::{HybridSideSwapService, SideSwapService};
+use side_swap::api::{ExecuteSwapResponse, HybridSideSwapService, SideSwapService};
 use signer::SdkSigner;
 use swapper::boltz::proxy::BoltzProxyFetcher;
 use tokio::sync::{watch, RwLock};
@@ -4069,6 +4069,95 @@ impl LiquidSdk {
             .subscribe_price_stream(asset_id, req.send_amount_sat)
             .await?;
         Ok(PrepareAssetSwapResponse { asset_swap })
+    }
+
+    pub async fn execute_asset_swap(
+        &self,
+        req: &ExecuteAssetSwapRequest,
+    ) -> Result<ExecuteAssetSwapResponse, PaymentError> {
+        self.sideswap_service.clone().start().await?;
+
+        let req_swap = &req.prepare_response.asset_swap;
+        let Some(ongoing_swap) = self.sideswap_service.get_current_price().await else {
+            return Err(PaymentError::generic(
+                "Cannot execute asset swap: swap not found.",
+            ));
+        };
+
+        ensure_sdk!(
+            ongoing_swap.fees_sat <= req_swap.fees_sat,
+            PaymentError::InvalidOrExpiredFees
+        );
+
+        ensure_sdk!(
+            req_swap.recv_amount == ongoing_swap.recv_amount
+                && req_swap.send_amount_sat == ongoing_swap.send_amount_sat,
+            PaymentError::generic(&format!(
+                "Asset swap amount mismatch: prev - send {} recv {} / new - send {} recv {}",
+                req_swap.send_amount_sat,
+                req_swap.recv_amount,
+                ongoing_swap.send_amount_sat,
+                ongoing_swap.recv_amount
+            ))
+        );
+
+        ensure_sdk!(
+            self.get_info().await?.wallet_info.balance_sat
+                >= ongoing_swap.fees_sat + req_swap.send_amount_sat,
+            PaymentError::InsufficientFunds
+        );
+
+        let ExecuteSwapResponse {
+            tx_id,
+            recv_address: destination,
+        } = self.sideswap_service.execute_swap().await?;
+        self.sideswap_service.stop().await;
+
+        // We insert a pseudo-tx in case LWK fails to pick up the new mempool tx for a while
+        // This makes the tx known to the SDK (get_info, list_payments) instantly
+        let tx_data = PaymentTxData {
+            tx_id: tx_id.clone(),
+            timestamp: Some(utils::now()),
+            amount: req_swap.recv_amount,
+            fees_sat: ongoing_swap.fees_sat,
+            payment_type: PaymentType::Send,
+            is_confirmed: false,
+            unblinding_data: None,
+            asset_id: req_swap.asset_id.clone(),
+        };
+
+        self.persister.insert_or_update_payment(
+            tx_data.clone(),
+            Some(PaymentTxDetails {
+                tx_id: tx_id.clone(),
+                destination: destination.clone(),
+                ..Default::default()
+            }),
+            false,
+        )?;
+        self.emit_payment_updated(Some(tx_id)).await?; // Emit Pending event
+
+        let asset_info = self
+            .persister
+            .get_asset_metadata(&req_swap.asset_id)?
+            .map(|ref am| AssetInfo {
+                name: am.name.clone(),
+                ticker: am.ticker.clone(),
+                amount: am.amount_from_sat(req_swap.send_amount_sat),
+                fees: None,
+            });
+        let payment_details = PaymentDetails::Liquid {
+            asset_id: req_swap.asset_id.clone(),
+            destination,
+            description: "Liquid transfer".to_string(),
+            asset_info,
+            lnurl_info: None,
+            bip353_address: None,
+        };
+
+        Ok(ExecuteAssetSwapResponse {
+            payment: Payment::from_tx_data(tx_data, None, payment_details),
+        })
     }
 }
 

--- a/lib/core/src/side_swap/api/mod.rs
+++ b/lib/core/src/side_swap/api/mod.rs
@@ -5,6 +5,7 @@ use log::{debug, error, info, warn};
 use maybe_sync::{MaybeSend, MaybeSync};
 use request_handler::SideSwapRequestHandler;
 use response_handler::SideSwapResponseHandler;
+use sdk_common::bitcoin::hashes::hex::ToHex as _;
 use sdk_common::prelude::RestClient;
 use sdk_common::utils::Arc;
 use sideswap_api::http_rpc::{
@@ -12,8 +13,8 @@ use sideswap_api::http_rpc::{
 };
 use sideswap_api::{
     Notification, Request, RequestId, RequestMessage, Response, ResponseMessage,
-    StartSwapWebRequest, StartSwapWebResponse, SubscribePriceStreamRequest,
-    SubscribePriceStreamResponse, UnsubscribePriceStreamRequest,
+    StartSwapWebRequest, SubscribePriceStreamRequest, SubscribePriceStreamResponse,
+    UnsubscribePriceStreamRequest,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -26,7 +27,7 @@ use boltz_client::boltz::tokio_tungstenite_wasm;
 use tokio_tungstenite_wasm::{connect, Message};
 
 use crate::bitcoin::base64;
-use crate::elements::{self, pset::PartiallySignedTransaction, AssetId, Txid};
+use crate::elements::{self, pset::PartiallySignedTransaction, AssetId};
 use crate::model::AssetSwap;
 use crate::wallet::OnchainWallet;
 
@@ -47,8 +48,13 @@ pub trait SideSwapService: MaybeSend + MaybeSync {
         send_amount_sat: u64,
     ) -> Result<AssetSwap>;
     async fn unsubscribe_price_stream(&self) -> Result<()>;
-    async fn prepare_swap(&self) -> Result<StartSwapWebResponse>;
-    async fn execute_swap(&self, start_res: StartSwapWebResponse) -> Result<Txid>;
+    async fn get_current_price(&self) -> Option<AssetSwap>;
+    async fn execute_swap(&self) -> Result<ExecuteSwapResponse>;
+}
+
+pub struct ExecuteSwapResponse {
+    pub recv_address: String,
+    pub tx_id: String,
 }
 
 struct ShutdownChannel {
@@ -143,6 +149,10 @@ impl HybridSideSwapService {
 #[sdk_macros::async_trait]
 impl SideSwapService for HybridSideSwapService {
     async fn start(self: Arc<Self>) -> Result<()> {
+        if *self.is_started.lock().await {
+            return Ok(());
+        }
+
         let ws = connect(&self.url).await?;
         self.set_started(true).await;
 
@@ -243,34 +253,36 @@ impl SideSwapService for HybridSideSwapService {
         Ok(())
     }
 
-    async fn prepare_swap(&self) -> Result<StartSwapWebResponse> {
+    async fn get_current_price(&self) -> Option<AssetSwap> {
+        self.ongoing_swap.lock().await.clone()
+    }
+
+    async fn execute_swap(&self) -> Result<ExecuteSwapResponse> {
         let Some(ref ongoing_swap) = *self.ongoing_swap.lock().await else {
-            bail!("Cannot start swap without subscribing to price stream first");
+            bail!("Cannot execute swap without subscribing to price stream first");
         };
 
         let req = Request::StartSwapWeb(StartSwapWebRequest {
-            price: ongoing_swap.price,
-            send_amount: ongoing_swap.send_amount as i64,
+            price: ongoing_swap.asset_price,
+            send_amount: ongoing_swap.send_amount_sat as i64,
             recv_amount: ongoing_swap.recv_amount as i64,
-            asset: AssetId::from_str(&ongoing_swap.asset)?,
+            asset: AssetId::from_str(&ongoing_swap.asset_id)?,
             send_bitcoins: true,
         });
         let request_id = self.request_handler.send(req).await?;
-        match self.response_handler.recv(request_id).await? {
+        let start_res = match self.response_handler.recv(request_id).await? {
             Ok(Response::StartSwapWeb(res)) => Ok(res),
             res => Err(Self::invalid_response(res)),
-        }
-    }
+        }?;
 
-    async fn execute_swap(&self, start_res: StartSwapWebResponse) -> Result<Txid> {
         let recv_addr = self.onchain_wallet.next_unused_address().await?;
         let change_addr = self.onchain_wallet.next_unused_change_address().await?;
 
         let body = serde_json::to_string(&SwapStartRequest {
             order_id: start_res.order_id,
             inputs: vec![],
-            recv_addr,
             change_addr,
+            recv_addr: recv_addr.clone(),
             send_asset: start_res.send_asset,
             send_amount: start_res.send_amount,
             recv_asset: start_res.recv_asset,
@@ -322,6 +334,9 @@ impl SideSwapService for HybridSideSwapService {
 
         let response: SwapSignResponse = serde_json::from_str(&raw_body)?;
         self.unset_ongoing_swap().await;
-        Ok(response.txid)
+        Ok(ExecuteSwapResponse {
+            tx_id: response.txid.to_hex(),
+            recv_address: recv_addr.to_string(),
+        })
     }
 }


### PR DESCRIPTION
Built on top of #897.

## Description
This PR:
- Adds the methods `prepare_asset_swap`/`execute_asset_swap` and the corresponding interfaces to allow the user to swap funds via the SideSwap service.
- Adds a cli command to allow for testing of the swapping service.

## To-dos
- [ ] Fix `RequestId` issue when sending messages (currently server returns error) 
- [ ] Limit the scope of the tradeable assets (we just want USDt for now)
- [ ] Regenerate bindings