### PR TITLE
Rescan swaps

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -207,8 +207,12 @@ pub(crate) enum Command {
         // Fee rate to use, in sat/vbyte
         fee_rate_sat_per_vbyte: u32,
     },
-    /// Rescan onchain swaps
-    RescanOnchainSwaps,
+    /// Rescan swaps
+    RescanSwaps {
+        /// A optional list of swap ids
+        #[clap(name = "swap_id", short = 's', long = "swap_id")]
+        swap_ids: Option<Vec<String>>,
+    },
     /// Get the balance and general info of the current instance
     GetInfo,
     /// Sign a message using the wallet private key
@@ -741,8 +745,11 @@ pub(crate) async fn handle_command(
                 .await?;
             command_result!(res)
         }
-        Command::RescanOnchainSwaps => {
-            sdk.rescan_onchain_swaps().await?;
+        Command::RescanSwaps { swap_ids } => {
+            sdk.rescan_swaps(&RescanSwapsRequest {
+                swap_ids: swap_ids.unwrap_or_default(),
+            })
+            .await?;
             command_result!("Rescanned successfully")
         }
         Command::Sync => {

--- a/lib/bindings/src/breez_sdk_liquid.udl
+++ b/lib/bindings/src/breez_sdk_liquid.udl
@@ -713,6 +713,10 @@ dictionary RefundResponse {
     string refund_tx_id;
 };
 
+dictionary RescanSwapsRequest {
+    sequence<string> swap_ids;
+};
+
 [Enum]
 interface SdkEvent {
     PaymentFailed(Payment details);
@@ -878,6 +882,9 @@ interface BindingLiquidSdk {
 
     [Throws=SdkError]
     void rescan_onchain_swaps();
+
+    [Throws=SdkError]
+    void rescan_swaps(RescanSwapsRequest req);
 
     [Throws=SdkError]
     void sync();

--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -295,6 +295,10 @@ impl BindingLiquidSdk {
         rt().block_on(self.sdk.rescan_onchain_swaps())
     }
 
+    pub fn rescan_swaps(&self, req: RescanSwapsRequest) -> SdkResult<()> {
+        rt().block_on(self.sdk.rescan_swaps(&req))
+    }
+
     pub fn sync(&self) -> SdkResult<()> {
         rt().block_on(self.sdk.sync(false))
     }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -938,6 +938,12 @@ pub struct RefundResponse {
     pub refund_tx_id: String,
 }
 
+/// An argument when calling [crate::sdk::LiquidSdk::rescan_onchain_swaps].
+#[derive(Debug, Serialize)]
+pub struct RescanSwapsRequest {
+    pub swap_ids: Vec<String>,
+}
+
 /// An asset balance to denote the balance for each asset.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AssetBalance {

--- a/lib/core/src/persist/mod.rs
+++ b/lib/core/src/persist/mod.rs
@@ -517,6 +517,25 @@ impl Persister {
         Ok(res.ok())
     }
 
+    pub(crate) fn list_swaps(&self) -> Result<Vec<Swap>> {
+        let send_swaps: Vec<Swap> = self
+            .list_send_swaps()?
+            .into_iter()
+            .map(Swap::Send)
+            .collect();
+        let receive_swaps: Vec<Swap> = self
+            .list_receive_swaps()?
+            .into_iter()
+            .map(Swap::Receive)
+            .collect();
+        let chain_swaps: Vec<Swap> = self
+            .list_chain_swaps()?
+            .into_iter()
+            .map(Swap::Chain)
+            .collect();
+        Ok([send_swaps, receive_swaps, chain_swaps].concat())
+    }
+
     pub(crate) fn list_ongoing_swaps(&self) -> Result<Vec<Swap>> {
         let ongoing_send_swaps: Vec<Swap> = self
             .list_ongoing_send_swaps()?

--- a/lib/core/src/persist/receive.rs
+++ b/lib/core/src/persist/receive.rs
@@ -225,6 +225,11 @@ impl Persister {
         })
     }
 
+    pub(crate) fn list_receive_swaps(&self) -> Result<Vec<ReceiveSwap>> {
+        let con = self.get_connection()?;
+        self.list_receive_swaps_where(&con, vec![])
+    }
+
     pub(crate) fn list_receive_swaps_where(
         &self,
         con: &Connection,

--- a/lib/core/src/persist/send.rs
+++ b/lib/core/src/persist/send.rs
@@ -243,6 +243,11 @@ impl Persister {
         })
     }
 
+    pub(crate) fn list_send_swaps(&self) -> Result<Vec<SendSwap>> {
+        let con = self.get_connection()?;
+        self.list_send_swaps_where(&con, vec![])
+    }
+
     pub(crate) fn list_send_swaps_where(
         &self,
         con: &Connection,

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -375,6 +375,12 @@ impl BindingLiquidSdk {
         Ok(())
     }
 
+    #[wasm_bindgen(js_name = "rescanSwaps")]
+    pub async fn rescan_swaps(&self, req: RescanSwapsRequest) -> WasmResult<()> {
+        self.sdk.rescan_swaps(&req.into()).await?;
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = "sync")]
     pub async fn sync(&self) -> WasmResult<()> {
         self.sdk.sync(false).await?;

--- a/lib/wasm/src/model.rs
+++ b/lib/wasm/src/model.rs
@@ -544,6 +544,11 @@ pub struct RefundResponse {
     pub refund_tx_id: String,
 }
 
+#[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::RescanSwapsRequest)]
+pub struct RescanSwapsRequest {
+    pub swap_ids: Vec<String>,
+}
+
 #[sdk_macros::extern_wasm_bindgen(breez_sdk_liquid::prelude::AssetBalance)]
 pub struct AssetBalance {
     pub asset_id: String,

--- a/packages/flutter_breez_liquid/rust/src/models.rs
+++ b/packages/flutter_breez_liquid/rust/src/models.rs
@@ -302,9 +302,9 @@ pub use breez_sdk_liquid::{
         PreparePayOnchainRequest, PreparePayOnchainResponse, PrepareReceiveRequest,
         PrepareReceiveResponse, PrepareRefundRequest, PrepareRefundResponse, PrepareSendRequest,
         PrepareSendResponse, ReceiveAmount, ReceivePaymentRequest, ReceivePaymentResponse,
-        RecommendedFees, RefundRequest, RefundResponse, RefundableSwap, RestoreRequest, SdkEvent,
-        SendDestination, SendPaymentRequest, SendPaymentResponse, SignMessageRequest,
-        SignMessageResponse, WalletInfo,
+        RecommendedFees, RefundRequest, RefundResponse, RefundableSwap, RescanSwapsRequest,
+        RestoreRequest, SdkEvent, SendDestination, SendPaymentRequest, SendPaymentResponse,
+        SignMessageRequest, SignMessageResponse, WalletInfo,
     },
     sdk::LiquidSdk,
 };
@@ -593,6 +593,11 @@ pub struct _RefundRequest {
 #[frb(mirror(RefundResponse))]
 pub struct _RefundResponse {
     pub refund_tx_id: String,
+}
+
+#[frb(mirror(RescanSwapsRequest))]
+pub struct _RescanSwapsRequest {
+    pub swap_ids: Vec<String>,
 }
 
 #[frb(mirror(RefundableSwap))]

--- a/packages/flutter_breez_liquid/rust/src/sdk.rs
+++ b/packages/flutter_breez_liquid/rust/src/sdk.rs
@@ -241,6 +241,10 @@ impl BreezSdkLiquid {
         self.sdk.rescan_onchain_swaps().await
     }
 
+    pub async fn rescan_swaps(&self, req: RescanSwapsRequest) -> Result<(), SdkError> {
+        self.sdk.rescan_swaps(&req).await
+    }
+
     #[frb(name = "sync")]
     pub async fn sync(&self) -> Result<(), SdkError> {
         self.sdk.sync(false).await.map_err(Into::into)


### PR DESCRIPTION
Adds rescan_swaps to allow re-scanning of all types of swaps, provided by a list of swap ids

Adds additional logging of swap struct data and script hashes during rescan/recovery