### PR TITLE
Remove deprecated Lightning payment method

### DIFF
--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayInvoice.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/job/LnurlPayInvoice.kt
@@ -76,7 +76,7 @@ class LnurlPayInvoiceJob(
                 )
             val prepareReceivePaymentRes =
                 liquidSDK.prepareReceivePayment(
-                    PrepareReceiveRequest(PaymentMethod.LIGHTNING, ReceiveAmount.Bitcoin(amountSat)),
+                    PrepareReceiveRequest(PaymentMethod.BOLT11_INVOICE, ReceiveAmount.Bitcoin(amountSat)),
                 )
             val receivePaymentResponse =
                 liquidSDK.receivePayment(

--- a/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift
+++ b/lib/bindings/langs/swift/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift
@@ -57,7 +57,7 @@ class LnurlPayInvoiceTask : LnurlPayTask {
             let plainTextMetadata = ResourceHelper.shared.getString(key: Constants.LNURL_PAY_METADATA_PLAIN_TEXT, fallback: Constants.DEFAULT_LNURL_PAY_METADATA_PLAIN_TEXT)
             let metadata = "[[\"text/plain\",\"\(plainTextMetadata)\"]]"
             let amount = ReceiveAmount.bitcoin(payerAmountSat: amountSat)
-            let prepareReceivePaymentRes = try liquidSDK.prepareReceivePayment(req: PrepareReceiveRequest(paymentMethod: PaymentMethod.lightning, amount: amount))
+            let prepareReceivePaymentRes = try liquidSDK.prepareReceivePayment(req: PrepareReceiveRequest(paymentMethod: PaymentMethod.bolt11Invoice, amount: amount))
             let receivePaymentRes = try liquidSDK.receivePayment(req: ReceivePaymentRequest(prepareResponse: prepareReceivePaymentRes, description: metadata, useDescriptionHash: true, payerNote: request!.comment))
             // Add the verify URL
             var verify: String?

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -467,7 +467,6 @@ dictionary SendPaymentResponse {
 };
 
 enum PaymentMethod {
-    "Lightning",
     "Bolt11Invoice",
     "Bolt12Offer",
     "BitcoinAddress",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -598,8 +598,6 @@ pub(crate) struct ReservedAddress {
 /// The send/receive methods supported by the SDK
 #[derive(Clone, Debug, Serialize)]
 pub enum PaymentMethod {
-    #[deprecated(since = "0.8.1", note = "Use `Bolt11Invoice` instead")]
-    Lightning,
     Bolt11Invoice,
     Bolt12Offer,
     BitcoinAddress,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -2858,7 +2858,7 @@ impl LiquidSdk {
 
         match req.payment_method.clone() {
             #[allow(deprecated)]
-            PaymentMethod::Bolt11Invoice | PaymentMethod::Lightning => {
+            PaymentMethod::Bolt11Invoice => {
                 let payer_amount_sat = match req.amount {
                     Some(ReceiveAmount::Asset { .. }) => {
                         return Err(PaymentError::asset_error(
@@ -3020,7 +3020,7 @@ impl LiquidSdk {
 
         match payment_method {
             #[allow(deprecated)]
-            PaymentMethod::Bolt11Invoice | PaymentMethod::Lightning => {
+            PaymentMethod::Bolt11Invoice => {
                 let amount_sat = match amount.clone() {
                     Some(ReceiveAmount::Asset { .. }) => {
                         return Err(PaymentError::asset_error(

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -356,7 +356,6 @@ pub struct ConnectWithSignerRequest {
 
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::PaymentMethod)]
 pub enum PaymentMethod {
-    Lightning,
     Bolt11Invoice,
     Bolt12Offer,
     BitcoinAddress,

--- a/packages/flutter_breez_liquid/rust/src/models.rs
+++ b/packages/flutter_breez_liquid/rust/src/models.rs
@@ -728,7 +728,6 @@ pub enum _PaymentDetails {
 
 #[frb(mirror(PaymentMethod))]
 pub enum _PaymentMethod {
-    Lightning,
     Bolt11Invoice,
     Bolt12Offer,
     BitcoinAddress,


### PR DESCRIPTION
Payment method `Lightning` is deprecated since 0.8.1