### PR TITLE
Use sats leeway for amountless swaps and set default

### DIFF
--- a/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
+++ b/lib/bindings/langs/flutter/breez_sdk_liquid/include/breez_sdk_liquid.h
@@ -16,11 +16,11 @@ typedef struct _Dart_Handle* Dart_Handle;
 
 #define ESTIMATED_BTC_CLAIM_TX_VSIZE 111
 
-#define ESTIMATED_BTC_LOCKUP_TX_VSIZE 154
-
 #define LIQUID_FEE_RATE_SAT_PER_VBYTE 0.1
 
 #define LIQUID_FEE_RATE_MSAT_PER_VBYTE (float)(LIQUID_FEE_RATE_SAT_PER_VBYTE * 1000.0)
+
+#define DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT 500
 
 #define MIN_FEE_RATE 0.1
 
@@ -714,7 +714,7 @@ typedef struct wire_cst_config {
   struct wire_cst_list_prim_u_8_strict *breez_api_key;
   struct wire_cst_list_external_input_parser *external_input_parsers;
   bool use_default_external_input_parsers;
-  uint32_t *onchain_fee_rate_leeway_sat_per_vbyte;
+  uint64_t *onchain_fee_rate_leeway_sat;
   struct wire_cst_list_asset_metadata *asset_metadata;
   struct wire_cst_list_prim_u_8_strict *sideswap_api_key;
 } wire_cst_config;

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -343,7 +343,7 @@ dictionary Config {
     u64? zero_conf_max_amount_sat;
     boolean use_default_external_input_parsers = true;
     sequence<ExternalInputParser>? external_input_parsers = null;
-    u32? onchain_fee_rate_leeway_sat_per_vbyte = null;
+    u64? onchain_fee_rate_leeway_sat = null;
     sequence<AssetMetadata>? asset_metadata = null;
     string? sideswap_api_key = null;
 };
