### PR TITLE
Rework draining to enable BOLT12 drain

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -405,24 +405,9 @@ pub(crate) async fn handle_command(
             drain,
             delay,
         } => {
-            let destination = match (invoice, offer, address) {
-                (Some(invoice), None, None) => Ok(invoice),
-                (None, Some(offer), None) => match amount_sat {
-                    Some(_) => Ok(offer),
-                    None => Err(anyhow!(
-                        "Must specify an amount for a BOLT12 offer."
-                    ))
-                },
-                (None, None, Some(address)) => Ok(address),
-                (Some(_), _, Some(_)) => {
-                    Err(anyhow::anyhow!(
-                        "Cannot specify both invoice and address at the same time."
-                    ))
-                }
-                _ => Err(anyhow!(
-                    "Must specify either a BOLT11 invoice, a BOLT12 offer or a direct/BIP21 address."
-                ))
-            }?;
+            let destination = invoice.or(offer.or(address)).ok_or(anyhow!(
+                "Must specify either a BOLT11 invoice, a BOLT12 offer or a direct/BIP21 address."
+            ))?;
             let amount = match (asset_id, amount, amount_sat, drain.unwrap_or(false)) {
                 (Some(asset_id), Some(receiver_amount), _, _) => Some(PayAmount::Asset {
                     asset_id,

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -285,6 +285,26 @@ typedef struct wire_cst_ln_url_pay_request_data {
   struct wire_cst_list_prim_u_8_strict *ln_address;
 } wire_cst_ln_url_pay_request_data;
 
+typedef struct wire_cst_PayAmount_Bitcoin {
+  uint64_t receiver_amount_sat;
+} wire_cst_PayAmount_Bitcoin;
+
+typedef struct wire_cst_PayAmount_Asset {
+  struct wire_cst_list_prim_u_8_strict *asset_id;
+  double receiver_amount;
+  bool *estimate_asset_fees;
+} wire_cst_PayAmount_Asset;
+
+typedef union PayAmountKind {
+  struct wire_cst_PayAmount_Bitcoin Bitcoin;
+  struct wire_cst_PayAmount_Asset Asset;
+} PayAmountKind;
+
+typedef struct wire_cst_pay_amount {
+  int32_t tag;
+  union PayAmountKind kind;
+} wire_cst_pay_amount;
+
 typedef struct wire_cst_aes_success_action_data {
   struct wire_cst_list_prim_u_8_strict *description;
   struct wire_cst_list_prim_u_8_strict *ciphertext;
@@ -328,6 +348,7 @@ typedef struct wire_cst_prepare_ln_url_pay_response {
   struct wire_cst_send_destination destination;
   uint64_t fees_sat;
   struct wire_cst_ln_url_pay_request_data data;
+  struct wire_cst_pay_amount amount;
   struct wire_cst_list_prim_u_8_strict *comment;
   struct wire_cst_success_action *success_action;
 } wire_cst_prepare_ln_url_pay_response;
@@ -365,26 +386,6 @@ typedef struct wire_cst_prepare_buy_bitcoin_request {
   int32_t provider;
   uint64_t amount_sat;
 } wire_cst_prepare_buy_bitcoin_request;
-
-typedef struct wire_cst_PayAmount_Bitcoin {
-  uint64_t receiver_amount_sat;
-} wire_cst_PayAmount_Bitcoin;
-
-typedef struct wire_cst_PayAmount_Asset {
-  struct wire_cst_list_prim_u_8_strict *asset_id;
-  double receiver_amount;
-  bool *estimate_asset_fees;
-} wire_cst_PayAmount_Asset;
-
-typedef union PayAmountKind {
-  struct wire_cst_PayAmount_Bitcoin Bitcoin;
-  struct wire_cst_PayAmount_Asset Asset;
-} PayAmountKind;
-
-typedef struct wire_cst_pay_amount {
-  int32_t tag;
-  union PayAmountKind kind;
-} wire_cst_pay_amount;
 
 typedef struct wire_cst_prepare_ln_url_pay_request {
   struct wire_cst_ln_url_pay_request_data data;
@@ -461,6 +462,7 @@ typedef struct wire_cst_restore_request {
 
 typedef struct wire_cst_prepare_send_response {
   struct wire_cst_send_destination destination;
+  struct wire_cst_pay_amount *amount;
   uint64_t *fees_sat;
   double *estimated_asset_fees;
 } wire_cst_prepare_send_response;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -423,6 +423,7 @@ dictionary PrepareLnUrlPayResponse {
     SendDestination destination;
     u64 fees_sat;
     LnUrlPayRequestData data;
+    PayAmount amount;
     string? comment = null;
     SuccessAction? success_action = null;
 };
@@ -445,6 +446,7 @@ interface SendDestination {
 
 dictionary PrepareSendResponse {
     SendDestination destination;
+    PayAmount? amount;
     u64? fees_sat;
     f64? estimated_asset_fees;
 };

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4297,6 +4297,7 @@ impl SseDecode for crate::model::PrepareLnUrlPayResponse {
         let mut var_destination = <crate::model::SendDestination>::sse_decode(deserializer);
         let mut var_feesSat = <u64>::sse_decode(deserializer);
         let mut var_data = <crate::bindings::LnUrlPayRequestData>::sse_decode(deserializer);
+        let mut var_amount = <crate::model::PayAmount>::sse_decode(deserializer);
         let mut var_comment = <Option<String>>::sse_decode(deserializer);
         let mut var_successAction =
             <Option<crate::bindings::SuccessAction>>::sse_decode(deserializer);
@@ -4304,6 +4305,7 @@ impl SseDecode for crate::model::PrepareLnUrlPayResponse {
             destination: var_destination,
             fees_sat: var_feesSat,
             data: var_data,
+            amount: var_amount,
             comment: var_comment,
             success_action: var_successAction,
         };
@@ -4412,10 +4414,12 @@ impl SseDecode for crate::model::PrepareSendResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_destination = <crate::model::SendDestination>::sse_decode(deserializer);
+        let mut var_amount = <Option<crate::model::PayAmount>>::sse_decode(deserializer);
         let mut var_feesSat = <Option<u64>>::sse_decode(deserializer);
         let mut var_estimatedAssetFees = <Option<f64>>::sse_decode(deserializer);
         return crate::model::PrepareSendResponse {
             destination: var_destination,
+            amount: var_amount,
             fees_sat: var_feesSat,
             estimated_asset_fees: var_estimatedAssetFees,
         };
@@ -6745,6 +6749,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareLnUrlPayResponse {
             self.destination.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
             self.data.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
             self.comment.into_into_dart().into_dart(),
             self.success_action.into_into_dart().into_dart(),
         ]
@@ -6921,6 +6926,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareSendResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.destination.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
             self.estimated_asset_fees.into_into_dart().into_dart(),
         ]
@@ -9085,6 +9091,7 @@ impl SseEncode for crate::model::PrepareLnUrlPayResponse {
         <crate::model::SendDestination>::sse_encode(self.destination, serializer);
         <u64>::sse_encode(self.fees_sat, serializer);
         <crate::bindings::LnUrlPayRequestData>::sse_encode(self.data, serializer);
+        <crate::model::PayAmount>::sse_encode(self.amount, serializer);
         <Option<String>>::sse_encode(self.comment, serializer);
         <Option<crate::bindings::SuccessAction>>::sse_encode(self.success_action, serializer);
     }
@@ -9157,6 +9164,7 @@ impl SseEncode for crate::model::PrepareSendResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::model::SendDestination>::sse_encode(self.destination, serializer);
+        <Option<crate::model::PayAmount>>::sse_encode(self.amount, serializer);
         <Option<u64>>::sse_encode(self.fees_sat, serializer);
         <Option<f64>>::sse_encode(self.estimated_asset_fees, serializer);
     }
@@ -11324,6 +11332,7 @@ mod io {
                 destination: self.destination.cst_decode(),
                 fees_sat: self.fees_sat.cst_decode(),
                 data: self.data.cst_decode(),
+                amount: self.amount.cst_decode(),
                 comment: self.comment.cst_decode(),
                 success_action: self.success_action.cst_decode(),
             }
@@ -11404,6 +11413,7 @@ mod io {
         fn cst_decode(self) -> crate::model::PrepareSendResponse {
             crate::model::PrepareSendResponse {
                 destination: self.destination.cst_decode(),
+                amount: self.amount.cst_decode(),
                 fees_sat: self.fees_sat.cst_decode(),
                 estimated_asset_fees: self.estimated_asset_fees.cst_decode(),
             }
@@ -12696,6 +12706,7 @@ mod io {
                 destination: Default::default(),
                 fees_sat: Default::default(),
                 data: Default::default(),
+                amount: Default::default(),
                 comment: core::ptr::null_mut(),
                 success_action: core::ptr::null_mut(),
             }
@@ -12808,6 +12819,7 @@ mod io {
         fn new_with_null_ptr() -> Self {
             Self {
                 destination: Default::default(),
+                amount: core::ptr::null_mut(),
                 fees_sat: core::ptr::null_mut(),
                 estimated_asset_fees: core::ptr::null_mut(),
             }
@@ -15213,6 +15225,7 @@ mod io {
         destination: wire_cst_send_destination,
         fees_sat: u64,
         data: wire_cst_ln_url_pay_request_data,
+        amount: wire_cst_pay_amount,
         comment: *mut wire_cst_list_prim_u_8_strict,
         success_action: *mut wire_cst_success_action,
     }
@@ -15269,6 +15282,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_prepare_send_response {
         destination: wire_cst_send_destination,
+        amount: *mut wire_cst_pay_amount,
         fees_sat: *mut u64,
         estimated_asset_fees: *mut f64,
     }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -729,6 +729,8 @@ pub enum SendDestination {
 #[derive(Debug, Serialize, Clone)]
 pub struct PrepareSendResponse {
     pub destination: SendDestination,
+    /// The optional amount to be sent in either Bitcoin or another asset
+    pub amount: Option<PayAmount>,
     /// The optional estimated fee in satoshi. Is set when there is Bitcoin available
     /// to pay fees. When not set, there are asset fees available to pay fees.
     pub fees_sat: Option<u64>,
@@ -2296,6 +2298,8 @@ pub struct PrepareLnUrlPayResponse {
     pub fees_sat: u64,
     /// The [LnUrlPayRequestData] returned by [parse]
     pub data: LnUrlPayRequestData,
+    /// The amount to send
+    pub amount: PayAmount,
     /// An optional comment for this payment
     pub comment: Option<String>,
     /// The unprocessed LUD-09 success action. This will be processed and decrypted if

--- a/lib/core/src/utils/mod.rs
+++ b/lib/core/src/utils/mod.rs
@@ -151,23 +151,23 @@ pub(crate) fn lbtc_asset_id(network: LiquidNetwork) -> AssetId {
     }
 }
 
-/// Increments the inversely calculated invoice amount up to the maximum drainable amount,
-/// as calculating the inverse invoice amount in some cases has rounding down errors
-pub(crate) fn increment_invoice_amount_up_to_drain_amount(
-    invoice_amount_sat: u64,
+/// Increments the inversely calculated receiver amount up to the maximum drainable amount,
+/// as calculating the inverse receiver amount in some cases has rounding down errors
+pub(crate) fn increment_receiver_amount_up_to_drain_amount(
+    receiver_amount_sat: u64,
     lbtc_pair: &SubmarinePair,
     drain_amount_sat: u64,
 ) -> u64 {
-    let incremented_amount_sat = invoice_amount_sat + 1;
+    let incremented_amount_sat = receiver_amount_sat + 1;
     let fees_sat = lbtc_pair.fees.total(incremented_amount_sat);
     if incremented_amount_sat + fees_sat <= drain_amount_sat {
-        increment_invoice_amount_up_to_drain_amount(
+        increment_receiver_amount_up_to_drain_amount(
             incremented_amount_sat,
             lbtc_pair,
             drain_amount_sat,
         )
     } else {
-        invoice_amount_sat
+        receiver_amount_sat
     }
 }
 

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -457,6 +457,7 @@ pub enum SendDestination {
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::PrepareSendResponse)]
 pub struct PrepareSendResponse {
     pub destination: SendDestination,
+    pub amount: Option<PayAmount>,
     pub fees_sat: Option<u64>,
     pub estimated_asset_fees: Option<f64>,
 }
@@ -789,6 +790,7 @@ pub struct PrepareLnUrlPayResponse {
     pub destination: SendDestination,
     pub fees_sat: u64,
     pub data: LnUrlPayRequestData,
+    pub amount: PayAmount,
     pub comment: Option<String>,
     pub success_action: Option<SuccessAction>,
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2986,13 +2986,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareLnUrlPayResponse dco_decode_prepare_ln_url_pay_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return PrepareLnUrlPayResponse(
       destination: dco_decode_send_destination(arr[0]),
       feesSat: dco_decode_u_64(arr[1]),
       data: dco_decode_ln_url_pay_request_data(arr[2]),
-      comment: dco_decode_opt_String(arr[3]),
-      successAction: dco_decode_opt_box_autoadd_success_action(arr[4]),
+      amount: dco_decode_pay_amount(arr[3]),
+      comment: dco_decode_opt_String(arr[4]),
+      successAction: dco_decode_opt_box_autoadd_success_action(arr[5]),
     );
   }
 
@@ -3084,11 +3085,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendResponse dco_decode_prepare_send_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return PrepareSendResponse(
       destination: dco_decode_send_destination(arr[0]),
-      feesSat: dco_decode_opt_box_autoadd_u_64(arr[1]),
-      estimatedAssetFees: dco_decode_opt_box_autoadd_f_64(arr[2]),
+      amount: dco_decode_opt_box_autoadd_pay_amount(arr[1]),
+      feesSat: dco_decode_opt_box_autoadd_u_64(arr[2]),
+      estimatedAssetFees: dco_decode_opt_box_autoadd_f_64(arr[3]),
     );
   }
 
@@ -5404,12 +5406,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_destination = sse_decode_send_destination(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
     var var_data = sse_decode_ln_url_pay_request_data(deserializer);
+    var var_amount = sse_decode_pay_amount(deserializer);
     var var_comment = sse_decode_opt_String(deserializer);
     var var_successAction = sse_decode_opt_box_autoadd_success_action(deserializer);
     return PrepareLnUrlPayResponse(
       destination: var_destination,
       feesSat: var_feesSat,
       data: var_data,
+      amount: var_amount,
       comment: var_comment,
       successAction: var_successAction,
     );
@@ -5501,10 +5505,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareSendResponse sse_decode_prepare_send_response(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_destination = sse_decode_send_destination(deserializer);
+    var var_amount = sse_decode_opt_box_autoadd_pay_amount(deserializer);
     var var_feesSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_estimatedAssetFees = sse_decode_opt_box_autoadd_f_64(deserializer);
     return PrepareSendResponse(
       destination: var_destination,
+      amount: var_amount,
       feesSat: var_feesSat,
       estimatedAssetFees: var_estimatedAssetFees,
     );
@@ -7683,6 +7689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_send_destination(self.destination, serializer);
     sse_encode_u_64(self.feesSat, serializer);
     sse_encode_ln_url_pay_request_data(self.data, serializer);
+    sse_encode_pay_amount(self.amount, serializer);
     sse_encode_opt_String(self.comment, serializer);
     sse_encode_opt_box_autoadd_success_action(self.successAction, serializer);
   }
@@ -7747,6 +7754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_prepare_send_response(PrepareSendResponse self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_send_destination(self.destination, serializer);
+    sse_encode_opt_box_autoadd_pay_amount(self.amount, serializer);
     sse_encode_opt_box_autoadd_u_64(self.feesSat, serializer);
     sse_encode_opt_box_autoadd_f_64(self.estimatedAssetFees, serializer);
   }

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3654,6 +3654,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     cst_api_fill_to_wire_send_destination(apiObj.destination, wireObj.destination);
     wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
     cst_api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
+    cst_api_fill_to_wire_pay_amount(apiObj.amount, wireObj.amount);
     wireObj.comment = cst_encode_opt_String(apiObj.comment);
     wireObj.success_action = cst_encode_opt_box_autoadd_success_action(apiObj.successAction);
   }
@@ -3734,6 +3735,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wire_cst_prepare_send_response wireObj,
   ) {
     cst_api_fill_to_wire_send_destination(apiObj.destination, wireObj.destination);
+    wireObj.amount = cst_encode_opt_box_autoadd_pay_amount(apiObj.amount);
     wireObj.fees_sat = cst_encode_opt_box_autoadd_u_64(apiObj.feesSat);
     wireObj.estimated_asset_fees = cst_encode_opt_box_autoadd_f_64(apiObj.estimatedAssetFees);
   }
@@ -6701,6 +6703,33 @@ final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
 }
 
+final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int receiver_amount_sat;
+}
+
+final class wire_cst_PayAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Double()
+  external double receiver_amount;
+
+  external ffi.Pointer<ffi.Bool> estimate_asset_fees;
+}
+
+final class PayAmountKind extends ffi.Union {
+  external wire_cst_PayAmount_Bitcoin Bitcoin;
+
+  external wire_cst_PayAmount_Asset Asset;
+}
+
+final class wire_cst_pay_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external PayAmountKind kind;
+}
+
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -6757,6 +6786,8 @@ final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
 
   external wire_cst_ln_url_pay_request_data data;
 
+  external wire_cst_pay_amount amount;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
 
   external ffi.Pointer<wire_cst_success_action> success_action;
@@ -6812,33 +6843,6 @@ final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
-}
-
-final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
-  @ffi.Uint64()
-  external int receiver_amount_sat;
-}
-
-final class wire_cst_PayAmount_Asset extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
-
-  @ffi.Double()
-  external double receiver_amount;
-
-  external ffi.Pointer<ffi.Bool> estimate_asset_fees;
-}
-
-final class PayAmountKind extends ffi.Union {
-  external wire_cst_PayAmount_Bitcoin Bitcoin;
-
-  external wire_cst_PayAmount_Asset Asset;
-}
-
-final class wire_cst_pay_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external PayAmountKind kind;
 }
 
 final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
@@ -6944,6 +6948,8 @@ final class wire_cst_restore_request extends ffi.Struct {
 
 final class wire_cst_prepare_send_response extends ffi.Struct {
   external wire_cst_send_destination destination;
+
+  external ffi.Pointer<wire_cst_pay_amount> amount;
 
   external ffi.Pointer<ffi.Uint64> fees_sat;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -1187,6 +1187,9 @@ class PrepareLnUrlPayResponse {
   /// The [LnUrlPayRequestData] returned by [parse]
   final LnUrlPayRequestData data;
 
+  /// The amount to send
+  final PayAmount amount;
+
   /// An optional comment for this payment
   final String? comment;
 
@@ -1198,13 +1201,19 @@ class PrepareLnUrlPayResponse {
     required this.destination,
     required this.feesSat,
     required this.data,
+    required this.amount,
     this.comment,
     this.successAction,
   });
 
   @override
   int get hashCode =>
-      destination.hashCode ^ feesSat.hashCode ^ data.hashCode ^ comment.hashCode ^ successAction.hashCode;
+      destination.hashCode ^
+      feesSat.hashCode ^
+      data.hashCode ^
+      amount.hashCode ^
+      comment.hashCode ^
+      successAction.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1214,6 +1223,7 @@ class PrepareLnUrlPayResponse {
           destination == other.destination &&
           feesSat == other.feesSat &&
           data == other.data &&
+          amount == other.amount &&
           comment == other.comment &&
           successAction == other.successAction;
 }
@@ -1430,6 +1440,9 @@ class PrepareSendRequest {
 class PrepareSendResponse {
   final SendDestination destination;
 
+  /// The optional amount to be sent in either Bitcoin or another asset
+  final PayAmount? amount;
+
   /// The optional estimated fee in satoshi. Is set when there is Bitcoin available
   /// to pay fees. When not set, there are asset fees available to pay fees.
   final BigInt? feesSat;
@@ -1439,10 +1452,10 @@ class PrepareSendResponse {
   /// are funds available in this asset to pay fees.
   final double? estimatedAssetFees;
 
-  const PrepareSendResponse({required this.destination, this.feesSat, this.estimatedAssetFees});
+  const PrepareSendResponse({required this.destination, this.amount, this.feesSat, this.estimatedAssetFees});
 
   @override
-  int get hashCode => destination.hashCode ^ feesSat.hashCode ^ estimatedAssetFees.hashCode;
+  int get hashCode => destination.hashCode ^ amount.hashCode ^ feesSat.hashCode ^ estimatedAssetFees.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1450,6 +1463,7 @@ class PrepareSendResponse {
       other is PrepareSendResponse &&
           runtimeType == other.runtimeType &&
           destination == other.destination &&
+          amount == other.amount &&
           feesSat == other.feesSat &&
           estimatedAssetFees == other.estimatedAssetFees;
 }

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4550,6 +4550,33 @@ final class wire_cst_ln_url_pay_request_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> ln_address;
 }
 
+final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
+  @ffi.Uint64()
+  external int receiver_amount_sat;
+}
+
+final class wire_cst_PayAmount_Asset extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
+
+  @ffi.Double()
+  external double receiver_amount;
+
+  external ffi.Pointer<ffi.Bool> estimate_asset_fees;
+}
+
+final class PayAmountKind extends ffi.Union {
+  external wire_cst_PayAmount_Bitcoin Bitcoin;
+
+  external wire_cst_PayAmount_Asset Asset;
+}
+
+final class wire_cst_pay_amount extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external PayAmountKind kind;
+}
+
 final class wire_cst_aes_success_action_data extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
@@ -4606,6 +4633,8 @@ final class wire_cst_prepare_ln_url_pay_response extends ffi.Struct {
 
   external wire_cst_ln_url_pay_request_data data;
 
+  external wire_cst_pay_amount amount;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> comment;
 
   external ffi.Pointer<wire_cst_success_action> success_action;
@@ -4661,33 +4690,6 @@ final class wire_cst_prepare_buy_bitcoin_request extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_sat;
-}
-
-final class wire_cst_PayAmount_Bitcoin extends ffi.Struct {
-  @ffi.Uint64()
-  external int receiver_amount_sat;
-}
-
-final class wire_cst_PayAmount_Asset extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> asset_id;
-
-  @ffi.Double()
-  external double receiver_amount;
-
-  external ffi.Pointer<ffi.Bool> estimate_asset_fees;
-}
-
-final class PayAmountKind extends ffi.Union {
-  external wire_cst_PayAmount_Bitcoin Bitcoin;
-
-  external wire_cst_PayAmount_Asset Asset;
-}
-
-final class wire_cst_pay_amount extends ffi.Struct {
-  @ffi.Int32()
-  external int tag;
-
-  external PayAmountKind kind;
 }
 
 final class wire_cst_prepare_ln_url_pay_request extends ffi.Struct {
@@ -4793,6 +4795,8 @@ final class wire_cst_restore_request extends ffi.Struct {
 
 final class wire_cst_prepare_send_response extends ffi.Struct {
   external wire_cst_send_destination destination;
+
+  external ffi.Pointer<wire_cst_pay_amount> amount;
 
   external ffi.Pointer<ffi.Uint64> fees_sat;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -2003,6 +2003,7 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
                 "destination",
                 "feesSat",
                 "data",
+                "amount",
             ),
         )
     ) {
@@ -2011,6 +2012,7 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
     val destination = prepareLnUrlPayResponse.getMap("destination")?.let { asSendDestination(it) }!!
     val feesSat = prepareLnUrlPayResponse.getDouble("feesSat").toULong()
     val data = prepareLnUrlPayResponse.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
+    val amount = prepareLnUrlPayResponse.getMap("amount")?.let { asPayAmount(it) }!!
     val comment = if (hasNonNullKey(prepareLnUrlPayResponse, "comment")) prepareLnUrlPayResponse.getString("comment") else null
     val successAction =
         if (hasNonNullKey(prepareLnUrlPayResponse, "successAction")) {
@@ -2020,7 +2022,7 @@ fun asPrepareLnUrlPayResponse(prepareLnUrlPayResponse: ReadableMap): PrepareLnUr
         } else {
             null
         }
-    return PrepareLnUrlPayResponse(destination, feesSat, data, comment, successAction)
+    return PrepareLnUrlPayResponse(destination, feesSat, data, amount, comment, successAction)
 }
 
 fun readableMapOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse): ReadableMap =
@@ -2028,6 +2030,7 @@ fun readableMapOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse): ReadableMap
         "destination" to readableMapOf(prepareLnUrlPayResponse.destination),
         "feesSat" to prepareLnUrlPayResponse.feesSat,
         "data" to readableMapOf(prepareLnUrlPayResponse.data),
+        "amount" to readableMapOf(prepareLnUrlPayResponse.amount),
         "comment" to prepareLnUrlPayResponse.comment,
         "successAction" to prepareLnUrlPayResponse.successAction?.let { readableMapOf(it) },
     )
@@ -2357,6 +2360,7 @@ fun asPrepareSendResponse(prepareSendResponse: ReadableMap): PrepareSendResponse
         return null
     }
     val destination = prepareSendResponse.getMap("destination")?.let { asSendDestination(it) }!!
