### PR TITLE
add support to scan bootleggers coffee and other yoyo merchants

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -86,6 +86,10 @@ pub const DEFAULT_EXTERNAL_INPUT_PARSERS: &[(&str, &str, &str)] = &[(
     "picknpay",
     "(.*)(za.co.electrum.picknpay)(.*)",
     "https://cryptoqr.net/.well-known/lnurlp/<input>",
+),(
+    "bootleggers",
+    "(.*)(wigroup\.co|yoyogroup\.co)(.*)",
+    "https://cryptoqr.net/.well-known/lnurlw/<input>",
 )];
 
 pub(crate) const NETWORK_PROPAGATION_GRACE_PERIOD: Duration = Duration::from_secs(120);


### PR DESCRIPTION
Moneybadger has added Bootleggers Coffee to our merchant network, and we are sponsoring Bitcoin meetups there across South Africa. https://www.moneybadger.co.za/meetups

Naturally, the big thing we get asked for is when Blink-based wallets will work :) We also got enquiries from some of the local blink-based wallets (e.g. Blitz)