### PR TITLE
fix: retired macOS-13 runner image

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   build-swift-package:
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Checkout breez-sdk-liquid repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Publish job failed: https://github.com/breez/breez-sdk-liquid/actions/runs/21513150453/job/61985950659