### PR TITLE
Update LWK for node.js compatible sleep

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.9.0"
-source = "git+https://github.com/breez/lwk?rev=9946a62ea8f7b5ff936f09c77ec597552c44c2bf#9946a62ea8f7b5ff936f09c77ec597552c44c2bf"
+source = "git+https://github.com/breez/lwk?rev=417405cabbebe89df758fe7990f80011808aff4e#417405cabbebe89df758fe7990f80011808aff4e"
 dependencies = [
  "aes-gcm-siv",
  "age",
@@ -2750,9 +2750,9 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio_with_wasm",
  "url",
  "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.9.0"
-source = "git+https://github.com/breez/lwk?rev=9946a62ea8f7b5ff936f09c77ec597552c44c2bf#9946a62ea8f7b5ff936f09c77ec597552c44c2bf"
+source = "git+https://github.com/breez/lwk?rev=417405cabbebe89df758fe7990f80011808aff4e#417405cabbebe89df758fe7990f80011808aff4e"
 dependencies = [
  "aes-gcm-siv",
  "age",
@@ -3128,9 +3128,9 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio_with_wasm",
  "url",
  "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -72,7 +72,7 @@ electrum-client = { version = "0.21.0", default-features = false, features = [
     "use-rustls-ring",
     "proxy",
 ] }
-lwk_wollet = { git = "https://github.com/breez/lwk", rev = "9946a62ea8f7b5ff936f09c77ec597552c44c2bf" }
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "417405cabbebe89df758fe7990f80011808aff4e" }
 maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
@@ -88,7 +88,7 @@ rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7e
 # Wasm dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 console_log = "1"
-lwk_wollet = { git = "https://github.com/breez/lwk", rev = "9946a62ea8f7b5ff936f09c77ec597552c44c2bf", default-features = false, features = [
+lwk_wollet = { git = "https://github.com/breez/lwk", rev = "417405cabbebe89df758fe7990f80011808aff4e", default-features = false, features = [
     "esplora",
 ] }
 maybe-sync = "0.1.1"


### PR DESCRIPTION
Fixes the issue where LWK panics if an async sleep is triggered in node.js because it depends on web_sys::Window

LWK commit: https://github.com/breez/lwk/commit/417405cabbebe89df758fe7990f80011808aff4e