### PR TITLE
Add swapproxy to regtest environment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "regtest/waterfalls-service/waterfalls"]
 	path = regtest/waterfalls-service/waterfalls
 	url = https://github.com/breez/waterfalls.git
+[submodule "regtest/swapproxy-service/swapproxy"]
+	path = regtest/swapproxy-service/swapproxy
+	url = https://github.com/breez/swapproxy.git

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_REGTEST, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -285,9 +285,11 @@ impl Config {
 
     pub(crate) fn default_boltz_url(&self) -> &str {
         match self.network {
+            // TODO: set swapproxy URLs for mainnet and testnet
             LiquidNetwork::Mainnet => BOLTZ_MAINNET_URL_V2,
             LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
-            LiquidNetwork::Regtest => BOLTZ_REGTEST,
+            // On regtest use the swapproxy instance by default
+            LiquidNetwork::Regtest => "http://localhost:8387/v2",
         }
     }
 

--- a/regtest/docker-compose.yml
+++ b/regtest/docker-compose.yml
@@ -34,6 +34,36 @@ services:
     network_mode: "host"
     build: ./proxy
 
+  swapproxy:
+    build: ./swapproxy-service
+    ports:
+      - 8387:8387
+    environment:
+      - BACKEND_URL=http://boltz-backend-nginx:9001
+      - WEBSOCKET_BACKEND_URL=ws://boltz-backend-nginx:9001/v2/ws
+      - PORT=8387
+      - SQLITE_DB_PATH=requests.db
+      - POSTGRES_URL=postgresql://admin:pass@swapproxy-db:5432/postgres
+      - DANGEROUS_NO_CA_CERT=YES
+    depends_on:
+      swapproxy-db:
+        condition: service_healthy
+
+  swapproxy-db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_DB=postgres
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --dbname postgres --username admin"]
+      interval: 5s
+      timeout: 30s
+      retries: 10
+      start_period: 5s
+
 volumes:
   bitcoin-data:
     name: boltz-bitcoind-data

--- a/regtest/start.sh
+++ b/regtest/start.sh
@@ -4,8 +4,12 @@ set -xe
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$SCRIPT_DIR/boltz"
+# Use boltz from https://github.com/BoltzExchange/boltz-backend/pull/959 while it isn't merged
+export BOLTZ_BACKEND_IMAGE=danielgranhao/boltz:latest
 ./start.sh
 
 cd "$SCRIPT_DIR"
 docker compose down
 docker compose up --remove-orphans -d
+
+./swapproxy-db-tool.sh --migrate

--- a/regtest/swapproxy-db-tool.sh
+++ b/regtest/swapproxy-db-tool.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Database connection details from docker-compose.yml
+DB_HOST="localhost"
+DB_PORT="5433"
+DB_NAME="postgres"
+DB_USER="admin"
+DB_PASSWORD="pass"
+
+# Check if an option is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No option provided"
+    echo "Usage: $0 --migrate | --set-extra-fee <fee_percentage>"
+    exit 1
+fi
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --migrate)
+            # SQL migrations
+            SQL_MIGRATIONS="
+            CREATE TABLE partners (
+                id SERIAL PRIMARY KEY,
+                email VARCHAR(255) UNIQUE NOT NULL,
+                api_key VARCHAR(2047) UNIQUE NOT NULL,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE fee_settings (
+                id SERIAL PRIMARY KEY,
+                partner_id INTEGER REFERENCES partners(id),
+                fee_percentage DECIMAL(5,2) NOT NULL DEFAULT 0,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(partner_id)
+            );
+
+            CREATE TABLE magic_links (
+                id SERIAL PRIMARY KEY,
+                partner_id INTEGER REFERENCES partners(id),
+                token VARCHAR(255) NOT NULL,
+                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                used BOOLEAN DEFAULT FALSE,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE analytics (
+                id SERIAL PRIMARY KEY,
+                partner_id INTEGER REFERENCES partners(id),
+                date DATE NOT NULL,
+                total_transactions INTEGER DEFAULT 0,
+                total_volume DECIMAL(20,8) DEFAULT 0,
+                total_fees DECIMAL(20,8) DEFAULT 0,
+                partner_revenue DECIMAL(20,8) DEFAULT 0,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE INDEX idx_partners_email ON partners(email);
+            CREATE INDEX idx_partners_api_key ON partners(api_key);
+            CREATE INDEX idx_fee_settings_partner_id ON fee_settings(partner_id);
+            CREATE INDEX idx_magic_links_token ON magic_links(token);
+            CREATE INDEX idx_analytics_partner_date ON analytics(partner_id, date);
+
+            CREATE OR REPLACE FUNCTION update_timestamp()
+            RETURNS TRIGGER AS \$\$
+            BEGIN
+                NEW.updated_at = CURRENT_TIMESTAMP;
+                RETURN NEW;
+            END;
+            \$\$ language 'plpgsql';
+
+            CREATE TRIGGER update_partners_timestamp
+                BEFORE UPDATE ON partners
+                FOR EACH ROW
+                EXECUTE FUNCTION update_timestamp();
+
+            CREATE TRIGGER update_fee_settings_timestamp
+                BEFORE UPDATE ON fee_settings
+                FOR EACH ROW
+                EXECUTE FUNCTION update_timestamp();
+
+            CREATE TRIGGER update_analytics_timestamp
+                BEFORE UPDATE ON analytics
+                FOR EACH ROW
+                EXECUTE FUNCTION update_timestamp();
+            "
+
+            # Execute the migrations
+            PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" << EOF
+            $SQL_MIGRATIONS
+EOF
+
+            # Check if the migrations were successful
+            if [ $? -eq 0 ]; then
+                echo "Migrations completed successfully"
+            else
+                echo "Error executing migrations"
+                exit 1
+            fi
+            shift
+            ;;
+        --set-extra-fee)
+            if [ -z "$2" ]; then
+                echo "Error: Fee percentage not provided"
+                echo "Usage: $0 --set-extra-fee <fee_percentage>"
+                exit 1
+            fi
+
+            # Validate fee percentage has at most 2 decimal places
+            if ! [[ "$2" =~ ^[0-9]+(\.[0-9]{1,2})?$ ]]; then
+                echo "Error: Fee percentage must have at most 2 decimal places"
+                exit 1
+            fi
+
+            # SQL to create partner and set fee
+            SQL_SET_FEE="
+            INSERT INTO partners (email, api_key)
+            VALUES ('extra_fee_partner@breez.technology', '')
+            ON CONFLICT (email) DO NOTHING;
+
+            INSERT INTO fee_settings (partner_id, fee_percentage)
+            SELECT id, $2
+            FROM partners
+            WHERE email = 'extra_fee_partner@breez.technology'
+            ON CONFLICT (partner_id) 
+            DO UPDATE SET fee_percentage = $2;"
+
+            # Execute the SQL
+            PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" << EOF
+            $SQL_SET_FEE
+EOF
+
+            # Check if the operation was successful
+            if [ $? -eq 0 ]; then
+                echo "Extra fee set to $2%"
+            else
+                echo "Error setting extra fee"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            echo "Usage: $0 --migrate | --set-extra-fee <fee_percentage>"
+            exit 1
+            ;;
+    esac
+done 

--- a/regtest/swapproxy-service/Dockerfile
+++ b/regtest/swapproxy-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+RUN apk add --no-cache gcc musl-dev
+COPY swapproxy/go.mod swapproxy/go.sum ./
+RUN go mod download
+COPY swapproxy/ .
+
+RUN CGO_ENABLED=1 GOOS=linux go build -o swapproxy
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/swapproxy .
+
+EXPOSE 8387
+
+CMD ["./swapproxy"] 


### PR DESCRIPTION
This PR adds the swapproxy to the regtest environment so we can start testing it locally. 

Changes:

- Configures swapproxy and an accompanying postgres instance on our docker compose
- Sets the SDK's default boltz url on regtest to the proxy url
- Adds a script for running migrations and setting fees on the swapproxy db
     - The swapproxy is running without validating api keys (on regtests we don't even use them). When running without api key validation, it tries to get the fees from a partner that has an empty api key.