### PR TITLE
build(ci): upgrade Flutter to 3.38.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -469,7 +469,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.35.3
+          flutter-version: 3.38.9
       - run: flutter --version
 
       - name: Set up just

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -31,7 +31,7 @@ on:
         required: true
 
 env:
-  FLUTTER_VERSION: '3.35.3'
+  FLUTTER_VERSION: '3.38.9'
   PROTOC_VERSION: '30.2'
   NDK_VERSION: '23.2.8568313'
   ANDROID_MIN_SDK: '24'


### PR DESCRIPTION
## Summary
- Upgrade Flutter from 3.35.3 to 3.38.9 in main.yml and publish-flutter.yml

## Context
Split from #1064.

## Test plan
- [x] CI workflows pass with Flutter 3.38.9