### PR TITLE
Connect with derivation path

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,6 +42,9 @@ pub(crate) struct Args {
     #[clap(long)]
     pub(crate) passphrase: Option<String>,
 
+    #[clap(long)]
+    pub(crate) derivation_path: Option<String>,
+
     #[clap(long, default_value = "false")]
     pub(crate) no_qrs: bool,
 
@@ -105,6 +108,7 @@ async fn main() -> Result<()> {
 
     let mnemonic = persistence.get_or_create_mnemonic(args.phrase_path.as_deref())?;
     let passphrase = args.passphrase.clone();
+    let derivation_path = args.derivation_path.clone();
     let network = args.network.unwrap_or(LiquidNetwork::Testnet);
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")
         .map(|var| var.into_string().expect("Expected valid API key string"));
@@ -133,6 +137,7 @@ async fn main() -> Result<()> {
             mnemonic: Some(mnemonic.to_string()),
             passphrase,
             seed: None,
+            derivation_path,
         },
         Some(plugins),
     )

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -362,6 +362,7 @@ dictionary ConnectRequest {
     string? mnemonic = null;
     string? passphrase = null;
     sequence<u8>? seed = null;
+    string? derivation_path = null;
 };
 
 dictionary ConnectWithSignerRequest {

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -601,6 +601,8 @@ pub struct ConnectRequest {
     pub passphrase: Option<String>,
     /// The optional Liquid wallet seed
     pub seed: Option<Vec<u8>>,
+    /// Optional BIP32 derivation path to derive an extended private key
+    pub derivation_path: Option<String>,
 }
 
 pub struct ConnectWithSignerRequest {

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -448,12 +448,19 @@ impl LiquidSdk {
 
     pub fn default_signer(req: &ConnectRequest) -> Result<SdkSigner> {
         let is_mainnet = req.config.network == LiquidNetwork::Mainnet;
+        let derivation_path = req.derivation_path.as_deref();
+
         match (&req.mnemonic, &req.seed) {
-            (None, Some(seed)) => Ok(SdkSigner::new_with_seed(seed.clone(), is_mainnet)?),
+            (None, Some(seed)) => Ok(SdkSigner::new_with_seed(
+                seed.clone(),
+                is_mainnet,
+                derivation_path,
+            )?),
             (Some(mnemonic), None) => Ok(SdkSigner::new(
                 mnemonic,
                 req.passphrase.as_ref().unwrap_or(&"".to_string()).as_ref(),
                 is_mainnet,
+                derivation_path,
             )?),
             _ => Err(anyhow!("Either `mnemonic` or `seed` must be set")),
         }

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -605,7 +605,8 @@ mod tests {
     #[sdk_macros::async_test_all]
     async fn test_sign_and_check_message() -> Result<()> {
         let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        let sdk_signer: Box<dyn Signer> = Box::new(SdkSigner::new(mnemonic, "", false).unwrap());
+        let sdk_signer: Box<dyn Signer> =
+            Box::new(SdkSigner::new(mnemonic, "", false, None).unwrap());
         let sdk_signer = Arc::new(sdk_signer);
 
         let config = Config::testnet_esplora(None);

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -349,6 +349,7 @@ pub struct ConnectRequest {
     pub mnemonic: Option<String>,
     pub passphrase: Option<String>,
     pub seed: Option<Vec<u8>>,
+    pub derivation_path: Option<String>,
 }
 
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::ConnectWithSignerRequest)]

--- a/packages/flutter_breez_liquid/rust/src/models.rs
+++ b/packages/flutter_breez_liquid/rust/src/models.rs
@@ -363,6 +363,7 @@ pub struct _ConnectRequest {
     pub mnemonic: Option<String>,
     pub passphrase: Option<String>,
     pub seed: Option<Vec<u8>>,
+    pub derivation_path: Option<String>,
 }
 
 #[frb(mirror(CreateBolt12InvoiceRequest))]


### PR DESCRIPTION
Adds an optional derivation path to the ConnectRequest to enable deriving an extended private key from the provided mnemonic/seed.

This is to support partners who derive a seed from a derivation path before connecting to the SDK, to reproduce the same extended private key in other applications (e.g. Misty or Web)