### PR TITLE
Fix: add missing SyncFailed event to frb mirror

### DIFF
--- a/packages/flutter_breez_liquid/rust/src/events.rs
+++ b/packages/flutter_breez_liquid/rust/src/events.rs
@@ -31,6 +31,10 @@ pub enum _SdkEvent {
     },
     /// Synced with mempool and onchain data
     Synced,
+    /// Failed to sync with mempool and onchain data
+    SyncFailed {
+        error: String,
+    },
     /// Synced with real-time data sync
     DataSynced {
         /// Indicates new data was pulled from other instances.


### PR DESCRIPTION
Created https://github.com/breez/breez-sdk-liquid/issues/1025 to look into preventing these issues in the future.