### PR TITLE
Lock flutter_rust_bridge_codegen install

### DIFF
--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -23,7 +23,7 @@ clean:
 frb:
 	# This is locked plist PR https://github.com/ebarnard/rust-plist/pull/152 is merged/released
 	cargo install cargo-expand --locked
-	cargo install flutter_rust_bridge_codegen --version 2.9.0
+	cargo install flutter_rust_bridge_codegen --version 2.9.0 --locked
 	dart pub global activate ffigen
 	dart pub global activate ffi
 	cargo install cargo-xcode

--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -40,6 +39,7 @@ String toString() {
 class $AesSuccessActionDataResultCopyWith<$Res>  {
 $AesSuccessActionDataResultCopyWith(AesSuccessActionDataResult _, $Res Function(AesSuccessActionDataResult) __);
 }
+
 
 
 /// @nodoc
@@ -204,6 +204,7 @@ $AmountCopyWith(Amount _, $Res Function(Amount) __);
 }
 
 
+
 /// @nodoc
 
 
@@ -366,6 +367,7 @@ String toString() {
 class $InputTypeCopyWith<$Res>  {
 $InputTypeCopyWith(InputType _, $Res Function(InputType) __);
 }
+
 
 
 /// @nodoc
@@ -1062,6 +1064,7 @@ $SuccessActionCopyWith(SuccessAction _, $Res Function(SuccessAction) __);
 }
 
 
+
 /// @nodoc
 
 
@@ -1288,6 +1291,7 @@ String toString() {
 class $SuccessActionProcessedCopyWith<$Res>  {
 $SuccessActionProcessedCopyWith(SuccessActionProcessed _, $Res Function(SuccessActionProcessed) __);
 }
+
 
 
 /// @nodoc

--- a/packages/dart/lib/src/bindings/duplicates.freezed.dart
+++ b/packages/dart/lib/src/bindings/duplicates.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -71,6 +70,7 @@ as String,
 }
 
 }
+
 
 
 /// @nodoc
@@ -301,6 +301,7 @@ $LnUrlCallbackStatusCopyWith(LnUrlCallbackStatus _, $Res Function(LnUrlCallbackS
 }
 
 
+
 /// @nodoc
 
 
@@ -427,6 +428,7 @@ String toString() {
 class $LnUrlPayErrorCopyWith<$Res>  {
 $LnUrlPayErrorCopyWith(LnUrlPayError _, $Res Function(LnUrlPayError) __);
 }
+
 
 
 /// @nodoc
@@ -1314,6 +1316,7 @@ as String,
 }
 
 
+
 /// @nodoc
 
 
@@ -1738,6 +1741,7 @@ String toString() {
 class $LnUrlWithdrawResultCopyWith<$Res>  {
 $LnUrlWithdrawResultCopyWith(LnUrlWithdrawResult _, $Res Function(LnUrlWithdrawResult) __);
 }
+
 
 
 /// @nodoc

--- a/packages/dart/lib/src/error.freezed.dart
+++ b/packages/dart/lib/src/error.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -40,6 +39,7 @@ String toString() {
 class $PaymentErrorCopyWith<$Res>  {
 $PaymentErrorCopyWith(PaymentError _, $Res Function(PaymentError) __);
 }
+
 
 
 /// @nodoc
@@ -1120,6 +1120,7 @@ String toString() {
 class $SdkErrorCopyWith<$Res>  {
 $SdkErrorCopyWith(SdkError _, $Res Function(SdkError) __);
 }
+
 
 
 /// @nodoc

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -71,6 +70,7 @@ as String,
 }
 
 }
+
 
 
 /// @nodoc
@@ -238,6 +238,7 @@ $GetPaymentRequestCopyWith(GetPaymentRequest _, $Res Function(GetPaymentRequest)
 }
 
 
+
 /// @nodoc
 
 
@@ -398,6 +399,7 @@ String toString() {
 class $ListPaymentDetailsCopyWith<$Res>  {
 $ListPaymentDetailsCopyWith(ListPaymentDetails _, $Res Function(ListPaymentDetails) __);
 }
+
 
 
 /// @nodoc
@@ -565,6 +567,7 @@ String toString() {
 class $LnUrlPayResultCopyWith<$Res>  {
 $LnUrlPayResultCopyWith(LnUrlPayResult _, $Res Function(LnUrlPayResult) __);
 }
+
 
 
 /// @nodoc
@@ -795,6 +798,7 @@ $PayAmountCopyWith(PayAmount _, $Res Function(PayAmount) __);
 }
 
 
+
 /// @nodoc
 
 
@@ -1023,6 +1027,7 @@ as String,
 }
 
 }
+
 
 
 /// @nodoc
@@ -1343,6 +1348,7 @@ $ReceiveAmountCopyWith(ReceiveAmount _, $Res Function(ReceiveAmount) __);
 }
 
 
+
 /// @nodoc
 
 
@@ -1505,6 +1511,7 @@ String toString() {
 class $SdkEventCopyWith<$Res>  {
 $SdkEventCopyWith(SdkEvent _, $Res Function(SdkEvent) __);
 }
+
 
 
 /// @nodoc
@@ -2194,6 +2201,7 @@ as String?,
 }
 
 }
+
 
 
 /// @nodoc


### PR DESCRIPTION
Locks the installation of flutter_rust_bridge_codegen to use only the dependency versions stated without attempting to upgrade. This is a stop-gap between now and [upgrading to 2.11.0](https://github.com/breez/breez-sdk-liquid/pull/971) which needs coordination with other libraries (e.g BDK)