### PR TITLE
Increase network propagation grace period

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -87,7 +87,7 @@ pub const DEFAULT_EXTERNAL_INPUT_PARSERS: &[(&str, &str, &str)] = &[(
     "https://cryptoqr.net/.well-known/lnurlp/<input>",
 )];
 
-pub(crate) const NETWORK_PROPAGATION_GRACE_PERIOD: Duration = Duration::from_secs(60);
+pub(crate) const NETWORK_PROPAGATION_GRACE_PERIOD: Duration = Duration::from_secs(120);
 
 pub struct LiquidSdkBuilder {
     config: Config,


### PR DESCRIPTION
Despite it being very rare, I've just seen logs from version 0.9.0 (it uses the current grace period) where the period wasn't long enough for us to see a receive swap claim tx in time before we cleared it from the swap. This, in turn, caused temporary payment duplication. In this specific case, the claim tx was seen ~10 seconds after it was cleared. 

Probably 90 secs would be enough, but I propose to set it to 120 secs to be on the safe side. Only downside of a larger number is that we increase the time it takes for a txid to be cleared in case its broadcast failed + we fail to update the db accordingly, which IMO is fine given the unlikelihood of such an occasion.