### PR TITLE
Notification Plugin: Disconnect SDK during shutdown

### DIFF
--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/BreezSdkLiquidConnector.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/BreezSdkLiquidConnector.kt
@@ -33,5 +33,12 @@ class BreezSdkLiquidConnector {
                 return liquidSDK!!
             }
         }
+
+        internal fun shutdownSDK() {
+            synchronized(this) {
+                liquidSDK?.disconnect()
+                liquidSDK = null
+            }
+        }
     }
 }

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
@@ -11,6 +11,7 @@ import breez_sdk_liquid.EventListener
 import breez_sdk_liquid.Logger
 import breez_sdk_liquid.SdkEvent
 import breez_sdk_liquid_notification.BreezSdkLiquidConnector.Companion.connectSDK
+import breez_sdk_liquid_notification.BreezSdkLiquidConnector.Companion.shutdownSDK
 import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_INVOICE_REQUEST
 import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INFO
 import breez_sdk_liquid_notification.Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE
@@ -104,6 +105,7 @@ abstract class ForegroundService :
     open fun shutdown() {
         logger.log(TAG, "Shutting down foreground service", "DEBUG")
         cancelNotification(applicationContext, NOTIFICATION_ID_REPLACEABLE)
+        shutdownSdkConnection()
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
@@ -217,6 +219,12 @@ abstract class ForegroundService :
                 job.start(liquidSDK!!)
             }
         }
+    }
+
+    private fun shutdownSdkConnection() {
+        logger.log(TAG, "Shutting down Breez Liquid SDK connection", "DEBUG")
+        shutdownSDK()
+        liquidSDK = null
     }
 
     /** Handles incoming events from the Breez Liquid SDK EventListener */

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquidConnector.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/BreezSDKLiquidConnector.swift
@@ -28,6 +28,14 @@ class BreezSDKLiquidConnector {
     static func unregister() {
         BreezSDKLiquidConnector.queue.sync { [] in
             BreezSDKLiquidConnector.sdkListener = nil
+            if let sdk = BreezSDKLiquidConnector.liquidSDK {
+                do {
+                    try sdk.disconnect()
+                } catch {
+                    os_log("Failed to disconnect SDK: %@", log: logger, type: .error, error.localizedDescription)
+                }
+                BreezSDKLiquidConnector.liquidSDK = nil
+            }
         }
     }
     


### PR DESCRIPTION
Force SDK disconnect during shutdown in case the foreground service isn't stopped