### PR TITLE
Explicitly set status OK in the LNURL verify response

### DIFF
--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayVerify.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayVerify.kt
@@ -30,10 +30,13 @@ data class LnurlVerifyRequest(
 // https://github.com/lnurl/luds/blob/luds/21.md
 @Serializable
 data class LnurlPayVerifyResponse(
+    val status: String,
     val settled: Boolean,
     val preimage: String?,
     val pr: String,
-)
+) {
+    constructor(settled: Boolean, preimage: String?, pr: String) : this("OK", settled, preimage, pr)
+}
 
 class LnurlPayVerifyJob(
     private val context: Context,

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayVerify.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayVerify.swift
@@ -7,11 +7,13 @@ struct LnurlVerifyRequest: Codable {
 }
 
 struct LnurlVerifyResponse: Decodable, Encodable {
+    let status: String
     let settled: Bool
     let preimage: String?
     let pr: String
     
     init(settled: Bool, preimage: String?, pr: String) {
+        self.status = "OK"
         self.settled = settled
         self.preimage = preimage
         self.pr = pr


### PR DESCRIPTION
LUD-21 seems to go against the convention of other LUDs that non-empty responses don't need an explicit `status` field set to `OK`, so we set one for this LUD.

Fixes https://github.com/breez/misty-breez/issues/564