### PR TITLE
fix: Wrong amount in payment tx data persisted on claim

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -916,7 +916,9 @@ impl ChainSwapHandler {
                                         tx_id: claim_tx_id.clone(),
                                         timestamp: Some(utils::now()),
                                         asset_id: self.config.lbtc_asset_id().to_string(),
-                                        amount: swap.receiver_amount_sat,
+                                        amount: swap
+                                            .accepted_receiver_amount_sat
+                                            .unwrap_or(swap.receiver_amount_sat),
                                         fees_sat: 0,
                                         payment_type: PaymentType::Receive,
                                         is_confirmed: false,


### PR DESCRIPTION
This fixes an issue where amountless swaps would temporarily show an amount of zero and fees equal to the amount received.

The payment tx data we insert on claim was using `receiver_amount_sat`, which for amountless swaps is 0. Now, we use `accepted_receiver_amount_sat` in case it's present.