### PR TITLE
bindings: Remove old ios_simulator_version_min linker opt

### DIFF
--- a/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/nativeInterop/cinterop/breez.def
+++ b/lib/bindings/langs/kotlin-multiplatform/breez-sdk-liquid-kmp/src/nativeInterop/cinterop/breez.def
@@ -9,4 +9,4 @@ libraryPaths.ios_simulator_x64 = src/lib/ios-simulator-x64
 libraryPaths.ios_x64 = src/lib/ios-simulator-x64
 
 
-linkerOpts = -ios_simulator_version_min 14.0.0 -framework Security
+linkerOpts = -framework Security


### PR DESCRIPTION
Flag is deprecated in Xcode 15+, and Kotlin/Native already handles minimum deployment target configuration through Gradle properties.