### PR TITLE
Add user lockup_tx_id to Bitcoin payment details

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -572,6 +572,7 @@ typedef struct wire_cst_PaymentDetails_Bitcoin {
   bool auto_accepted_fees;
   uint32_t *liquid_expiration_blockheight;
   uint32_t *bitcoin_expiration_blockheight;
+  struct wire_cst_list_prim_u_8_strict *lockup_tx_id;
   struct wire_cst_list_prim_u_8_strict *claim_tx_id;
   struct wire_cst_list_prim_u_8_strict *refund_tx_id;
   uint64_t *refund_tx_amount_sat;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -108,7 +108,7 @@ class SwapUpdatedTask : TaskProtocol {
     func getSwapId(details: PaymentDetails?) -> String? {
         if let details = details {
             switch details {
-            case let .bitcoin(swapId, _, _, _, _, _, _, _):
+            case let .bitcoin(swapId, _, _, _, _, _, _, _, _):
                 return swapId
             case let .lightning(swapId, _, _, _, _, _, _, _, _, _, _, _, _):
                 return swapId
@@ -121,7 +121,7 @@ class SwapUpdatedTask : TaskProtocol {
 
     func paymentClaimIsBroadcasted(details: PaymentDetails) -> Bool {
         switch details {
-        case let .bitcoin(_, _, _, _, _, claimTxId, _, _):
+        case let .bitcoin(_, _, _, _, _, _, claimTxId, _, _):
             return claimTxId != nil
         case let .lightning(_, _, _, _, _, _, _, _, _, _, claimTxId, _, _):
             return claimTxId != nil

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -631,7 +631,7 @@ dictionary AssetInfo {
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? bip353_address, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string asset_id, string destination, string description, AssetInfo? asset_info, LnUrlInfo? lnurl_info, string? bip353_address);
-    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? lockup_tx_id, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4085,6 +4085,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
                 let mut var_bitcoinExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
+                let mut var_lockupTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_claimTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
@@ -4094,6 +4095,7 @@ impl SseDecode for crate::model::PaymentDetails {
                     auto_accepted_fees: var_autoAcceptedFees,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
                     bitcoin_expiration_blockheight: var_bitcoinExpirationBlockheight,
+                    lockup_tx_id: var_lockupTxId,
                     claim_tx_id: var_claimTxId,
                     refund_tx_id: var_refundTxId,
                     refund_tx_amount_sat: var_refundTxAmountSat,
@@ -6512,6 +6514,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
+                lockup_tx_id,
                 claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -6522,6 +6525,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
                 auto_accepted_fees.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
                 bitcoin_expiration_blockheight.into_into_dart().into_dart(),
+                lockup_tx_id.into_into_dart().into_dart(),
                 claim_tx_id.into_into_dart().into_dart(),
                 refund_tx_id.into_into_dart().into_dart(),
                 refund_tx_amount_sat.into_into_dart().into_dart(),
@@ -8880,6 +8884,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
                 bitcoin_expiration_blockheight,
+                lockup_tx_id,
                 claim_tx_id,
                 refund_tx_id,
                 refund_tx_amount_sat,
@@ -8890,6 +8895,7 @@ impl SseEncode for crate::model::PaymentDetails {
                 <bool>::sse_encode(auto_accepted_fees, serializer);
                 <Option<u32>>::sse_encode(liquid_expiration_blockheight, serializer);
                 <Option<u32>>::sse_encode(bitcoin_expiration_blockheight, serializer);
+                <Option<String>>::sse_encode(lockup_tx_id, serializer);
                 <Option<String>>::sse_encode(claim_tx_id, serializer);
                 <Option<String>>::sse_encode(refund_tx_id, serializer);
                 <Option<u64>>::sse_encode(refund_tx_amount_sat, serializer);
@@ -11184,6 +11190,7 @@ mod io {
                         bitcoin_expiration_blockheight: ans
                             .bitcoin_expiration_blockheight
                             .cst_decode(),
+                        lockup_tx_id: ans.lockup_tx_id.cst_decode(),
                         claim_tx_id: ans.claim_tx_id.cst_decode(),
                         refund_tx_id: ans.refund_tx_id.cst_decode(),
                         refund_tx_amount_sat: ans.refund_tx_amount_sat.cst_decode(),
@@ -15094,6 +15101,7 @@ mod io {
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: *mut u32,
         bitcoin_expiration_blockheight: *mut u32,
+        lockup_tx_id: *mut wire_cst_list_prim_u_8_strict,
         claim_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
         refund_tx_amount_sat: *mut u64,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1943,7 +1943,10 @@ pub enum PaymentDetails {
         /// It should always be populated in case of an incoming chain swap
         bitcoin_expiration_blockheight: Option<u32>,
 
-        /// The claim tx id in case it has already been broadcast
+        /// The lockup tx id that initiates the swap
+        lockup_tx_id: Option<String>,
+
+        /// The claim tx id that claims the server lockup tx
         claim_tx_id: Option<String>,
 
         /// For a Send swap which was refunded, this is the refund tx id

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -540,6 +540,7 @@ impl Persister {
                 cs.actual_payer_amount_sat,
                 cs.accepted_receiver_amount_sat,
                 cs.auto_accepted_fees,
+                cs.user_lockup_tx_id,
                 cs.claim_tx_id,
                 rtx.amount,
                 pd.destination,
@@ -660,21 +661,22 @@ impl Persister {
         let maybe_chain_swap_actual_payer_amount_sat: Option<u64> = row.get(48)?;
         let maybe_chain_swap_accepted_receiver_amount_sat: Option<u64> = row.get(49)?;
         let maybe_chain_swap_auto_accepted_fees: Option<bool> = row.get(50)?;
-        let maybe_chain_swap_claim_tx_id: Option<String> = row.get(51)?;
+        let maybe_chain_swap_user_lockup_tx_id: Option<String> = row.get(51)?;
+        let maybe_chain_swap_claim_tx_id: Option<String> = row.get(52)?;
 
-        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(52)?;
+        let maybe_swap_refund_tx_amount_sat: Option<u64> = row.get(53)?;
 
-        let maybe_payment_details_destination: Option<String> = row.get(53)?;
-        let maybe_payment_details_description: Option<String> = row.get(54)?;
-        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(55)?;
+        let maybe_payment_details_destination: Option<String> = row.get(54)?;
+        let maybe_payment_details_description: Option<String> = row.get(55)?;
+        let maybe_payment_details_lnurl_info_json: Option<String> = row.get(56)?;
         let maybe_payment_details_lnurl_info: Option<LnUrlInfo> =
             maybe_payment_details_lnurl_info_json.and_then(|info| serde_json::from_str(&info).ok());
-        let maybe_payment_details_bip353_address: Option<String> = row.get(56)?;
-        let maybe_payment_details_asset_fees: Option<u64> = row.get(57)?;
+        let maybe_payment_details_bip353_address: Option<String> = row.get(57)?;
+        let maybe_payment_details_asset_fees: Option<u64> = row.get(58)?;
 
-        let maybe_asset_metadata_name: Option<String> = row.get(58)?;
-        let maybe_asset_metadata_ticker: Option<String> = row.get(59)?;
-        let maybe_asset_metadata_precision: Option<u8> = row.get(60)?;
+        let maybe_asset_metadata_name: Option<String> = row.get(59)?;
+        let maybe_asset_metadata_ticker: Option<String> = row.get(60)?;
+        let maybe_asset_metadata_precision: Option<u8> = row.get(61)?;
 
         let (swap, payment_type) = match maybe_receive_swap_id {
             Some(receive_swap_id) => {
@@ -869,6 +871,7 @@ impl Persister {
 
                 PaymentDetails::Bitcoin {
                     swap_id,
+                    lockup_tx_id: maybe_chain_swap_user_lockup_tx_id,
                     claim_tx_id: maybe_claim_tx_id,
                     refund_tx_id,
                     refund_tx_amount_sat,

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -715,6 +715,7 @@ pub enum PaymentDetails {
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: Option<u32>,
         bitcoin_expiration_blockheight: Option<u32>,
+        lockup_tx_id: Option<String>,
         claim_tx_id: Option<String>,
         refund_tx_id: Option<String>,
         refund_tx_amount_sat: Option<u64>,

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2866,9 +2866,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           autoAcceptedFees: dco_decode_bool(raw[3]),
           liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
           bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
-          claimTxId: dco_decode_opt_String(raw[6]),
-          refundTxId: dco_decode_opt_String(raw[7]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[8]),
+          lockupTxId: dco_decode_opt_String(raw[6]),
+          claimTxId: dco_decode_opt_String(raw[7]),
+          refundTxId: dco_decode_opt_String(raw[8]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[9]),
         );
       default:
         throw Exception("unreachable");
@@ -5256,6 +5257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_autoAcceptedFees = sse_decode_bool(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
         var var_bitcoinExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
+        var var_lockupTxId = sse_decode_opt_String(deserializer);
         var var_claimTxId = sse_decode_opt_String(deserializer);
         var var_refundTxId = sse_decode_opt_String(deserializer);
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
@@ -5265,6 +5267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           autoAcceptedFees: var_autoAcceptedFees,
           liquidExpirationBlockheight: var_liquidExpirationBlockheight,
           bitcoinExpirationBlockheight: var_bitcoinExpirationBlockheight,
+          lockupTxId: var_lockupTxId,
           claimTxId: var_claimTxId,
           refundTxId: var_refundTxId,
           refundTxAmountSat: var_refundTxAmountSat,
@@ -7551,6 +7554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         autoAcceptedFees: final autoAcceptedFees,
         liquidExpirationBlockheight: final liquidExpirationBlockheight,
         bitcoinExpirationBlockheight: final bitcoinExpirationBlockheight,
+        lockupTxId: final lockupTxId,
         claimTxId: final claimTxId,
         refundTxId: final refundTxId,
         refundTxAmountSat: final refundTxAmountSat,
@@ -7561,6 +7565,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_bool(autoAcceptedFees, serializer);
         sse_encode_opt_box_autoadd_u_32(liquidExpirationBlockheight, serializer);
         sse_encode_opt_box_autoadd_u_32(bitcoinExpirationBlockheight, serializer);
+        sse_encode_opt_String(lockupTxId, serializer);
         sse_encode_opt_String(claimTxId, serializer);
         sse_encode_opt_String(refundTxId, serializer);
         sse_encode_opt_box_autoadd_u_64(refundTxAmountSat, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3483,6 +3483,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_bitcoin_expiration_blockheight = cst_encode_opt_box_autoadd_u_32(
         apiObj.bitcoinExpirationBlockheight,
       );
+      var pre_lockup_tx_id = cst_encode_opt_String(apiObj.lockupTxId);
       var pre_claim_tx_id = cst_encode_opt_String(apiObj.claimTxId);
       var pre_refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
@@ -3492,6 +3493,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       wireObj.kind.Bitcoin.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
       wireObj.kind.Bitcoin.bitcoin_expiration_blockheight = pre_bitcoin_expiration_blockheight;
+      wireObj.kind.Bitcoin.lockup_tx_id = pre_lockup_tx_id;
       wireObj.kind.Bitcoin.claim_tx_id = pre_claim_tx_id;
       wireObj.kind.Bitcoin.refund_tx_id = pre_refund_tx_id;
       wireObj.kind.Bitcoin.refund_tx_amount_sat = pre_refund_tx_amount_sat;
@@ -7097,6 +7099,8 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> liquid_expiration_blockheight;
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lockup_tx_id;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -990,7 +990,10 @@ sealed class PaymentDetails with _$PaymentDetails {
     /// It should always be populated in case of an incoming chain swap
     int? bitcoinExpirationBlockheight,
 
-    /// The claim tx id in case it has already been broadcast
+    /// The lockup tx id that initiates the swap
+    String? lockupTxId,
+
+    /// The claim tx id that claims the server lockup tx
     String? claimTxId,
 
     /// For a Send swap which was refunded, this is the refund tx id

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1214,7 +1214,7 @@ as String?,
 
 
 class PaymentDetails_Bitcoin extends PaymentDetails {
-  const PaymentDetails_Bitcoin({required this.swapId, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
+  const PaymentDetails_Bitcoin({required this.swapId, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.lockupTxId, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
   
 
  final  String swapId;
@@ -1230,7 +1230,9 @@ class PaymentDetails_Bitcoin extends PaymentDetails {
 /// The height of the Bitcoin block at which the swap will no longer be valid
 /// It should always be populated in case of an incoming chain swap
  final  int? bitcoinExpirationBlockheight;
-/// The claim tx id in case it has already been broadcast
+/// The lockup tx id that initiates the swap
+ final  String? lockupTxId;
+/// The claim tx id that claims the server lockup tx
  final  String? claimTxId;
 /// For a Send swap which was refunded, this is the refund tx id
  final  String? refundTxId;
@@ -1247,16 +1249,16 @@ $PaymentDetails_BitcoinCopyWith<PaymentDetails_Bitcoin> get copyWith => _$Paymen
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.lockupTxId, lockupTxId) || other.lockupTxId == lockupTxId)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,swapId,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,claimTxId,refundTxId,refundTxAmountSat);
+int get hashCode => Object.hash(runtimeType,swapId,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,lockupTxId,claimTxId,refundTxId,refundTxAmountSat);
 
 @override
 String toString() {
-  return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+  return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, lockupTxId: $lockupTxId, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
 }
 
 
@@ -1267,7 +1269,7 @@ abstract mixin class $PaymentDetails_BitcoinCopyWith<$Res> implements $PaymentDe
   factory $PaymentDetails_BitcoinCopyWith(PaymentDetails_Bitcoin value, $Res Function(PaymentDetails_Bitcoin) _then) = _$PaymentDetails_BitcoinCopyWithImpl;
 @override @useResult
 $Res call({
- String swapId, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
+ String swapId, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? lockupTxId, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
 });
 
 
@@ -1284,14 +1286,15 @@ class _$PaymentDetails_BitcoinCopyWithImpl<$Res>
 
 /// Create a copy of PaymentDetails
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? lockupTxId = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
   return _then(PaymentDetails_Bitcoin(
 swapId: null == swapId ? _self.swapId : swapId // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,autoAcceptedFees: null == autoAcceptedFees ? _self.autoAcceptedFees : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
 as bool,liquidExpirationBlockheight: freezed == liquidExpirationBlockheight ? _self.liquidExpirationBlockheight : liquidExpirationBlockheight // ignore: cast_nullable_to_non_nullable
 as int?,bitcoinExpirationBlockheight: freezed == bitcoinExpirationBlockheight ? _self.bitcoinExpirationBlockheight : bitcoinExpirationBlockheight // ignore: cast_nullable_to_non_nullable
-as int?,claimTxId: freezed == claimTxId ? _self.claimTxId : claimTxId // ignore: cast_nullable_to_non_nullable
+as int?,lockupTxId: freezed == lockupTxId ? _self.lockupTxId : lockupTxId // ignore: cast_nullable_to_non_nullable
+as String?,claimTxId: freezed == claimTxId ? _self.claimTxId : claimTxId // ignore: cast_nullable_to_non_nullable
 as String?,refundTxId: freezed == refundTxId ? _self.refundTxId : refundTxId // ignore: cast_nullable_to_non_nullable
 as String?,refundTxAmountSat: freezed == refundTxAmountSat ? _self.refundTxAmountSat : refundTxAmountSat // ignore: cast_nullable_to_non_nullable
 as BigInt?,

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4949,6 +4949,8 @@ final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
 
   external ffi.Pointer<ffi.Uint32> bitcoin_expiration_blockheight;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> lockup_tx_id;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> claim_tx_id;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3638,6 +3638,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             } else {
                 null
             }
+        val lockupTxId = if (hasNonNullKey(paymentDetails, "lockupTxId")) paymentDetails.getString("lockupTxId") else null
         val claimTxId = if (hasNonNullKey(paymentDetails, "claimTxId")) paymentDetails.getString("claimTxId") else null
         val refundTxId = if (hasNonNullKey(paymentDetails, "refundTxId")) paymentDetails.getString("refundTxId") else null
         val refundTxAmountSat =
@@ -3656,6 +3657,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             autoAcceptedFees,
             bitcoinExpirationBlockheight,
             liquidExpirationBlockheight,
+            lockupTxId,
             claimTxId,
             refundTxId,
             refundTxAmountSat,
@@ -3699,6 +3701,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
             pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
             pushToMap(map, "bitcoinExpirationBlockheight", paymentDetails.bitcoinExpirationBlockheight)
             pushToMap(map, "liquidExpirationBlockheight", paymentDetails.liquidExpirationBlockheight)
+            pushToMap(map, "lockupTxId", paymentDetails.lockupTxId)
             pushToMap(map, "claimTxId", paymentDetails.claimTxId)
             pushToMap(map, "refundTxId", paymentDetails.refundTxId)
             pushToMap(map, "refundTxAmountSat", paymentDetails.refundTxAmountSat)

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4430,13 +4430,15 @@ enum BreezSDKLiquidMapper {
 
             let _liquidExpirationBlockheight = paymentDetails["liquidExpirationBlockheight"] as? UInt32
 
+            let _lockupTxId = paymentDetails["lockupTxId"] as? String
+
             let _claimTxId = paymentDetails["claimTxId"] as? String
 
             let _refundTxId = paymentDetails["refundTxId"] as? String
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, lockupTxId: _lockupTxId, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4478,7 +4480,7 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, claimTxId, refundTxId, refundTxAmountSat
+            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, lockupTxId, claimTxId, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "bitcoin",
@@ -4487,6 +4489,7 @@ enum BreezSDKLiquidMapper {
                 "autoAcceptedFees": autoAcceptedFees,
                 "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,
                 "liquidExpirationBlockheight": liquidExpirationBlockheight == nil ? nil : liquidExpirationBlockheight,
+                "lockupTxId": lockupTxId == nil ? nil : lockupTxId,
                 "claimTxId": claimTxId == nil ? nil : claimTxId,
                 "refundTxId": refundTxId == nil ? nil : refundTxId,
                 "refundTxAmountSat": refundTxAmountSat == nil ? nil : refundTxAmountSat,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -737,6 +737,7 @@ export type PaymentDetails = {
     autoAcceptedFees: boolean
     bitcoinExpirationBlockheight?: number
     liquidExpirationBlockheight?: number
+    lockupTxId?: string
     claimTxId?: string
     refundTxId?: string
     refundTxAmountSat?: number


### PR DESCRIPTION
When:
- Sending the `claim_tx_id` is the Bitcoin txid
- Receiving the `lockup_tx_id` is the Bitcoin txid

Fixes #916 