### PR TITLE
Fix LnUrl pay error mapping

### DIFF
--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -283,8 +283,21 @@ impl From<PaymentError> for LnUrlAuthError {
 
 impl From<PaymentError> for LnUrlPayError {
     fn from(err: PaymentError) -> Self {
-        Self::Generic {
-            err: err.to_string(),
+        match err {
+            PaymentError::AlreadyPaid => Self::AlreadyPaid,
+            PaymentError::AmountOutOfRange { min, max } => Self::InvalidAmount {
+                err: format!("Amount must be between {min} and {max}"),
+            },
+            PaymentError::AmountMissing { err } => Self::InvalidAmount {
+                err: format!("Amount is missing: {err}"),
+            },
+            PaymentError::InvalidNetwork { err } => Self::InvalidNetwork { err },
+            PaymentError::InsufficientFunds => Self::InsufficientBalance { err: String::new() },
+            PaymentError::InvalidInvoice { err } => Self::InvalidInvoice { err },
+            PaymentError::PaymentTimeout => Self::PaymentTimeout { err: String::new() },
+            _ => Self::Generic {
+                err: err.to_string(),
+            },
         }
     }
 }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -4703,8 +4703,7 @@ impl LiquidSdk {
                         disable_mrh: None,
                         payment_timeout_sec: None,
                     })
-                    .await
-                    .map_err(|e| LnUrlPayError::Generic { err: e.to_string() })?;
+                    .await?;
 
                 let destination = match prepare_response.destination {
                     SendDestination::Bolt11 { invoice, .. } => SendDestination::Bolt11 {
@@ -4766,8 +4765,7 @@ impl LiquidSdk {
                 use_asset_fees: None,
                 payer_note: prepare_response.comment.clone(),
             })
-            .await
-            .map_err(|e| LnUrlPayError::Generic { err: e.to_string() })?
+            .await?
             .payment;
 
         let maybe_sa_processed: Option<SuccessActionProcessed> = match prepare_response


### PR DESCRIPTION
This fixes the mapping of `PaymentError` to `LnUrlPayError`. Before, any payment error would be mapped to `Generic`. 