### PR TITLE
Plugins: Use `Weak` by default in `BindingLiquidSdk`

### DIFF
--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -1,15 +1,17 @@
 use std::sync::{Arc, Weak};
 
 mod nwc;
+mod plugin;
+
+pub use nwc::*;
+pub use plugin::*;
 
 use anyhow::Result;
 use breez_sdk_liquid::{error::*, logger::Logger, model::*, prelude::*};
-use log::{warn, Metadata, Record, SetLoggerError};
+use log::{Metadata, Record, SetLoggerError};
 use once_cell::sync::Lazy;
 use tokio::runtime::Runtime;
 use uniffi::deps::log::{Level, LevelFilter};
-
-pub use nwc::*;
 
 static RT: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
 
@@ -44,24 +46,6 @@ impl log::Log for UniffiBindingLogger {
     fn flush(&self) {}
 }
 
-pub struct PluginStorage {
-    pub(crate) storage: breez_sdk_liquid::prelude::PluginStorage,
-}
-
-impl PluginStorage {
-    pub fn set_item(&self, key: String, value: String) -> Result<(), PluginStorageError> {
-        self.storage.set_item(&key, value)
-    }
-
-    pub fn get_item(&self, key: String) -> Result<Option<String>, PluginStorageError> {
-        self.storage.get_item(&key)
-    }
-
-    pub fn remove_item(&self, key: String) -> Result<(), PluginStorageError> {
-        self.storage.remove_item(&key)
-    }
-}
-
 pub trait EventListener: Send + Sync {
     fn on_event(&self, e: SdkEvent);
 }
@@ -83,45 +67,6 @@ impl breez_sdk_liquid::prelude::EventListener for EventListenerWrapper {
     }
 }
 
