### PR TITLE
Fix tasks leaking

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "env_logger 0.11.8",
  "esplora-client",
  "flutter_rust_bridge",
+ "futures",
  "futures-util",
  "glob",
  "hex",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4"
 derivative = "2.2.0"
 env_logger = "0.11"
 flutter_rust_bridge = { version = "=2.9.0", features = ["chrono"], optional = true }
+futures = "0.3.31"
 log = { workspace = true }
 lwk_common = { git = "https://github.com/breez/lwk", rev = "c28d2a0dfc7b" }
 lwk_signer = { git = "https://github.com/breez/lwk", rev = "c28d2a0dfc7b", default-features = false }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -22,6 +22,7 @@ use std::cmp::PartialEq;
 use std::path::PathBuf;
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
+use tokio_with_wasm::alias as tokio;
 
 use crate::{
     bitcoin,
@@ -2529,6 +2530,11 @@ pub(crate) struct SyncContext {
     pub recoverable_swaps: Vec<Swap>,
     pub is_new_liquid_block: bool,
     pub is_new_bitcoin_block: bool,
+}
+
+pub(crate) struct TaskHandle {
+    pub name: String,
+    pub handle: tokio::task::JoinHandle<()>,
 }
 
 #[macro_export]

--- a/packages/wasm/examples/node-mem-usage-bench/.gitignore
+++ b/packages/wasm/examples/node-mem-usage-bench/.gitignore
@@ -1,0 +1,1 @@
+src/snapshots

--- a/packages/wasm/examples/node-mem-usage-bench/README.md
+++ b/packages/wasm/examples/node-mem-usage-bench/README.md
@@ -1,0 +1,31 @@
+# Breez SDK Nodeless - Wasm NodeJs Memory Usage tool
+
+- Tracks heap, external, and RSS memory after every round
+- Runs N create/destroy cycles (defaults: 20 rounds × 120 instances)
+- Forces GC and waits for native threads to exit
+- Saves heap‑snapshots (initial, after round‑0, after final round)
+
+## Prerequisites
+
+Copy the `example.env` file to `.env` and set the BREEZ_API_KEY environment variable.
+
+## Build
+
+If you are running from a local Wasm package, build the Wasm package first in the [Wasm package](../../) directory.
+
+```bash
+cd ..
+make build
+```
+
+Install the dependencies
+
+```bash
+npm i
+```
+
+## Run
+
+```bash
+npm run memory-test [rounds] [instances]
+```

--- a/packages/wasm/examples/node-mem-usage-bench/example.env
+++ b/packages/wasm/examples/node-mem-usage-bench/example.env
@@ -1,0 +1,1 @@
+BREEZ_API_KEY = ""

--- a/packages/wasm/examples/node-mem-usage-bench/package-lock.json
+++ b/packages/wasm/examples/node-mem-usage-bench/package-lock.json
@@ -1,0 +1,23 @@
+{
+    "name": "node-mem-usage-bench",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "node-mem-usage-bench",
+            "version": "0.0.0",
+            "dependencies": {
+                "@breeztech/breez-sdk-liquid": "file:../../"
+            }
+        },
+        "../..": {
+            "version": "0.10.3",
+            "license": "MIT"
+        },
+        "node_modules/@breeztech/breez-sdk-liquid": {
+            "resolved": "../..",
+            "link": true
+        }
+    }
+}

--- a/packages/wasm/examples/node-mem-usage-bench/package.json
+++ b/packages/wasm/examples/node-mem-usage-bench/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "node-mem-usage-bench",
+    "private": true,
+    "version": "0.0.0",
+    "main": "src/main.js",
+    "scripts": {
+        "memory-test": "node --expose-gc --inspect=0 src/main.js"
+    },
+    "dependencies": {
+        "@breeztech/breez-sdk-liquid": "file:../../"
+    }
+}

