### PR TITLE
Set api key on boltz client requests

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4291,8 +4291,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
+version = "0.7.1"
+source = "git+https://github.com/breez/breez-sdk?rev=5d96541a4cb03f30b8c4197a619ea52a98bc0bfe#5d96541a4cb03f30b8c4197a619ea52a98bc0bfe"
 dependencies = [
  "aes",
  "anyhow",
@@ -4336,8 +4336,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-macros"
-version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
+version = "0.7.1"
+source = "git+https://github.com/breez/breez-sdk?rev=5d96541a4cb03f30b8c4197a619ea52a98bc0bfe#5d96541a4cb03f30b8c4197a619ea52a98bc0bfe"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1#f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=a51930a211110623f8354842d2ea1a961c598a79#a51930a211110623f8354842d2ea1a961c598a79"
 dependencies = [
  "async-trait",
  "bip39",
@@ -713,7 +713,7 @@ dependencies = [
  "mockall",
  "prost 0.11.9",
  "prost 0.13.5",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "rusqlite",
  "rusqlite_migration",
  "sdk-common",
@@ -2125,18 +2125,23 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2453,6 +2458,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2797,7 +2812,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "regex-lite",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2858,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1#f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=a51930a211110623f8354842d2ea1a961c598a79#a51930a211110623f8354842d2ea1a961c598a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3874,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3902,24 +3917,22 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.27",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.11",
- "windows-registry",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -4304,7 +4317,7 @@ dependencies = [
  "prost 0.13.5",
  "querystring",
  "regex",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "sdk-macros",
  "serde",
  "serde_json",
@@ -5164,6 +5177,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,7 +5639,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4620,8 +4620,8 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "sdk-common"
-version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
+version = "0.7.1"
+source = "git+https://github.com/breez/breez-sdk?rev=5d96541a4cb03f30b8c4197a619ea52a98bc0bfe#5d96541a4cb03f30b8c4197a619ea52a98bc0bfe"
 dependencies = [
  "aes",
  "anyhow",
@@ -4665,8 +4665,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-macros"
-version = "0.6.2"
-source = "git+https://github.com/breez/breez-sdk?rev=247343395d02563087bade9aeb319ee6d9cdd549#247343395d02563087bade9aeb319ee6d9cdd549"
+version = "0.7.1"
+source = "git+https://github.com/breez/breez-sdk?rev=5d96541a4cb03f30b8c4197a619ea52a98bc0bfe#5d96541a4cb03f30b8c4197a619ea52a98bc0bfe"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.3.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1#f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=a51930a211110623f8354842d2ea1a961c598a79#a51930a211110623f8354842d2ea1a961c598a79"
 dependencies = [
  "async-trait",
  "bip39",
@@ -814,7 +814,7 @@ dependencies = [
  "prost 0.11.9",
  "prost 0.13.5",
  "rand 0.8.5",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "rusqlite",
  "rusqlite_migration",
  "sdk-common",
@@ -2361,18 +2361,23 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2689,6 +2694,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3033,7 +3048,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "regex-lite",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3094,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
-source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1#f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?rev=a51930a211110623f8354842d2ea1a961c598a79#a51930a211110623f8354842d2ea1a961c598a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4182,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4210,24 +4225,22 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.27",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.11",
- "windows-registry",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -4633,7 +4646,7 @@ dependencies = [
  "prost 0.13.5",
  "querystring",
  "regex",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "sdk-macros",
  "serde",
  "serde_json",
@@ -5586,6 +5599,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6342,7 +6373,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,8 +37,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "247343395d02563087bade9aeb319ee6d9cdd549", features = ["liquid"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "247343395d02563087bade9aeb319ee6d9cdd549" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "5d96541a4cb03f30b8c4197a619ea52a98bc0bfe", features = ["liquid"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "5d96541a4cb03f30b8c4197a619ea52a98bc0bfe" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -76,7 +76,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 prost = "^0.11"
 tonic = { version = "^0.8", features = ["tls", "tls-webpki-roots"] }
 uuid = { version = "1.8.0", features = ["v4"] }
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1", features = [
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "a51930a211110623f8354842d2ea1a961c598a79", features = [
     "electrum",
     "ws",
 ] }
@@ -98,7 +98,7 @@ tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",
 ] }
-boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "f25a8c180c5f1017677bc8ea01ed934ca0f8d2e1", features = [
+boltz-client = { git = "https://github.com/SatoshiPortal/boltz-rust", rev = "a51930a211110623f8354842d2ea1a961c598a79", features = [
     "ws",
 ] }
 rusqlite = { git = "https://github.com/Spxg/rusqlite", rev = "e36644127f31fa6e7ea0999b59432deb4a07f220", features = [

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -41,6 +41,7 @@ pub const LIQUID_FEE_RATE_SAT_PER_VBYTE: f64 = 0.1;
 pub const LIQUID_FEE_RATE_MSAT_PER_VBYTE: f32 = (LIQUID_FEE_RATE_SAT_PER_VBYTE * 1000.0) as f32;
 pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 pub const BREEZ_LIQUID_ESPLORA_URL: &str = "https://lq1.breez.technology/liquid/api";
+pub const BREEZ_SWAP_PROXY_URL: &str = "https://swap.breez.technology/v2";
 
 const SIDESWAP_API_KEY: &str = "97fb6a1dfa37ee6656af92ef79675cc03b8ac4c52e04655f41edbd5af888dcc2";
 
@@ -285,8 +286,7 @@ impl Config {
 
     pub(crate) fn default_boltz_url(&self) -> &str {
         match self.network {
-            // TODO: set swapproxy URLs for mainnet and testnet
-            LiquidNetwork::Mainnet => BOLTZ_MAINNET_URL_V2,
+            LiquidNetwork::Mainnet => BREEZ_SWAP_PROXY_URL,
             LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
             // On regtest use the swapproxy instance by default
             LiquidNetwork::Regtest => "http://localhost:8387/v2",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -286,7 +286,13 @@ impl Config {
 
     pub(crate) fn default_boltz_url(&self) -> &str {
         match self.network {
-            LiquidNetwork::Mainnet => BREEZ_SWAP_PROXY_URL,
+            LiquidNetwork::Mainnet => {
+                if self.breez_api_key.is_some() {
+                    BREEZ_SWAP_PROXY_URL
+                } else {
+                    BOLTZ_MAINNET_URL_V2
+                }
+            }
             LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
             // On regtest use the swapproxy instance by default
             LiquidNetwork::Regtest => "http://localhost:8387/v2",

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -2,12 +2,14 @@ use std::{sync::OnceLock, time::Duration};
 
 use super::{ProxyUrlFetcher, Swapper};
 use crate::bitcoin::secp256k1::rand;
+use crate::model::BREEZ_SWAP_PROXY_URL;
 use crate::{
     error::{PaymentError, SdkError},
     model::LIQUID_FEE_RATE_SAT_PER_VBYTE,
     prelude::{ChainSwap, Config, Direction, LiquidNetwork, SendSwap, Swap, Transaction, Utxo},
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use boltz_client::reqwest::header::HeaderMap;
 use boltz_client::{
     boltz::{
         self, BoltzApiClientV2, ChainPair, Cooperative, CreateBolt12OfferRequest,
@@ -43,6 +45,7 @@ const MAX_RETRY_DELAY_SECS: u64 = 10;
 pub(crate) struct BoltzClient {
     referral_id: Option<String>,
     inner: BoltzApiClientV2,
+    ws_auth_api_key: Option<String>,
 }
 
 pub struct BoltzSwapper<P: ProxyUrlFetcher> {
@@ -89,11 +92,33 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
 
         let boltz_url = boltz_api_base_url.unwrap_or(self.config.default_boltz_url().to_string());
 
-        let boltz_client = self.boltz_client.get_or_init(|| BoltzClient {
-            inner: BoltzApiClientV2::new(boltz_url, Some(CONNECTION_TIMEOUT)),
+        let mut ws_auth_api_key = None;
+        let mut headers = HeaderMap::new();
+        if boltz_url == BREEZ_SWAP_PROXY_URL {
+            match &self.config.breez_api_key {
+                Some(api_key) => {
+                    ws_auth_api_key = Some(api_key.clone());
+                    headers.insert("authorization", format!("Bearer {api_key}").parse()?);
+                }
+                None => {
+                    bail!("Cannot start Boltz client: Breez API key is not set")
+                }
+            }
+        }
+
+        let inner = BoltzApiClientV2::with_client(
+            boltz_url,
+            boltz_client::reqwest::Client::builder()
+                .default_headers(headers)
+                .build()?,
+            Some(CONNECTION_TIMEOUT),
+        );
+        let client = self.boltz_client.get_or_init(|| BoltzClient {
+            inner,
             referral_id,
+            ws_auth_api_key,
         });
-        Ok(boltz_client)
+        Ok(client)
     }
 
     fn get_liquid_client(&self) -> Result<&LiquidClient> {

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -24,7 +24,7 @@ use boltz_client::{
 };
 use client::{BitcoinClient, LiquidClient};
 use log::{info, warn};
-use proxy::split_proxy_url;
+use proxy::split_boltz_url;
 use rand::Rng;
 use sdk_common::utils::Arc;
 use tokio::sync::broadcast;
@@ -85,7 +85,13 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
         let (boltz_api_base_url, referral_id) = match &self.config.network {
             LiquidNetwork::Testnet | LiquidNetwork::Regtest => (None, None),
             LiquidNetwork::Mainnet => match self.proxy_url.fetch().await {
-                Ok(Some(swapper_proxy_url)) => split_proxy_url(swapper_proxy_url),
+                Ok(Some(boltz_swapper_urls)) => {
+                    if self.config.breez_api_key.is_some() {
+                        split_boltz_url(&boltz_swapper_urls.proxy_url)
+                    } else {
+                        split_boltz_url(&boltz_swapper_urls.boltz_url)
+                    }
+                }
                 _ => (None, None),
             },
         };

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -12,6 +12,7 @@ use boltz_client::{
 };
 use maybe_sync::{MaybeSend, MaybeSync};
 use mockall::automock;
+use sdk_common::prelude::BoltzSwapperUrls;
 use sdk_common::utils::Arc;
 use tokio::sync::{broadcast, watch};
 
@@ -62,7 +63,7 @@ pub trait Swapper: MaybeSend + MaybeSync {
     /// Get a submarine pair information
     async fn get_submarine_pairs(&self) -> Result<Option<SubmarinePair>, PaymentError>;
 
-    /// Get a submarine swap's preimage    
+    /// Get a submarine swap's preimage
     async fn get_submarine_preimage(&self, swap_id: &str) -> Result<String, PaymentError>;
 
     /// Get send swap claim tx details which includes the preimage as a proof of payment.
@@ -163,5 +164,5 @@ pub trait SwapperStatusStream: MaybeSend + MaybeSync {
 
 #[sdk_macros::async_trait]
 pub(crate) trait ProxyUrlFetcher: MaybeSend + MaybeSync + 'static {
-    async fn fetch(&self) -> Result<&Option<String>>;
+    async fn fetch(&self) -> Result<&Option<BoltzSwapperUrls>>;
 }

--- a/lib/core/src/test_utils/swapper.rs
+++ b/lib/core/src/test_utils/swapper.rs
@@ -12,6 +12,7 @@ use boltz_client::{
 };
 use lwk_wollet::secp256k1;
 use sdk_common::invoice::parse_invoice;
+use sdk_common::prelude::BoltzSwapperUrls;
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 
 use crate::{
@@ -413,7 +414,7 @@ impl MockProxyUrlFetcher {
 
 #[sdk_macros::async_trait]
 impl ProxyUrlFetcher for MockProxyUrlFetcher {
-    async fn fetch(&self) -> Result<&Option<String>> {
+    async fn fetch(&self) -> Result<&Option<BoltzSwapperUrls>> {
         Ok(&None)
     }
 }


### PR DESCRIPTION
This PR sets up authentication for the swap proxy.

Changes:

- Boltz client is updated to allow use of a custom reqwest client
- [sdk-common is updated](https://github.com/breez/breez-sdk-greenlight/pull/1231) to provide both the boltz url and proxy url. When an api key is available, the proxy url is used.
- When using our swap proxy:
    - The api key is added to the headers of http requests
    - The api key is sent as the first message when connecting to the status stream ws. See https://github.com/breez/swapproxy/pull/10.