-pub trait Plugin: Send + Sync {
-    fn id(&self) -> String;
-    fn on_start(&self, sdk: Arc<BindingLiquidSdk>, storage: Arc<PluginStorage>);
-    fn on_stop(&self);
-}
-
-struct PluginWrapper {
-    inner: Box<dyn Plugin>,
-}
-
-#[sdk_macros::async_trait]
-impl breez_sdk_liquid::plugin::Plugin for PluginWrapper {
-    fn id(&self) -> String {
-        self.inner.id()
-    }
-
-    async fn on_start(
-        &self,
-        sdk: Weak<LiquidSdk>,
-        storage: breez_sdk_liquid::prelude::PluginStorage,
-    ) {
-        let Some(sdk) = sdk.upgrade() else {
-            warn!(
-                "Tried to start plugin {} while SDK was unavailable",
-                self.id()
-            );
-            return;
-        };
-        self.inner.on_start(
-            BindingLiquidSdk { sdk }.into(),
-            PluginStorage { storage }.into(),
-        );
-    }
-
-    async fn on_stop(&self) {
-        self.inner.on_stop();
-    }
-}
-
 /// If used, this must be called before `connect`
 pub fn set_logger(logger: Box<dyn Logger>) -> Result<(), SdkError> {
     UniffiBindingLogger::init(logger).map_err(|_| SdkError::generic("Logger already created"))
@@ -129,7 +74,7 @@ pub fn set_logger(logger: Box<dyn Logger>) -> Result<(), SdkError> {
 
 pub fn connect(
     req: ConnectRequest,
-    plugins: Option<Vec<Box<dyn Plugin>>>,
+    plugins: Option<Vec<Box<dyn plugin::Plugin>>>,
 ) -> Result<Arc<BindingLiquidSdk>, SdkError> {
     rt().block_on(async {
         let plugins = plugins.map(|plugins| {
@@ -142,14 +87,16 @@ pub fn connect(
                 .collect()
         });
         let sdk = LiquidSdk::connect(req, plugins).await?;
-        Ok(Arc::from(BindingLiquidSdk { sdk }))
+        Ok(Arc::from(BindingLiquidSdk {
+            sdk: Arc::downgrade(&sdk),
+        }))
     })
 }
 
 pub fn connect_with_signer(
     req: ConnectWithSignerRequest,
     signer: Box<dyn Signer>,
-    plugins: Option<Vec<Box<dyn Plugin>>>,
+    plugins: Option<Vec<Box<dyn plugin::Plugin>>>,
 ) -> Result<Arc<BindingLiquidSdk>, SdkError> {
     rt().block_on(async {
         let plugins = plugins.map(|plugins| {
@@ -162,7 +109,9 @@ pub fn connect_with_signer(
                 .collect()
         });
         let sdk = LiquidSdk::connect_with_signer(req, signer, plugins).await?;
-        Ok(Arc::from(BindingLiquidSdk { sdk }))
+        Ok(Arc::from(BindingLiquidSdk {
+            sdk: Arc::downgrade(&sdk),
+        }))
     })
 }
 
@@ -178,202 +127,214 @@ pub fn parse_invoice(input: String) -> Result<LNInvoice, PaymentError> {
 }
 
 pub struct BindingLiquidSdk {
-    sdk: Arc<LiquidSdk>,
+    sdk: Weak<LiquidSdk>,
 }
 
 impl BindingLiquidSdk {
+    fn sdk(&self) -> Result<Arc<LiquidSdk>, anyhow::Error> {
+        self.sdk
+            .upgrade()
+            .ok_or(anyhow::anyhow!("SDK is not available"))
+    }
+
     pub fn add_event_listener(&self, listener: Box<dyn EventListener>) -> SdkResult<String> {
         let listener: Box<dyn breez_sdk_liquid::prelude::EventListener> =
             Box::new(EventListenerWrapper::new(listener));
-        rt().block_on(self.sdk.add_event_listener(listener))
+        rt().block_on(self.sdk()?.add_event_listener(listener))
     }
 
     pub fn remove_event_listener(&self, id: String) -> SdkResult<()> {
-        rt().block_on(self.sdk.remove_event_listener(id))
+        rt().block_on(self.sdk()?.remove_event_listener(id))
     }
 
     pub fn get_info(&self) -> Result<GetInfoResponse, SdkError> {
-        rt().block_on(self.sdk.get_info())
+        rt().block_on(self.sdk()?.get_info())
     }
 
     pub fn sign_message(&self, req: SignMessageRequest) -> SdkResult<SignMessageResponse> {
-        self.sdk.sign_message(&req)
+        self.sdk()?.sign_message(&req)
     }
 
     pub fn check_message(&self, req: CheckMessageRequest) -> SdkResult<CheckMessageResponse> {
-        self.sdk.check_message(&req)
+        self.sdk()?.check_message(&req)
     }
 
     pub fn parse(&self, input: String) -> Result<InputType, PaymentError> {
-        rt().block_on(async { self.sdk.parse(&input).await })
+        rt().block_on(async { self.sdk()?.parse(&input).await })
     }
 
     pub fn prepare_send_payment(
         &self,
         req: PrepareSendRequest,
     ) -> Result<PrepareSendResponse, PaymentError> {
-        rt().block_on(self.sdk.prepare_send_payment(&req))
+        rt().block_on(self.sdk()?.prepare_send_payment(&req))
     }
 
     pub fn send_payment(
         &self,
         req: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, PaymentError> {
-        rt().block_on(self.sdk.send_payment(&req))
+        rt().block_on(self.sdk()?.send_payment(&req))
     }
 
     pub fn prepare_receive_payment(
         &self,
         req: PrepareReceiveRequest,
     ) -> Result<PrepareReceiveResponse, PaymentError> {
-        rt().block_on(self.sdk.prepare_receive_payment(&req))
+        rt().block_on(self.sdk()?.prepare_receive_payment(&req))
     }
 
     pub fn receive_payment(
         &self,
         req: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, PaymentError> {
-        rt().block_on(self.sdk.receive_payment(&req))
+        rt().block_on(self.sdk()?.receive_payment(&req))
     }
 
     pub fn create_bolt12_invoice(
         &self,
         req: CreateBolt12InvoiceRequest,
     ) -> Result<CreateBolt12InvoiceResponse, PaymentError> {
-        rt().block_on(self.sdk.create_bolt12_invoice(&req))
+        rt().block_on(self.sdk()?.create_bolt12_invoice(&req))
     }
 
     pub fn fetch_lightning_limits(&self) -> Result<LightningPaymentLimitsResponse, PaymentError> {
-        rt().block_on(self.sdk.fetch_lightning_limits())
+        rt().block_on(self.sdk()?.fetch_lightning_limits())
     }
 
     pub fn fetch_onchain_limits(&self) -> Result<OnchainPaymentLimitsResponse, PaymentError> {
-        rt().block_on(self.sdk.fetch_onchain_limits())
+        rt().block_on(self.sdk()?.fetch_onchain_limits())
     }
 
     pub fn prepare_pay_onchain(
         &self,
         req: PreparePayOnchainRequest,
     ) -> Result<PreparePayOnchainResponse, PaymentError> {
-        rt().block_on(self.sdk.prepare_pay_onchain(&req))
+        rt().block_on(self.sdk()?.prepare_pay_onchain(&req))
     }
 
     pub fn pay_onchain(&self, req: PayOnchainRequest) -> Result<SendPaymentResponse, PaymentError> {
-        rt().block_on(self.sdk.pay_onchain(&req))
+        rt().block_on(self.sdk()?.pay_onchain(&req))
     }
 
     pub fn prepare_buy_bitcoin(
         &self,
         req: PrepareBuyBitcoinRequest,
     ) -> Result<PrepareBuyBitcoinResponse, PaymentError> {
-        rt().block_on(self.sdk.prepare_buy_bitcoin(&req))
+        rt().block_on(self.sdk()?.prepare_buy_bitcoin(&req))
     }
 
     pub fn buy_bitcoin(&self, req: BuyBitcoinRequest) -> Result<String, PaymentError> {
-        rt().block_on(self.sdk.buy_bitcoin(&req))
+        rt().block_on(self.sdk()?.buy_bitcoin(&req))
     }
 
     pub fn list_payments(&self, req: ListPaymentsRequest) -> Result<Vec<Payment>, PaymentError> {
-        rt().block_on(self.sdk.list_payments(&req))
+        rt().block_on(self.sdk()?.list_payments(&req))
     }
 
     pub fn get_payment(&self, req: GetPaymentRequest) -> Result<Option<Payment>, PaymentError> {
-        rt().block_on(self.sdk.get_payment(&req))
+        rt().block_on(self.sdk()?.get_payment(&req))
     }
 
     pub fn fetch_payment_proposed_fees(
         &self,
         req: FetchPaymentProposedFeesRequest,
     ) -> SdkResult<FetchPaymentProposedFeesResponse> {
-        rt().block_on(self.sdk.fetch_payment_proposed_fees(&req))
+        rt().block_on(self.sdk()?.fetch_payment_proposed_fees(&req))
     }
 
     pub fn accept_payment_proposed_fees(
         &self,
         req: AcceptPaymentProposedFeesRequest,
     ) -> Result<(), PaymentError> {
-        rt().block_on(self.sdk.accept_payment_proposed_fees(&req))
+        rt().block_on(self.sdk()?.accept_payment_proposed_fees(&req))
     }
 
     pub fn prepare_lnurl_pay(
         &self,
         req: PrepareLnUrlPayRequest,
     ) -> Result<PrepareLnUrlPayResponse, LnUrlPayError> {
-        rt().block_on(self.sdk.prepare_lnurl_pay(req))
+        rt().block_on(self.sdk()?.prepare_lnurl_pay(req))
     }
 
     pub fn lnurl_pay(&self, req: model::LnUrlPayRequest) -> Result<LnUrlPayResult, LnUrlPayError> {
-        rt().block_on(self.sdk.lnurl_pay(req))
+        rt().block_on(self.sdk()?.lnurl_pay(req))
     }
 
     pub fn lnurl_withdraw(
         &self,
         req: LnUrlWithdrawRequest,
     ) -> Result<LnUrlWithdrawResult, LnUrlWithdrawError> {
-        rt().block_on(self.sdk.lnurl_withdraw(req))
+        rt().block_on(self.sdk()?.lnurl_withdraw(req))
     }
 
     pub fn lnurl_auth(
         &self,
         req_data: LnUrlAuthRequestData,
     ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
-        rt().block_on(self.sdk.lnurl_auth(req_data))
+        rt().block_on(
+            self.sdk()
+                .map_err(|err| LnUrlAuthError::Generic {
+                    err: err.to_string(),
+                })?
+                .lnurl_auth(req_data),
+        )
     }
 
     pub fn register_webhook(&self, webhook_url: String) -> Result<(), SdkError> {
-        rt().block_on(self.sdk.register_webhook(webhook_url))
+        rt().block_on(self.sdk()?.register_webhook(webhook_url))
     }
 
     pub fn unregister_webhook(&self) -> Result<(), SdkError> {
-        rt().block_on(self.sdk.unregister_webhook())
+        rt().block_on(self.sdk()?.unregister_webhook())
     }
 
     pub fn fetch_fiat_rates(&self) -> Result<Vec<Rate>, SdkError> {
-        rt().block_on(self.sdk.fetch_fiat_rates())
+        rt().block_on(self.sdk()?.fetch_fiat_rates())
     }
 
     pub fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>, SdkError> {
-        rt().block_on(self.sdk.list_fiat_currencies())
+        rt().block_on(self.sdk()?.list_fiat_currencies())
     }
 
     pub fn list_refundables(&self) -> SdkResult<Vec<RefundableSwap>> {
-        rt().block_on(self.sdk.list_refundables())
+        rt().block_on(self.sdk()?.list_refundables())
     }
 
     pub fn prepare_refund(&self, req: PrepareRefundRequest) -> SdkResult<PrepareRefundResponse> {
-        rt().block_on(self.sdk.prepare_refund(&req))
+        rt().block_on(self.sdk()?.prepare_refund(&req))
     }
 
     pub fn refund(&self, req: RefundRequest) -> Result<RefundResponse, PaymentError> {
-        rt().block_on(self.sdk.refund(&req))
+        rt().block_on(self.sdk()?.refund(&req))
     }
 
     pub fn rescan_onchain_swaps(&self) -> SdkResult<()> {
-        rt().block_on(self.sdk.rescan_onchain_swaps())
+        rt().block_on(self.sdk()?.rescan_onchain_swaps())
     }
 
     pub fn sync(&self) -> SdkResult<()> {
-        rt().block_on(self.sdk.sync(false))
+        rt().block_on(self.sdk()?.sync(false))
     }
 
     pub fn recommended_fees(&self) -> SdkResult<RecommendedFees> {
-        rt().block_on(self.sdk.recommended_fees())
+        rt().block_on(self.sdk()?.recommended_fees())
     }
 
     pub fn empty_wallet_cache(&self) -> SdkResult<()> {
-        self.sdk.empty_wallet_cache().map_err(Into::into)
+        self.sdk()?.empty_wallet_cache().map_err(Into::into)
     }
 
     pub fn backup(&self, req: BackupRequest) -> SdkResult<()> {
-        self.sdk.backup(req).map_err(Into::into)
+        self.sdk()?.backup(req).map_err(Into::into)
     }
 
     pub fn restore(&self, req: RestoreRequest) -> SdkResult<()> {
-        self.sdk.restore(req).map_err(Into::into)
+        self.sdk()?.restore(req).map_err(Into::into)
     }
 
     pub fn disconnect(&self) -> SdkResult<()> {
-        rt().block_on(self.sdk.disconnect())
+        rt().block_on(self.sdk()?.disconnect())
     }
 }
 

--- a/lib/bindings/src/nwc.rs
+++ b/lib/bindings/src/nwc.rs
@@ -76,7 +76,7 @@ impl Plugin for BindingNwcService {
         let cloned = self.inner.clone();
         rt().spawn(async move {
             cloned
-                .on_start(Arc::downgrade(&sdk.sdk), storage.storage.clone())
+                .on_start(sdk.sdk.clone(), storage.storage.clone())
                 .await;
         });
     }

--- a/lib/bindings/src/plugin.rs
+++ b/lib/bindings/src/plugin.rs
@@ -1,0 +1,58 @@
+use std::sync::{Arc, Weak};
+
+use breez_sdk_liquid::prelude::*;
+use sdk_macros;
+
+use crate::BindingLiquidSdk;
+
+pub use breez_sdk_liquid::plugin::PluginStorageError;
+
+pub struct PluginStorage {
+    pub(crate) storage: breez_sdk_liquid::plugin::PluginStorage,
+}
+
+impl PluginStorage {
+    pub fn set_item(&self, key: String, value: String) -> Result<(), PluginStorageError> {
+        self.storage.set_item(&key, value)
+    }
+
+    pub fn get_item(&self, key: String) -> Result<Option<String>, PluginStorageError> {
+        self.storage.get_item(&key)
+    }
+
+    pub fn remove_item(&self, key: String) -> Result<(), PluginStorageError> {
+        self.storage.remove_item(&key)
+    }
+}
+
+pub trait Plugin: Send + Sync {
+    fn id(&self) -> String;
+    fn on_start(&self, sdk: Arc<BindingLiquidSdk>, storage: Arc<PluginStorage>);
+    fn on_stop(&self);
+}
+
+pub(crate) struct PluginWrapper {
+    pub(crate) inner: Box<dyn Plugin>,
+}
+
+#[sdk_macros::async_trait]
+impl breez_sdk_liquid::plugin::Plugin for PluginWrapper {
+    fn id(&self) -> String {
+        self.inner.id()
+    }
+
+    async fn on_start(
+        &self,
+        sdk: Weak<LiquidSdk>,
+        storage: breez_sdk_liquid::plugin::PluginStorage,
+    ) {
+        self.inner.on_start(
+            BindingLiquidSdk { sdk }.into(),
+            PluginStorage { storage }.into(),
+        );
+    }
+
+    async fn on_stop(&self) {
+        self.inner.on_stop();
+    }
+}

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -203,6 +203,5 @@ pub mod prelude {
     pub use crate::*;
     pub use crate::model::*;
     pub use crate::sdk::*;
-    pub use crate::plugin::*;
     pub use crate::signer::SdkSigner;
 }

--- a/lib/plugins/nwc/src/lib.rs
+++ b/lib/plugins/nwc/src/lib.rs
@@ -14,7 +14,10 @@ use crate::{
     sdk_event::SdkEventListener,
 };
 use anyhow::{bail, Result};
-use breez_sdk_liquid::prelude::*;
+use breez_sdk_liquid::{
+    plugin::{Plugin, PluginStorage},
+    prelude::*,
+};
 use log::{debug, error, info, warn};
 use nostr_sdk::{
     nips::nip44::{decrypt, encrypt, Version},


### PR DESCRIPTION
This PR changes the default inner field of `BindingLiquidSdk`. We do so primarily to support graceful error handling on all plugin methods if the SDK is not available during plugin execution. In the case of the main SDK instance (returned by `connect`), the Arc upgrade should always succeed without errors, so the way that works remains unchanged.