--- a/packages/wasm/examples/node-mem-usage-bench/src/main.js
+++ b/packages/wasm/examples/node-mem-usage-bench/src/main.js
@@ -1,0 +1,194 @@
+const fs = require('fs')
+const path = require('path')
+const v8 = require('v8')
+
+const { connect, defaultConfig } = require('@breeztech/breez-sdk-liquid/node')
+
+// Error handling configuration
+const SILENT_ERRORS = process.env.SILENT_ERRORS === 'true'
+
+process.on('uncaughtException', (err) => {
+  if (!SILENT_ERRORS) {
+    console.error('Uncaught Exception:', err.message)
+    console.error(err.stack)
+  }
+})
+
+process.on('unhandledRejection', (reason, promise) => {
+  if (!SILENT_ERRORS) {
+    console.error('Unhandled Rejection at:', promise, 'reason:', reason)
+  }
+})
+
+const ROUNDS = parseInt(process.argv[2] || '20', 10) // test depth
+const INSTANCES = parseInt(process.argv[3] || '120', 10) // width per round
+const SHUTDOWN_GRACE_MS = 2_000 // gives grace period for shutdown
+const SNAPDIR = path.join(__dirname, 'snapshots')
+const API_KEY = process.env.BREEZ_API_KEY
+if (!API_KEY) {
+  console.error('BREEZ_API_KEY is not set')
+  process.exit(1)
+}
+
+if (!global.gc) {
+  console.error('\nMust run with  --expose-gc\n')
+  process.exit(1)
+}
+if (!fs.existsSync(SNAPDIR)) fs.mkdirSync(SNAPDIR, { recursive: true })
+
+/* helpers */
+
+function memNow() {
+  const m = process.memoryUsage()
+  return { ts: Date.now(), heap: m.heapUsed, ext: m.external, rss: m.rss }
+}
+function mb(bytes) {
+  return (bytes / 1_048_576).toFixed(1)
+}
+function printMem(tag, m) {
+  console.log(`${tag.padEnd(15)}  heap=${mb(m.heap)} MB  ext=${mb(m.ext)} MB  rss=${mb(m.rss)} MB`)
+}
+function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+function writeSnapshot(label) {
+  return new Promise((resolve) => {
+    const file = fs.createWriteStream(path.join(SNAPDIR, `${label}-${Date.now()}.heapsnapshot`))
+    v8.getHeapSnapshot().pipe(file).on('finish', resolve)
+  })
+}
+
+/* test round */
+
+async function createAndDestroyRound(roundIdx) {
+  const instances = []
+  const listeners = []
+  const listenerIds = []
+
+  /* 1. create */
+  const createPromises = Array.from({ length: INSTANCES }, async (_, i) => {
+    const cfg = defaultConfig('testnet', API_KEY)
+    cfg.workingDir = `./breez/memory-test-${roundIdx}-${i}`
+
+    const seed = [...new Uint8Array(32).fill((roundIdx + i) & 0xff)]
+
+    try {
+      const sdk = await connect({ config: cfg, seed })
+      const noop = () => {}
+      const listenerId = await sdk.addEventListener(noop)
+      return { sdk, listener: noop, listenerId, index: i }
+    } catch (e) {
+      console.error(`Failed to create instance ${i} in round ${roundIdx}:`, e.message)
+      if (!SILENT_ERRORS) {
+        console.error('Stack trace:', e.stack)
+      }
+      return null
+    }
+  })
+
+  const results = await Promise.all(createPromises)
+  
+  // Filter out failed instances and populate arrays
+  results.forEach(result => {
+    if (result) {
+      instances.push(result.sdk)
+      listeners.push(result.listener)
+      listenerIds.push(result.listenerId)
+    }
+  })
+
+  /* 2. tear‑down */
+  // Remove event listeners in parallel
+  const removeListenerPromises = instances.map((instance, i) => 
+    instance.removeEventListener(listenerIds[i]).catch((err) => {
+      console.error(`Failed to remove event listener ${i} in round ${roundIdx}:`, err.message)
+    })
+  )
+  await Promise.all(removeListenerPromises)
+
+  // Disconnect instances in parallel
+  const disconnectPromises = instances.map((instance, i) => 
+    instance.disconnect().catch((err) => {
+      console.error(`Failed to disconnect instance ${i} in round ${roundIdx}:`, err.message)
+    })
+  )
+  await Promise.all(disconnectPromises)
+
+  // give some time to shutdown
+  await delay(SHUTDOWN_GRACE_MS)
+
+  // break JS references properly
+  instances.splice(0, instances.length)
+  listeners.splice(0, listeners.length)
+  listenerIds.splice(0, listenerIds.length)
+
+  /* 3. collect */
+  global.gc()
+
+  await delay(10000) // take some time to collect
+
+  const m = memNow()
+  printMem(`after round ${roundIdx + 1}`, m)
+  return m
+}
+
+/* main */
+
+const main = async () => {
+  console.log('\n' + '='.repeat(80))
+  console.log(`  MEMORY TEST: ${ROUNDS} rounds × ${INSTANCES} instances per round`)
+  console.log(`  Silent errors: ${SILENT_ERRORS ? 'ON' : 'OFF'}`)
+  console.log('='.repeat(80))
+  const initial = memNow()
+  printMem('Initial', initial)
+  console.log('Writing initial heap snapshot...')
+  await writeSnapshot('initial')
+  console.log('')
+
+  const series = []
+
+  for (let r = 0; r < ROUNDS; r++) {
+    process.stdout.write(`Round ${(r + 1).toString().padStart(2)}/${ROUNDS} ... `)
+    try {
+      const roundResult = await createAndDestroyRound(r)
+      series.push(roundResult)
+      
+      if (r === 0 || r === ROUNDS - 1) {
+        console.log(`Writing heap snapshot for round ${r}...`)
+        await writeSnapshot(`round-${r}`)
+      }
+    } catch (e) {
+      console.log(`✗ FAILED: ${e.message}`)
+      if (!SILENT_ERRORS) {
+        console.error('Stack trace:', e.stack)
+      }
+    }
+  }
+
+  /* summary */
+  const first = series[0]
+  const last = series[series.length - 1]
+  const heapChange = mb(last.heap - first.heap)
+  const externalChange = mb(last.ext - first.ext)
+  const rssChange = mb(last.rss - first.rss)
+
+  console.log('\n' + '='.repeat(80))
+  console.log('  SUMMARY')
+  console.log('='.repeat(80))
+  
+  if (series.length === 0) {
+    console.log('No successful rounds completed!')
+    return
+  }
+
+  console.log(`Successful rounds: ${series.length}/${ROUNDS}`)
+  console.log('')
+  console.log(`Memory changes (first → last successful round):`)
+  console.log(`  Heap:     ${heapChange.padStart(8)} MB`)
+  console.log(`  External: ${externalChange.padStart(8)} MB`)
+  console.log(`  RSS:      ${rssChange.padStart(8)} MB`)
+  console.log('='.repeat(80) + '\n')
+}
+
+main()

