### PR TITLE
Fix pending refund shown as pending incoming balance

### DIFF
--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -4125,7 +4125,7 @@ impl LiquidSdk {
                     }
                 },
                 PaymentType::Receive => {
-                    if is_lbtc_asset_id {
+                    if is_lbtc_asset_id && payment.status != RefundPending {
                         pending_receive_sat += payment.amount_sat;
                     }
                 }


### PR DESCRIPTION
This fixes a bug where pending refunds were accounted for as part of the pending incoming balance. 