### PR TITLE
fix: update Vite config to include WASM assets and optimize dependencies

### DIFF
--- a/packages/wasm/examples/web-vite/vite.config.ts
+++ b/packages/wasm/examples/web-vite/vite.config.ts
@@ -6,4 +6,9 @@ import topLevelAwait from "vite-plugin-top-level-await";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), wasm(), topLevelAwait()],
+  assetsInclude: ['**/*.wasm'],
+  // prevent prebundle that breaks `new URL(..., import.meta.url)` in deps
+  optimizeDeps: {
+    exclude: ['@breeztech/breez-sdk-liquid'],
+  },
 })


### PR DESCRIPTION
This PR aims to fix the Vite's example WebAssembly loading error `CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 64 6f @+0` 

The problem was how Vite was handling .wasm and did not include the file - causing the HTML page to load in the `init` function. 