### PR TITLE
CLI: Add phrase file arg

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,8 +24,11 @@ pub(crate) struct Args {
 
     #[clap(short, long, value_parser = parse_network_arg)]
     pub(crate) network: Option<LiquidNetwork>,
-
+    
     #[clap(short, long)]
+    pub(crate) phrase_file: Option<String>,
+    
+    #[clap(long)]
     pub(crate) passphrase: Option<String>,
 }
 
@@ -79,7 +82,7 @@ async fn main() -> Result<()> {
         info!("No history found");
     }
 
-    let mnemonic = persistence.get_or_create_mnemonic()?;
+    let mnemonic = persistence.get_or_create_mnemonic(args.phrase_file.as_deref())?;
     let passphrase = args.passphrase;
     let network = args.network.unwrap_or(LiquidNetwork::Testnet);
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,10 +24,10 @@ pub(crate) struct Args {
 
     #[clap(short, long, value_parser = parse_network_arg)]
     pub(crate) network: Option<LiquidNetwork>,
-    
+
     #[clap(short, long)]
-    pub(crate) phrase_file: Option<String>,
-    
+    pub(crate) phrase_path: Option<String>,
+
     #[clap(long)]
     pub(crate) passphrase: Option<String>,
 }
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
         info!("No history found");
     }
 
-    let mnemonic = persistence.get_or_create_mnemonic(args.phrase_file.as_deref())?;
+    let mnemonic = persistence.get_or_create_mnemonic(args.phrase_path.as_deref())?;
     let passphrase = args.passphrase;
     let network = args.network.unwrap_or(LiquidNetwork::Testnet);
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")

--- a/cli/src/persist.rs
+++ b/cli/src/persist.rs
@@ -15,8 +15,8 @@ pub(crate) struct CliPersistence {
 }
 
 impl CliPersistence {
-    pub(crate) fn get_or_create_mnemonic(&self) -> Result<Mnemonic> {
-        let filename = Path::new(&self.data_dir).join(PHRASE_FILE_NAME);
+    pub(crate) fn get_or_create_mnemonic(&self, phrase_file_name: Option<&str>) -> Result<Mnemonic> {
+        let filename = Path::new(&self.data_dir).join(phrase_file_name.unwrap_or(PHRASE_FILE_NAME));
 
         let mnemonic = match fs::read_to_string(filename.clone()) {
             Ok(phrase) => Mnemonic::from_str(&phrase).unwrap(),

--- a/cli/src/persist.rs
+++ b/cli/src/persist.rs
@@ -15,11 +15,13 @@ pub(crate) struct CliPersistence {
 }
 
 impl CliPersistence {
-    pub(crate) fn get_or_create_mnemonic(&self, phrase_file_name: Option<&str>) -> Result<Mnemonic> {
-        let filename = Path::new(&self.data_dir).join(phrase_file_name.unwrap_or(PHRASE_FILE_NAME));
+    pub(crate) fn get_or_create_mnemonic(&self, phrase_path: Option<&str>) -> Result<Mnemonic> {
+        let maybe_custom_filename = phrase_path.map(PathBuf::from);
+        let filename =
+            maybe_custom_filename.unwrap_or(Path::new(&self.data_dir).join(PHRASE_FILE_NAME));
 
         let mnemonic = match fs::read_to_string(filename.clone()) {
-            Ok(phrase) => Mnemonic::from_str(&phrase).unwrap(),
+            Ok(phrase) => Mnemonic::from_str(&phrase)?,
             Err(e) => {
                 if e.kind() != io::ErrorKind::NotFound {
                     panic!("Can't read from file: {}, err {e}", filename.display());


### PR DESCRIPTION
This adds a convenient argument to the CLI that allows specifying which phrase file name is used. Not providing one keeps the same default.