### PR TITLE
Clarify no api key error messages

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -311,7 +311,7 @@ impl Config {
         match &self.liquid_explorer {
             BlockchainExplorer::Esplora { url, .. } => {
                 if url == BREEZ_LIQUID_ESPLORA_URL && self.breez_api_key.is_none() {
-                    bail!("Cannot start the Breez Esplora chain service without providing a valid API key. See https://sdk-doc-liquid.breez.technology/guide/getting_started.html#api-key")
+                    bail!("Cannot start the Breez Esplora chain service without providing an API key. See https://sdk-doc-liquid.breez.technology/guide/getting_started.html#api-key")
                 }
                 Ok(Arc::new(EsploraLiquidChainService::new(self.clone())))
             }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -281,7 +281,7 @@ impl LiquidSdkBuilder {
                         && self.config.breez_api_key.is_none()
                     {
                         anyhow::bail!(
-                            "Cannot start the Breez real-time sync service without providing a valid API key. See https://sdk-doc-liquid.breez.technology/guide/getting_started.html#api-key",
+                            "Cannot start the Breez real-time sync service without providing an API key. See https://sdk-doc-liquid.breez.technology/guide/getting_started.html#api-key",
                         );
                     }
 


### PR DESCRIPTION
The "valid" makes the error message confusing, as it may be interpreted as if an api key was provided, but it was invalid. 