### PR TITLE
Expose bitcoin destination address

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -570,6 +570,7 @@ typedef struct wire_cst_PaymentDetails_Liquid {
 
 typedef struct wire_cst_PaymentDetails_Bitcoin {
   struct wire_cst_list_prim_u_8_strict *swap_id;
+  struct wire_cst_list_prim_u_8_strict *destination_address;
   struct wire_cst_list_prim_u_8_strict *description;
   bool auto_accepted_fees;
   uint32_t *liquid_expiration_blockheight;

--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -570,7 +570,7 @@ typedef struct wire_cst_PaymentDetails_Liquid {
 
 typedef struct wire_cst_PaymentDetails_Bitcoin {
   struct wire_cst_list_prim_u_8_strict *swap_id;
-  struct wire_cst_list_prim_u_8_strict *destination_address;
+  struct wire_cst_list_prim_u_8_strict *bitcoin_address;
   struct wire_cst_list_prim_u_8_strict *description;
   bool auto_accepted_fees;
   uint32_t *liquid_expiration_blockheight;

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/SwapUpdated.swift
@@ -108,7 +108,7 @@ class SwapUpdatedTask : TaskProtocol {
     func getSwapId(details: PaymentDetails?) -> String? {
         if let details = details {
             switch details {
-            case let .bitcoin(swapId, _, _, _, _, _, _, _, _):
+            case let .bitcoin(swapId, _, _, _, _, _, _, _, _, _):
                 return swapId
             case let .lightning(swapId, _, _, _, _, _, _, _, _, _, _, _, _):
                 return swapId
@@ -121,7 +121,7 @@ class SwapUpdatedTask : TaskProtocol {
 
     func paymentClaimIsBroadcasted(details: PaymentDetails) -> Bool {
         switch details {
-        case let .bitcoin(_, _, _, _, _, _, claimTxId, _, _):
+        case let .bitcoin(_, _, _, _, _, _, _, claimTxId, _, _):
             return claimTxId != nil
         case let .lightning(_, _, _, _, _, _, _, _, _, _, claimTxId, _, _):
             return claimTxId != nil

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -633,7 +633,7 @@ dictionary AssetInfo {
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? bip353_address, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string asset_id, string destination, string description, AssetInfo? asset_info, LnUrlInfo? lnurl_info, string? bip353_address);
-    Bitcoin(string swap_id, string destination_address, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? lockup_tx_id, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Bitcoin(string swap_id, string bitcoin_address, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? lockup_tx_id, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -633,7 +633,7 @@ dictionary AssetInfo {
 interface PaymentDetails {
     Lightning(string swap_id, string description, u32 liquid_expiration_blockheight, string? preimage, string? invoice, string? bolt12_offer, string? payment_hash, string? destination_pubkey, LnUrlInfo? lnurl_info, string? bip353_address, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
     Liquid(string asset_id, string destination, string description, AssetInfo? asset_info, LnUrlInfo? lnurl_info, string? bip353_address);
-    Bitcoin(string swap_id, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? lockup_tx_id, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
+    Bitcoin(string swap_id, string destination_address, string description, boolean auto_accepted_fees, u32? bitcoin_expiration_blockheight, u32? liquid_expiration_blockheight, string? lockup_tx_id, string? claim_tx_id, string? refund_tx_id, u64? refund_tx_amount_sat);
 };
 
 dictionary Payment {

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4081,6 +4081,7 @@ impl SseDecode for crate::model::PaymentDetails {
             }
             2 => {
                 let mut var_swapId = <String>::sse_decode(deserializer);
+                let mut var_destinationAddress = <String>::sse_decode(deserializer);
                 let mut var_description = <String>::sse_decode(deserializer);
                 let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
@@ -4091,6 +4092,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Bitcoin {
                     swap_id: var_swapId,
+                    destination_address: var_destinationAddress,
                     description: var_description,
                     auto_accepted_fees: var_autoAcceptedFees,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
@@ -6514,6 +6516,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             .into_dart(),
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
+                destination_address,
                 description,
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
@@ -6525,6 +6528,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             } => [
                 2.into_dart(),
                 swap_id.into_into_dart().into_dart(),
+                destination_address.into_into_dart().into_dart(),
                 description.into_into_dart().into_dart(),
                 auto_accepted_fees.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
@@ -8886,6 +8890,7 @@ impl SseEncode for crate::model::PaymentDetails {
             }
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
+                destination_address,
                 description,
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
@@ -8897,6 +8902,7 @@ impl SseEncode for crate::model::PaymentDetails {
             } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(swap_id, serializer);
+                <String>::sse_encode(destination_address, serializer);
                 <String>::sse_encode(description, serializer);
                 <bool>::sse_encode(auto_accepted_fees, serializer);
                 <Option<u32>>::sse_encode(liquid_expiration_blockheight, serializer);
@@ -11190,6 +11196,7 @@ mod io {
                     let ans = unsafe { self.kind.Bitcoin };
                     crate::model::PaymentDetails::Bitcoin {
                         swap_id: ans.swap_id.cst_decode(),
+                        destination_address: ans.destination_address.cst_decode(),
                         description: ans.description.cst_decode(),
                         auto_accepted_fees: ans.auto_accepted_fees.cst_decode(),
                         liquid_expiration_blockheight: ans
@@ -15109,6 +15116,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_PaymentDetails_Bitcoin {
         swap_id: *mut wire_cst_list_prim_u_8_strict,
+        destination_address: *mut wire_cst_list_prim_u_8_strict,
         description: *mut wire_cst_list_prim_u_8_strict,
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: *mut u32,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -4081,7 +4081,7 @@ impl SseDecode for crate::model::PaymentDetails {
             }
             2 => {
                 let mut var_swapId = <String>::sse_decode(deserializer);
-                let mut var_destinationAddress = <String>::sse_decode(deserializer);
+                let mut var_bitcoinAddress = <String>::sse_decode(deserializer);
                 let mut var_description = <String>::sse_decode(deserializer);
                 let mut var_autoAcceptedFees = <bool>::sse_decode(deserializer);
                 let mut var_liquidExpirationBlockheight = <Option<u32>>::sse_decode(deserializer);
@@ -4092,7 +4092,7 @@ impl SseDecode for crate::model::PaymentDetails {
                 let mut var_refundTxAmountSat = <Option<u64>>::sse_decode(deserializer);
                 return crate::model::PaymentDetails::Bitcoin {
                     swap_id: var_swapId,
-                    destination_address: var_destinationAddress,
+                    bitcoin_address: var_bitcoinAddress,
                     description: var_description,
                     auto_accepted_fees: var_autoAcceptedFees,
                     liquid_expiration_blockheight: var_liquidExpirationBlockheight,
@@ -6516,7 +6516,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             .into_dart(),
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
-                destination_address,
+                bitcoin_address,
                 description,
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
@@ -6528,7 +6528,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentDetails {
             } => [
                 2.into_dart(),
                 swap_id.into_into_dart().into_dart(),
-                destination_address.into_into_dart().into_dart(),
+                bitcoin_address.into_into_dart().into_dart(),
                 description.into_into_dart().into_dart(),
                 auto_accepted_fees.into_into_dart().into_dart(),
                 liquid_expiration_blockheight.into_into_dart().into_dart(),
@@ -8890,7 +8890,7 @@ impl SseEncode for crate::model::PaymentDetails {
             }
             crate::model::PaymentDetails::Bitcoin {
                 swap_id,
-                destination_address,
+                bitcoin_address,
                 description,
                 auto_accepted_fees,
                 liquid_expiration_blockheight,
@@ -8902,7 +8902,7 @@ impl SseEncode for crate::model::PaymentDetails {
             } => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(swap_id, serializer);
-                <String>::sse_encode(destination_address, serializer);
+                <String>::sse_encode(bitcoin_address, serializer);
                 <String>::sse_encode(description, serializer);
                 <bool>::sse_encode(auto_accepted_fees, serializer);
                 <Option<u32>>::sse_encode(liquid_expiration_blockheight, serializer);
@@ -11196,7 +11196,7 @@ mod io {
                     let ans = unsafe { self.kind.Bitcoin };
                     crate::model::PaymentDetails::Bitcoin {
                         swap_id: ans.swap_id.cst_decode(),
-                        destination_address: ans.destination_address.cst_decode(),
+                        bitcoin_address: ans.bitcoin_address.cst_decode(),
                         description: ans.description.cst_decode(),
                         auto_accepted_fees: ans.auto_accepted_fees.cst_decode(),
                         liquid_expiration_blockheight: ans
@@ -15116,7 +15116,7 @@ mod io {
     #[derive(Clone, Copy)]
     pub struct wire_cst_PaymentDetails_Bitcoin {
         swap_id: *mut wire_cst_list_prim_u_8_strict,
-        destination_address: *mut wire_cst_list_prim_u_8_strict,
+        bitcoin_address: *mut wire_cst_list_prim_u_8_strict,
         description: *mut wire_cst_list_prim_u_8_strict,
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: *mut u32,

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1929,6 +1929,9 @@ pub enum PaymentDetails {
     Bitcoin {
         swap_id: String,
 
+        /// The Bitcoin destination address of the swap.
+        destination_address: String,
+
         /// Represents the invoice description
         description: String,
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1796,9 +1796,8 @@ pub struct PaymentSwapData {
     pub refund_tx_amount_sat: Option<u64>,
 
     /// Present only for chain swaps.
-    /// In case of an outgoing chain swap, it's the Bitcoin address which will receive the funds
-    /// In case of an incoming chain swap, it's the Liquid address which will receive the funds
-    pub claim_address: Option<String>,
+    /// It's the Bitcoin address that receives funds.
+    pub bitcoin_address: Option<String>,
 
     /// Payment status derived from the swap status
     pub status: PaymentState,
@@ -1929,8 +1928,8 @@ pub enum PaymentDetails {
     Bitcoin {
         swap_id: String,
 
-        /// The Bitcoin destination address of the swap.
-        destination_address: String,
+        /// The Bitcoin address that receives funds.
+        bitcoin_address: String,
 
         /// Represents the invoice description
         description: String,
@@ -2127,7 +2126,7 @@ impl Payment {
             tx_id: Some(tx.tx_id),
             unblinding_data: tx.unblinding_data,
             // When the swap is present and of type send and receive, we retrieve the destination from the invoice.
-            // If it's a chain swap instead, we use the `claim_address` field from the swap data (either pure Bitcoin or Liquid address).
+            // If it's a chain swap instead, we use the `bitcoin_address` field from the swap data.
             // Otherwise, we specify the Liquid address (BIP21 or pure), set in `payment_details.address`.
             destination: match &swap {
                 Some(PaymentSwapData {
@@ -2143,9 +2142,9 @@ impl Payment {
                 }) => bolt12_offer.clone().or(invoice.clone()),
                 Some(PaymentSwapData {
                     swap_type: PaymentSwapType::Chain,
-                    claim_address,
+                    bitcoin_address,
                     ..
-                }) => claim_address.clone(),
+                }) => bitcoin_address.clone(),
                 _ => match &details {
                     PaymentDetails::Liquid { destination, .. } => Some(destination.clone()),
                     _ => None,

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -105,7 +105,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert_eq!(payment.payment_type, PaymentType::Receive);
     assert_eq!(payment.status, PaymentState::Complete);
     assert!(
-        matches!(&payment.details, PaymentDetails::Bitcoin { destination_address, .. } if *destination_address == address)
+        matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
 
     // --------------SEND--------------
@@ -171,7 +171,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert_eq!(payment.payment_type, PaymentType::Send);
     assert_eq!(payment.status, PaymentState::Complete);
     assert!(
-        matches!(&payment.details, PaymentDetails::Bitcoin { destination_address, .. } if *destination_address == address)
+        matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
 
     // ----------------REFUND--------------

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -104,7 +104,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert_eq!(payment.fees_sat, prepare_response.fees_sat);
     assert_eq!(payment.payment_type, PaymentType::Receive);
     assert_eq!(payment.status, PaymentState::Complete);
-    assert!(matches!(payment.details, PaymentDetails::Bitcoin { .. }));
+    assert!(
+        matches!(&payment.details, PaymentDetails::Bitcoin { destination_address, .. } if *destination_address == address)
+    );
 
     // --------------SEND--------------
 
@@ -120,7 +122,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
                 },
                 fee_rate_sat_per_vbyte: None,
             },
-            address,
+            address.clone(),
         )
         .await
         .unwrap();
@@ -168,7 +170,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert_eq!(payment.fees_sat, fees_sat);
     assert_eq!(payment.payment_type, PaymentType::Send);
     assert_eq!(payment.status, PaymentState::Complete);
-    assert!(matches!(payment.details, PaymentDetails::Bitcoin { .. }));
+    assert!(
+        matches!(&payment.details, PaymentDetails::Bitcoin { destination_address, .. } if *destination_address == address)
+    );
 
     // ----------------REFUND--------------
 

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -712,7 +712,7 @@ pub enum PaymentDetails {
     },
     Bitcoin {
         swap_id: String,
-        destination_address: String,
+        bitcoin_address: String,
         description: String,
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: Option<u32>,

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -712,6 +712,7 @@ pub enum PaymentDetails {
     },
     Bitcoin {
         swap_id: String,
+        destination_address: String,
         description: String,
         auto_accepted_fees: bool,
         liquid_expiration_blockheight: Option<u32>,

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2862,7 +2862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return PaymentDetails_Bitcoin(
           swapId: dco_decode_String(raw[1]),
-          destinationAddress: dco_decode_String(raw[2]),
+          bitcoinAddress: dco_decode_String(raw[2]),
           description: dco_decode_String(raw[3]),
           autoAcceptedFees: dco_decode_bool(raw[4]),
           liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
@@ -5256,7 +5256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         );
       case 2:
         var var_swapId = sse_decode_String(deserializer);
-        var var_destinationAddress = sse_decode_String(deserializer);
+        var var_bitcoinAddress = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
         var var_autoAcceptedFees = sse_decode_bool(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
@@ -5267,7 +5267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
         return PaymentDetails_Bitcoin(
           swapId: var_swapId,
-          destinationAddress: var_destinationAddress,
+          bitcoinAddress: var_bitcoinAddress,
           description: var_description,
           autoAcceptedFees: var_autoAcceptedFees,
           liquidExpirationBlockheight: var_liquidExpirationBlockheight,
@@ -7559,7 +7559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_String(bip353Address, serializer);
       case PaymentDetails_Bitcoin(
         swapId: final swapId,
-        destinationAddress: final destinationAddress,
+        bitcoinAddress: final bitcoinAddress,
         description: final description,
         autoAcceptedFees: final autoAcceptedFees,
         liquidExpirationBlockheight: final liquidExpirationBlockheight,
@@ -7571,7 +7571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ):
         sse_encode_i_32(2, serializer);
         sse_encode_String(swapId, serializer);
-        sse_encode_String(destinationAddress, serializer);
+        sse_encode_String(bitcoinAddress, serializer);
         sse_encode_String(description, serializer);
         sse_encode_bool(autoAcceptedFees, serializer);
         sse_encode_opt_box_autoadd_u_32(liquidExpirationBlockheight, serializer);

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2862,14 +2862,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return PaymentDetails_Bitcoin(
           swapId: dco_decode_String(raw[1]),
-          description: dco_decode_String(raw[2]),
-          autoAcceptedFees: dco_decode_bool(raw[3]),
-          liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[4]),
-          bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
-          lockupTxId: dco_decode_opt_String(raw[6]),
-          claimTxId: dco_decode_opt_String(raw[7]),
-          refundTxId: dco_decode_opt_String(raw[8]),
-          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[9]),
+          destinationAddress: dco_decode_String(raw[2]),
+          description: dco_decode_String(raw[3]),
+          autoAcceptedFees: dco_decode_bool(raw[4]),
+          liquidExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[5]),
+          bitcoinExpirationBlockheight: dco_decode_opt_box_autoadd_u_32(raw[6]),
+          lockupTxId: dco_decode_opt_String(raw[7]),
+          claimTxId: dco_decode_opt_String(raw[8]),
+          refundTxId: dco_decode_opt_String(raw[9]),
+          refundTxAmountSat: dco_decode_opt_box_autoadd_u_64(raw[10]),
         );
       default:
         throw Exception("unreachable");
@@ -5255,6 +5256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         );
       case 2:
         var var_swapId = sse_decode_String(deserializer);
+        var var_destinationAddress = sse_decode_String(deserializer);
         var var_description = sse_decode_String(deserializer);
         var var_autoAcceptedFees = sse_decode_bool(deserializer);
         var var_liquidExpirationBlockheight = sse_decode_opt_box_autoadd_u_32(deserializer);
@@ -5265,6 +5267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_refundTxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
         return PaymentDetails_Bitcoin(
           swapId: var_swapId,
+          destinationAddress: var_destinationAddress,
           description: var_description,
           autoAcceptedFees: var_autoAcceptedFees,
           liquidExpirationBlockheight: var_liquidExpirationBlockheight,
@@ -7556,6 +7559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_String(bip353Address, serializer);
       case PaymentDetails_Bitcoin(
         swapId: final swapId,
+        destinationAddress: final destinationAddress,
         description: final description,
         autoAcceptedFees: final autoAcceptedFees,
         liquidExpirationBlockheight: final liquidExpirationBlockheight,
@@ -7567,6 +7571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ):
         sse_encode_i_32(2, serializer);
         sse_encode_String(swapId, serializer);
+        sse_encode_String(destinationAddress, serializer);
         sse_encode_String(description, serializer);
         sse_encode_bool(autoAcceptedFees, serializer);
         sse_encode_opt_box_autoadd_u_32(liquidExpirationBlockheight, serializer);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3475,7 +3475,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     }
     if (apiObj is PaymentDetails_Bitcoin) {
       var pre_swap_id = cst_encode_String(apiObj.swapId);
-      var pre_destination_address = cst_encode_String(apiObj.destinationAddress);
+      var pre_bitcoin_address = cst_encode_String(apiObj.bitcoinAddress);
       var pre_description = cst_encode_String(apiObj.description);
       var pre_auto_accepted_fees = cst_encode_bool(apiObj.autoAcceptedFees);
       var pre_liquid_expiration_blockheight = cst_encode_opt_box_autoadd_u_32(
@@ -3490,7 +3490,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
       wireObj.tag = 2;
       wireObj.kind.Bitcoin.swap_id = pre_swap_id;
-      wireObj.kind.Bitcoin.destination_address = pre_destination_address;
+      wireObj.kind.Bitcoin.bitcoin_address = pre_bitcoin_address;
       wireObj.kind.Bitcoin.description = pre_description;
       wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       wireObj.kind.Bitcoin.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
@@ -7099,7 +7099,7 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_address;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bitcoin_address;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3475,6 +3475,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     }
     if (apiObj is PaymentDetails_Bitcoin) {
       var pre_swap_id = cst_encode_String(apiObj.swapId);
+      var pre_destination_address = cst_encode_String(apiObj.destinationAddress);
       var pre_description = cst_encode_String(apiObj.description);
       var pre_auto_accepted_fees = cst_encode_bool(apiObj.autoAcceptedFees);
       var pre_liquid_expiration_blockheight = cst_encode_opt_box_autoadd_u_32(
@@ -3489,6 +3490,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_refund_tx_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.refundTxAmountSat);
       wireObj.tag = 2;
       wireObj.kind.Bitcoin.swap_id = pre_swap_id;
+      wireObj.kind.Bitcoin.destination_address = pre_destination_address;
       wireObj.kind.Bitcoin.description = pre_description;
       wireObj.kind.Bitcoin.auto_accepted_fees = pre_auto_accepted_fees;
       wireObj.kind.Bitcoin.liquid_expiration_blockheight = pre_liquid_expiration_blockheight;
@@ -7096,6 +7098,8 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
 
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_address;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -974,6 +974,9 @@ sealed class PaymentDetails with _$PaymentDetails {
   const factory PaymentDetails.bitcoin({
     required String swapId,
 
+    /// The Bitcoin destination address of the swap.
+    required String destinationAddress,
+
     /// Represents the invoice description
     required String description,
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -974,8 +974,8 @@ sealed class PaymentDetails with _$PaymentDetails {
   const factory PaymentDetails.bitcoin({
     required String swapId,
 
-    /// The Bitcoin destination address of the swap.
-    required String destinationAddress,
+    /// The Bitcoin address that receives funds.
+    required String bitcoinAddress,
 
     /// Represents the invoice description
     required String description,

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1214,12 +1214,12 @@ as String?,
 
 
 class PaymentDetails_Bitcoin extends PaymentDetails {
-  const PaymentDetails_Bitcoin({required this.swapId, required this.destinationAddress, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.lockupTxId, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
+  const PaymentDetails_Bitcoin({required this.swapId, required this.bitcoinAddress, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.lockupTxId, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
   
 
  final  String swapId;
-/// The Bitcoin destination address of the swap.
- final  String destinationAddress;
+/// The Bitcoin address that receives funds.
+ final  String bitcoinAddress;
 /// Represents the invoice description
 @override final  String description;
 /// For an amountless receive swap, this indicates if fees were automatically accepted.
@@ -1251,16 +1251,16 @@ $PaymentDetails_BitcoinCopyWith<PaymentDetails_Bitcoin> get copyWith => _$Paymen
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.destinationAddress, destinationAddress) || other.destinationAddress == destinationAddress)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.lockupTxId, lockupTxId) || other.lockupTxId == lockupTxId)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.bitcoinAddress, bitcoinAddress) || other.bitcoinAddress == bitcoinAddress)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.lockupTxId, lockupTxId) || other.lockupTxId == lockupTxId)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,swapId,destinationAddress,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,lockupTxId,claimTxId,refundTxId,refundTxAmountSat);
+int get hashCode => Object.hash(runtimeType,swapId,bitcoinAddress,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,lockupTxId,claimTxId,refundTxId,refundTxAmountSat);
 
 @override
 String toString() {
-  return 'PaymentDetails.bitcoin(swapId: $swapId, destinationAddress: $destinationAddress, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, lockupTxId: $lockupTxId, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+  return 'PaymentDetails.bitcoin(swapId: $swapId, bitcoinAddress: $bitcoinAddress, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, lockupTxId: $lockupTxId, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
 }
 
 
@@ -1271,7 +1271,7 @@ abstract mixin class $PaymentDetails_BitcoinCopyWith<$Res> implements $PaymentDe
   factory $PaymentDetails_BitcoinCopyWith(PaymentDetails_Bitcoin value, $Res Function(PaymentDetails_Bitcoin) _then) = _$PaymentDetails_BitcoinCopyWithImpl;
 @override @useResult
 $Res call({
- String swapId, String destinationAddress, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? lockupTxId, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
+ String swapId, String bitcoinAddress, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? lockupTxId, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
 });
 
 
@@ -1288,10 +1288,10 @@ class _$PaymentDetails_BitcoinCopyWithImpl<$Res>
 
 /// Create a copy of PaymentDetails
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? destinationAddress = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? lockupTxId = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? bitcoinAddress = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? lockupTxId = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
   return _then(PaymentDetails_Bitcoin(
 swapId: null == swapId ? _self.swapId : swapId // ignore: cast_nullable_to_non_nullable
-as String,destinationAddress: null == destinationAddress ? _self.destinationAddress : destinationAddress // ignore: cast_nullable_to_non_nullable
+as String,bitcoinAddress: null == bitcoinAddress ? _self.bitcoinAddress : bitcoinAddress // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,autoAcceptedFees: null == autoAcceptedFees ? _self.autoAcceptedFees : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
 as bool,liquidExpirationBlockheight: freezed == liquidExpirationBlockheight ? _self.liquidExpirationBlockheight : liquidExpirationBlockheight // ignore: cast_nullable_to_non_nullable

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1214,10 +1214,12 @@ as String?,
 
 
 class PaymentDetails_Bitcoin extends PaymentDetails {
-  const PaymentDetails_Bitcoin({required this.swapId, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.lockupTxId, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
+  const PaymentDetails_Bitcoin({required this.swapId, required this.destinationAddress, required this.description, required this.autoAcceptedFees, this.liquidExpirationBlockheight, this.bitcoinExpirationBlockheight, this.lockupTxId, this.claimTxId, this.refundTxId, this.refundTxAmountSat}): super._();
   
 
  final  String swapId;
+/// The Bitcoin destination address of the swap.
+ final  String destinationAddress;
 /// Represents the invoice description
 @override final  String description;
 /// For an amountless receive swap, this indicates if fees were automatically accepted.
@@ -1249,16 +1251,16 @@ $PaymentDetails_BitcoinCopyWith<PaymentDetails_Bitcoin> get copyWith => _$Paymen
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.lockupTxId, lockupTxId) || other.lockupTxId == lockupTxId)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentDetails_Bitcoin&&(identical(other.swapId, swapId) || other.swapId == swapId)&&(identical(other.destinationAddress, destinationAddress) || other.destinationAddress == destinationAddress)&&(identical(other.description, description) || other.description == description)&&(identical(other.autoAcceptedFees, autoAcceptedFees) || other.autoAcceptedFees == autoAcceptedFees)&&(identical(other.liquidExpirationBlockheight, liquidExpirationBlockheight) || other.liquidExpirationBlockheight == liquidExpirationBlockheight)&&(identical(other.bitcoinExpirationBlockheight, bitcoinExpirationBlockheight) || other.bitcoinExpirationBlockheight == bitcoinExpirationBlockheight)&&(identical(other.lockupTxId, lockupTxId) || other.lockupTxId == lockupTxId)&&(identical(other.claimTxId, claimTxId) || other.claimTxId == claimTxId)&&(identical(other.refundTxId, refundTxId) || other.refundTxId == refundTxId)&&(identical(other.refundTxAmountSat, refundTxAmountSat) || other.refundTxAmountSat == refundTxAmountSat));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,swapId,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,lockupTxId,claimTxId,refundTxId,refundTxAmountSat);
+int get hashCode => Object.hash(runtimeType,swapId,destinationAddress,description,autoAcceptedFees,liquidExpirationBlockheight,bitcoinExpirationBlockheight,lockupTxId,claimTxId,refundTxId,refundTxAmountSat);
 
 @override
 String toString() {
-  return 'PaymentDetails.bitcoin(swapId: $swapId, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, lockupTxId: $lockupTxId, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
+  return 'PaymentDetails.bitcoin(swapId: $swapId, destinationAddress: $destinationAddress, description: $description, autoAcceptedFees: $autoAcceptedFees, liquidExpirationBlockheight: $liquidExpirationBlockheight, bitcoinExpirationBlockheight: $bitcoinExpirationBlockheight, lockupTxId: $lockupTxId, claimTxId: $claimTxId, refundTxId: $refundTxId, refundTxAmountSat: $refundTxAmountSat)';
 }
 
 
@@ -1269,7 +1271,7 @@ abstract mixin class $PaymentDetails_BitcoinCopyWith<$Res> implements $PaymentDe
   factory $PaymentDetails_BitcoinCopyWith(PaymentDetails_Bitcoin value, $Res Function(PaymentDetails_Bitcoin) _then) = _$PaymentDetails_BitcoinCopyWithImpl;
 @override @useResult
 $Res call({
- String swapId, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? lockupTxId, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
+ String swapId, String destinationAddress, String description, bool autoAcceptedFees, int? liquidExpirationBlockheight, int? bitcoinExpirationBlockheight, String? lockupTxId, String? claimTxId, String? refundTxId, BigInt? refundTxAmountSat
 });
 
 
@@ -1286,9 +1288,10 @@ class _$PaymentDetails_BitcoinCopyWithImpl<$Res>
 
 /// Create a copy of PaymentDetails
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? lockupTxId = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? swapId = null,Object? destinationAddress = null,Object? description = null,Object? autoAcceptedFees = null,Object? liquidExpirationBlockheight = freezed,Object? bitcoinExpirationBlockheight = freezed,Object? lockupTxId = freezed,Object? claimTxId = freezed,Object? refundTxId = freezed,Object? refundTxAmountSat = freezed,}) {
   return _then(PaymentDetails_Bitcoin(
 swapId: null == swapId ? _self.swapId : swapId // ignore: cast_nullable_to_non_nullable
+as String,destinationAddress: null == destinationAddress ? _self.destinationAddress : destinationAddress // ignore: cast_nullable_to_non_nullable
 as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String,autoAcceptedFees: null == autoAcceptedFees ? _self.autoAcceptedFees : autoAcceptedFees // ignore: cast_nullable_to_non_nullable
 as bool,liquidExpirationBlockheight: freezed == liquidExpirationBlockheight ? _self.liquidExpirationBlockheight : liquidExpirationBlockheight // ignore: cast_nullable_to_non_nullable

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4944,7 +4944,7 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 
-  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_address;
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> bitcoin_address;
 
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -4944,6 +4944,8 @@ final class wire_cst_PaymentDetails_Liquid extends ffi.Struct {
 final class wire_cst_PaymentDetails_Bitcoin extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> swap_id;
 
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> destination_address;
+
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> description;
 
   @ffi.Bool()

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3621,6 +3621,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
     }
     if (type == "bitcoin") {
         val swapId = paymentDetails.getString("swapId")!!
+        val destinationAddress = paymentDetails.getString("destinationAddress")!!
         val description = paymentDetails.getString("description")!!
         val autoAcceptedFees = paymentDetails.getBoolean("autoAcceptedFees")
         val bitcoinExpirationBlockheight =
@@ -3658,6 +3659,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             }
         return PaymentDetails.Bitcoin(
             swapId,
+            destinationAddress,
             description,
             autoAcceptedFees,
             bitcoinExpirationBlockheight,
@@ -3702,6 +3704,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
         is PaymentDetails.Bitcoin -> {
             pushToMap(map, "type", "bitcoin")
             pushToMap(map, "swapId", paymentDetails.swapId)
+            pushToMap(map, "destinationAddress", paymentDetails.destinationAddress)
             pushToMap(map, "description", paymentDetails.description)
             pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
             pushToMap(map, "bitcoinExpirationBlockheight", paymentDetails.bitcoinExpirationBlockheight)

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -3621,7 +3621,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
     }
     if (type == "bitcoin") {
         val swapId = paymentDetails.getString("swapId")!!
-        val destinationAddress = paymentDetails.getString("destinationAddress")!!
+        val bitcoinAddress = paymentDetails.getString("bitcoinAddress")!!
         val description = paymentDetails.getString("description")!!
         val autoAcceptedFees = paymentDetails.getBoolean("autoAcceptedFees")
         val bitcoinExpirationBlockheight =
@@ -3659,7 +3659,7 @@ fun asPaymentDetails(paymentDetails: ReadableMap): PaymentDetails? {
             }
         return PaymentDetails.Bitcoin(
             swapId,
-            destinationAddress,
+            bitcoinAddress,
             description,
             autoAcceptedFees,
             bitcoinExpirationBlockheight,
@@ -3704,7 +3704,7 @@ fun readableMapOf(paymentDetails: PaymentDetails): ReadableMap? {
         is PaymentDetails.Bitcoin -> {
             pushToMap(map, "type", "bitcoin")
             pushToMap(map, "swapId", paymentDetails.swapId)
-            pushToMap(map, "destinationAddress", paymentDetails.destinationAddress)
+            pushToMap(map, "bitcoinAddress", paymentDetails.bitcoinAddress)
             pushToMap(map, "description", paymentDetails.description)
             pushToMap(map, "autoAcceptedFees", paymentDetails.autoAcceptedFees)
             pushToMap(map, "bitcoinExpirationBlockheight", paymentDetails.bitcoinExpirationBlockheight)

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4432,6 +4432,9 @@ enum BreezSDKLiquidMapper {
             guard let _swapId = paymentDetails["swapId"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
             }
+            guard let _destinationAddress = paymentDetails["destinationAddress"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destinationAddress", typeName: "PaymentDetails"))
+            }
             guard let _description = paymentDetails["description"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
             }
@@ -4450,7 +4453,7 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.bitcoin(swapId: _swapId, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, lockupTxId: _lockupTxId, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.bitcoin(swapId: _swapId, destinationAddress: _destinationAddress, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, lockupTxId: _lockupTxId, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4492,11 +4495,12 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, lockupTxId, claimTxId, refundTxId, refundTxAmountSat
+            swapId, destinationAddress, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, lockupTxId, claimTxId, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "bitcoin",
                 "swapId": swapId,
+                "destinationAddress": destinationAddress,
                 "description": description,
                 "autoAcceptedFees": autoAcceptedFees,
                 "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -4432,8 +4432,8 @@ enum BreezSDKLiquidMapper {
             guard let _swapId = paymentDetails["swapId"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "swapId", typeName: "PaymentDetails"))
             }
-            guard let _destinationAddress = paymentDetails["destinationAddress"] as? String else {
-                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "destinationAddress", typeName: "PaymentDetails"))
+            guard let _bitcoinAddress = paymentDetails["bitcoinAddress"] as? String else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bitcoinAddress", typeName: "PaymentDetails"))
             }
             guard let _description = paymentDetails["description"] as? String else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "description", typeName: "PaymentDetails"))
@@ -4453,7 +4453,7 @@ enum BreezSDKLiquidMapper {
 
             let _refundTxAmountSat = paymentDetails["refundTxAmountSat"] as? UInt64
 
-            return PaymentDetails.bitcoin(swapId: _swapId, destinationAddress: _destinationAddress, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, lockupTxId: _lockupTxId, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
+            return PaymentDetails.bitcoin(swapId: _swapId, bitcoinAddress: _bitcoinAddress, description: _description, autoAcceptedFees: _autoAcceptedFees, bitcoinExpirationBlockheight: _bitcoinExpirationBlockheight, liquidExpirationBlockheight: _liquidExpirationBlockheight, lockupTxId: _lockupTxId, claimTxId: _claimTxId, refundTxId: _refundTxId, refundTxAmountSat: _refundTxAmountSat)
         }
 
         throw SdkError.Generic(message: "Unexpected type \(type) for enum PaymentDetails")
@@ -4495,12 +4495,12 @@ enum BreezSDKLiquidMapper {
             ]
 
         case let .bitcoin(
-            swapId, destinationAddress, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, lockupTxId, claimTxId, refundTxId, refundTxAmountSat
+            swapId, bitcoinAddress, description, autoAcceptedFees, bitcoinExpirationBlockheight, liquidExpirationBlockheight, lockupTxId, claimTxId, refundTxId, refundTxAmountSat
         ):
             return [
                 "type": "bitcoin",
                 "swapId": swapId,
-                "destinationAddress": destinationAddress,
+                "bitcoinAddress": bitcoinAddress,
                 "description": description,
                 "autoAcceptedFees": autoAcceptedFees,
                 "bitcoinExpirationBlockheight": bitcoinExpirationBlockheight == nil ? nil : bitcoinExpirationBlockheight,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -735,6 +735,7 @@ export type PaymentDetails = {
 } | {
     type: PaymentDetailsVariant.BITCOIN,
     swapId: string
+    destinationAddress: string
     description: string
     autoAcceptedFees: boolean
     bitcoinExpirationBlockheight?: number

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -735,7 +735,7 @@ export type PaymentDetails = {
 } | {
     type: PaymentDetailsVariant.BITCOIN,
     swapId: string
-    destinationAddress: string
+    bitcoinAddress: string
     description: string
     autoAcceptedFees: boolean
     bitcoinExpirationBlockheight?: number


### PR DESCRIPTION
Resolves #913

This exposes `bitcoin_address` in `PaymentDetails::Bitcoin`. The goal is to allow integrators to match created receive chain swaps with the resulting payment.

I opted for exposing just the address (not the bip21) as it is simpler and keeps the field consistent across payment directions. 
