### PR TITLE
Optimize bitcoin tip fetch + gracefully handle errors

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -864,7 +864,7 @@ pub struct BlockchainInfo {
 #[derive(Copy, Clone)]
 pub(crate) struct ChainTips {
     pub liquid_tip: u32,
-    pub bitcoin_tip: u32,
+    pub bitcoin_tip: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -2500,6 +2500,20 @@ impl From<electrum_client::GetBalanceRes> for BtcScriptBalance {
     }
 }
 
+pub(crate) struct GetSyncContextRequest {
+    pub partial_sync: Option<bool>,
+    pub last_liquid_tip: u32,
+    pub last_bitcoin_tip: u32,
+}
+
+pub(crate) struct SyncContext {
+    pub maybe_liquid_tip: Option<u32>,
+    pub maybe_bitcoin_tip: Option<u32>,
+    pub recoverable_swaps: Vec<Swap>,
+    pub is_new_liquid_block: bool,
+    pub is_new_bitcoin_block: bool,
+}
+
 #[macro_export]
 macro_rules! get_updated_fields {
     ($($var:ident),* $(,)?) => {{

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -226,12 +226,6 @@ impl Persister {
         })
     }
 
-    pub(crate) fn has_chain_swaps(&self) -> Result<bool> {
-        let con: Connection = self.get_connection()?;
-        let result = con.query_row("SELECT 1 FROM chain_swaps LIMIT 1", [], |_| Ok(()));
-        Ok(result.is_ok())
-    }
-
     pub(crate) fn list_chain_swaps(&self) -> Result<Vec<ChainSwap>> {
         let con: Connection = self.get_connection()?;
         self.list_chain_swaps_where(&con, vec![])

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -227,10 +227,9 @@ impl Persister {
     }
 
     pub(crate) fn has_chain_swaps(&self) -> Result<bool> {
-        // The following may be optimized to not fetch all chain swaps
         let con: Connection = self.get_connection()?;
-        let chain_swaps = self.list_chain_swaps_where(&con, vec![])?;
-        Ok(!chain_swaps.is_empty())
+        let result = con.query_row("SELECT 1 FROM chain_swaps LIMIT 1", [], |_| Ok(()));
+        Ok(result.is_ok())
     }
 
     pub(crate) fn list_chain_swaps(&self) -> Result<Vec<ChainSwap>> {

--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -226,6 +226,13 @@ impl Persister {
         })
     }
 
+    pub(crate) fn has_chain_swaps(&self) -> Result<bool> {
+        // The following may be optimized to not fetch all chain swaps
+        let con: Connection = self.get_connection()?;
+        let chain_swaps = self.list_chain_swaps_where(&con, vec![])?;
+        Ok(!chain_swaps.is_empty())
+    }
+
     pub(crate) fn list_chain_swaps(&self) -> Result<Vec<ChainSwap>> {
         let con: Connection = self.get_connection()?;
         self.list_chain_swaps_where(&con, vec![])

--- a/lib/core/src/recover/handlers/handle_chain_receive_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_receive_swap.rs
@@ -42,7 +42,7 @@ impl ChainReceiveSwapHandler {
     /// Recover and update a chain receive swap with data from the chain
     pub async fn recover_swap(
         chain_swap: &mut ChainSwap,
-        context: &RecoveryContext,
+        context: &ChainSwapRecoveryContext,
         is_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = &chain_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_chain_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_chain_send_swap.rs
@@ -39,7 +39,7 @@ impl ChainSendSwapHandler {
     /// Recover and update a chain send swap with data from the chain
     pub async fn recover_swap(
         chain_swap: &mut ChainSwap,
-        context: &RecoveryContext,
+        context: &ChainSwapRecoveryContext,
         is_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = &chain_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_receive_swap.rs
+++ b/lib/core/src/recover/handlers/handle_receive_swap.rs
@@ -39,7 +39,7 @@ impl ReceiveSwapHandler {
     /// Recover and update a receive swap with data from the chain
     pub(crate) async fn recover_swap(
         receive_swap: &mut ReceiveSwap,
-        context: &RecoveryContext,
+        context: &ReceiveOrSendSwapRecoveryContext,
         is_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = &receive_swap.id.clone();

--- a/lib/core/src/recover/handlers/handle_send_swap.rs
+++ b/lib/core/src/recover/handlers/handle_send_swap.rs
@@ -40,7 +40,7 @@ impl SendSwapHandler {
     /// Recover and update a send swap with data from the chain
     pub async fn recover_swap(
         send_swap: &mut SendSwap,
-        context: &RecoveryContext,
+        context: &ReceiveOrSendSwapRecoveryContext,
         is_within_grace_period: bool,
     ) -> Result<()> {
         let swap_id = send_swap.id.clone();
@@ -188,7 +188,7 @@ impl SendSwapHandler {
 
     /// Tries to recover the preimage for a send swap
     async fn recover_preimage(
-        context: &RecoveryContext,
+        context: &ReceiveOrSendSwapRecoveryContext,
         claim_tx_id: Option<LBtcHistory>,
         swap_id: &str,
         swapper: Arc<dyn Swapper>,

--- a/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_receive_swap_tests_integration.rs
@@ -6,12 +6,12 @@ mod test {
         model::{LBtcHistory, PaymentState, ReceiveSwap, SwapMetadata},
         recover::{
             handlers::{tests::create_mock_lbtc_wallet_tx, ReceiveSwapHandler},
-            model::{RecoveryContext, TxMap},
+            model::{ReceiveOrSendSwapRecoveryContext, TxMap},
         },
         swapper::MockSwapper,
     };
     use elements::{Address as ElementsAddress, Script, Txid};
-    use lwk_wollet::{elements_miniscript::slip77::MasterBlindingKey, WalletTx};
+    use lwk_wollet::WalletTx;
     use sdk_common::utils::Arc;
     use std::{collections::HashMap, str::FromStr};
 
@@ -264,7 +264,7 @@ mod test {
     }
 
     // Helper function to setup test data
-    fn setup_test_data() -> (ReceiveSwap, RecoveryContext) {
+    fn setup_test_data() -> (ReceiveSwap, ReceiveOrSendSwapRecoveryContext) {
         // Create a test receive swap
         let receive_swap = ReceiveSwap {
             id: "test-swap-id".to_string(),
@@ -297,18 +297,13 @@ mod test {
         };
 
         // Create empty recovery context
-        let recovery_context = RecoveryContext {
+        let recovery_context = ReceiveOrSendSwapRecoveryContext {
             lbtc_script_to_history_map: HashMap::new(),
-            btc_script_to_history_map: HashMap::new(),
-            btc_script_to_txs_map: HashMap::new(),
-            btc_script_to_balance_map: HashMap::new(),
             tx_map: TxMap {
                 outgoing_tx_map: HashMap::new(),
                 incoming_tx_map: HashMap::new(),
             },
             liquid_tip_height: 900, // Below timeout height
-            bitcoin_tip_height: 900,
-            master_blinding_key: MasterBlindingKey::from_seed(&[]),
             swapper: Arc::new(MockSwapper::new()),
             liquid_chain_service: Arc::new(MockLiquidChainService::new()),
         };
@@ -318,12 +313,12 @@ mod test {
 
     // Helper to add a claim transaction to the recovery context
     fn add_claim_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         claim_script: &Script,
         tx_id_hex: &str,
         height: u32,
         amount: u64,
-    ) -> (RecoveryContext, WalletTx) {
+    ) -> (ReceiveOrSendSwapRecoveryContext, WalletTx) {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx
@@ -356,11 +351,11 @@ mod test {
     }
 
     fn add_lockup_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         lockup_script: &Script,
         tx_id_hex: &str,
         height: u32,
-    ) -> RecoveryContext {
+    ) -> ReceiveOrSendSwapRecoveryContext {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx
@@ -385,12 +380,12 @@ mod test {
 
     // Helper to add an MRH transaction to the recovery context
     fn add_mrh_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         mrh_script: &Script,
         tx_id_hex: &str,
         height: u32,
         amount: u64,
-    ) -> (RecoveryContext, WalletTx) {
+    ) -> (ReceiveOrSendSwapRecoveryContext, WalletTx) {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx

--- a/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
+++ b/lib/core/src/recover/handlers/tests/handle_send_swap_tests_integration.rs
@@ -11,7 +11,6 @@ mod test {
     use crate::swapper::MockSwapper;
     use lwk_wollet::elements::script::Script;
     use lwk_wollet::elements::Txid;
-    use lwk_wollet::elements_miniscript::slip77::MasterBlindingKey;
     use lwk_wollet::WalletTx;
     use mockall::predicate::*;
     use sdk_common::utils::Arc;
@@ -318,7 +317,7 @@ mod test {
     }
 
     // Helper function to setup test data
-    fn setup_test_data() -> (SendSwap, RecoveryContext) {
+    fn setup_test_data() -> (SendSwap, ReceiveOrSendSwapRecoveryContext) {
         // Create a test send swap
         let send_swap = SendSwap {
             id: "test-swap-id".to_string(),
@@ -347,18 +346,13 @@ mod test {
         };
 
         // Create empty recovery context
-        let recovery_context = RecoveryContext {
+        let recovery_context = ReceiveOrSendSwapRecoveryContext {
             lbtc_script_to_history_map: HashMap::new(),
-            btc_script_to_history_map: HashMap::new(),
-            btc_script_to_txs_map: HashMap::new(),
-            btc_script_to_balance_map: HashMap::new(),
             tx_map: TxMap {
                 outgoing_tx_map: HashMap::new(),
                 incoming_tx_map: HashMap::new(),
             },
             liquid_tip_height: 900, // Below timeout height
-            bitcoin_tip_height: 900,
-            master_blinding_key: MasterBlindingKey::from_seed(&[]),
             swapper: Arc::new(MockSwapper::new()),
             liquid_chain_service: Arc::new(MockLiquidChainService::new()),
         };
@@ -368,11 +362,11 @@ mod test {
 
     // Helper to add an outgoing transaction (lockup) to the recovery context
     fn add_outgoing_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         script: &Script,
         tx_id_hex: &str,
         height: u32,
-    ) -> RecoveryContext {
+    ) -> ReceiveOrSendSwapRecoveryContext {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx
@@ -403,11 +397,11 @@ mod test {
 
     // Helper to add a claim tx to the history without adding it to the wallet tx map
     fn add_claim_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         script: &Script,
         tx_id_hex: &str,
         height: u32,
-    ) -> RecoveryContext {
+    ) -> ReceiveOrSendSwapRecoveryContext {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx
@@ -432,12 +426,12 @@ mod test {
 
     // Helper to add an incoming transaction (refund) to the recovery context
     fn add_incoming_tx_to_context(
-        mut context: RecoveryContext,
+        mut context: ReceiveOrSendSwapRecoveryContext,
         script: &Script,
         tx_id_hex: &str,
         height: u32,
         amount: u64,
-    ) -> (RecoveryContext, WalletTx) {
+    ) -> (ReceiveOrSendSwapRecoveryContext, WalletTx) {
         let tx_id = Txid::from_str(tx_id_hex).unwrap();
 
         // Create history tx

--- a/lib/core/src/recover/model.rs
+++ b/lib/core/src/recover/model.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 use crate::swapper::Swapper;
 
 /// A map of all our known LWK onchain txs, indexed by tx ID. Essentially our own cache of the LWK txs.
+#[derive(Clone)]
 pub(crate) struct TxMap {
     pub(crate) outgoing_tx_map: HashMap<elements::Txid, WalletTx>,
     pub(crate) incoming_tx_map: HashMap<elements::Txid, WalletTx>,
@@ -141,13 +142,19 @@ impl SwapsList {
     }
 }
 
-pub(crate) struct RecoveryContext {
+pub(crate) struct ReceiveOrSendSwapRecoveryContext {
+    pub(crate) lbtc_script_to_history_map: HashMap<LBtcScript, Vec<LBtcHistory>>,
+    pub(crate) liquid_chain_service: Arc<dyn LiquidChainService>,
+    pub(crate) swapper: Arc<dyn Swapper>,
+    pub(crate) tx_map: TxMap,
+    pub(crate) liquid_tip_height: u32,
+}
+
+pub(crate) struct ChainSwapRecoveryContext {
     pub(crate) lbtc_script_to_history_map: HashMap<LBtcScript, Vec<LBtcHistory>>,
     pub(crate) btc_script_to_history_map: HashMap<BtcScript, Vec<BtcHistory>>,
     pub(crate) btc_script_to_txs_map: HashMap<BtcScript, Vec<bitcoin::Transaction>>,
     pub(crate) btc_script_to_balance_map: HashMap<BtcScript, BtcScriptBalance>,
-    pub(crate) liquid_chain_service: Arc<dyn LiquidChainService>,
-    pub(crate) swapper: Arc<dyn Swapper>,
     pub(crate) tx_map: TxMap,
     pub(crate) master_blinding_key: MasterBlindingKey,
     pub(crate) liquid_tip_height: u32,

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, ensure, Result};
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 
 use super::handlers::{
     ChainReceiveSwapHandler, ChainSendSwapHandler, ReceiveSwapHandler, SendSwapHandler,
@@ -133,7 +133,7 @@ impl Recoverer {
                 }
                 Swap::Chain(s) => {
                     let Some(recovery_context) = &chain_swap_recovery_context else {
-                        warn!("Skipping recovery for chain swap {swap_id} because chain swaps recovery context is not available");
+                        error!("Skipping recovery for chain swap {swap_id} because chain swaps recovery context is not available");
                         continue;
                     };
                     match s.direction {

--- a/lib/core/src/recover/recoverer.rs
+++ b/lib/core/src/recover/recoverer.rs
@@ -81,7 +81,14 @@ impl Recoverer {
         let chain_tips = match maybe_chain_tips {
             None => ChainTips {
                 liquid_tip: self.liquid_chain_service.tip().await?,
-                bitcoin_tip: self.bitcoin_chain_service.tip().await?,
+                bitcoin_tip: {
+                    if swaps.iter().any(|s| matches!(s, Swap::Chain(_))) {
+                        self.bitcoin_chain_service.tip().await.ok()
+                    } else {
+                        info!("No chain swaps to recover, skipping bitcoin tip fetch");
+                        None
+                    }
+                },
             },
             Some(tips) => tips,
         };
@@ -95,8 +102,8 @@ impl Recoverer {
 
         // Convert swaps to SwapsList and fetch history data
         let swaps_list = swaps.to_vec().try_into()?;
-        let recovery_context = self
-            .create_recovery_context(
+        let (swap_recovery_context, chain_swap_recovery_context) = self
+            .create_recovery_contexts(
                 &swaps_list,
                 TxMap::from_raw_tx_map(raw_tx_map.clone()),
                 chain_tips.liquid_tip,
@@ -112,32 +119,42 @@ impl Recoverer {
                 < NETWORK_PROPAGATION_GRACE_PERIOD.as_secs() as u32;
             let res = match swap {
                 Swap::Send(s) => {
-                    SendSwapHandler::recover_swap(s, &recovery_context, is_within_grace_period)
+                    SendSwapHandler::recover_swap(s, &swap_recovery_context, is_within_grace_period)
                         .await
                 }
 
                 Swap::Receive(s) => {
-                    ReceiveSwapHandler::recover_swap(s, &recovery_context, is_within_grace_period)
-                        .await
+                    ReceiveSwapHandler::recover_swap(
+                        s,
+                        &swap_recovery_context,
+                        is_within_grace_period,
+                    )
+                    .await
                 }
-                Swap::Chain(s) => match s.direction {
-                    Direction::Outgoing => {
-                        ChainSendSwapHandler::recover_swap(
-                            s,
-                            &recovery_context,
-                            is_within_grace_period,
-                        )
-                        .await
+                Swap::Chain(s) => {
+                    let Some(recovery_context) = &chain_swap_recovery_context else {
+                        warn!("Skipping recovery for chain swap {swap_id} because chain swaps recovery context is not available");
+                        continue;
+                    };
+                    match s.direction {
+                        Direction::Outgoing => {
+                            ChainSendSwapHandler::recover_swap(
+                                s,
+                                recovery_context,
+                                is_within_grace_period,
+                            )
+                            .await
+                        }
+                        Direction::Incoming => {
+                            ChainReceiveSwapHandler::recover_swap(
+                                s,
+                                recovery_context,
+                                is_within_grace_period,
+                            )
+                            .await
+                        }
                     }
-                    Direction::Incoming => {
-                        ChainReceiveSwapHandler::recover_swap(
-                            s,
-                            &recovery_context,
-                            is_within_grace_period,
-                        )
-                        .await
-                    }
-                },
+                }
             };
             if let Err(err) = res {
                 warn!("Error recovering data for swap {swap_id}: {err}");
@@ -180,36 +197,59 @@ impl Recoverer {
     }
 
     /// For a given [SwapList], this fetches the script histories from the chain services
-    async fn create_recovery_context(
+    async fn create_recovery_contexts(
         &self,
         swaps_list: &SwapsList,
         tx_map: TxMap,
         liquid_tip_height: u32,
-        bitcoin_tip_height: u32,
+        bitcoin_tip_height: Option<u32>,
         master_blinding_key: MasterBlindingKey,
-    ) -> Result<RecoveryContext> {
+    ) -> Result<(
+        ReceiveOrSendSwapRecoveryContext,
+        Option<ChainSwapRecoveryContext>,
+    )> {
         // Fetch history data for each lbtc swap script
         let lbtc_script_to_history_map = self
             .fetch_lbtc_history_map(swaps_list.get_swap_lbtc_scripts())
             .await?;
 
-        // Fetch history data for each btc swap script
-        let (btc_script_to_history_map, btc_script_to_txs_map, btc_script_to_balance_map) = self
-            .fetch_btc_script_maps(swaps_list.get_swap_btc_scripts())
-            .await?;
+        let chain_swap_recovery_context = if let Some(bitcoin_tip_height) = bitcoin_tip_height {
+            // Fetch history data for each btc swap script
+            let (btc_script_to_history_map, btc_script_to_txs_map, btc_script_to_balance_map) =
+                self.fetch_btc_script_maps(swaps_list.get_swap_btc_scripts())
+                    .await?;
 
-        Ok(RecoveryContext {
-            lbtc_script_to_history_map,
-            btc_script_to_history_map,
-            btc_script_to_txs_map,
-            btc_script_to_balance_map,
-            tx_map,
-            liquid_tip_height,
-            bitcoin_tip_height,
-            master_blinding_key,
-            liquid_chain_service: self.liquid_chain_service.clone(),
-            swapper: self.swapper.clone(),
-        })
+            Some(ChainSwapRecoveryContext {
+                lbtc_script_to_history_map: lbtc_script_to_history_map.clone(),
+                btc_script_to_history_map,
+                btc_script_to_txs_map,
+                btc_script_to_balance_map,
+                tx_map: tx_map.clone(),
+                liquid_tip_height,
+                bitcoin_tip_height,
+                master_blinding_key,
+            })
+        } else {
+            if swaps_list
+                .swaps_by_id
+                .values()
+                .any(|s| matches!(s, Swap::Chain(_)))
+            {
+                warn!("Not creating chain swaps recovery context because bitcoin tip is not available");
+            }
+            None
+        };
+
+        Ok((
+            ReceiveOrSendSwapRecoveryContext {
+                lbtc_script_to_history_map,
+                tx_map,
+                liquid_tip_height,
+                liquid_chain_service: self.liquid_chain_service.clone(),
+                swapper: self.swapper.clone(),
+            },
+            chain_swap_recovery_context,
+        ))
     }
 
     async fn fetch_lbtc_history_map(


### PR DESCRIPTION
This PR:
- Optimizes fetching of the Bitcoin tip by only doing it if the SDK knows of any chain swap
- Gracefully handles Bitcoin tip fetching errors by allowing the sync of other swaps to function normally. If we needed the tip but couldn't fetch it, only chain swaps are not synced. Warnings are logged accordingly.