### PR TITLE
Add safety check to make sure swaps haven't expired before claim

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -857,6 +857,26 @@ impl ChainSwapHandler {
         let swap = self.fetch_chain_swap_by_id(swap_id)?;
         ensure_sdk!(swap.claim_tx_id.is_none(), PaymentError::AlreadyClaimed);
 
+        // Make sure the claim timeout block height has not been reached (with 10 blocks margin for incoming, 2 blocks margin for outgoing)
+        match swap.direction {
+            Direction::Incoming => {
+                let liquid_tip = self.liquid_chain_service.tip().await?;
+                if liquid_tip > swap.claim_timeout_block_height - 10 {
+                    return Err(PaymentError::Generic {
+                        err: format!("Preventing claim for incoming chain swap {swap_id} as timeout block height {} has been/will soon be reached (liquid tip: {liquid_tip})", swap.claim_timeout_block_height),
+                    });
+                }
+            }
+            Direction::Outgoing => {
+                let bitcoin_tip = self.bitcoin_chain_service.tip().await?;
+                if bitcoin_tip > swap.claim_timeout_block_height - 2 {
+                    return Err(PaymentError::Generic {
+                        err: format!("Preventing claim for outgoing chain swap {swap_id} as timeout block height {} has been/will soon be reached (bitcoin tip: {bitcoin_tip})", swap.claim_timeout_block_height),
+                    });
+                }
+            }
+        }
+
         debug!("Initiating claim for Chain Swap {swap_id}");
         // Derive a new Liquid address if one is not already set for an incoming swap,
         // or use the set Bitcoin address for an outgoing swap


### PR DESCRIPTION
We've seen in the wild a case where an SDK instance attempted to coop claim an incoming chain swap that had been expired for 3+ hours. This is dangerous as the swapper will likely have already refunded the server lockup to themselves, and the claim attempt shares our partial sig, allowing the swapper to also claim the user's lockup. 

Unfortunately, we have no logs to analyze the exact sequence of events that led to this behavior, but it was likely triggered by connectivity issues when trying to chain sync, which prevented us from syncing the chain swap and updating its status. 

This proposed change should prevent this from happening again. We make sure the claim timeout hasn't been reached before claiming (with a small margin). 