### PR TITLE
Improve timeout error description

### DIFF
--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -108,7 +108,7 @@ pub enum PaymentError {
     #[error("Boltz did not return any pairs from the request")]
     PairsNotFound,
 
-    #[error("The payment timed out")]
+    #[error("Payment start could not be verified within the configured timeout")]
     PaymentTimeout,
 
     #[error("Could not store the swap details locally")]


### PR DESCRIPTION
This improves the error description for `PaymentTimeout`. This error doesn't guarantee that a payment hasn't been started, and the new description communicates that more clearly.