@@ -355,14 +355,14 @@ enum LiquidNetwork {
 };
 
 dictionary ConnectRequest {
-    Config config;    
+    Config config;
     string? mnemonic = null;
     string? passphrase = null;
     sequence<u8>? seed = null;
 };
 
 dictionary ConnectWithSignerRequest {
-  Config config;  
+  Config config;
 };
 
 dictionary AssetBalance {
@@ -716,7 +716,7 @@ interface SdkEvent {
     DataSynced(boolean did_pull_new_records);
 };
 
-callback interface EventListener {    
+callback interface EventListener {
     void on_event(SdkEvent e);
 };
 
@@ -752,7 +752,7 @@ namespace breez_sdk_liquid {
 
     [Throws=SdkError]
     void set_logger(Logger logger);
-    
+
     [Throws=SdkError]
     Config default_config(LiquidNetwork network, string? breez_api_key);
 
@@ -761,7 +761,7 @@ namespace breez_sdk_liquid {
 };
 
 [Error]
-interface SignerError { 
+interface SignerError {
     Generic(string err);
 };
 

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -17,6 +17,7 @@ use tokio::sync::{broadcast, Mutex};
 use tokio_with_wasm::alias as tokio;
 
 use crate::error::is_txn_mempool_conflict_error;
+use crate::model::DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT;
 use crate::{
     chain::{bitcoin::BitcoinChainService, liquid::LiquidChainService},
     elements, ensure_sdk,
@@ -35,7 +36,6 @@ use crate::{
 
 // Estimates based on https://github.com/BoltzExchange/boltz-backend/blob/ee4c77be1fcb9bb2b45703c542ad67f7efbf218d/lib/rates/FeeProvider.ts#L68
 pub const ESTIMATED_BTC_CLAIM_TX_VSIZE: u64 = 111;
-pub const ESTIMATED_BTC_LOCKUP_TX_VSIZE: u64 = 154;
 
 pub(crate) struct ChainSwapHandler {
     config: Config,
@@ -492,9 +492,8 @@ impl ChainSwapHandler {
         // Min auto accept server lockup quote
         let server_fees_leeway_sat = self
             .config
-            .onchain_fee_rate_leeway_sat_per_vbyte
-            .unwrap_or(0) as u64
-            * ESTIMATED_BTC_LOCKUP_TX_VSIZE;
+            .onchain_fee_rate_leeway_sat
+            .unwrap_or(DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT);
         let min_auto_accept_server_lockup_amount_sat =
             server_lockup_amount_estimate_sat.saturating_sub(server_fees_leeway_sat);
 

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2636,7 +2636,7 @@ impl SseDecode for crate::model::Config {
         let mut var_externalInputParsers =
             <Option<Vec<crate::bindings::ExternalInputParser>>>::sse_decode(deserializer);
         let mut var_useDefaultExternalInputParsers = <bool>::sse_decode(deserializer);
-        let mut var_onchainFeeRateLeewaySatPerVbyte = <Option<u32>>::sse_decode(deserializer);
+        let mut var_onchainFeeRateLeewaySat = <Option<u64>>::sse_decode(deserializer);
         let mut var_assetMetadata =
             <Option<Vec<crate::model::AssetMetadata>>>::sse_decode(deserializer);
         let mut var_sideswapApiKey = <Option<String>>::sse_decode(deserializer);
@@ -2651,7 +2651,7 @@ impl SseDecode for crate::model::Config {
             breez_api_key: var_breezApiKey,
             external_input_parsers: var_externalInputParsers,
             use_default_external_input_parsers: var_useDefaultExternalInputParsers,
-            onchain_fee_rate_leeway_sat_per_vbyte: var_onchainFeeRateLeewaySatPerVbyte,
+            onchain_fee_rate_leeway_sat: var_onchainFeeRateLeewaySat,
             asset_metadata: var_assetMetadata,
             sideswap_api_key: var_sideswapApiKey,
         };
@@ -5333,7 +5333,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::Config {
             self.use_default_external_input_parsers
                 .into_into_dart()
                 .into_dart(),
-            self.onchain_fee_rate_leeway_sat_per_vbyte
+            self.onchain_fee_rate_leeway_sat
                 .into_into_dart()
                 .into_dart(),
             self.asset_metadata.into_into_dart().into_dart(),
@@ -7759,7 +7759,7 @@ impl SseEncode for crate::model::Config {
             serializer,
         );
         <bool>::sse_encode(self.use_default_external_input_parsers, serializer);
-        <Option<u32>>::sse_encode(self.onchain_fee_rate_leeway_sat_per_vbyte, serializer);
+        <Option<u64>>::sse_encode(self.onchain_fee_rate_leeway_sat, serializer);
         <Option<Vec<crate::model::AssetMetadata>>>::sse_encode(self.asset_metadata, serializer);
         <Option<String>>::sse_encode(self.sideswap_api_key, serializer);
     }
@@ -10262,9 +10262,7 @@ mod io {
                 use_default_external_input_parsers: self
                     .use_default_external_input_parsers
                     .cst_decode(),
-                onchain_fee_rate_leeway_sat_per_vbyte: self
-                    .onchain_fee_rate_leeway_sat_per_vbyte
-                    .cst_decode(),
+                onchain_fee_rate_leeway_sat: self.onchain_fee_rate_leeway_sat.cst_decode(),
                 asset_metadata: self.asset_metadata.cst_decode(),
                 sideswap_api_key: self.sideswap_api_key.cst_decode(),
             }
@@ -12016,7 +12014,7 @@ mod io {
                 breez_api_key: core::ptr::null_mut(),
                 external_input_parsers: core::ptr::null_mut(),
                 use_default_external_input_parsers: Default::default(),
-                onchain_fee_rate_leeway_sat_per_vbyte: core::ptr::null_mut(),
+                onchain_fee_rate_leeway_sat: core::ptr::null_mut(),
                 asset_metadata: core::ptr::null_mut(),
                 sideswap_api_key: core::ptr::null_mut(),
             }
@@ -14342,7 +14340,7 @@ mod io {
         breez_api_key: *mut wire_cst_list_prim_u_8_strict,
         external_input_parsers: *mut wire_cst_list_external_input_parser,
         use_default_external_input_parsers: bool,
-        onchain_fee_rate_leeway_sat_per_vbyte: *mut u32,
+        onchain_fee_rate_leeway_sat: *mut u64,
         asset_metadata: *mut wire_cst_list_asset_metadata,
         sideswap_api_key: *mut wire_cst_list_prim_u_8_strict,
     }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -42,6 +42,7 @@ pub const LIQUID_FEE_RATE_MSAT_PER_VBYTE: f32 = (LIQUID_FEE_RATE_SAT_PER_VBYTE *
 pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 pub const BREEZ_LIQUID_ESPLORA_URL: &str = "https://lq1.breez.technology/liquid/api";
 pub const BREEZ_SWAP_PROXY_URL: &str = "https://swap.breez.technology/v2";
+pub const DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT: u64 = 500;
 
 const SIDESWAP_API_KEY: &str = "97fb6a1dfa37ee6656af92ef79675cc03b8ac4c52e04655f41edbd5af888dcc2";
 
@@ -85,12 +86,12 @@ pub struct Config {
     /// Set this to false in order to prevent their use.
     pub use_default_external_input_parsers: bool,
     /// For payments where the onchain fees can only be estimated on creation, this can be used
-    /// in order to automatically allow slightly more expensive fees. If the actual fee rate ends up
+    /// in order to automatically allow slightly more expensive fees. If the actual fee ends up
     /// being above the sum of the initial estimate and this leeway, the payment will require
     /// user fee acceptance. See [WaitingFeeAcceptance](PaymentState::WaitingFeeAcceptance).
     ///
-    /// Defaults to zero.
-    pub onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
+    /// Defaults to [DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT].
+    pub onchain_fee_rate_leeway_sat: Option<u64>,
     /// A set of asset metadata used by [LiquidSdk::parse](crate::sdk::LiquidSdk::parse) when the input is a
     /// [LiquidAddressData] and the [asset_id](LiquidAddressData::asset_id) differs from the Liquid Bitcoin asset.
     /// See [AssetMetadata] for more details on how define asset metadata.
@@ -118,7 +119,7 @@ impl Config {
             breez_api_key,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: Some(SIDESWAP_API_KEY.to_string()),
         }
@@ -142,7 +143,7 @@ impl Config {
             breez_api_key,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: Some(SIDESWAP_API_KEY.to_string()),
         }
@@ -165,7 +166,7 @@ impl Config {
             breez_api_key,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: Some(SIDESWAP_API_KEY.to_string()),
         }
@@ -189,7 +190,7 @@ impl Config {
             breez_api_key,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: Some(SIDESWAP_API_KEY.to_string()),
         }
@@ -212,7 +213,7 @@ impl Config {
             breez_api_key: None,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: None,
         }
@@ -236,7 +237,7 @@ impl Config {
             breez_api_key: None,
             external_input_parsers: None,
             use_default_external_input_parsers: true,
-            onchain_fee_rate_leeway_sat_per_vbyte: None,
+            onchain_fee_rate_leeway_sat: None,
             asset_metadata: None,
             sideswap_api_key: None,
         }

--- a/lib/core/src/test_utils/sdk.rs
+++ b/lib/core/src/test_utils/sdk.rs
@@ -42,7 +42,7 @@ pub(crate) async fn new_liquid_sdk_with_chain_services(
     status_stream: Arc<MockStatusStream>,
     liquid_chain_service: Arc<MockLiquidChainService>,
     bitcoin_chain_service: Arc<MockBitcoinChainService>,
-    onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
+    onchain_fee_rate_leeway_sat: Option<u64>,
 ) -> Result<Arc<LiquidSdk>> {
     let mut config = Config::testnet_esplora(None);
     config.working_dir = persister
@@ -50,7 +50,7 @@ pub(crate) async fn new_liquid_sdk_with_chain_services(
         .to_str()
         .ok_or(anyhow!("An invalid SDK directory was specified"))?
         .to_string();
-    config.onchain_fee_rate_leeway_sat_per_vbyte = onchain_fee_rate_leeway_sat_per_vbyte;
+    config.onchain_fee_rate_leeway_sat = onchain_fee_rate_leeway_sat;
 
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
     let rest_client: Arc<dyn RestClient> = Arc::new(MockRestClient::new());

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -311,7 +311,7 @@ pub struct Config {
     pub breez_api_key: Option<String>,
     pub external_input_parsers: Option<Vec<ExternalInputParser>>,
     pub use_default_external_input_parsers: bool,
-    pub onchain_fee_rate_leeway_sat_per_vbyte: Option<u32>,
+    pub onchain_fee_rate_leeway_sat: Option<u64>,
     pub asset_metadata: Option<Vec<AssetMetadata>>,
     pub sideswap_api_key: Option<String>,
 }

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1982,7 +1982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       breezApiKey: dco_decode_opt_String(arr[7]),
       externalInputParsers: dco_decode_opt_list_external_input_parser(arr[8]),
       useDefaultExternalInputParsers: dco_decode_bool(arr[9]),
-      onchainFeeRateLeewaySatPerVbyte: dco_decode_opt_box_autoadd_u_32(arr[10]),
+      onchainFeeRateLeewaySat: dco_decode_opt_box_autoadd_u_64(arr[10]),
       assetMetadata: dco_decode_opt_list_asset_metadata(arr[11]),
       sideswapApiKey: dco_decode_opt_String(arr[12]),
     );
@@ -4054,7 +4054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_breezApiKey = sse_decode_opt_String(deserializer);
     var var_externalInputParsers = sse_decode_opt_list_external_input_parser(deserializer);
     var var_useDefaultExternalInputParsers = sse_decode_bool(deserializer);
-    var var_onchainFeeRateLeewaySatPerVbyte = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_onchainFeeRateLeewaySat = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_assetMetadata = sse_decode_opt_list_asset_metadata(deserializer);
     var var_sideswapApiKey = sse_decode_opt_String(deserializer);
     return Config(
@@ -4068,7 +4068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       breezApiKey: var_breezApiKey,
       externalInputParsers: var_externalInputParsers,
       useDefaultExternalInputParsers: var_useDefaultExternalInputParsers,
-      onchainFeeRateLeewaySatPerVbyte: var_onchainFeeRateLeewaySatPerVbyte,
+      onchainFeeRateLeewaySat: var_onchainFeeRateLeewaySat,
       assetMetadata: var_assetMetadata,
       sideswapApiKey: var_sideswapApiKey,
     );
@@ -6599,7 +6599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.breezApiKey, serializer);
     sse_encode_opt_list_external_input_parser(self.externalInputParsers, serializer);
     sse_encode_bool(self.useDefaultExternalInputParsers, serializer);
-    sse_encode_opt_box_autoadd_u_32(self.onchainFeeRateLeewaySatPerVbyte, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.onchainFeeRateLeewaySat, serializer);
     sse_encode_opt_list_asset_metadata(self.assetMetadata, serializer);
     sse_encode_opt_String(self.sideswapApiKey, serializer);
   }

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2759,9 +2759,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.breez_api_key = cst_encode_opt_String(apiObj.breezApiKey);
     wireObj.external_input_parsers = cst_encode_opt_list_external_input_parser(apiObj.externalInputParsers);
     wireObj.use_default_external_input_parsers = cst_encode_bool(apiObj.useDefaultExternalInputParsers);
-    wireObj.onchain_fee_rate_leeway_sat_per_vbyte = cst_encode_opt_box_autoadd_u_32(
-      apiObj.onchainFeeRateLeewaySatPerVbyte,
-    );
+    wireObj.onchain_fee_rate_leeway_sat = cst_encode_opt_box_autoadd_u_64(apiObj.onchainFeeRateLeewaySat);
     wireObj.asset_metadata = cst_encode_opt_list_asset_metadata(apiObj.assetMetadata);
     wireObj.sideswap_api_key = cst_encode_opt_String(apiObj.sideswapApiKey);
   }
@@ -7314,7 +7312,7 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Bool()
   external bool use_default_external_input_parsers;
 
-  external ffi.Pointer<ffi.Uint32> onchain_fee_rate_leeway_sat_per_vbyte;
+  external ffi.Pointer<ffi.Uint64> onchain_fee_rate_leeway_sat;
 
   external ffi.Pointer<wire_cst_list_asset_metadata> asset_metadata;
 
@@ -8003,11 +8001,11 @@ final class wire_cst_sign_message_response extends ffi.Struct {
 
 const int ESTIMATED_BTC_CLAIM_TX_VSIZE = 111;
 
-const int ESTIMATED_BTC_LOCKUP_TX_VSIZE = 154;
-
 const double LIQUID_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LIQUID_FEE_RATE_MSAT_PER_VBYTE = 100.0;
+
+const int DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT = 500;
 
 const double MIN_FEE_RATE = 0.1;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -286,12 +286,12 @@ class Config {
   final bool useDefaultExternalInputParsers;
 
   /// For payments where the onchain fees can only be estimated on creation, this can be used
-  /// in order to automatically allow slightly more expensive fees. If the actual fee rate ends up
+  /// in order to automatically allow slightly more expensive fees. If the actual fee ends up
   /// being above the sum of the initial estimate and this leeway, the payment will require
   /// user fee acceptance. See [WaitingFeeAcceptance](PaymentState::WaitingFeeAcceptance).
   ///
-  /// Defaults to zero.
-  final int? onchainFeeRateLeewaySatPerVbyte;
+  /// Defaults to [DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT].
+  final BigInt? onchainFeeRateLeewaySat;
 
   /// A set of asset metadata used by [LiquidSdk::parse](crate::sdk::LiquidSdk::parse) when the input is a
   /// [LiquidAddressData] and the [asset_id](LiquidAddressData::asset_id) differs from the Liquid Bitcoin asset.
@@ -313,7 +313,7 @@ class Config {
     this.breezApiKey,
     this.externalInputParsers,
     required this.useDefaultExternalInputParsers,
-    this.onchainFeeRateLeewaySatPerVbyte,
+    this.onchainFeeRateLeewaySat,
     this.assetMetadata,
     this.sideswapApiKey,
   });
@@ -330,7 +330,7 @@ class Config {
       breezApiKey.hashCode ^
       externalInputParsers.hashCode ^
       useDefaultExternalInputParsers.hashCode ^
-      onchainFeeRateLeewaySatPerVbyte.hashCode ^
+      onchainFeeRateLeewaySat.hashCode ^
       assetMetadata.hashCode ^
       sideswapApiKey.hashCode;
 
@@ -349,7 +349,7 @@ class Config {
           breezApiKey == other.breezApiKey &&
           externalInputParsers == other.externalInputParsers &&
           useDefaultExternalInputParsers == other.useDefaultExternalInputParsers &&
-          onchainFeeRateLeewaySatPerVbyte == other.onchainFeeRateLeewaySatPerVbyte &&
+          onchainFeeRateLeewaySat == other.onchainFeeRateLeewaySat &&
           assetMetadata == other.assetMetadata &&
           sideswapApiKey == other.sideswapApiKey;
 }

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -5157,7 +5157,7 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Bool()
   external bool use_default_external_input_parsers;
 
-  external ffi.Pointer<ffi.Uint32> onchain_fee_rate_leeway_sat_per_vbyte;
+  external ffi.Pointer<ffi.Uint64> onchain_fee_rate_leeway_sat;
 
   external ffi.Pointer<wire_cst_list_asset_metadata> asset_metadata;
 
@@ -6138,11 +6138,11 @@ final class UniffiVTableCallbackInterfaceSigner extends ffi.Struct {
 
 const int ESTIMATED_BTC_CLAIM_TX_VSIZE = 111;
 
-const int ESTIMATED_BTC_LOCKUP_TX_VSIZE = 154;
-
 const double LIQUID_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LIQUID_FEE_RATE_MSAT_PER_VBYTE = 100.0;
+
+const int DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT = 500;
 
 const double MIN_FEE_RATE = 0.1;
 

--- a/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezsdkliquid/BreezSDKLiquidMapper.kt
@@ -459,13 +459,13 @@ fun asConfig(config: ReadableMap): Config? {
         } else {
             null
         }
-    val onchainFeeRateLeewaySatPerVbyte =
+    val onchainFeeRateLeewaySat =
         if (hasNonNullKey(
                 config,
-                "onchainFeeRateLeewaySatPerVbyte",
+                "onchainFeeRateLeewaySat",
             )
         ) {
-            config.getInt("onchainFeeRateLeewaySatPerVbyte").toUInt()
+            config.getDouble("onchainFeeRateLeewaySat").toULong()
         } else {
             null
         }
@@ -491,7 +491,7 @@ fun asConfig(config: ReadableMap): Config? {
         zeroConfMaxAmountSat,
         useDefaultExternalInputParsers,
         externalInputParsers,
-        onchainFeeRateLeewaySatPerVbyte,
+        onchainFeeRateLeewaySat,
         assetMetadata,
         sideswapApiKey,
     )
@@ -509,7 +509,7 @@ fun readableMapOf(config: Config): ReadableMap =
         "zeroConfMaxAmountSat" to config.zeroConfMaxAmountSat,
         "useDefaultExternalInputParsers" to config.useDefaultExternalInputParsers,
         "externalInputParsers" to config.externalInputParsers?.let { readableArrayOf(it) },
-        "onchainFeeRateLeewaySatPerVbyte" to config.onchainFeeRateLeewaySatPerVbyte,
+        "onchainFeeRateLeewaySat" to config.onchainFeeRateLeewaySat,
         "assetMetadata" to config.assetMetadata?.let { readableArrayOf(it) },
         "sideswapApiKey" to config.sideswapApiKey,
     )

--- a/packages/react-native/ios/BreezSDKLiquidMapper.swift
+++ b/packages/react-native/ios/BreezSDKLiquidMapper.swift
@@ -558,12 +558,12 @@ enum BreezSDKLiquidMapper {
             externalInputParsers = try asExternalInputParserList(arr: externalInputParsersTmp)
         }
 
-        var onchainFeeRateLeewaySatPerVbyte: UInt32?
-        if hasNonNilKey(data: config, key: "onchainFeeRateLeewaySatPerVbyte") {
-            guard let onchainFeeRateLeewaySatPerVbyteTmp = config["onchainFeeRateLeewaySatPerVbyte"] as? UInt32 else {
-                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "onchainFeeRateLeewaySatPerVbyte"))
+        var onchainFeeRateLeewaySat: UInt64?
+        if hasNonNilKey(data: config, key: "onchainFeeRateLeewaySat") {
+            guard let onchainFeeRateLeewaySatTmp = config["onchainFeeRateLeewaySat"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "onchainFeeRateLeewaySat"))
             }
-            onchainFeeRateLeewaySatPerVbyte = onchainFeeRateLeewaySatPerVbyteTmp
+            onchainFeeRateLeewaySat = onchainFeeRateLeewaySatTmp
         }
         var assetMetadata: [AssetMetadata]?
         if let assetMetadataTmp = config["assetMetadata"] as? [[String: Any?]] {
@@ -578,7 +578,7 @@ enum BreezSDKLiquidMapper {
             sideswapApiKey = sideswapApiKeyTmp
         }
 
-        return Config(liquidExplorer: liquidExplorer, bitcoinExplorer: bitcoinExplorer, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySatPerVbyte: onchainFeeRateLeewaySatPerVbyte, assetMetadata: assetMetadata, sideswapApiKey: sideswapApiKey)
+        return Config(liquidExplorer: liquidExplorer, bitcoinExplorer: bitcoinExplorer, workingDir: workingDir, network: network, paymentTimeoutSec: paymentTimeoutSec, syncServiceUrl: syncServiceUrl, breezApiKey: breezApiKey, zeroConfMaxAmountSat: zeroConfMaxAmountSat, useDefaultExternalInputParsers: useDefaultExternalInputParsers, externalInputParsers: externalInputParsers, onchainFeeRateLeewaySat: onchainFeeRateLeewaySat, assetMetadata: assetMetadata, sideswapApiKey: sideswapApiKey)
     }
 
     static func dictionaryOf(config: Config) -> [String: Any?] {
@@ -593,7 +593,7 @@ enum BreezSDKLiquidMapper {
             "zeroConfMaxAmountSat": config.zeroConfMaxAmountSat == nil ? nil : config.zeroConfMaxAmountSat,
             "useDefaultExternalInputParsers": config.useDefaultExternalInputParsers,
             "externalInputParsers": config.externalInputParsers == nil ? nil : arrayOf(externalInputParserList: config.externalInputParsers!),
-            "onchainFeeRateLeewaySatPerVbyte": config.onchainFeeRateLeewaySatPerVbyte == nil ? nil : config.onchainFeeRateLeewaySatPerVbyte,
+            "onchainFeeRateLeewaySat": config.onchainFeeRateLeewaySat == nil ? nil : config.onchainFeeRateLeewaySat,
             "assetMetadata": config.assetMetadata == nil ? nil : arrayOf(assetMetadataList: config.assetMetadata!),
             "sideswapApiKey": config.sideswapApiKey == nil ? nil : config.sideswapApiKey,
         ]

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -100,7 +100,7 @@ export interface Config {
     zeroConfMaxAmountSat?: number
     useDefaultExternalInputParsers: boolean
     externalInputParsers?: ExternalInputParser[]
-    onchainFeeRateLeewaySatPerVbyte?: number
+    onchainFeeRateLeewaySat?: number
     assetMetadata?: AssetMetadata[]
     sideswapApiKey?: string
 }


### PR DESCRIPTION
This PR:

- Change the configurable leeway for amountless swaps to be denominated in sats instead of sats/vbyte
- Sets the default to 500 sats