### PR TITLE
NWC: Rename `wallet_public_key` to `wallet_service_public_key`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "aes",
  "anyhow",
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -4440,7 +4440,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 [[package]]
 name = "sdk-common"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "aes",
  "anyhow",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,8 +20,8 @@ anyhow = "1.0"
 log = "0.4.20"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "27452b5fd80be52ef047b3e3acb51dc6779b4a38", features = ["liquid", "nwc"] }
-sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "27452b5fd80be52ef047b3e3acb51dc6779b4a38" }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "113749fd36dd7a20358dc40526c4a30147f8c1a8", features = ["liquid", "nwc"] }
+sdk-macros = { git = "https://github.com/breez/breez-sdk", rev = "113749fd36dd7a20358dc40526c4a30147f8c1a8" }
 thiserror = "1.0"
 
 [patch.crates-io]

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -60,7 +60,7 @@ dictionary LNOffer {
 };
 
 dictionary NostrConnectionUri {
-    string wallet_public_key;
+    string wallet_service_public_key;
     string app_public_key;
     string app_secret;
     sequence<string> relays;

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -80,7 +80,7 @@ pub struct LNOffer {
 
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::NostrWalletConnectUri)]
 pub struct NostrWalletConnectUri {
-    pub wallet_public_key: String,
+    pub wallet_service_public_key: String,
     pub app_public_key: String,
     pub app_secret: String,
     pub relays: Vec<String>,

--- a/packages/flutter_breez_liquid/rust/Cargo.lock
+++ b/packages/flutter_breez_liquid/rust/Cargo.lock
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "aes",
  "anyhow",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "sdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/breez/breez-sdk?rev=27452b5fd80be52ef047b3e3acb51dc6779b4a38#27452b5fd80be52ef047b3e3acb51dc6779b4a38"
+source = "git+https://github.com/breez/breez-sdk?rev=113749fd36dd7a20358dc40526c4a30147f8c1a8#113749fd36dd7a20358dc40526c4a30147f8c1a8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/flutter_breez_liquid/rust/Cargo.toml
+++ b/packages/flutter_breez_liquid/rust/Cargo.toml
@@ -12,7 +12,7 @@ flutter_rust_bridge = "=2.9.0"
 # Replaced with release commit during publishing
 breez-sdk-liquid = { path = "../../../lib/core" }
 breez-sdk-liquid-nwc = { path = "../../../lib/plugins/nwc" }
-sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "27452b5fd80be52ef047b3e3acb51dc6779b4a38", features = ["liquid", "nwc"] }
+sdk-common = { git = "https://github.com/breez/breez-sdk", rev = "113749fd36dd7a20358dc40526c4a30147f8c1a8", features = ["liquid", "nwc"] }
 async-trait = "0.1.86"
 futures = "0.3"
 

--- a/packages/flutter_breez_liquid/rust/src/models.rs
+++ b/packages/flutter_breez_liquid/rust/src/models.rs
@@ -94,7 +94,7 @@ pub struct _LNOffer {
 
 #[frb(mirror(NostrWalletConnectUri))]
 pub struct _NostrWalletConnectUri {
-    pub wallet_public_key: String,
+    pub wallet_service_public_key: String,
     pub app_public_key: String,
     pub app_secret: String,
     pub relays: Vec<String>,


### PR DESCRIPTION
This is done to keep naming consistent across all application usages.
See:
- Breez-LNURL: https://github.com/breez/breez-lnurl/commit/3ac093380ff9 + https://github.com/breez/breez-lnurl/commit/bd4ad3040985
- Misty: https://github.com/breez/misty-breez/commit/960796f73fd3