+    val amount = if (hasNonNullKey(prepareSendResponse, "amount")) prepareSendResponse.getMap("amount")?.let { asPayAmount(it) } else null
     val feesSat = if (hasNonNullKey(prepareSendResponse, "feesSat")) prepareSendResponse.getDouble("feesSat").toULong() else null
     val estimatedAssetFees =
         if (hasNonNullKey(
@@ -2368,12 +2372,13 @@ fun asPrepareSendResponse(prepareSendResponse: ReadableMap): PrepareSendResponse
         } else {
             null
         }
-    return PrepareSendResponse(destination, feesSat, estimatedAssetFees)
+    return PrepareSendResponse(destination, amount, feesSat, estimatedAssetFees)
 }
 
 fun readableMapOf(prepareSendResponse: PrepareSendResponse): ReadableMap =
     readableMapOf(
         "destination" to readableMapOf(prepareSendResponse.destination),
+        "amount" to prepareSendResponse.amount?.let { readableMapOf(it) },
         "feesSat" to prepareSendResponse.feesSat,
         "estimatedAssetFees" to prepareSendResponse.estimatedAssetFees,
     )

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -2392,6 +2392,11 @@ enum BreezSDKLiquidMapper {
         }
         let data = try asLnUrlPayRequestData(lnUrlPayRequestData: dataTmp)
 
