### PR TITLE
ci: Check flutter_breez_liquid Rust package for errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -478,21 +478,15 @@ jobs:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Unignore frb_generated.rs
-        working-directory: packages/flutter_breez_liquid/rust/src
-        run: sed -i '' '/frb_generated\.rs/d' .gitignore || true
-
       - name: Install flutter_rust_bridge_codegen dependencies
         working-directory: packages/flutter_breez_liquid/
         run: just frb
 
-      - name: Generate Dart/Flutter bindings & Softlink C Headers
+      - name: Generate Dart/Flutter bindings & Check Rust package for errors
         working-directory: packages/flutter_breez_liquid/
-        run: just codegen
-
-      - name: Check flutter_breez_liquid Rust package for errors
-        working-directory: packages/flutter_breez_liquid/rust
-        run: cargo check
+        run: |
+            just codegen
+            cd rust && cargo check
 
       - name: Static Analysis
         working-directory: packages/flutter_breez_liquid/


### PR DESCRIPTION
Fixes #1025 

This PR adds `cargo check` step on `flutter_breez_liquid` Rust package to catch errors.

**Note:** This branch points to a ref before `SyncFailed` event is mirrored on `flutter_breez_liquid` to ensure CI catches any related errors. 
## ⚠️ Re: Note 
~Workflow points to `main` branch by default on push events:~ Workflow points to commit that would result from the merge of the PR!  [GitHub Action Docs: pull_request](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)
```
# Triggers the workflow on push events but only for the "main" branch
  push:
    branches: [ main ]
```
~This resulted in _false positives_ & _true negatives_ for the CI checks of this PR.~

I have triggered a run manually to verify the changes are working as expected: [CI](https://github.com/breez/breez-sdk-liquid/actions/runs/18463395740)