### PR TITLE
ci: add GitHub Actions workflow for precompiling binaries on release

### DIFF
--- a/.github/workflows/precompile-binaries.yml
+++ b/.github/workflows/precompile-binaries.yml
@@ -1,0 +1,36 @@
+on:
+  release:
+    types: [published]
+
+name: Precompile Binaries
+
+jobs:
+  Precompile:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - name: Install GTK
+        if: (matrix.os == 'ubuntu-latest')
+        run: sudo apt-get update && sudo apt-get install libgtk-3-dev
+      - name: Precompile
+        if: (matrix.os == 'macOS-latest') || (matrix.os == 'windows-latest')
+        run: dart run build_tool precompile-binaries -v --manifest-dir=../../../../lib/core --repository=breez/breez-sdk-liquid
+        working-directory: packages/dart/cargokit/build_tool
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+      - name: Precompile (with Android)
+        if: (matrix.os == 'ubuntu-latest')
+        run: dart run build_tool precompile-binaries -v --manifest-dir=../../../../lib/core --repository=breez/breez-sdk-liquid --android-sdk-location=/usr/local/lib/android/sdk --android-ndk-version=24.0.8215888 --android-min-sdk-version=23
+        working-directory: packages/dart/cargokit/build_tool
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}


### PR DESCRIPTION
This PR introduces minimal changes to be able to test the switch to using [precompiled binaries](https://github.com/irondash/cargokit/blob/main/docs/precompiled_binaries.md) via [Cargokit](https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin).
_Ref branch: [cargokit](https://github.com/breez/breez-sdk-liquid/tree/cargokit)_

Our SDK uses `flutter_rust_bridge` to expose a native Rust library to Flutter. When our Flutter plugin is used alongside another Flutter plugin built with `flutter_rust_bridge`, we’ve encountered iOS linking issues:
-  The framework is not found at runtime, or
- The generated framework gets its content hash symbol stripped, breaking initialization.

This PR adopts the recommended approach by frb that's also used by other conflicting plugins: prebuilding and bundling native binaries using Cargokit to avoid runtime build/link issues, particularly on iOS.

**Changelist:**
- Adds a GitHub Actions workflow that precompiles Rust binaries on release.