### PR TITLE
Bindings(Python) - Prevent unnecessary casting for data enums

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -5605,8 +5605,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "uniffi"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "camino",
@@ -5621,8 +5620,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "askama",
@@ -5645,8 +5643,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "camino",
@@ -5656,8 +5653,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -5666,8 +5662,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5680,8 +5675,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "bincode",
  "camino",
@@ -5698,8 +5692,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5710,8 +5703,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "camino",
@@ -5723,8 +5715,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -6023,8 +6014,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/breez/uniffi-rs?rev=28d4dd232a1603cb88213380a9e0415f1ae0757d#28d4dd232a1603cb88213380a9e0415f1ae0757d"
 dependencies = [
  "nom",
 ]

--- a/lib/bindings/Cargo.toml
+++ b/lib/bindings/Cargo.toml
@@ -19,8 +19,8 @@ anyhow = { workspace = true }
 breez-sdk-liquid = { path = "../core" }
 breez-sdk-liquid-nwc = { path = "../plugins/nwc" }
 log = { workspace = true }
-uniffi = { package = "uniffi", version = "0.28.0", features = [ "bindgen-tests", "cli" ] }
-uniffi_bindgen = { package = "uniffi_bindgen", version = "0.28.0" }
+uniffi = { git = "https://github.com/breez/uniffi-rs", rev = "28d4dd232a1603cb88213380a9e0415f1ae0757d", features = [ "bindgen-tests", "cli" ] }
+uniffi_bindgen = { git = "https://github.com/breez/uniffi-rs", rev = "28d4dd232a1603cb88213380a9e0415f1ae0757d" }
 camino = "1.1.1"
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt"] }
@@ -30,5 +30,5 @@ sdk-macros = { workspace = true }
 async-trait = "0.1.86"
 
 [build-dependencies]
-uniffi = { package = "uniffi", version = "0.28.0", features = [ "build" ] }
+uniffi = { git = "https://github.com/breez/uniffi-rs", rev = "28d4dd232a1603cb88213380a9e0415f1ae0757d", features = [ "build" ] }
 glob = "0.3.1"


### PR DESCRIPTION
This PR switches to our fork of uniffi-rs with the following fix: instead of having to manually cast data enums to their parent type:
```python
payAmount = PayAmount.DRAIN
sendPayment = sdk.prepare_send_payment(amount=cast(PayAmount, payAmount),...)
```
we now have a direct way to infer the parent class of a data enum. This slightly changes the interface to:
```python
payAmount = PayAmount.DRAIN() # <- Notice the ()
sendPayment = sdk.prepare_send_payment(amount=payAmount,...)
```