+        guard let amountTmp = prepareLnUrlPayResponse["amount"] as? [String: Any?] else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amount", typeName: "PrepareLnUrlPayResponse"))
+        }
+        let amount = try asPayAmount(payAmount: amountTmp)
+
         var comment: String?
         if hasNonNilKey(data: prepareLnUrlPayResponse, key: "comment") {
             guard let commentTmp = prepareLnUrlPayResponse["comment"] as? String else {
@@ -2404,7 +2409,7 @@ enum BreezSDKLiquidMapper {
             successAction = try asSuccessAction(successAction: successActionTmp)
         }
 
-        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, data: data, comment: comment, successAction: successAction)
+        return PrepareLnUrlPayResponse(destination: destination, feesSat: feesSat, data: data, amount: amount, comment: comment, successAction: successAction)
     }
 
     static func dictionaryOf(prepareLnUrlPayResponse: PrepareLnUrlPayResponse) -> [String: Any?] {
@@ -2412,6 +2417,7 @@ enum BreezSDKLiquidMapper {
             "destination": dictionaryOf(sendDestination: prepareLnUrlPayResponse.destination),
             "feesSat": prepareLnUrlPayResponse.feesSat,
             "data": dictionaryOf(lnUrlPayRequestData: prepareLnUrlPayResponse.data),
+            "amount": dictionaryOf(payAmount: prepareLnUrlPayResponse.amount),
             "comment": prepareLnUrlPayResponse.comment == nil ? nil : prepareLnUrlPayResponse.comment,
             "successAction": prepareLnUrlPayResponse.successAction == nil ? nil : dictionaryOf(successAction: prepareLnUrlPayResponse.successAction!),
         ]
@@ -2743,6 +2749,11 @@ enum BreezSDKLiquidMapper {
         }
         let destination = try asSendDestination(sendDestination: destinationTmp)
 
+        var amount: PayAmount?
+        if let amountTmp = prepareSendResponse["amount"] as? [String: Any?] {
+            amount = try asPayAmount(payAmount: amountTmp)
+        }
+
         var feesSat: UInt64?
         if hasNonNilKey(data: prepareSendResponse, key: "feesSat") {
             guard let feesSatTmp = prepareSendResponse["feesSat"] as? UInt64 else {
@@ -2758,12 +2769,13 @@ enum BreezSDKLiquidMapper {
             estimatedAssetFees = estimatedAssetFeesTmp
         }
 
-        return PrepareSendResponse(destination: destination, feesSat: feesSat, estimatedAssetFees: estimatedAssetFees)
+        return PrepareSendResponse(destination: destination, amount: amount, feesSat: feesSat, estimatedAssetFees: estimatedAssetFees)
     }
 
     static func dictionaryOf(prepareSendResponse: PrepareSendResponse) -> [String: Any?] {
         return [
             "destination": dictionaryOf(sendDestination: prepareSendResponse.destination),
+            "amount": prepareSendResponse.amount == nil ? nil : dictionaryOf(payAmount: prepareSendResponse.amount!),
             "feesSat": prepareSendResponse.feesSat == nil ? nil : prepareSendResponse.feesSat,
             "estimatedAssetFees": prepareSendResponse.estimatedAssetFees == nil ? nil : prepareSendResponse.estimatedAssetFees,
         ]

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -356,6 +356,7 @@ export interface PrepareLnUrlPayResponse {
     destination: SendDestination
     feesSat: number
     data: LnUrlPayRequestData
+    amount: PayAmount
     comment?: string
     successAction?: SuccessAction
 }
@@ -404,6 +405,7 @@ export interface PrepareSendRequest {
 
 export interface PrepareSendResponse {
     destination: SendDestination
+    amount?: PayAmount
     feesSat?: number
     estimatedAssetFees?: number
 }


### PR DESCRIPTION
Enables BOLT12 drain by inverse calculating the receiver amount the same way as LNURL-pay. We also add the `PayAmount` to the prepare responses to allow them to be used in when sending to determine if the request was a drain.

**Testing notes:**
- Re-test draining via LNURL/lightning address to SDK/non-SDK devices
- Test draining via BOLT12 Offer/BIP535 address to SDK/non-SDK devices

Fixes #922 
Fixes https://github.com/breez/misty-breez/issues/544