--- a/packages/wasm/makefile
+++ b/packages/wasm/makefile
@@ -8,3 +8,23 @@ build:
 	cp -r ../../lib/wasm/pkg/deno deno
 	cp -r ../../lib/wasm/pkg/node node
 	cp -r ../../lib/wasm/pkg/web web
+
+build-node:
+	make -C ../../lib/wasm build-node
+	rm -rf node
+	cp -r ../../lib/wasm/pkg/node node
+
+build-deno:
+	make -C ../../lib/wasm build-deno
+	rm -rf deno
+	cp -r ../../lib/wasm/pkg/deno deno
+
+build-web:
+	make -C ../../lib/wasm build-web
+	rm -rf web
+	cp -r ../../lib/wasm/pkg/web web
+
+build-bundle:
+	make -C ../../lib/wasm build-bundle
+	rm -rf bundle
+	cp -r ../../lib/wasm/pkg/bundle bundle


### PR DESCRIPTION
This PR fixes memory leaks caused by tasks not shutting down soon after when we send the shutdown signal. There were several places within background tasks where futures were being awaited without allowing early shutdown.

A node.js Wasm testbench is also added that allows checking memory usage as batches of SDK instances are connected and disconnected. Before this fix, starting/stopping 50k instances in batches of 100 led to external memory increasing from ~50MB to ~350MB. With the fix, the same test leads to an increase of ~0.6MB.