### PR TITLE
fix: eliminate chain swap test flakiness (#996) + WASM test flakiness (#997)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/breez/waterfalls.git
 [submodule "regtest/swapproxy-service/swapproxy"]
 	path = regtest/swapproxy-service/swapproxy
-	url = https://github.com/breez/swapproxy.git
+	url = https://github.com/maggo83/swapproxy.git

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -338,7 +338,7 @@ impl ChainSwapHandler {
 
             // If swap state is unrecoverable, either:
             // 1. The transaction failed
-            // 2. Lockup failed (too little/too much funds were sent)
+            // 2. Lockup failed (too little/too much funds were sent; incl. amountless receive swaps)
             // 3. The claim lockup was refunded
             // 4. The swap has expired (>24h)
             // We initiate a cooperative refund, and then fallback to a regular one
@@ -350,10 +350,20 @@ impl ChainSwapHandler {
                 let is_zero_amount = swap.payer_amount_sat == 0;
                 if matches!(swap_state, ChainSwapStates::TransactionLockupFailed) && is_zero_amount
                 {
-                    if let Err(e) = self.handle_amountless_update(swap).await {
-                        // In case of error, we log the error but don't mark as refundable,
-                        // letting the recovery logic handle the state.
-                        error!("Failed to accept the quote for swap {}: {e:?}", &swap.id);
+                    // Assumption: after a successful quote acceptance for a swap id, swapper does
+                    // not provide renegotiation via subsequent lockupFailed updates. Therefore,
+                    // ignore post-accept duplicates to avoid regressing accepted amount state.
+                    if swap.is_waiting_fee_acceptance() {
+                        if let Err(e) = self.handle_amountless_update(swap).await {
+                            // In case of error, we log the error but don't mark as refundable,
+                            // letting the recovery logic handle the state.
+                            error!("Failed to accept the quote for swap {}: {e:?}", &swap.id);
+                        }
+                    } else {
+                        debug!(
+                            "Ignoring repeated TransactionLockupFailed for already-accepted zero-amount swap {}",
+                            &swap.id
+                        );
                     }
                     return Ok(());
                 }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -5865,6 +5865,78 @@ mod tests {
     }
 
     #[sdk_macros::async_test_all]
+    async fn test_zero_amount_chain_swap_repeated_lockup_failed_is_idempotent() -> Result<()> {
+        create_persister!(persister);
+        let swapper = Arc::new(MockSwapper::new());
+        let status_stream = Arc::new(MockStatusStream::new());
+        let liquid_chain_service = Arc::new(MockLiquidChainService::new());
+        let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
+
+        // Configure replay-path quote inputs so that any reprocessing would compute
+        // different values than the pre-accepted swap snapshot below.
+        swapper.set_zero_amount_swap_mock_config(ZeroAmountSwapMockConfig {
+            user_lockup_sat: 50_000,
+            onchain_fee_increase_sat: 1_000,
+        });
+        bitcoin_chain_service.set_script_balance_sat(50_000);
+
+        let sdk = new_liquid_sdk_with_chain_services(
+            persister.clone(),
+            swapper.clone(),
+            status_stream.clone(),
+            liquid_chain_service,
+            bitcoin_chain_service.clone(),
+            Some(500),
+        )
+        .await?;
+
+        LiquidSdk::track_swap_updates(&sdk);
+
+        tokio::spawn(async move {
+            // Simulate a swap that already completed zero-amount fee acceptance.
+            let mut swap = new_chain_swap(
+                Direction::Incoming,
+                Some(PaymentState::Created),
+                false,
+                None,
+                true,
+                true,
+                None,
+            );
+            swap.actual_payer_amount_sat = Some(50_000);
+            swap.accepted_receiver_amount_sat = Some(49_672);
+            swap.auto_accepted_fees = true;
+
+            let swap_id = swap.id.clone();
+            persister.insert_or_update_chain_swap(&swap).unwrap();
+
+            status_stream
+                .clone()
+                .send_mock_update(boltz::SwapStatus {
+                    id: swap_id.clone(),
+                    status: ChainSwapStates::TransactionLockupFailed.to_string(),
+                    transaction: None,
+                    zero_conf_rejected: None,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            let persisted_swap = persister
+                .fetch_chain_swap_by_id(&swap_id)
+                .unwrap()
+                .expect("Could not retrieve chain swap");
+
+            // Replayed lockupFailed must not regress previously accepted values.
+            assert_eq!(persisted_swap.accepted_receiver_amount_sat, Some(49_672));
+            assert_eq!(persisted_swap.actual_payer_amount_sat, Some(50_000));
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    #[sdk_macros::async_test_all]
     async fn test_background_tasks() -> Result<()> {
         create_persister!(persister);
         let swapper = Arc::new(MockSwapper::new());

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -735,7 +735,7 @@ impl LiquidSdk {
                 .on_bitcoin_block(*current_bitcoin_block)
                 .await;
             self.receive_swap_handler
-                .on_bitcoin_block(*current_liquid_block)
+                .on_bitcoin_block(*current_bitcoin_block)
                 .await;
             self.send_swap_handler
                 .on_bitcoin_block(*current_bitcoin_block)

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -3,7 +3,6 @@ use breez_sdk_liquid::model::{
     PrepareReceiveRequest, PrepareRefundRequest, ReceiveAmount, RefundRequest, SdkEvent,
 };
 use serial_test::serial;
-use std::time::Duration;
 
 use crate::regtest::{utils, ChainBackend, SdkNodeHandle, TIMEOUT};
 
@@ -31,15 +30,6 @@ async fn bitcoin_esplora() {
 
 async fn bitcoin(mut handle: SdkNodeHandle) {
     let indexers = handle.indexers;
-
-    // Derive the one-poll-cycle timeout from the SDK's configured sync period.
-    // Add 1s as buffer
-    let one_poll_cycle = Duration::from_secs(handle.onchain_sync_period_sec as u64 + 1);
-    assert!(
-        one_poll_cycle * 2 <= TIMEOUT,
-        "TIMEOUT ({TIMEOUT:?}) must be at least 2x one_poll_cycle ({one_poll_cycle:?}) \
-         to leave room for the try-then-mine retry pattern",
-    );
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
@@ -130,29 +120,14 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     //    liquid block.
     // If that is detected by timeout, mine one more block and wait with
     // reduced timeout
-    let waiting_event = match handle
-        .wait_for_event(
-            |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
-            one_poll_cycle,
-        )
-        .await
-    {
-        Ok(event) => event,
-        Err(_) => {
-            // Tip N was consumed with stale waterfalls data.  Mine N+1
-            // so the poller gets a fresh tip with consistent data.
-            utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
-                .await
-                .unwrap();
-            handle
-                .wait_for_event(
-                    |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
-                    TIMEOUT.saturating_sub(one_poll_cycle),
-                )
-                .await
-                .unwrap()
-        }
-    };
+    let waiting_event = utils::wait_for_event_with_retry(
+        &mut handle,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         handle.get_pending_receive_sat().await.unwrap(),
@@ -298,27 +273,14 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    let waiting_event = match handle
-        .wait_for_event(
-            |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
-            one_poll_cycle,
-        )
-        .await
-    {
-        Ok(event) => event,
-        Err(_) => {
-            utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
-                .await
-                .unwrap();
-            handle
-                .wait_for_event(
-                    |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
-                    TIMEOUT.saturating_sub(one_poll_cycle),
-                )
-                .await
-                .unwrap()
-        }
-    };
+    let waiting_event = utils::wait_for_event_with_retry(
+        &mut handle,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -1,11 +1,8 @@
-use std::time::Duration;
-
 use breez_sdk_liquid::model::{
     PayAmount, PaymentDetails, PaymentMethod, PaymentState, PaymentType, PreparePayOnchainRequest,
     PrepareReceiveRequest, PrepareRefundRequest, ReceiveAmount, RefundRequest, SdkEvent,
 };
 use serial_test::serial;
-use tokio_with_wasm::alias as tokio;
 
 use crate::regtest::{utils, ChainBackend, SdkNodeHandle, TIMEOUT};
 
@@ -63,15 +60,11 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm user lockup
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm user lockup.
+    utils::mine_bitcoin_then_liquid(1).await.unwrap();
 
-    // Wait for swapper to lock up funds
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    // Confirm swapper lockup
-    utils::mine_blocks(1).await.unwrap();
-
+    // Wait for the SDK to detect the server lockup and broadcast the
+    // claim tx (emitted as PaymentWaitingConfirmation).
     handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
@@ -86,8 +79,8 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     );
     assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
 
-    // Confirm claim tx
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm claim tx.
+    utils::mine_bitcoin_then_liquid(1).await.unwrap();
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
@@ -130,16 +123,11 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let fees_sat = prepare_response.total_fees_sat;
     let sender_amount_sat = receiver_amount_sat + fees_sat;
 
-    // Confirm user lockup
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm user lockup.
+    utils::mine_bitcoin_then_liquid(1).await.unwrap();
 
-    // Wait for swapper to lock up funds
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    // Confirm swapper lockup
-    utils::mine_blocks(1).await.unwrap();
-
-    // Wait for sdk to broadcast claim tx
+    // Wait for the SDK to detect the server lockup and broadcast the
+    // claim tx (emitted as PaymentWaitingConfirmation).
     handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
@@ -148,8 +136,8 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm claim tx
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm claim tx.
+    utils::mine_bitcoin_then_liquid(1).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847
@@ -271,7 +259,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         &refund_rbf_response.refund_tx_id
     );
 
-    utils::mine_blocks(1).await.unwrap();
+    utils::mine_bitcoin_then_liquid(1).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -95,6 +95,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
             details.details
         );
     };
+    handle
+        .assert_wallet_pending(receiver_amount_sat, 0, 0)
+        .await;
 
     let server_lockup_txid = utils::poll_boltz_server_lockup_txid(swap_id, TIMEOUT)
         .await
@@ -129,11 +132,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     .await
     .unwrap();
 
-    assert_eq!(
-        handle.get_pending_receive_sat().await.unwrap(),
-        receiver_amount_sat
-    );
-    assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
+    handle
+        .assert_wallet_pending(receiver_amount_sat, 0, 0)
+        .await;
 
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
@@ -283,6 +284,19 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     )
     .await
     .unwrap();
+
+    let pending_receive_sat = handle.get_pending_receive_sat().await.unwrap();
+    assert!(
+        pending_receive_sat > 0,
+        "Amountless RECEIVE should expose pending_receive_sat > 0 once claim is waiting"
+    );
+    assert!(
+        pending_receive_sat <= payer_amount_sat,
+        "Amountless RECEIVE pending_receive_sat ({pending_receive_sat}) should not exceed payer amount ({payer_amount_sat})"
+    );
+    handle
+        .assert_wallet_pending(pending_receive_sat, 0, balance_before_amountless)
+        .await;
 
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
@@ -436,6 +450,14 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         )
         .await
         .unwrap();
+
+    handle
+        .assert_wallet_pending(
+            0,
+            sender_amount_sat,
+            initial_balance_sat - sender_amount_sat,
+        )
+        .await;
 
     // Ensure the BTC claim tx is in bitcoind's mempool before mining.
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -191,12 +191,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     //
     // To stop skipping recovery we need more time for esplora to settle
     // + at least one new liquid block
-    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, Some(&indexers))
-        .await
-        .unwrap();
-    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
-        .await
-        .unwrap();
+    utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
@@ -246,13 +241,8 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
          must not exceed send max_zero_conf_sat ({})",
         onchain_limits.send.max_zero_conf_sat
     );
-    assert!(
-        initial_balance_sat >= receiver_amount_sat,
-        "SEND requires sufficient balance: have {initial_balance_sat} sat, \
-         need at least {receiver_amount_sat} sat"
-    );
 
-    let (prepare_response, _) = handle
+    let (prepare_response, send_response) = handle
         .send_onchain_payment(
             &PreparePayOnchainRequest {
                 amount: PayAmount::Bitcoin {
@@ -273,18 +263,46 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
          need {sender_amount_sat} sat (receiver: {receiver_amount_sat} + fees: {fees_sat})"
     );
 
-    // Ensure the L-BTC user-lockup is in the Liquid mempool before mining.
-    utils::wait_for_mempool_tx(utils::Chain::Liquid, TIMEOUT)
+    // SDK should have broadcast L-BTC user-lockup already
+    let PaymentDetails::Bitcoin {
+        swap_id,
+        lockup_tx_id,
+        ..
+    } = &send_response.payment.details
+    else {
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            send_response.payment.details
+        );
+    };
+    let user_lockup_txid = lockup_tx_id
+        .as_ref()
+        .expect("lockup_tx_id should be set after pay_onchain returns");
+
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, user_lockup_txid, TIMEOUT)
         .await
         .unwrap();
+
+    // Get Boltz's expected lockup txid as early as possible
+    let server_lockup_txid = utils::poll_boltz_server_lockup_txid(swap_id, TIMEOUT)
+        .await
+        .unwrap();
+
+    assert!(
+        utils::poll_boltz_zero_conf_accepted(swap_id, TIMEOUT)
+            .await
+            .unwrap(),
+        "Boltz should accept zero-conf for SEND swap {swap_id} \
+        (receiver_amount_sat = {receiver_amount_sat})"
+    );
 
     // Confirm the L-BTC user-lockup on Liquid.
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
         .unwrap();
 
-    // Wait for Boltz to broadcast the BTC server-lockup.
-    utils::wait_for_mempool_tx(utils::Chain::Bitcoin, TIMEOUT)
+    // Wait for Bolt's BTC server-lockup to appear in bitcoind's mempool.
+    utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, &server_lockup_txid, TIMEOUT)
         .await
         .unwrap();
 
@@ -314,7 +332,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm claim tx.
+    // Confirm lock-up and claim tx (on bitcoin).
+    // Additional liquid block is needed to circumvent gating introduced in #978
+    // (this liquid block could also confirm Boltz's L-BTC claim tx)
     utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
@@ -345,7 +365,18 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
 
-    // ----------------REFUND--------------
+    // Cleanup: flush mempools, (e.g. Boltz's deferred L-BTC claim and
+    // any other pending transactions, so the REFUND section starts
+    // with clean mempools.
+    utils::drain_mempools(10).await.unwrap();
+
+    // ----------------REFUND with RBF--------------
+    // Incoming chain swap with incorrect user lockup amount:
+    // BTC user-lockup → BTC refund.
+    // This tests the cooperative refund path: the refund is
+    // confirmed by both SDK and Boltz (not timeout)
+    // User fee-bump is also tested
+    // TODO: add a non-cooperative test case
 
     let payer_amount_sat = 100_000;
     let lockup_amount_sat = payer_amount_sat - 1;
@@ -361,10 +392,15 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let bip21 = receive_response.destination;
     let address = bip21.split(':').nth(1).unwrap().split('?').next().unwrap();
 
-    utils::send_to_address_bitcoind(&address, lockup_amount_sat)
+    // BTC user-lockup creation. Wrong amount will already be flagged by Boltz in mempool w/o confirmation
+    let user_lockup_txid = utils::send_to_address_bitcoind(&address, lockup_amount_sat)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, &user_lockup_txid, TIMEOUT)
         .await
         .unwrap();
 
+    // SDK and Boltz should detect the wrong amount BTC user-lockup and start refund process
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentRefundable { .. }), TIMEOUT)
         .await
@@ -378,9 +414,33 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert_eq!(refundable.swap_address, address);
     assert!(refundable.last_refund_tx_id.is_none());
 
+    // Create refund tx
     let refund_address = utils::generate_address_bitcoind().await.unwrap();
     let refund_fee_rate = 1;
-    let refund_rbf_fee_rate = 2;
+
+    let prepare_refund_response = handle
+        .sdk
+        .prepare_refund(&PrepareRefundRequest {
+            swap_address: address.to_string(),
+            refund_address: refund_address.clone(),
+            fee_rate_sat_per_vbyte: refund_fee_rate,
+        })
+        .await
+        .unwrap();
+    assert!(
+        prepare_refund_response.last_refund_tx_id.is_none(),
+        "No refund tx should exist yet"
+    );
+    // With fee_rate = 1 sat/vB, fee == vsize
+    assert_eq!(
+        prepare_refund_response.tx_fee_sat,
+        prepare_refund_response.tx_vsize as u64
+    );
+    assert!(
+        prepare_refund_response.tx_fee_sat < lockup_amount_sat,
+        "Refund fee ({}) must be less than lockup amount ({lockup_amount_sat})",
+        prepare_refund_response.tx_fee_sat
+    );
 
     let refund_response = handle
         .sdk
@@ -392,6 +452,14 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
+    utils::wait_for_tx_in_mempool(
+        utils::Chain::Bitcoin,
+        &refund_response.refund_tx_id,
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
+
     handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentRefundPending { .. }),
@@ -400,6 +468,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
+    // User fee-bump
     let refundables = handle.sdk.list_refundables().await.unwrap();
 
     assert_eq!(refundables.len(), 1);
@@ -411,25 +480,23 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         &refund_response.refund_tx_id
     );
 
-    let _prepare_refund_rbf_response = handle
-        .sdk
-        .prepare_refund(&PrepareRefundRequest {
-            swap_address: address.to_string(),
-            refund_address: refund_address.clone(),
-            fee_rate_sat_per_vbyte: refund_rbf_fee_rate,
-        })
-        .await
-        .unwrap();
-
     let refund_rbf_response = handle
         .sdk
         .refund(&RefundRequest {
             swap_address: address.to_string(),
             refund_address,
-            fee_rate_sat_per_vbyte: refund_rbf_fee_rate,
+            fee_rate_sat_per_vbyte: refund_fee_rate * 2,
         })
         .await
         .unwrap();
+
+    utils::wait_for_tx_in_mempool(
+        utils::Chain::Bitcoin,
+        &refund_rbf_response.refund_tx_id,
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     let refundables = handle.sdk.list_refundables().await.unwrap();
 
@@ -442,6 +509,23 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         &refund_rbf_response.refund_tx_id
     );
 
+    // The following fails because the payment's refund_tx_amount_sat is None.
+    // Related issue: https://github.com/breez/breez-sdk-liquid/issues/773
+    // TODO: uncomment once the issue is fixed
+    /*{
+        let payments = handle.get_payments().await.unwrap();
+        let payment = &payments[0];
+        assert!(matches!(
+            payment.details,
+            PaymentDetails::Bitcoin {
+                refund_tx_amount_sat: Some(refund_tx_amount_sat),
+                ..
+            } if refund_tx_amount_sat == lockup_amount_sat - prepare_refund_response.tx_fee_sat * 2
+        ));
+    }*/
+
+    // Confirm the BTC refund tx (on bitcoin).
+    // Additional liquid block is needed to circumvent gating introduced in #978
     utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
@@ -459,19 +543,16 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let refundables = handle.sdk.list_refundables().await.unwrap();
     assert_eq!(refundables.len(), 0);
 
+    // Cleanup: flush mempools
+    utils::drain_mempools(10).await.unwrap();
+
+    // ----------------FINAL ASSERTIONS--------------
+    // Verify the complete payment history across all three sections.
+
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 3);
     let payment = &payments[0];
     assert_eq!(payment.status, PaymentState::Failed);
-    // The following fails because the payment's refund_tx_amount_sat is None. Related issue: https://github.com/breez/breez-sdk-liquid/issues/773
-    // TODO: uncomment once the issue is fixed
-    /*assert!(matches!(
-        payment.details,
-        PaymentDetails::Bitcoin {
-            refund_tx_amount_sat: Some(refund_tx_amount_sat),
-            ..
-        } if refund_tx_amount_sat == lockup_amount_sat - prepare_refund_rbf_response.tx_fee_sat
-    ));*/
 
     // On node.js, without disconnecting the sdk, the wasm-pack test process fails after the test succeeds
     handle.sdk.disconnect().await.unwrap();

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -221,8 +221,162 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     );
 
     // Cleanup: flush mempools, (e.g. Boltz's deferred BTC claim and
-    // any other pending transactions, so the SEND section starts
-    // with clean mempools.
+    // any other pending transactions, so the AMOUNTLESS RECEIVE section
+    // starts with clean mempools.
+    utils::drain_mempools(10).await.unwrap();
+
+    // -------------- AMOUNTLESS RECEIVE (auto-accept) --------------
+    // Incoming chain swap without a pre-agreed amount: the SDK creates a
+    // swap with amount=None, payer sends an arbitrary BTC amount.  Boltz
+    // reports TransactionLockupFailed (expected for zero-amount swaps),
+    // and the SDK validates the proposed fees.  With the default fee
+    // leeway (500 sat), the actual Boltz server fee closely matches the
+    // advertised fee in regtest, so the SDK auto-accepts and the swap
+    // proceeds like a normal receive.
+
+    let balance_before_amountless = handle.get_balance_sat().await.unwrap();
+
+    let (prepare_response_amountless, receive_response_amountless) = handle
+        .receive_payment(&PrepareReceiveRequest {
+            payment_method: PaymentMethod::BitcoinAddress,
+            amount: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(prepare_response_amountless.amount.is_none());
+
+    let bip21 = receive_response_amountless.destination;
+    let address = bip21.split(':').nth(1).unwrap().split('?').next().unwrap();
+
+    // Payer sends an arbitrary amount to the swap address
+    let payer_amount_sat = 50_000;
+    let user_lockup_txid = utils::send_to_address_bitcoind(&address, payer_amount_sat)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, &user_lockup_txid, TIMEOUT)
+        .await
+        .unwrap();
+    // Boltz needs a confirmed BTC lockup (BTC maxZeroConfAmount = 0)
+    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, None)
+        .await
+        .unwrap();
+
+    // SDK detects the lockup via TransactionMempool/Confirmed → Pending.
+    // Boltz then reports TransactionLockupFailed (zero-amount), the SDK
+    // auto-accepts the fees, and Boltz broadcasts the L-BTC server-lockup.
+    let pending_event = handle
+        .wait_for_event(|e| matches!(e, SdkEvent::PaymentPending { .. }), TIMEOUT)
+        .await
+        .unwrap();
+
+    let SdkEvent::PaymentPending { details } = &pending_event else {
+        panic!("Expected PaymentPending, got {pending_event:?}");
+    };
+    let PaymentDetails::Bitcoin { swap_id, .. } = &details.details else {
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            details.details
+        );
+    };
+    let swap_id = swap_id.clone();
+
+    // After auto-accept, Boltz broadcasts the L-BTC server-lockup
+    let server_lockup_txid = utils::poll_boltz_server_lockup_txid(&swap_id, TIMEOUT)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, &server_lockup_txid, TIMEOUT)
+        .await
+        .unwrap();
+
+    // Confirm the L-BTC server-lockup so the SDK can claim.
+    // For amountless swaps, PaymentWaitingFeeAcceptance (claim_tx_id: None)
+    // may arrive first once the zero-amount quote is auto-accepted — it is
+    // harmlessly consumed by the predicate.  The actual claim produces
+    // PaymentWaitingConfirmation, identical to the RECEIVE path.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+
+    let waiting_event = match handle
+        .wait_for_event(
+            |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+            one_poll_cycle,
+        )
+        .await
+    {
+        Ok(event) => event,
+        Err(_) => {
+            utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+                .await
+                .unwrap();
+            handle
+                .wait_for_event(
+                    |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+                    TIMEOUT.saturating_sub(one_poll_cycle),
+                )
+                .await
+                .unwrap()
+        }
+    };
+
+    let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
+        panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
+    };
+    let PaymentDetails::Bitcoin { claim_tx_id, .. } = &details.details else {
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            details.details
+        );
+    };
+    let claim_tx_id = claim_tx_id
+        .as_ref()
+        .expect("claim_tx_id should be set in PaymentWaitingConfirmation");
+
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, &claim_tx_id, TIMEOUT)
+        .await
+        .unwrap();
+
+    // Confirm the L-BTC claim tx
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+
+    // Workaround for esplora duplicate-tx edge case (see RECEIVE section)
+    utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
+
+    handle
+        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
+        .await
+        .unwrap();
+
+    // Workaround for #828
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+    handle.sdk.sync(false).await.unwrap();
+
+    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
+
+    let payments = handle.get_payments().await.unwrap();
+    assert_eq!(payments.len(), 2);
+    let payment = &payments[0];
+    assert_eq!(payment.payment_type, PaymentType::Receive);
+    assert_eq!(payment.status, PaymentState::Complete);
+    assert!(
+        matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, auto_accepted_fees, .. }
+            if *bitcoin_address == address && *auto_accepted_fees)
+    );
+    // For an auto-accepted amountless receive, amount + fees = payer_amount
+    assert_eq!(payment.amount_sat + payment.fees_sat, payer_amount_sat);
+
+    let receiver_amount_sat_amountless = payment.amount_sat;
+    assert_eq!(
+        handle.get_balance_sat().await.unwrap(),
+        balance_before_amountless + receiver_amount_sat_amountless
+    );
+
+    // Cleanup: flush mempools so the SEND section starts clean.
     utils::drain_mempools(10).await.unwrap();
 
     // -------------- SEND (zero-conf) --------------
@@ -354,7 +508,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     );
 
     let payments = handle.get_payments().await.unwrap();
-    assert_eq!(payments.len(), 2);
+    assert_eq!(payments.len(), 3);
     let payment = &payments[0];
     assert_eq!(payment.amount_sat, receiver_amount_sat);
     assert_eq!(payment.fees_sat, fees_sat);
@@ -546,10 +700,10 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     utils::drain_mempools(10).await.unwrap();
 
     // ----------------FINAL ASSERTIONS--------------
-    // Verify the complete payment history across all three sections.
+    // Verify the complete payment history across all four sections.
 
     let payments = handle.get_payments().await.unwrap();
-    assert_eq!(payments.len(), 3);
+    assert_eq!(payments.len(), 4);
     let payment = &payments[0];
     assert_eq!(payment.status, PaymentState::Failed);
 

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -3,6 +3,7 @@ use breez_sdk_liquid::model::{
     PrepareReceiveRequest, PrepareRefundRequest, ReceiveAmount, RefundRequest, SdkEvent,
 };
 use serial_test::serial;
+use std::time::Duration;
 
 use crate::regtest::{utils, ChainBackend, SdkNodeHandle, TIMEOUT};
 
@@ -29,6 +30,17 @@ async fn bitcoin_esplora() {
 }
 
 async fn bitcoin(mut handle: SdkNodeHandle) {
+    let indexers = handle.indexers;
+
+    // Derive the one-poll-cycle timeout from the SDK's configured sync period.
+    // Add 1s as buffer
+    let one_poll_cycle = Duration::from_secs(handle.onchain_sync_period_sec as u64 + 1);
+    assert!(
+        one_poll_cycle * 2 <= TIMEOUT,
+        "TIMEOUT ({TIMEOUT:?}) must be at least 2x one_poll_cycle ({one_poll_cycle:?}) \
+         to leave room for the try-then-mine retry pattern",
+    );
+
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
         .await
@@ -67,34 +79,80 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let bip21 = receive_response.destination;
     let address = bip21.split(':').nth(1).unwrap().split('?').next().unwrap();
 
-    utils::send_to_address_bitcoind(&address, payer_amount_sat)
+    // BTC user-lockup creation and confirmation
+    let user_lockup_txid = utils::send_to_address_bitcoind(&address, payer_amount_sat)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, &user_lockup_txid, TIMEOUT)
+        .await
+        .unwrap();
+    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, None)
         .await
         .unwrap();
 
-    // Confirm the BTC user-lockup first.  Boltz requires at least one
-    // confirmation before broadcasting the L-BTC server-lockup in regtest
-    // (BTC maxZeroConfAmount = 0).
-    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, true)
+    // SDK and Boltz should detect the BTC user-lockup. Boltz should issue L-BTC server-lockup
+    // -> ensure server-lockup tx is in mempool before mining its confirmation
+    let pending_event = handle
+        .wait_for_event(|e| matches!(e, SdkEvent::PaymentPending { .. }), TIMEOUT)
+        .await
+        .unwrap();
+    let SdkEvent::PaymentPending { details } = &pending_event else {
+        panic!("Expected PaymentPending, got {pending_event:?}");
+    };
+    let PaymentDetails::Bitcoin { swap_id, .. } = &details.details else {
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            details.details
+        );
+    };
+
+    let server_lockup_txid = utils::poll_boltz_server_lockup_txid(swap_id, TIMEOUT)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, &server_lockup_txid, TIMEOUT)
         .await
         .unwrap();
 
-    // Ensure the Boltz server-lockup is in the Liquid mempool before
-    // mining, so that it gets included and confirmed in this block.
-    utils::wait_for_liquid_mempool_tx(TIMEOUT).await.unwrap();
-
-    utils::mine_and_index_blocks(1, utils::Chain::Liquid, true)
+    // Confirm the L-BTC server-lockup
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
         .unwrap();
 
-    // Wait for the SDK to detect the server lockup and broadcast the
-    // claim tx (emitted as PaymentWaitingConfirmation).
-    let waiting_event = handle
+    // SDK should detect server-lockup confirmation and eventually issue a
+    // claim tx on liquid
+    //
+    // The SDK's background poller is not synched with mining/indexers
+    // -> might fire after server-lockup tx was mined but not all indexers have
+    //    caught up
+    // -> then it "consumes" the new block w/o detecting lockup tx and does
+    //    not issue PaymentWaitingConfirmation.
+    // -> On next poll(s) it won't update internal state if there is no new
+    //    liquid block.
+    // If that is detected by timeout, mine one more block and wait with
+    // reduced timeout
+    let waiting_event = match handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
-            TIMEOUT,
+            one_poll_cycle,
         )
         .await
-        .unwrap();
+    {
+        Ok(event) => event,
+        Err(_) => {
+            // Tip N was consumed with stale waterfalls data.  Mine N+1
+            // so the poller gets a fresh tip with consistent data.
+            utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+                .await
+                .unwrap();
+            handle
+                .wait_for_event(
+                    |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+                    TIMEOUT.saturating_sub(one_poll_cycle),
+                )
+                .await
+                .unwrap()
+        }
+    };
 
     assert_eq!(
         handle.get_pending_receive_sat().await.unwrap(),
@@ -102,26 +160,56 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     );
     assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
 
-    // Extract the claim_tx_id from the event and wait for it to reach
-    // elementsd's mempool before mining the confirming block.
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
     };
     let PaymentDetails::Bitcoin { claim_tx_id, .. } = &details.details else {
-        panic!("Expected PaymentDetails::Bitcoin, got {:?}", details.details);
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            details.details
+        );
     };
-    let claim_tx_id = claim_tx_id.as_ref().expect("claim_tx_id should be set in PaymentWaitingConfirmation");
-    utils::wait_for_tx_in_liquid_mempool(claim_tx_id, TIMEOUT)
+    let claim_tx_id = claim_tx_id
+        .as_ref()
+        .expect("claim_tx_id should be set in PaymentWaitingConfirmation");
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, claim_tx_id, TIMEOUT)
         .await
         .unwrap();
 
-    // Confirm claim tx.
-    utils::mine_bitcoin_then_liquid(1).await.unwrap();
+    // Confirm the L-BTC claim tx. In theory only a Liquid block is needed —
+    // PaymentSucceeded depends solely on the claim confirmation on Liquid.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+
+    // TODO
+    // Workaround for #XXX (maybe same as #847?): Esplora sometimes has same
+    // claim TX twice in its output (once confirmed, once in mempool) which
+    // leads to script history >2 which triggers the edge case in
+    // determine_incoming_lockup_and_claim_txs() and triggers 120s "grace period"
+    // skipping recovery -> test timeout.
+    //
+    // To stop skipping recovery we need more time for esplora to settle
+    // + at least one new liquid block
+    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, Some(&indexers))
+        .await
+        .unwrap();
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
         .await
         .unwrap();
+
+    //TODO
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+    handle.sdk.sync(false).await.unwrap();
 
     assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
     assert_eq!(handle.get_balance_sat().await.unwrap(), receiver_amount_sat);
@@ -136,6 +224,11 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     assert!(
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
+
+    // Cleanup: flush mempools, (e.g. Boltz's deferred BTC claim and
+    // any other pending transactions, so the SEND section starts
+    // with clean mempools.
+    utils::drain_mempools(10).await.unwrap();
 
     // -------------- SEND (zero-conf) --------------
     // Outgoing chain swap: L-BTC user-lockup → BTC server-lockup → SDK claims BTC.
@@ -153,6 +246,11 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
          must not exceed send max_zero_conf_sat ({})",
         onchain_limits.send.max_zero_conf_sat
     );
+    assert!(
+        initial_balance_sat >= receiver_amount_sat,
+        "SEND requires sufficient balance: have {initial_balance_sat} sat, \
+         need at least {receiver_amount_sat} sat"
+    );
 
     let (prepare_response, _) = handle
         .send_onchain_payment(
@@ -169,17 +267,26 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
 
     let fees_sat = prepare_response.total_fees_sat;
     let sender_amount_sat = receiver_amount_sat + fees_sat;
+    assert!(
+        initial_balance_sat >= sender_amount_sat,
+        "SEND requires sufficient balance: have {initial_balance_sat} sat, \
+         need {sender_amount_sat} sat (receiver: {receiver_amount_sat} + fees: {fees_sat})"
+    );
 
     // Ensure the L-BTC user-lockup is in the Liquid mempool before mining.
-    utils::wait_for_liquid_mempool_tx(TIMEOUT).await.unwrap();
+    utils::wait_for_mempool_tx(utils::Chain::Liquid, TIMEOUT)
+        .await
+        .unwrap();
 
     // Confirm the L-BTC user-lockup on Liquid.
-    utils::mine_and_index_blocks(1, utils::Chain::Liquid, true)
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
         .unwrap();
 
     // Wait for Boltz to broadcast the BTC server-lockup.
-    utils::wait_for_bitcoin_mempool_tx(TIMEOUT).await.unwrap();
+    utils::wait_for_mempool_tx(utils::Chain::Bitcoin, TIMEOUT)
+        .await
+        .unwrap();
 
     // Zero-conf: SDK claims from mempool without a BTC confirmation.
     let waiting_event = handle
@@ -195,21 +302,31 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
     };
     let PaymentDetails::Bitcoin { claim_tx_id, .. } = &details.details else {
-        panic!("Expected PaymentDetails::Bitcoin, got {:?}", details.details);
+        panic!(
+            "Expected PaymentDetails::Bitcoin, got {:?}",
+            details.details
+        );
     };
-    let claim_tx_id = claim_tx_id.as_ref().expect("claim_tx_id should be set in PaymentWaitingConfirmation");
-    utils::wait_for_tx_in_bitcoin_mempool(claim_tx_id, TIMEOUT)
+    let claim_tx_id = claim_tx_id
+        .as_ref()
+        .expect("claim_tx_id should be set in PaymentWaitingConfirmation");
+    utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, claim_tx_id, TIMEOUT)
         .await
         .unwrap();
 
     // Confirm claim tx.
-    utils::mine_bitcoin_then_liquid(1).await.unwrap();
+    utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847
     let _ = handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
         .await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
     assert_eq!(
@@ -325,13 +442,18 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         &refund_rbf_response.refund_tx_id
     );
 
-    utils::mine_bitcoin_then_liquid(1).await.unwrap();
+    utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847
     let _ = handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentFailed { .. }), TIMEOUT)
         .await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
     let refundables = handle.sdk.list_refundables().await.unwrap();

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -230,7 +230,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     // This tests the zero-conf path: the send amount is within the Boltz
     // zero-conf threshold, so the SDK accepts the BTC server-lockup from
     // mempool and claims without waiting for a BTC confirmation.
-    // TODO: add a non-zero-conf SEND test with amount > send.max_zero_conf_sat
 
     let initial_balance_sat = handle.get_balance_sat().await.unwrap();
     let address = utils::generate_address_bitcoind().await.unwrap();

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -34,8 +34,19 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // --------------RECEIVE--------------
+    // -------------- RECEIVE (non-zero-conf) --------------
+    // Incoming chain swap: BTC user-lockup → L-BTC server-lockup → SDK claims L-BTC.
+    // This tests the non-zero-conf path: Boltz requires a confirmed BTC
+    // lockup before broadcasting the L-BTC server-lockup, and the SDK
+    // requires a confirmed server-lockup before claiming.
+    let onchain_limits = handle.sdk.fetch_onchain_limits().await.unwrap();
     let payer_amount_sat = 100_000;
+    assert!(
+        payer_amount_sat > onchain_limits.receive.max_zero_conf_sat,
+        "RECEIVE test assumes non-zero-conf: payer_amount_sat ({payer_amount_sat}) \
+         must exceed receive max_zero_conf_sat ({})",
+        onchain_limits.receive.max_zero_conf_sat
+    );
 
     let (prepare_response, receive_response) = handle
         .receive_payment(&PrepareReceiveRequest {
@@ -60,12 +71,24 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm user lockup.
-    utils::mine_bitcoin_then_liquid(1).await.unwrap();
+    // Confirm the BTC user-lockup first.  Boltz requires at least one
+    // confirmation before broadcasting the L-BTC server-lockup in regtest
+    // (BTC maxZeroConfAmount = 0).
+    utils::mine_and_index_blocks(1, utils::Chain::Bitcoin, true)
+        .await
+        .unwrap();
+
+    // Ensure the Boltz server-lockup is in the Liquid mempool before
+    // mining, so that it gets included and confirmed in this block.
+    utils::wait_for_liquid_mempool_tx(TIMEOUT).await.unwrap();
+
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, true)
+        .await
+        .unwrap();
 
     // Wait for the SDK to detect the server lockup and broadcast the
     // claim tx (emitted as PaymentWaitingConfirmation).
-    handle
+    let waiting_event = handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
             TIMEOUT,
@@ -78,6 +101,19 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         receiver_amount_sat
     );
     assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
+
+    // Extract the claim_tx_id from the event and wait for it to reach
+    // elementsd's mempool before mining the confirming block.
+    let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
+        panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
+    };
+    let PaymentDetails::Bitcoin { claim_tx_id, .. } = &details.details else {
+        panic!("Expected PaymentDetails::Bitcoin, got {:?}", details.details);
+    };
+    let claim_tx_id = claim_tx_id.as_ref().expect("claim_tx_id should be set in PaymentWaitingConfirmation");
+    utils::wait_for_tx_in_liquid_mempool(claim_tx_id, TIMEOUT)
+        .await
+        .unwrap();
 
     // Confirm claim tx.
     utils::mine_bitcoin_then_liquid(1).await.unwrap();
@@ -101,11 +137,22 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
 
-    // --------------SEND--------------
+    // -------------- SEND (zero-conf) --------------
+    // Outgoing chain swap: L-BTC user-lockup → BTC server-lockup → SDK claims BTC.
+    // This tests the zero-conf path: the send amount is within the Boltz
+    // zero-conf threshold, so the SDK accepts the BTC server-lockup from
+    // mempool and claims without waiting for a BTC confirmation.
+    // TODO: add a non-zero-conf SEND test with amount > send.max_zero_conf_sat
 
     let initial_balance_sat = handle.get_balance_sat().await.unwrap();
     let address = utils::generate_address_bitcoind().await.unwrap();
     let receiver_amount_sat = 50_000;
+    assert!(
+        receiver_amount_sat <= onchain_limits.send.max_zero_conf_sat,
+        "SEND test assumes zero-conf: receiver_amount_sat ({receiver_amount_sat}) \
+         must not exceed send max_zero_conf_sat ({})",
+        onchain_limits.send.max_zero_conf_sat
+    );
 
     let (prepare_response, _) = handle
         .send_onchain_payment(
@@ -123,16 +170,35 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let fees_sat = prepare_response.total_fees_sat;
     let sender_amount_sat = receiver_amount_sat + fees_sat;
 
-    // Confirm user lockup.
-    utils::mine_bitcoin_then_liquid(1).await.unwrap();
+    // Ensure the L-BTC user-lockup is in the Liquid mempool before mining.
+    utils::wait_for_liquid_mempool_tx(TIMEOUT).await.unwrap();
 
-    // Wait for the SDK to detect the server lockup and broadcast the
-    // claim tx (emitted as PaymentWaitingConfirmation).
-    handle
+    // Confirm the L-BTC user-lockup on Liquid.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, true)
+        .await
+        .unwrap();
+
+    // Wait for Boltz to broadcast the BTC server-lockup.
+    utils::wait_for_bitcoin_mempool_tx(TIMEOUT).await.unwrap();
+
+    // Zero-conf: SDK claims from mempool without a BTC confirmation.
+    let waiting_event = handle
         .wait_for_event(
             |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
             TIMEOUT,
         )
+        .await
+        .unwrap();
+
+    // Ensure the BTC claim tx is in bitcoind's mempool before mining.
+    let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
+        panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
+    };
+    let PaymentDetails::Bitcoin { claim_tx_id, .. } = &details.details else {
+        panic!("Expected PaymentDetails::Bitcoin, got {:?}", details.details);
+    };
+    let claim_tx_id = claim_tx_id.as_ref().expect("claim_tx_id should be set in PaymentWaitingConfirmation");
+    utils::wait_for_tx_in_bitcoin_mempool(claim_tx_id, TIMEOUT)
         .await
         .unwrap();
 

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -181,16 +181,18 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle.get_balance_sat().await.unwrap(), receiver_amount_sat);
+    handle.assert_wallet_settled(receiver_amount_sat).await;
 
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 1);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, receiver_amount_sat);
-    assert_eq!(payment.fees_sat, prepare_response.fees_sat);
-    assert_eq!(payment.payment_type, PaymentType::Receive);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        receiver_amount_sat,
+        prepare_response.fees_sat,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     assert!(
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
@@ -319,24 +321,29 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     handle.sdk.sync(false).await.unwrap();
 
     assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
+    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
 
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 2);
     let payment = &payments[0];
-    assert_eq!(payment.payment_type, PaymentType::Receive);
-    assert_eq!(payment.status, PaymentState::Complete);
+    // For an auto-accepted amountless receive, amount + fees = payer_amount
+    assert_eq!(payment.amount_sat + payment.fees_sat, payer_amount_sat);
+    utils::assert_payment(
+        payment,
+        payment.amount_sat,
+        payment.fees_sat,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     assert!(
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, auto_accepted_fees, .. }
             if *bitcoin_address == address && *auto_accepted_fees)
     );
-    // For an auto-accepted amountless receive, amount + fees = payer_amount
-    assert_eq!(payment.amount_sat + payment.fees_sat, payer_amount_sat);
 
     let receiver_amount_sat_amountless = payment.amount_sat;
-    assert_eq!(
-        handle.get_balance_sat().await.unwrap(),
-        balance_before_amountless + receiver_amount_sat_amountless
-    );
+    handle
+        .assert_wallet_settled(balance_before_amountless + receiver_amount_sat_amountless)
+        .await;
 
     // Cleanup: flush mempools so the SEND section starts clean.
     utils::drain_mempools(10).await.unwrap();
@@ -464,18 +471,20 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
-    assert_eq!(
-        handle.get_balance_sat().await.unwrap(),
-        initial_balance_sat - sender_amount_sat
-    );
+    handle
+        .assert_wallet_settled(initial_balance_sat - sender_amount_sat)
+        .await;
 
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 3);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, receiver_amount_sat);
-    assert_eq!(payment.fees_sat, fees_sat);
-    assert_eq!(payment.payment_type, PaymentType::Send);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        receiver_amount_sat,
+        fees_sat,
+        PaymentType::Send,
+        PaymentState::Complete,
+    );
     assert!(
         matches!(&payment.details, PaymentDetails::Bitcoin { bitcoin_address, .. } if *bitcoin_address == address)
     );
@@ -664,9 +673,14 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     // ----------------FINAL ASSERTIONS--------------
     // Verify the complete payment history across all four sections.
 
+    handle
+        .assert_wallet_settled(initial_balance_sat - sender_amount_sat)
+        .await;
+
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 4);
     let payment = &payments[0];
+    assert_eq!(payment.payment_type, PaymentType::Receive);
     assert_eq!(payment.status, PaymentState::Failed);
 
     // On node.js, without disconnecting the sdk, the wasm-pack test process fails after the test succeeds

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -37,7 +37,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .unwrap();
 
     // -------------- RECEIVE (non-zero-conf) --------------
-    // Incoming chain swap: BTC user-lockup → L-BTC server-lockup → SDK claims L-BTC.
     // This tests the non-zero-conf path: Boltz requires a confirmed BTC
     // lockup before broadcasting the L-BTC server-lockup, and the SDK
     // requires a confirmed server-lockup before claiming.
@@ -81,7 +80,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .unwrap();
 
     // SDK and Boltz should detect the BTC user-lockup. Boltz should issue L-BTC server-lockup
-    // -> ensure server-lockup tx is in mempool before mining its confirmation
     let pending_event = handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentPending { .. }), TIMEOUT)
         .await
@@ -113,16 +111,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
 
     // SDK should detect server-lockup confirmation and eventually issue a
     // claim tx on liquid
-    //
-    // The SDK's background poller is not synched with mining/indexers
-    // -> might fire after server-lockup tx was mined but not all indexers have
-    //    caught up
-    // -> then it "consumes" the new block w/o detecting lockup tx and does
-    //    not issue PaymentWaitingConfirmation.
-    // -> On next poll(s) it won't update internal state if there is no new
-    //    liquid block.
-    // If that is detected by timeout, mine one more block and wait with
-    // reduced timeout
     let waiting_event = utils::wait_for_event_with_retry(
         &mut handle,
         &indexers,
@@ -152,14 +140,13 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm the L-BTC claim tx. In theory only a Liquid block is needed —
-    // PaymentSucceeded depends solely on the claim confirmation on Liquid.
+    // Confirm the L-BTC claim tx
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
         .unwrap();
 
     // TODO
-    // Workaround for #XXX (maybe same as #847?): Esplora sometimes has same
+    // Workaround for #1097: Esplora sometimes has same
     // claim TX twice in its output (once confirmed, once in mempool) which
     // leads to script history >2 which triggers the edge case in
     // determine_incoming_lockup_and_claim_txs() and triggers 120s "grace period"
@@ -242,7 +229,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
 
     // SDK detects the lockup via TransactionMempool/Confirmed → Pending.
     // Boltz then reports TransactionLockupFailed (zero-amount), the SDK
-    // auto-accepts the fees, and Boltz broadcasts the L-BTC server-lockup.
+    // auto-accepts the fees...
     let pending_event = handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentPending { .. }), TIMEOUT)
         .await
@@ -259,7 +246,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     };
     let swap_id = swap_id.clone();
 
-    // After auto-accept, Boltz broadcasts the L-BTC server-lockup
+    //... after auto-accept, Boltz broadcasts the L-BTC server-lockup
     let server_lockup_txid = utils::poll_boltz_server_lockup_txid(&swap_id, TIMEOUT)
         .await
         .unwrap();
@@ -267,11 +254,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Confirm the L-BTC server-lockup so the SDK can claim.
-    // For amountless swaps, PaymentWaitingFeeAcceptance (claim_tx_id: None)
-    // may arrive first once the zero-amount quote is auto-accepted — it is
-    // harmlessly consumed by the predicate.  The actual claim produces
-    // PaymentWaitingConfirmation, identical to the RECEIVE path.
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
         .unwrap();
@@ -284,19 +266,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     )
     .await
     .unwrap();
-
-    let pending_receive_sat = handle.get_pending_receive_sat().await.unwrap();
-    assert!(
-        pending_receive_sat > 0,
-        "Amountless RECEIVE should expose pending_receive_sat > 0 once claim is waiting"
-    );
-    assert!(
-        pending_receive_sat <= payer_amount_sat,
-        "Amountless RECEIVE pending_receive_sat ({pending_receive_sat}) should not exceed payer amount ({payer_amount_sat})"
-    );
-    handle
-        .assert_wallet_pending(pending_receive_sat, 0, balance_before_amountless)
-        .await;
 
     let SdkEvent::PaymentWaitingConfirmation { details } = &waiting_event else {
         panic!("Expected PaymentWaitingConfirmation, got {waiting_event:?}");
@@ -311,6 +280,19 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .as_ref()
         .expect("claim_tx_id should be set in PaymentWaitingConfirmation");
 
+    let pending_receive_sat = handle.get_pending_receive_sat().await.unwrap();
+    assert!(
+        pending_receive_sat > 0,
+        "Amountless RECEIVE should expose pending_receive_sat > 0 once claim is waiting"
+    );
+    assert!(
+        pending_receive_sat <= payer_amount_sat,
+        "Amountless RECEIVE pending_receive_sat ({pending_receive_sat}) should not exceed payer amount ({payer_amount_sat})"
+    );
+    handle
+        .assert_wallet_pending(pending_receive_sat, 0, balance_before_amountless)
+        .await;
+
     utils::wait_for_tx_in_mempool(utils::Chain::Liquid, &claim_tx_id, TIMEOUT)
         .await
         .unwrap();
@@ -320,7 +302,7 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Workaround for esplora duplicate-tx edge case (see RECEIVE section)
+    // Workaround for #1097 esplora duplicate-tx edge case (see RECEIVE section)
     utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
     handle
@@ -363,7 +345,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     utils::drain_mempools(10).await.unwrap();
 
     // -------------- SEND (zero-conf) --------------
-    // Outgoing chain swap: L-BTC user-lockup → BTC server-lockup → SDK claims BTC.
     // This tests the zero-conf path: the send amount is within the Boltz
     // zero-conf threshold, so the SDK accepts the BTC server-lockup from
     // mempool and claims without waiting for a BTC confirmation.
@@ -419,7 +400,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Get Boltz's expected lockup txid as early as possible
     let server_lockup_txid = utils::poll_boltz_server_lockup_txid(swap_id, TIMEOUT)
         .await
         .unwrap();
@@ -437,7 +417,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    // Wait for Bolt's BTC server-lockup to appear in bitcoind's mempool.
     utils::wait_for_tx_in_mempool(utils::Chain::Bitcoin, &server_lockup_txid, TIMEOUT)
         .await
         .unwrap();
@@ -674,8 +653,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     // Additional liquid block is needed to circumvent gating introduced in #978
     utils::mine_bitcoin_then_liquid(1, &indexers).await.unwrap();
 
-    // TODO: figure out why on Wasm this event is occasionally skipped
-    // https://github.com/breez/breez-sdk-liquid/issues/847
     let _ = handle
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentFailed { .. }), TIMEOUT)
         .await;
@@ -689,12 +666,6 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let refundables = handle.sdk.list_refundables().await.unwrap();
     assert_eq!(refundables.len(), 0);
 
-    // Cleanup: flush mempools
-    utils::drain_mempools(10).await.unwrap();
-
-    // ----------------FINAL ASSERTIONS--------------
-    // Verify the complete payment history across all four sections.
-
     handle
         .assert_wallet_settled(initial_balance_sat - sender_amount_sat)
         .await;
@@ -704,6 +675,9 @@ async fn bitcoin(mut handle: SdkNodeHandle) {
     let payment = &payments[0];
     assert_eq!(payment.payment_type, PaymentType::Receive);
     assert_eq!(payment.status, PaymentState::Failed);
+
+    // Cleanup: flush mempools
+    utils::drain_mempools(10).await.unwrap();
 
     // On node.js, without disconnecting the sdk, the wasm-pack test process fails after the test succeeds
     handle.sdk.disconnect().await.unwrap();

--- a/lib/core/tests/regtest/bitcoin.rs
+++ b/lib/core/tests/regtest/bitcoin.rs
@@ -29,7 +29,7 @@ async fn bitcoin_esplora() {
 }
 
 async fn bitcoin(mut handle: SdkNodeHandle) {
-    let indexers = handle.indexers;
+    let indexers = utils::Indexers::from_handles(&[&handle]);
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -1,10 +1,7 @@
-use std::time::Duration;
-
 use breez_sdk_liquid::model::{
     PaymentDetails, PaymentState, PaymentType, PrepareReceiveRequest, PrepareSendRequest, SdkEvent,
 };
 use serial_test::serial;
-use tokio_with_wasm::alias as tokio;
 
 use crate::regtest::{
     utils::{self},
@@ -39,6 +36,19 @@ async fn bolt11_esplora() {
     bolt11(handle_alice, handle_bob).await;
 }
 
+#[sdk_macros::async_test_not_wasm]
+#[serial]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+async fn bolt11_mixed() {
+    let handle_alice = SdkNodeHandle::init_node(ChainBackend::Electrum)
+        .await
+        .unwrap();
+    let handle_bob = SdkNodeHandle::init_node(ChainBackend::Esplora)
+        .await
+        .unwrap();
+    bolt11(handle_alice, handle_bob).await;
+}
+
 async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) {
     handle_alice
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
@@ -48,6 +58,14 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
         .await
         .unwrap();
+
+    // Merge indexers from both handles: if either node uses an indexer, we must wait for it.
+    let indexers = utils::Indexers {
+        btc_esplora: handle_alice.indexers.btc_esplora || handle_bob.indexers.btc_esplora,
+        btc_electrs: handle_alice.indexers.btc_electrs || handle_bob.indexers.btc_electrs,
+        lbtc_esplora: handle_alice.indexers.lbtc_esplora || handle_bob.indexers.lbtc_esplora,
+        waterfalls: handle_alice.indexers.waterfalls || handle_bob.indexers.waterfalls,
+    };
 
     // -------------------RECEIVE SWAP-------------------
     let payer_amount_sat = 200_000;
@@ -77,7 +95,10 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         receiver_amount_sat
     );
 
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm the server lockup and wait for swap to complete
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     utils::wait_for_event_with_retry(
         &mut handle_alice,
@@ -88,9 +109,11 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     .await
     .unwrap();
 
-    // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
-    // https://github.com/breez/breez-sdk-liquid/issues/828
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
 
     assert_eq!(handle_alice.get_pending_receive_sat().await.unwrap(), 0);
@@ -142,7 +165,10 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         initial_balance - payer_amount_sat
     );
 
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm the server lockup and wait for swap to complete
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     utils::wait_for_event_with_retry(
         &mut handle_alice,
@@ -153,9 +179,11 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     .await
     .unwrap();
 
-    // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
-    // https://github.com/breez/breez-sdk-liquid/issues/828
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
 
     assert_eq!(handle_alice.get_pending_receive_sat().await.unwrap(), 0);
@@ -206,7 +234,10 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm the liquid tx
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847
@@ -226,9 +257,11 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     .await
     .unwrap();
 
-    // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
-    // https://github.com/breez/breez-sdk-liquid/issues/828
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
     handle_bob.sdk.sync(false).await.unwrap();
 

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -234,8 +234,6 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    // TODO: figure out why on Wasm this event is occasionally skipped
-    // https://github.com/breez/breez-sdk-liquid/issues/847
     let _ = utils::wait_for_event_with_retry(
         &mut handle_alice,
         &indexers,

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -90,10 +90,9 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    assert_eq!(
-        handle_alice.get_pending_receive_sat().await.unwrap(),
-        receiver_amount_sat
-    );
+    handle_alice
+        .assert_wallet_pending(receiver_amount_sat, 0, 0)
+        .await;
 
     // Confirm the server lockup and wait for swap to complete
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
@@ -156,14 +155,9 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    assert_eq!(
-        handle_alice.get_pending_send_sat().await.unwrap(),
-        payer_amount_sat
-    );
-    assert_eq!(
-        handle_alice.get_balance_sat().await.unwrap(),
-        initial_balance - payer_amount_sat
-    );
+    handle_alice
+        .assert_wallet_pending(0, payer_amount_sat, initial_balance - payer_amount_sat)
+        .await;
 
     // Confirm the server lockup and wait for swap to complete
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -116,20 +116,20 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle_alice.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle_alice.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(
-        handle_alice.get_balance_sat().await.unwrap(),
-        receiver_amount_sat
-    );
+    handle_alice
+        .assert_wallet_settled(receiver_amount_sat)
+        .await;
 
     let payments = handle_alice.get_payments().await.unwrap();
     assert_eq!(payments.len(), 1);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, receiver_amount_sat);
-    assert_eq!(payment.fees_sat, prepare_response.fees_sat);
-    assert_eq!(payment.payment_type, PaymentType::Receive);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        receiver_amount_sat,
+        prepare_response.fees_sat,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     assert!(matches!(payment.details, PaymentDetails::Lightning { .. }));
 
     // -------------------SEND SWAP-------------------
@@ -186,24 +186,25 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle_alice.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle_alice.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(
-        handle_alice.get_balance_sat().await.unwrap(),
-        initial_balance - payer_amount_sat
-    );
+    handle_alice
+        .assert_wallet_settled(initial_balance - payer_amount_sat)
+        .await;
 
     let payments = handle_alice.get_payments().await.unwrap();
     assert_eq!(payments.len(), 2);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, receiver_amount_sat);
-    assert_eq!(payment.fees_sat, prepare_response.fees_sat.unwrap());
-    assert_eq!(payment.payment_type, PaymentType::Send);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        receiver_amount_sat,
+        prepare_response.fees_sat.unwrap(),
+        PaymentType::Send,
+        PaymentState::Complete,
+    );
     assert!(matches!(payment.details, PaymentDetails::Lightning { .. }));
 
     // -------------------MRH-------------------
     let receiver_amount_sat = 50_000;
+    let alice_balance_before_mrh = handle_alice.get_balance_sat().await.unwrap();
 
     let (_, receive_response) = handle_bob
         .receive_payment(&PrepareReceiveRequest {
@@ -265,23 +266,25 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     handle_alice.sdk.sync(false).await.unwrap();
     handle_bob.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle_bob.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle_bob.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(
-        handle_bob.get_balance_sat().await.unwrap(),
-        receiver_amount_sat
-    );
+    handle_alice
+        .assert_wallet_settled(
+            alice_balance_before_mrh
+                - receiver_amount_sat
+                - prepare_response_send.fees_sat.unwrap(),
+        )
+        .await;
+    handle_bob.assert_wallet_settled(receiver_amount_sat).await;
 
     let alice_payments = handle_alice.get_payments().await.unwrap();
     assert_eq!(alice_payments.len(), 3);
     let alice_payment = &alice_payments[0];
-    assert_eq!(alice_payment.amount_sat, receiver_amount_sat);
-    assert_eq!(
-        alice_payment.fees_sat,
-        prepare_response_send.fees_sat.unwrap()
+    utils::assert_payment(
+        alice_payment,
+        receiver_amount_sat,
+        prepare_response_send.fees_sat.unwrap(),
+        PaymentType::Send,
+        PaymentState::Complete,
     );
-    assert_eq!(alice_payment.payment_type, PaymentType::Send);
-    assert_eq!(alice_payment.status, PaymentState::Complete);
     assert!(matches!(
         alice_payment.details,
         PaymentDetails::Liquid { .. }
@@ -290,10 +293,13 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     let bob_payments = handle_bob.get_payments().await.unwrap();
     assert_eq!(bob_payments.len(), 1);
     let bob_payment = &bob_payments[0];
-    assert_eq!(bob_payment.amount_sat, receiver_amount_sat);
-    assert_eq!(bob_payment.fees_sat, 0);
-    assert_eq!(bob_payment.payment_type, PaymentType::Receive);
-    assert_eq!(bob_payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        bob_payment,
+        receiver_amount_sat,
+        0,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     // TODO: figure out why occasionally this fails (details = Liquid)
     // https://github.com/breez/breez-sdk-liquid/issues/829
     /*assert!(matches!(

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -59,13 +59,7 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    // Merge indexers from both handles: if either node uses an indexer, we must wait for it.
-    let indexers = utils::Indexers {
-        btc_esplora: handle_alice.indexers.btc_esplora || handle_bob.indexers.btc_esplora,
-        btc_electrs: handle_alice.indexers.btc_electrs || handle_bob.indexers.btc_electrs,
-        lbtc_esplora: handle_alice.indexers.lbtc_esplora || handle_bob.indexers.lbtc_esplora,
-        waterfalls: handle_alice.indexers.waterfalls || handle_bob.indexers.waterfalls,
-    };
+    let indexers = utils::Indexers::from_handles(&[&handle_alice, &handle_bob]);
 
     // -------------------RECEIVE SWAP-------------------
     let payer_amount_sat = 200_000;

--- a/lib/core/tests/regtest/bolt11.rs
+++ b/lib/core/tests/regtest/bolt11.rs
@@ -79,10 +79,14 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     utils::mine_blocks(1).await.unwrap();
 
-    handle_alice
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await
-        .unwrap();
+    utils::wait_for_event_with_retry(
+        &mut handle_alice,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
     // https://github.com/breez/breez-sdk-liquid/issues/828
@@ -140,10 +144,14 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     utils::mine_blocks(1).await.unwrap();
 
-    handle_alice
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await
-        .unwrap();
+    utils::wait_for_event_with_retry(
+        &mut handle_alice,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
     // https://github.com/breez/breez-sdk-liquid/issues/828
@@ -202,13 +210,21 @@ async fn bolt11(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     // TODO: figure out why on Wasm this event is occasionally skipped
     // https://github.com/breez/breez-sdk-liquid/issues/847
-    let _ = handle_alice
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await;
-    handle_bob
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await
-        .unwrap();
+    let _ = utils::wait_for_event_with_retry(
+        &mut handle_alice,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await;
+    utils::wait_for_event_with_retry(
+        &mut handle_bob,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
     // https://github.com/breez/breez-sdk-liquid/issues/828

--- a/lib/core/tests/regtest/bolt12.rs
+++ b/lib/core/tests/regtest/bolt12.rs
@@ -1,14 +1,11 @@
-use std::time::Duration;
-
 use breez_sdk_liquid::model::{
     PayAmount, PaymentDetails, PaymentMethod, PaymentState, PaymentType, PrepareReceiveRequest,
     PrepareSendRequest, SdkEvent,
 };
 use serial_test::serial;
-use tokio_with_wasm::alias as tokio;
 
 use crate::regtest::{
-    utils::{self, mine_blocks},
+    utils::{self},
     ChainBackend, SdkNodeHandle, TIMEOUT,
 };
 
@@ -40,6 +37,19 @@ async fn bolt12_esplora() {
     bolt12(handle_alice, handle_bob).await;
 }
 
+#[sdk_macros::async_test_not_wasm]
+#[serial]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+async fn bolt12_mixed() {
+    let handle_alice = SdkNodeHandle::init_node(ChainBackend::Esplora)
+        .await
+        .unwrap();
+    let handle_bob = SdkNodeHandle::init_node(ChainBackend::Electrum)
+        .await
+        .unwrap();
+    bolt12(handle_alice, handle_bob).await;
+}
+
 async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) {
     handle_alice
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
@@ -49,6 +59,14 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
         .await
         .unwrap();
+
+    // Merge indexers from both handles: if either node uses an indexer, we must wait for it.
+    let indexers = utils::Indexers {
+        btc_esplora: handle_alice.indexers.btc_esplora || handle_bob.indexers.btc_esplora,
+        btc_electrs: handle_alice.indexers.btc_electrs || handle_bob.indexers.btc_electrs,
+        lbtc_esplora: handle_alice.indexers.lbtc_esplora || handle_bob.indexers.lbtc_esplora,
+        waterfalls: handle_alice.indexers.waterfalls || handle_bob.indexers.waterfalls,
+    };
 
     // -------------------SETUP-------------------
     // Setup Alice with some funds
@@ -75,7 +93,10 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    utils::mine_blocks(1).await.unwrap();
+    // Confirm the server lockup and wait for swap to complete
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     handle_alice
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
@@ -98,7 +119,7 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     // -------------------MRH-------------------
     let receiver_amount_sat = 50_000;
 
-    let (_, _) = handle_alice
+    let (prepare_response_send, _) = handle_alice
         .send_payment(&PrepareSendRequest {
             destination: offer,
             amount: Some(PayAmount::Bitcoin {
@@ -110,16 +131,21 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    mine_blocks(1).await.unwrap();
+    // Confirm the send TX and wait for swap to complete
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     handle_bob
         .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
         .await
         .unwrap();
 
-    // TODO: this shouldn't be needed, but without it, sometimes get_balance_sat isn't updated in time
-    // https://github.com/breez/breez-sdk-liquid/issues/828
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
 
     assert_eq!(handle_bob.get_pending_receive_sat().await.unwrap(), 0);
@@ -132,9 +158,15 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     let alice_payments = handle_alice.get_payments().await.unwrap();
     assert_eq!(alice_payments.len(), 2);
     let alice_payment = &alice_payments[0];
+    // For BOLT12 MRH payments, prepare_send_payment estimates a submarine swap fee.
+    // At send_payment time the SDK detects the MRH and routes via a direct Liquid tx,
+    // so the actual fee is lower. Read back from the Liquid Esplora indexer.
+    let prepare_fees_sat = prepare_response_send.fees_sat.unwrap();
+    let alice_tx_id = alice_payment.tx_id.as_ref().unwrap();
+    let actual_fees_sat = utils::get_lbtc_tx_fee_sat(alice_tx_id).await.unwrap();
+    assert!(actual_fees_sat <= prepare_fees_sat);
     assert_eq!(alice_payment.amount_sat, receiver_amount_sat);
-    // The prepare response gives the fees for a swap, so instead we test the Liquid fee
-    assert_eq!(alice_payment.fees_sat, 26);
+    assert_eq!(alice_payment.fees_sat, actual_fees_sat);
     assert_eq!(alice_payment.payment_type, PaymentType::Send);
     assert_eq!(alice_payment.status, PaymentState::Complete);
     assert!(matches!(

--- a/lib/core/tests/regtest/bolt12.rs
+++ b/lib/core/tests/regtest/bolt12.rs
@@ -107,7 +107,9 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
 
     handle_alice.assert_wallet_settled(amount_sat).await;
 
-    // -------------------CREATE BOLT12 OFFER-------------------
+    // -------------------RECEIVE SWAP-------------------
+    // TODO: Receive to an offer using the CLN node
+
     let (_, receive_response) = handle_bob
         .receive_payment(&PrepareReceiveRequest {
             payment_method: PaymentMethod::Bolt12Offer,

--- a/lib/core/tests/regtest/bolt12.rs
+++ b/lib/core/tests/regtest/bolt12.rs
@@ -60,13 +60,7 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
-    // Merge indexers from both handles: if either node uses an indexer, we must wait for it.
-    let indexers = utils::Indexers {
-        btc_esplora: handle_alice.indexers.btc_esplora || handle_bob.indexers.btc_esplora,
-        btc_electrs: handle_alice.indexers.btc_electrs || handle_bob.indexers.btc_electrs,
-        lbtc_esplora: handle_alice.indexers.lbtc_esplora || handle_bob.indexers.lbtc_esplora,
-        waterfalls: handle_alice.indexers.waterfalls || handle_bob.indexers.waterfalls,
-    };
+    let indexers = utils::Indexers::from_handles(&[&handle_alice, &handle_bob]);
 
     // -------------------SETUP-------------------
     // Setup Alice with some funds

--- a/lib/core/tests/regtest/bolt12.rs
+++ b/lib/core/tests/regtest/bolt12.rs
@@ -93,6 +93,8 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
+    handle_alice.assert_wallet_pending(amount_sat, 0, 0).await;
+
     // Confirm the server lockup and wait for swap to complete
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
@@ -132,6 +134,17 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         })
         .await
         .unwrap();
+
+    handle_bob
+        .wait_for_event(
+            |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+            TIMEOUT,
+        )
+        .await
+        .unwrap();
+    handle_bob
+        .assert_wallet_pending(receiver_amount_sat, 0, 0)
+        .await;
 
     // Confirm the send TX and wait for swap to complete
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))

--- a/lib/core/tests/regtest/bolt12.rs
+++ b/lib/core/tests/regtest/bolt12.rs
@@ -103,6 +103,8 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
 
+    handle_alice.assert_wallet_settled(amount_sat).await;
+
     // -------------------CREATE BOLT12 OFFER-------------------
     let (_, receive_response) = handle_bob
         .receive_payment(&PrepareReceiveRequest {
@@ -147,28 +149,30 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
         .await
         .unwrap();
     handle_alice.sdk.sync(false).await.unwrap();
+    handle_bob.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle_bob.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle_bob.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(
-        handle_bob.get_balance_sat().await.unwrap(),
-        receiver_amount_sat
-    );
-
-    let alice_payments = handle_alice.get_payments().await.unwrap();
-    assert_eq!(alice_payments.len(), 2);
-    let alice_payment = &alice_payments[0];
     // For BOLT12 MRH payments, prepare_send_payment estimates a submarine swap fee.
     // At send_payment time the SDK detects the MRH and routes via a direct Liquid tx,
     // so the actual fee is lower. Read back from the Liquid Esplora indexer.
     let prepare_fees_sat = prepare_response_send.fees_sat.unwrap();
+    let alice_payments = handle_alice.get_payments().await.unwrap();
+    assert_eq!(alice_payments.len(), 2);
+    let alice_payment = &alice_payments[0];
     let alice_tx_id = alice_payment.tx_id.as_ref().unwrap();
     let actual_fees_sat = utils::get_lbtc_tx_fee_sat(alice_tx_id).await.unwrap();
     assert!(actual_fees_sat <= prepare_fees_sat);
-    assert_eq!(alice_payment.amount_sat, receiver_amount_sat);
-    assert_eq!(alice_payment.fees_sat, actual_fees_sat);
-    assert_eq!(alice_payment.payment_type, PaymentType::Send);
-    assert_eq!(alice_payment.status, PaymentState::Complete);
+
+    handle_alice
+        .assert_wallet_settled(amount_sat - receiver_amount_sat - actual_fees_sat)
+        .await;
+
+    utils::assert_payment(
+        alice_payment,
+        receiver_amount_sat,
+        actual_fees_sat,
+        PaymentType::Send,
+        PaymentState::Complete,
+    );
     assert!(matches!(
         alice_payment.details,
         PaymentDetails::Liquid { .. }
@@ -177,10 +181,15 @@ async fn bolt12(mut handle_alice: SdkNodeHandle, mut handle_bob: SdkNodeHandle) 
     let bob_payments = handle_bob.get_payments().await.unwrap();
     assert_eq!(bob_payments.len(), 1);
     let bob_payment = &bob_payments[0];
-    assert_eq!(bob_payment.amount_sat, receiver_amount_sat);
-    assert_eq!(bob_payment.fees_sat, 0);
-    assert_eq!(bob_payment.payment_type, PaymentType::Receive);
-    assert_eq!(bob_payment.status, PaymentState::Complete);
+    handle_bob.assert_wallet_settled(receiver_amount_sat).await;
+
+    utils::assert_payment(
+        bob_payment,
+        receiver_amount_sat,
+        0,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     // TODO: figure out why occasionally this fails (details = Liquid)
     // https://github.com/breez/breez-sdk-liquid/issues/829
     /*assert!(matches!(

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -28,6 +28,8 @@ async fn liquid_esplora() {
 }
 
 async fn liquid(mut handle: SdkNodeHandle) {
+    let indexers = handle.indexers;
+
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)
         .await
@@ -49,7 +51,10 @@ async fn liquid(mut handle: SdkNodeHandle) {
     let address = receive_response.destination;
     let amount_sat = 100_000;
 
-    utils::send_to_address_elementsd(&address, amount_sat)
+    let receive_tx_id = utils::send_to_address_elementsd(&address, amount_sat)
+        .await
+        .unwrap();
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, &receive_tx_id, TIMEOUT)
         .await
         .unwrap();
 
@@ -62,9 +67,12 @@ async fn liquid(mut handle: SdkNodeHandle) {
         .unwrap();
 
     assert_eq!(handle.get_pending_receive_sat().await.unwrap(), amount_sat);
+    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
     assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
 
-    utils::mine_blocks(1).await.unwrap();
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     utils::wait_for_event_with_retry(
         &mut handle,
@@ -75,7 +83,15 @@ async fn liquid(mut handle: SdkNodeHandle) {
     .await
     .unwrap();
 
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+    handle.sdk.sync(false).await.unwrap();
+
     assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
+    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
     assert_eq!(handle.get_balance_sat().await.unwrap(), amount_sat);
 
     let payments = handle.get_payments().await.unwrap();
@@ -93,7 +109,7 @@ async fn liquid(mut handle: SdkNodeHandle) {
     let address = utils::generate_address_elementsd().await.unwrap();
     let receiver_amount_sat = 50_000;
 
-    let (prepare_response, _) = handle
+    let (prepare_response, send_response) = handle
         .send_payment(&PrepareSendRequest {
             destination: address,
             amount: Some(PayAmount::Bitcoin {
@@ -108,7 +124,18 @@ async fn liquid(mut handle: SdkNodeHandle) {
     let fees_sat = prepare_response.fees_sat.unwrap();
     let sender_amount_sat = receiver_amount_sat + fees_sat;
 
-    utils::mine_blocks(1).await.unwrap();
+    let send_tx_id = send_response
+        .payment
+        .tx_id
+        .as_ref()
+        .expect("tx_id should be set after send_payment returns");
+    utils::wait_for_tx_in_mempool(utils::Chain::Liquid, send_tx_id, TIMEOUT)
+        .await
+        .unwrap();
+
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
 
     utils::wait_for_event_with_retry(
         &mut handle,
@@ -119,6 +146,15 @@ async fn liquid(mut handle: SdkNodeHandle) {
     .await
     .unwrap();
 
+    // Workaround for #828: mine an extra Liquid block so that sync() sees a
+    // new tip and takes the full scan path, refreshing the LWK wallet state.
+    utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
+        .await
+        .unwrap();
+    handle.sdk.sync(false).await.unwrap();
+
+    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
+    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
     assert_eq!(
         handle.get_balance_sat().await.unwrap(),
         initial_balance_sat - sender_amount_sat

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -66,9 +66,7 @@ async fn liquid(mut handle: SdkNodeHandle) {
         .await
         .unwrap();
 
-    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), amount_sat);
-    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(handle.get_balance_sat().await.unwrap(), 0);
+    handle.assert_wallet_pending(amount_sat, 0, 0).await;
 
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await
@@ -133,6 +131,21 @@ async fn liquid(mut handle: SdkNodeHandle) {
     utils::wait_for_tx_in_mempool(utils::Chain::Liquid, send_tx_id, TIMEOUT)
         .await
         .unwrap();
+
+    handle
+        .wait_for_event(
+            |e| matches!(e, SdkEvent::PaymentWaitingConfirmation { .. }),
+            TIMEOUT,
+        )
+        .await
+        .unwrap();
+    handle
+        .assert_wallet_pending(
+            0,
+            sender_amount_sat,
+            initial_balance_sat - sender_amount_sat,
+        )
+        .await;
 
     utils::mine_and_index_blocks(1, utils::Chain::Liquid, Some(&indexers))
         .await

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -28,7 +28,7 @@ async fn liquid_esplora() {
 }
 
 async fn liquid(mut handle: SdkNodeHandle) {
-    let indexers = handle.indexers;
+    let indexers = utils::Indexers::from_handles(&[&handle]);
 
     handle
         .wait_for_event(|e| matches!(e, SdkEvent::Synced { .. }), TIMEOUT)

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -90,17 +90,18 @@ async fn liquid(mut handle: SdkNodeHandle) {
         .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(handle.get_balance_sat().await.unwrap(), amount_sat);
+    handle.assert_wallet_settled(amount_sat).await;
 
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 1);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, amount_sat);
-    assert_eq!(payment.fees_sat, 0);
-    assert_eq!(payment.payment_type, PaymentType::Receive);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        amount_sat,
+        0,
+        PaymentType::Receive,
+        PaymentState::Complete,
+    );
     assert!(matches!(payment.details, PaymentDetails::Liquid { .. }));
 
     // --------------SEND--------------
@@ -153,20 +154,20 @@ async fn liquid(mut handle: SdkNodeHandle) {
         .unwrap();
     handle.sdk.sync(false).await.unwrap();
 
-    assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
-    assert_eq!(handle.get_pending_send_sat().await.unwrap(), 0);
-    assert_eq!(
-        handle.get_balance_sat().await.unwrap(),
-        initial_balance_sat - sender_amount_sat
-    );
+    handle
+        .assert_wallet_settled(initial_balance_sat - sender_amount_sat)
+        .await;
 
     let payments = handle.get_payments().await.unwrap();
     assert_eq!(payments.len(), 2);
     let payment = &payments[0];
-    assert_eq!(payment.amount_sat, receiver_amount_sat);
-    assert_eq!(payment.fees_sat, fees_sat);
-    assert_eq!(payment.payment_type, PaymentType::Send);
-    assert_eq!(payment.status, PaymentState::Complete);
+    utils::assert_payment(
+        payment,
+        receiver_amount_sat,
+        fees_sat,
+        PaymentType::Send,
+        PaymentState::Complete,
+    );
     assert!(matches!(payment.details, PaymentDetails::Liquid { .. }));
 
     // On node.js, without disconnecting the sdk, the wasm-pack test process fails after the test succeeds

--- a/lib/core/tests/regtest/liquid.rs
+++ b/lib/core/tests/regtest/liquid.rs
@@ -66,10 +66,14 @@ async fn liquid(mut handle: SdkNodeHandle) {
 
     utils::mine_blocks(1).await.unwrap();
 
-    handle
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await
-        .unwrap();
+    utils::wait_for_event_with_retry(
+        &mut handle,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(handle.get_pending_receive_sat().await.unwrap(), 0);
     assert_eq!(handle.get_balance_sat().await.unwrap(), amount_sat);
@@ -106,10 +110,14 @@ async fn liquid(mut handle: SdkNodeHandle) {
 
     utils::mine_blocks(1).await.unwrap();
 
-    handle
-        .wait_for_event(|e| matches!(e, SdkEvent::PaymentSucceeded { .. }), TIMEOUT)
-        .await
-        .unwrap();
+    utils::wait_for_event_with_retry(
+        &mut handle,
+        &indexers,
+        |e| matches!(e, SdkEvent::PaymentSucceeded { .. }),
+        TIMEOUT,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         handle.get_balance_sat().await.unwrap(),

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -213,4 +213,24 @@ impl SdkNodeHandle {
         assert_eq!(self.get_pending_send_sat().await.unwrap(), 0);
         assert_eq!(self.get_balance_sat().await.unwrap(), expected_balance_sat);
     }
+
+    /// Assert wallet state while a payment is in-flight.
+    /// Explicitly checks pending receive amount, pending send amount,
+    /// and confirmed balance.
+    pub async fn assert_wallet_pending(
+        &self,
+        expected_pending_receive_sat: u64,
+        expected_pending_send_sat: u64,
+        expected_balance_sat: u64,
+    ) {
+        assert_eq!(
+            self.get_pending_receive_sat().await.unwrap(),
+            expected_pending_receive_sat
+        );
+        assert_eq!(
+            self.get_pending_send_sat().await.unwrap(),
+            expected_pending_send_sat
+        );
+        assert_eq!(self.get_balance_sat().await.unwrap(), expected_balance_sat);
+    }
 }

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -37,6 +37,8 @@ impl EventListener for ForwardingEventListener {
 
 pub struct SdkNodeHandle {
     pub sdk: Arc<LiquidSdk>,
+    pub indexers: utils::Indexers,
+    pub onchain_sync_period_sec: u32,
     receiver: Receiver<SdkEvent>,
 }
 
@@ -63,7 +65,13 @@ impl SdkNodeHandle {
             ChainBackend::Electrum => Config::regtest(),
             ChainBackend::Esplora => Config::regtest_esplora(),
         };
+        let indexers = match backend {
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+            ChainBackend::Electrum => utils::Indexers::electrum(),
+            ChainBackend::Esplora => utils::Indexers::esplora(),
+        };
         config.working_dir = data_dir.to_str().unwrap().to_string();
+        let onchain_sync_period_sec = config.onchain_sync_period_sec;
 
         #[cfg(all(target_family = "wasm", target_os = "unknown"))]
         let sdk = {
@@ -108,7 +116,12 @@ impl SdkNodeHandle {
         let listener = ForwardingEventListener { sender };
         sdk.add_event_listener(Box::new(listener)).await?;
 
-        Ok(Self { sdk, receiver })
+        Ok(Self {
+            sdk,
+            indexers,
+            onchain_sync_period_sec,
+            receiver,
+        })
     }
 
     pub async fn get_balance_sat(&self) -> Result<u64> {

--- a/lib/core/tests/regtest/mod.rs
+++ b/lib/core/tests/regtest/mod.rs
@@ -206,4 +206,11 @@ impl SdkNodeHandle {
         })
         .await?
     }
+
+    /// Assert that no pending funds are in-flight and the confirmed balance matches expectation.
+    pub async fn assert_wallet_settled(&self, expected_balance_sat: u64) {
+        assert_eq!(self.get_pending_receive_sat().await.unwrap(), 0);
+        assert_eq!(self.get_pending_send_sat().await.unwrap(), 0);
+        assert_eq!(self.get_balance_sat().await.unwrap(), expected_balance_sat);
+    }
 }

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -13,6 +13,7 @@ const PROXY_URL: &str = "http://localhost:51234/proxy";
 const SWAPPROXY_URL: &str = "http://localhost:8387";
 
 const BTC_ESPLORA_URL: &str = "http://localhost:4002/api";
+const BTC_ELECTRS_URL: &str = "http://localhost:3002";
 const LBTC_ESPLORA_URL: &str = "http://localhost:3120/api";
 const WATERFALLS_URL: &str = "http://localhost:3102";
 
@@ -32,24 +33,27 @@ pub enum Chain {
 #[derive(Clone, Copy)]
 pub struct Indexers {
     pub btc_esplora: bool,
+    pub btc_electrs: bool,
     pub lbtc_esplora: bool,
     pub waterfalls: bool,
 }
 
 impl Indexers {
-    /// Electrum environment: only esplora/electrs, no waterfalls.
+    /// Electrum environment: esplora + electrs, no waterfalls.
     pub fn electrum() -> Self {
         Self {
             btc_esplora: true,
+            btc_electrs: true,
             lbtc_esplora: true,
             waterfalls: false,
         }
     }
 
-    /// Esplora environment: esplora/electrs + waterfalls.
+    /// Esplora environment: esplora + waterfalls (no electrs needed).
     pub fn esplora() -> Self {
         Self {
             btc_esplora: true,
+            btc_electrs: false,
             lbtc_esplora: true,
             waterfalls: true,
         }
@@ -248,17 +252,21 @@ pub async fn wait_for_indexers(chain: Chain, indexers: &Indexers) -> Result<(), 
     let wait_bitcoin = matches!(chain, Chain::Bitcoin | Chain::Both);
     let wait_liquid = matches!(chain, Chain::Liquid | Chain::Both);
 
-    if wait_bitcoin && indexers.btc_esplora {
+    if wait_bitcoin {
         let h = get_daemon_blockcount(BITCOIND_URL, BITCOIND_COOKIE.unwrap()).await?;
-        wait_for_indexer_tip(BTC_ESPLORA_URL, h, timeout).await?;
+        if indexers.btc_esplora {
+            wait_for_indexer_tip(BTC_ESPLORA_URL, h, timeout).await?;
+        }
+        if indexers.btc_electrs {
+            wait_for_indexer_tip(BTC_ELECTRS_URL, h, timeout).await?;
+        }
     }
     if wait_liquid {
+        let h = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
         if indexers.lbtc_esplora {
-            let h = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
             wait_for_indexer_tip(LBTC_ESPLORA_URL, h, timeout).await?;
         }
         if indexers.waterfalls {
-            let h = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
             wait_for_waterfalls_tip(h, timeout).await?;
         }
     }

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -288,34 +288,6 @@ fn chain_name(chain: Chain) -> &'static str {
     }
 }
 
-pub async fn wait_for_mempool_tx(
-    chain: Chain,
-    timeout: Duration,
-) -> Result<String, Box<dyn Error>> {
-    let (url, cookie) = chain_rpc_params(chain);
-    let poll_interval = Duration::from_millis(100);
-    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
-
-    for _ in 0..iterations {
-        let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
-        if let Some(arr) = result.as_array() {
-            if let Some(first) = arr.first() {
-                if let Some(txid) = first.as_str() {
-                    return Ok(txid.to_string());
-                }
-            }
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
-
-    Err(format!(
-        "{} mempool did not contain any transaction within {:?}",
-        chain_name(chain),
-        timeout
-    )
-    .into())
-}
-
 /// Poll a daemon's mempool until `txid` appears.
 pub async fn wait_for_tx_in_mempool(
     chain: Chain,
@@ -412,6 +384,60 @@ pub async fn poll_boltz_server_lockup_txid(
 
     Err(format!(
         "Boltz did not broadcast server lockup for chain swap {} within {:?}",
+        swap_id, timeout
+    )
+    .into())
+}
+
+pub async fn poll_boltz_zero_conf_accepted(
+    swap_id: &str,
+    timeout: Duration,
+) -> Result<bool, Box<dyn Error>> {
+    // Duplicate the id so Express always parses `ids` as an array
+    // (a single `?ids=X` is parsed as a string, not a one-element array).
+    let url = format!(
+        "{}/v2/swap/status?ids={}&ids={}",
+        SWAPPROXY_URL, swap_id, swap_id
+    );
+    let client = Client::new();
+    let poll_interval = Duration::from_millis(200);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        if let Ok(resp) = client
+            .get(PROXY_URL)
+            .header("X-Proxy-URL", &url)
+            .send()
+            .await
+        {
+            if let Ok(body) = resp.json::<Value>().await {
+                if let Some(swap_status) = body.get(swap_id) {
+                    // If `zeroConfRejected` is present, use it directly.
+                    if let Some(rejected) = swap_status
+                        .get("zeroConfRejected")
+                        .and_then(|v| v.as_bool())
+                    {
+                        return Ok(!rejected);
+                    }
+                    // If the swap already advanced past mempool (e.g. confirmed,
+                    // claimed), zero-conf was implicitly accepted — the field is
+                    // only present transiently during `transaction.mempool`.
+                    if let Some(status) = swap_status.get("status").and_then(|v| v.as_str()) {
+                        match status {
+                            "transaction.confirmed" | "transaction.claimed" => {
+                                return Ok(true);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Boltz did not report zeroConfRejected for chain swap {} within {:?}",
         swap_id, timeout
     )
     .into())

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -2,6 +2,8 @@ use base64::Engine;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::error::Error;
+use std::time::Duration;
+use tokio_with_wasm::alias as tokio;
 
 const BITCOIND_URL: &str = "http://localhost:18443/wallet/client";
 const ELEMENTSD_URL: &str = "http://localhost:18884/wallet/client";
@@ -9,9 +11,24 @@ const LND_URL: &str = "https://localhost:8081";
 
 const PROXY_URL: &str = "http://localhost:51234/proxy";
 
+/// Esplora HTTP endpoints for checking indexer tip heights.
+/// BTC: esplora container → electrs (same process as Electrum at 19001).
+/// L-BTC: nginx → waterfalls → esplora → electrs-liquid (same process as
+///        Electrum at 19002).
+const BTC_ESPLORA_URL: &str = "http://localhost:4002/api";
+const LBTC_ESPLORA_URL: &str = "http://localhost:3120/api";
+
 const BITCOIND_COOKIE: Option<&str> = option_env!("BITCOIND_COOKIE");
 const ELEMENTSD_COOKIE: &str = "regtest:regtest";
 const LND_MACAROON_HEX: Option<&str> = option_env!("LND_MACAROON_HEX");
+
+/// Which blockchain(s) to mine on.
+#[derive(Clone, Copy)]
+pub enum Chain {
+    Bitcoin,
+    Liquid,
+    Both,
+}
 
 async fn json_rpc_request(
     url: &str,
@@ -141,24 +158,101 @@ pub async fn pay_invoice_lnd(invoice: &str) -> Result<(), Box<dyn Error>> {
 }
 
 pub async fn mine_blocks(n_blocks: u64) -> Result<(), Box<dyn Error>> {
-    let address_btc = generate_address_bitcoind().await?;
-    let address_lqd = generate_address_elementsd().await?;
+    mine_and_index_blocks(n_blocks, Chain::Both, false).await
+}
 
-    json_rpc_request(
-        BITCOIND_URL,
-        BITCOIND_COOKIE.unwrap(),
-        "generatetoaddress",
-        json!([n_blocks, address_btc]),
-    )
-    .await?;
+/// Mine one block on Bitcoin first, then one on Liquid, waiting for each
+/// indexer before proceeding.  The ordering matters: by the time the
+/// Liquid block arrives and triggers the SDK's background poller, the BTC
+/// electrs has already indexed its block, so `on_bitcoin_block` will see
+/// the new tip.  Without this ordering the gating optimisation in
+/// `get_sync_context` (PR #978) can permanently skip the BTC tip fetch.
+pub async fn mine_bitcoin_then_liquid(n_blocks: u64) -> Result<(), Box<dyn Error>> {
+    mine_and_index_blocks(n_blocks, Chain::Bitcoin, true).await?;
+    mine_and_index_blocks(n_blocks, Chain::Liquid, true).await
+}
 
-    json_rpc_request(
-        ELEMENTSD_URL,
-        ELEMENTSD_COOKIE,
-        "generatetoaddress",
-        json!([n_blocks, address_lqd]),
-    )
-    .await?;
+pub async fn mine_and_index_blocks(
+    n_blocks: u64,
+    chain: Chain,
+    wait_for_indexer: bool,
+) -> Result<(), Box<dyn Error>> {
+    let mine_bitcoin = matches!(chain, Chain::Bitcoin | Chain::Both);
+    let mine_liquid = matches!(chain, Chain::Liquid | Chain::Both);
+
+    if mine_bitcoin {
+        let address = generate_address_bitcoind().await?;
+        json_rpc_request(
+            BITCOIND_URL,
+            BITCOIND_COOKIE.unwrap(),
+            "generatetoaddress",
+            json!([n_blocks, address]),
+        )
+        .await?;
+    }
+
+    if mine_liquid {
+        let address = generate_address_elementsd().await?;
+        json_rpc_request(
+            ELEMENTSD_URL,
+            ELEMENTSD_COOKIE,
+            "generatetoaddress",
+            json!([n_blocks, address]),
+        )
+        .await?;
+    }
+
+    if wait_for_indexer {
+        let timeout = Duration::from_secs(30);
+        if mine_bitcoin {
+            let daemon_height = get_daemon_blockcount(BITCOIND_URL, BITCOIND_COOKIE.unwrap()).await?;
+            wait_for_indexer_tip(BTC_ESPLORA_URL, daemon_height, timeout).await?;
+        }
+        if mine_liquid {
+            let daemon_height = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
+            wait_for_indexer_tip(LBTC_ESPLORA_URL, daemon_height, timeout).await?;
+        }
+    }
 
     Ok(())
+}
+
+/// Query a daemon's current block height via JSON-RPC `getblockcount`.
+async fn get_daemon_blockcount(url: &str, cookie: &str) -> Result<u64, Box<dyn Error>> {
+    let result = json_rpc_request(url, cookie, "getblockcount", json!([])).await?;
+    result
+        .as_u64()
+        .ok_or_else(|| "getblockcount did not return a number".into())
+}
+
+/// Poll an esplora HTTP endpoint until the reported tip height is at least
+/// `expected_height`.  Times out after `timeout`.
+async fn wait_for_indexer_tip(
+    esplora_url: &str,
+    expected_height: u64,
+    timeout: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let url = format!("{}/blocks/tip/height", esplora_url);
+    let client = Client::new();
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        if let Ok(resp) = client.get(&url).send().await {
+            if let Ok(text) = resp.text().await {
+                if let Ok(tip) = text.trim().parse::<u64>() {
+                    if tip >= expected_height {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Indexer at {} did not reach height {} within {:?}",
+        esplora_url, expected_height, timeout
+    )
+    .into())
 }

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -59,6 +59,24 @@ impl Indexers {
             waterfalls: true,
         }
     }
+
+    /// Merge any number of handles: if any node uses an indexer, we must wait for it.
+    pub fn from_handles(handles: &[&super::SdkNodeHandle]) -> Self {
+        handles.iter().fold(
+            Self {
+                btc_esplora: false,
+                btc_electrs: false,
+                lbtc_esplora: false,
+                waterfalls: false,
+            },
+            |acc, h| Self {
+                btc_esplora: acc.btc_esplora || h.indexers.btc_esplora,
+                btc_electrs: acc.btc_electrs || h.indexers.btc_electrs,
+                lbtc_esplora: acc.lbtc_esplora || h.indexers.lbtc_esplora,
+                waterfalls: acc.waterfalls || h.indexers.waterfalls,
+            },
+        )
+    }
 }
 
 pub fn assert_payment(

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -61,9 +61,6 @@ impl Indexers {
     }
 }
 
-/// Assert the common scalar fields of a completed payment.
-/// Checks amount, fees, type, and status.
-/// Any additional fields (e.g. `details`) must be asserted by the caller.
 pub fn assert_payment(
     payment: &Payment,
     expected_amount_sat: u64,
@@ -222,12 +219,11 @@ pub async fn pay_invoice_lnd(invoice: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// To avoid permanently skipped BTC tip fetches due to PR #978:
 /// Mine one block on Bitcoin first, then one on Liquid, waiting for each
-/// indexer before proceeding.  The ordering matters: by the time the
-/// Liquid block arrives and triggers the SDK's background poller, the BTC
-/// electrs has already indexed its block, so `on_bitcoin_block` will see
-/// the new tip.  Without this ordering the gating optimisation in
-/// `get_sync_context` (PR #978) can permanently skip the BTC tip fetch.
+/// indexer before proceeding.
+/// This ensures when the SDK's background poller sees the Liquid block,
+/// the BTC block is fully indexed.
 pub async fn mine_bitcoin_then_liquid(
     n_blocks: u64,
     indexers: &Indexers,
@@ -275,9 +271,6 @@ pub async fn mine_and_index_blocks(
     Ok(())
 }
 
-/// Wait for all indexing services listed in `indexers` to catch up with
-/// the daemon tip for the given chain(s).  Each individual wait function
-/// assumes its service is running and will fail loudly if unreachable.
 pub async fn wait_for_indexers(chain: Chain, indexers: &Indexers) -> Result<(), Box<dyn Error>> {
     let timeout = Duration::from_secs(30);
     let wait_bitcoin = matches!(chain, Chain::Bitcoin | Chain::Both);
@@ -311,6 +304,61 @@ async fn get_daemon_blockcount(url: &str, cookie: &str) -> Result<u64, Box<dyn E
         .ok_or_else(|| "getblockcount did not return a number".into())
 }
 
+async fn wait_for_waterfalls_tip(
+    expected_height: u64,
+    timeout: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let url = format!("{}/block-height/{}", WATERFALLS_URL, expected_height);
+    let client = Client::new();
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Waterfalls did not index Liquid height {} within {:?}",
+        expected_height, timeout
+    )
+    .into())
+}
+
+async fn wait_for_indexer_tip(
+    esplora_url: &str,
+    expected_height: u64,
+    timeout: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let url = format!("{}/blocks/tip/height", esplora_url);
+    let client = Client::new();
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        if let Ok(resp) = client.get(&url).send().await {
+            if let Ok(text) = resp.text().await {
+                if let Ok(tip) = text.trim().parse::<u64>() {
+                    if tip >= expected_height {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Indexer at {} did not reach height {} within {:?}",
+        esplora_url, expected_height, timeout
+    )
+    .into())
+}
+
 fn chain_rpc_params(chain: Chain) -> (&'static str, &'static str) {
     match chain {
         Chain::Bitcoin => (BITCOIND_URL, BITCOIND_COOKIE.unwrap()),
@@ -327,7 +375,6 @@ fn chain_name(chain: Chain) -> &'static str {
     }
 }
 
-/// Poll a daemon's mempool until `txid` appears.
 pub async fn wait_for_tx_in_mempool(
     chain: Chain,
     txid: &str,
@@ -394,20 +441,7 @@ where
     }
 }
 
-/// Check whether a single chain's mempool is empty.
-async fn is_mempool_empty(chain: Chain) -> Result<bool, Box<dyn Error>> {
-    let (url, cookie) = chain_rpc_params(chain);
-    let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
-    Ok(result.as_array().map_or(true, |a| a.is_empty()))
-}
-
-/// Check whether both the Bitcoin and Liquid mempools are empty.
-async fn both_mempools_empty() -> Result<bool, Box<dyn Error>> {
-    Ok(is_mempool_empty(Chain::Bitcoin).await? && is_mempool_empty(Chain::Liquid).await?)
-}
-
 /// Mine blocks on both chains until both mempools are empty
-/// Gives up after `max_rounds` mining iterations.
 pub async fn drain_mempools(max_rounds: u32) -> Result<(), Box<dyn Error>> {
     let settle = Duration::from_millis(1000);
 
@@ -427,6 +461,16 @@ pub async fn drain_mempools(max_rounds: u32) -> Result<(), Box<dyn Error>> {
     }
 
     Err(format!("Mempools not empty after {max_rounds} rounds of mining").into())
+}
+
+async fn is_mempool_empty(chain: Chain) -> Result<bool, Box<dyn Error>> {
+    let (url, cookie) = chain_rpc_params(chain);
+    let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
+    Ok(result.as_array().map_or(true, |a| a.is_empty()))
+}
+
+async fn both_mempools_empty() -> Result<bool, Box<dyn Error>> {
+    Ok(is_mempool_empty(Chain::Bitcoin).await? && is_mempool_empty(Chain::Liquid).await?)
 }
 
 pub async fn poll_boltz_server_lockup_txid(
@@ -516,61 +560,6 @@ pub async fn poll_boltz_zero_conf_accepted(
     Err(format!(
         "Boltz did not report zeroConfRejected for chain swap {} within {:?}",
         swap_id, timeout
-    )
-    .into())
-}
-
-async fn wait_for_waterfalls_tip(
-    expected_height: u64,
-    timeout: Duration,
-) -> Result<(), Box<dyn Error>> {
-    let url = format!("{}/block-height/{}", WATERFALLS_URL, expected_height);
-    let client = Client::new();
-    let poll_interval = Duration::from_millis(100);
-    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
-
-    for _ in 0..iterations {
-        if let Ok(resp) = client.get(&url).send().await {
-            if resp.status().is_success() {
-                return Ok(());
-            }
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
-
-    Err(format!(
-        "Waterfalls did not index Liquid height {} within {:?}",
-        expected_height, timeout
-    )
-    .into())
-}
-
-async fn wait_for_indexer_tip(
-    esplora_url: &str,
-    expected_height: u64,
-    timeout: Duration,
-) -> Result<(), Box<dyn Error>> {
-    let url = format!("{}/blocks/tip/height", esplora_url);
-    let client = Client::new();
-    let poll_interval = Duration::from_millis(100);
-    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
-
-    for _ in 0..iterations {
-        if let Ok(resp) = client.get(&url).send().await {
-            if let Ok(text) = resp.text().await {
-                if let Ok(tip) = text.trim().parse::<u64>() {
-                    if tip >= expected_height {
-                        return Ok(());
-                    }
-                }
-            }
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
-
-    Err(format!(
-        "Indexer at {} did not reach height {} within {:?}",
-        esplora_url, expected_height, timeout
     )
     .into())
 }

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -225,6 +225,124 @@ async fn get_daemon_blockcount(url: &str, cookie: &str) -> Result<u64, Box<dyn E
         .ok_or_else(|| "getblockcount did not return a number".into())
 }
 
+/// Poll elementsd's `getrawmempool` until it contains at least one
+/// transaction.  Returns the txid of the first entry found.
+/// Times out with an error if the mempool stays empty.
+pub async fn wait_for_liquid_mempool_tx(timeout: Duration) -> Result<String, Box<dyn Error>> {
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        let result =
+            json_rpc_request(ELEMENTSD_URL, ELEMENTSD_COOKIE, "getrawmempool", json!([])).await?;
+        if let Some(arr) = result.as_array() {
+            if let Some(first) = arr.first() {
+                if let Some(txid) = first.as_str() {
+                    return Ok(txid.to_string());
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Liquid mempool did not contain any transaction within {:?}",
+        timeout
+    )
+    .into())
+}
+
+/// Poll elementsd's `getrawmempool` until `txid` appears.
+/// Times out with an error if the transaction is not seen.
+pub async fn wait_for_tx_in_liquid_mempool(
+    txid: &str,
+    timeout: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        let result =
+            json_rpc_request(ELEMENTSD_URL, ELEMENTSD_COOKIE, "getrawmempool", json!([])).await?;
+        if let Some(arr) = result.as_array() {
+            if arr.iter().any(|v| v.as_str() == Some(txid)) {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Transaction {} did not appear in Liquid mempool within {:?}",
+        txid, timeout
+    )
+    .into())
+}
+
+/// Poll bitcoind's `getrawmempool` until it contains at least one
+/// transaction.  Returns the txid of the first entry found.
+/// Times out with an error if the mempool stays empty.
+pub async fn wait_for_bitcoin_mempool_tx(timeout: Duration) -> Result<String, Box<dyn Error>> {
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        let result = json_rpc_request(
+            BITCOIND_URL,
+            BITCOIND_COOKIE.unwrap(),
+            "getrawmempool",
+            json!([]),
+        )
+        .await?;
+        if let Some(arr) = result.as_array() {
+            if let Some(first) = arr.first() {
+                if let Some(txid) = first.as_str() {
+                    return Ok(txid.to_string());
+                }
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Bitcoin mempool did not contain any transaction within {:?}",
+        timeout
+    )
+    .into())
+}
+
+/// Poll bitcoind's `getrawmempool` until `txid` appears.
+/// Times out with an error if the transaction is not seen.
+pub async fn wait_for_tx_in_bitcoin_mempool(
+    txid: &str,
+    timeout: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let poll_interval = Duration::from_millis(100);
+    let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
+
+    for _ in 0..iterations {
+        let result = json_rpc_request(
+            BITCOIND_URL,
+            BITCOIND_COOKIE.unwrap(),
+            "getrawmempool",
+            json!([]),
+        )
+        .await?;
+        if let Some(arr) = result.as_array() {
+            if arr.iter().any(|v| v.as_str() == Some(txid)) {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    Err(format!(
+        "Transaction {} did not appear in Bitcoin mempool within {:?}",
+        txid, timeout
+    )
+    .into())
+}
+
 /// Poll an esplora HTTP endpoint until the reported tip height is at least
 /// `expected_height`.  Times out after `timeout`.
 async fn wait_for_indexer_tip(

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -10,24 +10,50 @@ const ELEMENTSD_URL: &str = "http://localhost:18884/wallet/client";
 const LND_URL: &str = "https://localhost:8081";
 
 const PROXY_URL: &str = "http://localhost:51234/proxy";
+const SWAPPROXY_URL: &str = "http://localhost:8387";
 
-/// Esplora HTTP endpoints for checking indexer tip heights.
-/// BTC: esplora container → electrs (same process as Electrum at 19001).
-/// L-BTC: nginx → waterfalls → esplora → electrs-liquid (same process as
-///        Electrum at 19002).
 const BTC_ESPLORA_URL: &str = "http://localhost:4002/api";
 const LBTC_ESPLORA_URL: &str = "http://localhost:3120/api";
+const WATERFALLS_URL: &str = "http://localhost:3102";
 
 const BITCOIND_COOKIE: Option<&str> = option_env!("BITCOIND_COOKIE");
 const ELEMENTSD_COOKIE: &str = "regtest:regtest";
 const LND_MACAROON_HEX: Option<&str> = option_env!("LND_MACAROON_HEX");
 
-/// Which blockchain(s) to mine on.
 #[derive(Clone, Copy)]
 pub enum Chain {
     Bitcoin,
     Liquid,
     Both,
+}
+
+/// Describes which indexing services are present in the test environment
+/// and must be waited on after mining.
+#[derive(Clone, Copy)]
+pub struct Indexers {
+    pub btc_esplora: bool,
+    pub lbtc_esplora: bool,
+    pub waterfalls: bool,
+}
+
+impl Indexers {
+    /// Electrum environment: only esplora/electrs, no waterfalls.
+    pub fn electrum() -> Self {
+        Self {
+            btc_esplora: true,
+            lbtc_esplora: true,
+            waterfalls: false,
+        }
+    }
+
+    /// Esplora environment: esplora/electrs + waterfalls.
+    pub fn esplora() -> Self {
+        Self {
+            btc_esplora: true,
+            lbtc_esplora: true,
+            waterfalls: true,
+        }
+    }
 }
 
 async fn json_rpc_request(
@@ -158,7 +184,7 @@ pub async fn pay_invoice_lnd(invoice: &str) -> Result<(), Box<dyn Error>> {
 }
 
 pub async fn mine_blocks(n_blocks: u64) -> Result<(), Box<dyn Error>> {
-    mine_and_index_blocks(n_blocks, Chain::Both, false).await
+    mine_and_index_blocks(n_blocks, Chain::Both, None).await
 }
 
 /// Mine one block on Bitcoin first, then one on Liquid, waiting for each
@@ -167,57 +193,78 @@ pub async fn mine_blocks(n_blocks: u64) -> Result<(), Box<dyn Error>> {
 /// electrs has already indexed its block, so `on_bitcoin_block` will see
 /// the new tip.  Without this ordering the gating optimisation in
 /// `get_sync_context` (PR #978) can permanently skip the BTC tip fetch.
-pub async fn mine_bitcoin_then_liquid(n_blocks: u64) -> Result<(), Box<dyn Error>> {
-    mine_and_index_blocks(n_blocks, Chain::Bitcoin, true).await?;
-    mine_and_index_blocks(n_blocks, Chain::Liquid, true).await
+pub async fn mine_bitcoin_then_liquid(
+    n_blocks: u64,
+    indexers: &Indexers,
+) -> Result<(), Box<dyn Error>> {
+    mine_and_index_blocks(n_blocks, Chain::Bitcoin, Some(indexers)).await?;
+    mine_and_index_blocks(n_blocks, Chain::Liquid, Some(indexers)).await
 }
 
 pub async fn mine_and_index_blocks(
     n_blocks: u64,
     chain: Chain,
-    wait_for_indexer: bool,
+    indexers: Option<&Indexers>,
 ) -> Result<(), Box<dyn Error>> {
     let mine_bitcoin = matches!(chain, Chain::Bitcoin | Chain::Both);
     let mine_liquid = matches!(chain, Chain::Liquid | Chain::Both);
 
-    if mine_bitcoin {
-        let address = generate_address_bitcoind().await?;
-        json_rpc_request(
-            BITCOIND_URL,
-            BITCOIND_COOKIE.unwrap(),
-            "generatetoaddress",
-            json!([n_blocks, address]),
-        )
-        .await?;
-    }
-
-    if mine_liquid {
-        let address = generate_address_elementsd().await?;
-        json_rpc_request(
-            ELEMENTSD_URL,
-            ELEMENTSD_COOKIE,
-            "generatetoaddress",
-            json!([n_blocks, address]),
-        )
-        .await?;
-    }
-
-    if wait_for_indexer {
-        let timeout = Duration::from_secs(30);
+    for _ in 0..n_blocks {
         if mine_bitcoin {
-            let daemon_height = get_daemon_blockcount(BITCOIND_URL, BITCOIND_COOKIE.unwrap()).await?;
-            wait_for_indexer_tip(BTC_ESPLORA_URL, daemon_height, timeout).await?;
+            let address = generate_address_bitcoind().await?;
+            json_rpc_request(
+                BITCOIND_URL,
+                BITCOIND_COOKIE.unwrap(),
+                "generatetoaddress",
+                json!([1, address]),
+            )
+            .await?;
         }
+
         if mine_liquid {
-            let daemon_height = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
-            wait_for_indexer_tip(LBTC_ESPLORA_URL, daemon_height, timeout).await?;
+            let address = generate_address_elementsd().await?;
+            json_rpc_request(
+                ELEMENTSD_URL,
+                ELEMENTSD_COOKIE,
+                "generatetoaddress",
+                json!([1, address]),
+            )
+            .await?;
+        }
+
+        if let Some(idx) = indexers {
+            wait_for_indexers(chain, idx).await?;
         }
     }
 
     Ok(())
 }
 
-/// Query a daemon's current block height via JSON-RPC `getblockcount`.
+/// Wait for all indexing services listed in `indexers` to catch up with
+/// the daemon tip for the given chain(s).  Each individual wait function
+/// assumes its service is running and will fail loudly if unreachable.
+pub async fn wait_for_indexers(chain: Chain, indexers: &Indexers) -> Result<(), Box<dyn Error>> {
+    let timeout = Duration::from_secs(30);
+    let wait_bitcoin = matches!(chain, Chain::Bitcoin | Chain::Both);
+    let wait_liquid = matches!(chain, Chain::Liquid | Chain::Both);
+
+    if wait_bitcoin && indexers.btc_esplora {
+        let h = get_daemon_blockcount(BITCOIND_URL, BITCOIND_COOKIE.unwrap()).await?;
+        wait_for_indexer_tip(BTC_ESPLORA_URL, h, timeout).await?;
+    }
+    if wait_liquid {
+        if indexers.lbtc_esplora {
+            let h = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
+            wait_for_indexer_tip(LBTC_ESPLORA_URL, h, timeout).await?;
+        }
+        if indexers.waterfalls {
+            let h = get_daemon_blockcount(ELEMENTSD_URL, ELEMENTSD_COOKIE).await?;
+            wait_for_waterfalls_tip(h, timeout).await?;
+        }
+    }
+    Ok(())
+}
+
 async fn get_daemon_blockcount(url: &str, cookie: &str) -> Result<u64, Box<dyn Error>> {
     let result = json_rpc_request(url, cookie, "getblockcount", json!([])).await?;
     result
@@ -225,16 +272,32 @@ async fn get_daemon_blockcount(url: &str, cookie: &str) -> Result<u64, Box<dyn E
         .ok_or_else(|| "getblockcount did not return a number".into())
 }
 
-/// Poll elementsd's `getrawmempool` until it contains at least one
-/// transaction.  Returns the txid of the first entry found.
-/// Times out with an error if the mempool stays empty.
-pub async fn wait_for_liquid_mempool_tx(timeout: Duration) -> Result<String, Box<dyn Error>> {
+fn chain_rpc_params(chain: Chain) -> (&'static str, &'static str) {
+    match chain {
+        Chain::Bitcoin => (BITCOIND_URL, BITCOIND_COOKIE.unwrap()),
+        Chain::Liquid => (ELEMENTSD_URL, ELEMENTSD_COOKIE),
+        Chain::Both => panic!("chain_rpc_params requires a single chain, not Both"),
+    }
+}
+
+fn chain_name(chain: Chain) -> &'static str {
+    match chain {
+        Chain::Bitcoin => "Bitcoin",
+        Chain::Liquid => "Liquid",
+        Chain::Both => "Bitcoin+Liquid",
+    }
+}
+
+pub async fn wait_for_mempool_tx(
+    chain: Chain,
+    timeout: Duration,
+) -> Result<String, Box<dyn Error>> {
+    let (url, cookie) = chain_rpc_params(chain);
     let poll_interval = Duration::from_millis(100);
     let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
 
     for _ in 0..iterations {
-        let result =
-            json_rpc_request(ELEMENTSD_URL, ELEMENTSD_COOKIE, "getrawmempool", json!([])).await?;
+        let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
         if let Some(arr) = result.as_array() {
             if let Some(first) = arr.first() {
                 if let Some(txid) = first.as_str() {
@@ -246,24 +309,25 @@ pub async fn wait_for_liquid_mempool_tx(timeout: Duration) -> Result<String, Box
     }
 
     Err(format!(
-        "Liquid mempool did not contain any transaction within {:?}",
+        "{} mempool did not contain any transaction within {:?}",
+        chain_name(chain),
         timeout
     )
     .into())
 }
 
-/// Poll elementsd's `getrawmempool` until `txid` appears.
-/// Times out with an error if the transaction is not seen.
-pub async fn wait_for_tx_in_liquid_mempool(
+/// Poll a daemon's mempool until `txid` appears.
+pub async fn wait_for_tx_in_mempool(
+    chain: Chain,
     txid: &str,
     timeout: Duration,
 ) -> Result<(), Box<dyn Error>> {
+    let (url, cookie) = chain_rpc_params(chain);
     let poll_interval = Duration::from_millis(100);
     let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
 
     for _ in 0..iterations {
-        let result =
-            json_rpc_request(ELEMENTSD_URL, ELEMENTSD_COOKIE, "getrawmempool", json!([])).await?;
+        let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
         if let Some(arr) = result.as_array() {
             if arr.iter().any(|v| v.as_str() == Some(txid)) {
                 return Ok(());
@@ -273,30 +337,72 @@ pub async fn wait_for_tx_in_liquid_mempool(
     }
 
     Err(format!(
-        "Transaction {} did not appear in Liquid mempool within {:?}",
-        txid, timeout
+        "Transaction {} did not appear in {} mempool within {:?}",
+        txid,
+        chain_name(chain),
+        timeout
     )
     .into())
 }
 
-/// Poll bitcoind's `getrawmempool` until it contains at least one
-/// transaction.  Returns the txid of the first entry found.
-/// Times out with an error if the mempool stays empty.
-pub async fn wait_for_bitcoin_mempool_tx(timeout: Duration) -> Result<String, Box<dyn Error>> {
-    let poll_interval = Duration::from_millis(100);
+/// Check whether a single chain's mempool is empty.
+async fn is_mempool_empty(chain: Chain) -> Result<bool, Box<dyn Error>> {
+    let (url, cookie) = chain_rpc_params(chain);
+    let result = json_rpc_request(url, cookie, "getrawmempool", json!([])).await?;
+    Ok(result.as_array().map_or(true, |a| a.is_empty()))
+}
+
+/// Check whether both the Bitcoin and Liquid mempools are empty.
+async fn both_mempools_empty() -> Result<bool, Box<dyn Error>> {
+    Ok(is_mempool_empty(Chain::Bitcoin).await? && is_mempool_empty(Chain::Liquid).await?)
+}
+
+/// Mine blocks on both chains until both mempools are empty
+/// Gives up after `max_rounds` mining iterations.
+pub async fn drain_mempools(max_rounds: u32) -> Result<(), Box<dyn Error>> {
+    let settle = Duration::from_millis(1000);
+
+    for _ in 0..max_rounds {
+        mine_and_index_blocks(1, Chain::Both, None).await?;
+
+        if !both_mempools_empty().await? {
+            continue; // more txs than fit in one block, mine again
+        }
+
+        // Quiescence check: wait for deferred broadcasts.
+        tokio::time::sleep(settle).await;
+        if both_mempools_empty().await? {
+            return Ok(());
+        }
+        // Something appeared after the first check — loop and mine again
+    }
+
+    Err(format!("Mempools not empty after {max_rounds} rounds of mining").into())
+}
+
+pub async fn poll_boltz_server_lockup_txid(
+    swap_id: &str,
+    timeout: Duration,
+) -> Result<String, Box<dyn Error>> {
+    let url = format!("{}/v2/swap/chain/{}/transactions", SWAPPROXY_URL, swap_id);
+    let client = Client::new();
+    let poll_interval = Duration::from_millis(200);
     let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
 
     for _ in 0..iterations {
-        let result = json_rpc_request(
-            BITCOIND_URL,
-            BITCOIND_COOKIE.unwrap(),
-            "getrawmempool",
-            json!([]),
-        )
-        .await?;
-        if let Some(arr) = result.as_array() {
-            if let Some(first) = arr.first() {
-                if let Some(txid) = first.as_str() {
+        if let Ok(resp) = client
+            .get(PROXY_URL)
+            .header("X-Proxy-URL", &url)
+            .send()
+            .await
+        {
+            if let Ok(body) = resp.json::<Value>().await {
+                if let Some(txid) = body
+                    .get("serverLock")
+                    .and_then(|sl| sl.get("transaction"))
+                    .and_then(|tx| tx.get("id"))
+                    .and_then(|id| id.as_str())
+                {
                     return Ok(txid.to_string());
                 }
             }
@@ -305,31 +411,24 @@ pub async fn wait_for_bitcoin_mempool_tx(timeout: Duration) -> Result<String, Bo
     }
 
     Err(format!(
-        "Bitcoin mempool did not contain any transaction within {:?}",
-        timeout
+        "Boltz did not broadcast server lockup for chain swap {} within {:?}",
+        swap_id, timeout
     )
     .into())
 }
 
-/// Poll bitcoind's `getrawmempool` until `txid` appears.
-/// Times out with an error if the transaction is not seen.
-pub async fn wait_for_tx_in_bitcoin_mempool(
-    txid: &str,
+async fn wait_for_waterfalls_tip(
+    expected_height: u64,
     timeout: Duration,
 ) -> Result<(), Box<dyn Error>> {
+    let url = format!("{}/block-height/{}", WATERFALLS_URL, expected_height);
+    let client = Client::new();
     let poll_interval = Duration::from_millis(100);
     let iterations = (timeout.as_millis() / poll_interval.as_millis()).max(1) as u64;
 
     for _ in 0..iterations {
-        let result = json_rpc_request(
-            BITCOIND_URL,
-            BITCOIND_COOKIE.unwrap(),
-            "getrawmempool",
-            json!([]),
-        )
-        .await?;
-        if let Some(arr) = result.as_array() {
-            if arr.iter().any(|v| v.as_str() == Some(txid)) {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
                 return Ok(());
             }
         }
@@ -337,14 +436,12 @@ pub async fn wait_for_tx_in_bitcoin_mempool(
     }
 
     Err(format!(
-        "Transaction {} did not appear in Bitcoin mempool within {:?}",
-        txid, timeout
+        "Waterfalls did not index Liquid height {} within {:?}",
+        expected_height, timeout
     )
     .into())
 }
 
-/// Poll an esplora HTTP endpoint until the reported tip height is at least
-/// `expected_height`.  Times out after `timeout`.
 async fn wait_for_indexer_tip(
     esplora_url: &str,
     expected_height: u64,

--- a/lib/core/tests/regtest/utils.rs
+++ b/lib/core/tests/regtest/utils.rs
@@ -1,4 +1,5 @@
 use base64::Engine;
+use breez_sdk_liquid::model::{Payment, PaymentState, PaymentType, SdkEvent};
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::error::Error;
@@ -58,6 +59,22 @@ impl Indexers {
             waterfalls: true,
         }
     }
+}
+
+/// Assert the common scalar fields of a completed payment.
+/// Checks amount, fees, type, and status.
+/// Any additional fields (e.g. `details`) must be asserted by the caller.
+pub fn assert_payment(
+    payment: &Payment,
+    expected_amount_sat: u64,
+    expected_fees_sat: u64,
+    expected_type: PaymentType,
+    expected_status: PaymentState,
+) {
+    assert_eq!(payment.amount_sat, expected_amount_sat);
+    assert_eq!(payment.fees_sat, expected_fees_sat);
+    assert_eq!(payment.payment_type, expected_type);
+    assert_eq!(payment.status, expected_status);
 }
 
 async fn json_rpc_request(
@@ -170,6 +187,24 @@ pub async fn send_to_address_elementsd(
     .ok_or_else(|| "Invalid response".into())
 }
 
+pub async fn get_lbtc_tx_fee_sat(tx_id: &str) -> Result<u64, Box<dyn Error>> {
+    let client = Client::new();
+    let url = format!("{LBTC_ESPLORA_URL}/tx/{tx_id}");
+
+    let response = client
+        .get(PROXY_URL)
+        .header("X-Proxy-URL", url)
+        .send()
+        .await?
+        .json::<Value>()
+        .await?;
+
+    response
+        .get("fee")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "Missing or invalid fee field in liquid esplora tx response".into())
+}
+
 pub async fn generate_invoice_lnd(amount_sat: u64) -> Result<String, Box<dyn Error>> {
     let response = lnd_request("v1/invoices", json!({ "value": amount_sat })).await?;
     response["payment_request"]
@@ -185,10 +220,6 @@ pub async fn pay_invoice_lnd(invoice: &str) -> Result<(), Box<dyn Error>> {
     )
     .await?;
     Ok(())
-}
-
-pub async fn mine_blocks(n_blocks: u64) -> Result<(), Box<dyn Error>> {
-    mine_and_index_blocks(n_blocks, Chain::Both, None).await
 }
 
 /// Mine one block on Bitcoin first, then one on Liquid, waiting for each
@@ -323,6 +354,44 @@ pub async fn wait_for_tx_in_mempool(
         timeout
     )
     .into())
+}
+
+/// Wait for an SDK event, with optional retry and mine if initial timeout occurs.
+/// With #978's poller gating optimization, there can be a race condition between
+/// the SDK's internal poller and the indexers after mining a liquid block.
+/// To force an update it might be required to mine an additional liquid block.
+/// However always mining can lead to unexpected side-effect / further state advances
+/// so it is only added when also after one polling cycle the expected event is not
+/// emitted.
+pub async fn wait_for_event_with_retry<F>(
+    handle: &mut super::SdkNodeHandle,
+    indexers: &Indexers,
+    event_match: F,
+    total_timeout: Duration,
+) -> Result<SdkEvent, Box<dyn Error>>
+where
+    F: Fn(&SdkEvent) -> bool,
+{
+    let first_timeout = Duration::from_secs(handle.onchain_sync_period_sec as u64 + 1);
+    assert!(
+        first_timeout * 2 <= total_timeout,
+        "total_timeout ({total_timeout:?}) must be at least 2x one_poll_cycle ({first_timeout:?}) \
+         to leave room for the try-then-mine retry pattern",
+    );
+
+    match handle.wait_for_event(&event_match, first_timeout).await {
+        Ok(event) => Ok(event),
+        Err(_) => {
+            // Tip N was consumed with stale indexer data. Mine N+1
+            // so the poller gets a fresh tip with consistent data.
+            mine_and_index_blocks(1, Chain::Liquid, Some(indexers)).await?;
+            let remaining_timeout = total_timeout.saturating_sub(first_timeout);
+            handle
+                .wait_for_event(&event_match, remaining_timeout)
+                .await
+                .map_err(|e| format!("Event wait timed out after retry: {e}").into())
+        }
+    }
 }
 
 /// Check whether a single chain's mempool is empty.


### PR DESCRIPTION
## Summary

Closes #996, #997 and #847. References #828, #829, #978

### Root cause analysis (#996)

Reasons the chain swap E2E tests were flaky:
1. Chain tip gating (#978) + indexer processing times → race condition into deadlock (also root-cause of #847)
2. "Early" (not synced mempool readiness) mining → unconfirmed TX → test condition timeout
3. Unexpected reaction/output from esplora: same tx reported as mined and in mempool (see #1097) → degradation into test timeout
4. Even after SDK has advanced internal states, further LWK updates of wallet balances are delayed (see #828) → race condition into test failure

Details:
1. Base situation: tests use one function to mine one bitcoin and one liquid block to advance state. However different propagation times of Bitcoin and Liquid blocks through their indexers (esplora/electrs) combined with async background polling for chain states by the SDK can lead to a situation where:
   1.1. The Liquid block is indexed before the Bitcoin block
   1.2. The SDK's background polling (`track_new_blocks()`) updates swap states but does not receive/handle payment because the Bitcoin block is not yet detected (because it was not indexed when polling detected the liquid block). But the liquid block was indexed and detected and "consumed" by the gating introduced in #978
   1.3. Subsequently no new blocks get mined and the polling will never detect the latest Bitcoin block, because it is gated according to #978 → no further advances in system state (deadlock → timeout)
   1.4. Even if only the Liquid tx/block is relevant, it is not possible to guarantee the SDK's background poller runs after the block has been fully processed by all relevant indexers and might consume the Liquid tip w/o retrieving all the relevant information from it. (Most likely root-cause of #847 as well)

   **Effect in production:**
   - The deadlock gets auto-resolved after a new Liquid block (~1 min) is mined
   - Detection of new Bitcoin blocks can be delayed by one Liquid block
   - This trade-off appears acceptable given that swap timeouts >> 1 min, and was probably considered when creating #978
   - *Behavior is acceptable in production*

   **Effect in regtest:**
   - No automatic block generation → permanent deadlock → test hangs until timeout

2. Some test steps expect one of the test entities (SDK or Boltz) to broadcast a TX and then mine a block to confirm that TX w/o confirming that the TX is actually in the mempool already

   **Effect in production:** No negative effect as this TX will be included in one of the next blocks. Not a fault of SDK.
   **Effect in regtest:** No new blocks are produced → test waits with timeout on some reaction to the assumed newly mined transaction → timeout

3. `determine_incoming_lockup_and_claim_txs()` checks via the blockexplorer how many transactions are available for a certain script (swap claim). It assumes the first tx is the lockup tx, the second is the claim tx. If more than 2 tx are reported it assumes this to be strange and does nothing, triggering the SDK to go into a 120s grace period where it skips recovery. However esplora sometimes reports a freshly mined claim tx twice in one query: once still as in the mempool and once freshly confirmed, thus triggering the "this is strange" path which suppresses further updates of the swap state (unless some other conditions are met, e.g. new liquid block is mined), which exceeds the test's timeout.

   **Effect in production:** After the next liquid block (60s < 120s grace period) the state is healed and claim continues to finalized. Acceptable, but UX could be improved.
   **Effect in regtest:** No new blocks produced → timeout → failed test

4. Even when the swap is detected as successfully completed, SDK still has to wait on LWK to complete its queries to update the wallet balances completely (see #828). Tests assumed that immediately after "PaymentSucceeded" the wallet balances are up-to-date → stale wallet balances do not match expectation → failed test

   **Effect in production:** Depending on the propagation delay the user might not even notice. Otherwise heals once delay has passed. Not critical.
   **Effect in regtest:** Test fails due to unexpected wallet amounts after "PaymentSucceeded"

### Proposed solution (#996)

General guidelines/goals:
1. Do not change production code if there is no bug
2. Make implicit assumptions better visible by converting them to explicit checks
3. Make system state at each test step predictable/understood

This includes:
* Enable the test environment to have more granular control over the mining process and timing:
  - Add option to mine on either chain (Bitcoin, Liquid) or both
  - Add option to wait for indexer(s) to catch up before continuing
  - Extract expected TX id and utilities to wait until they are in the mempool
  - Add a utility to drain mempools at the end of a test section
  - Move (series of) common checks into utility functions such that individual checks are not forgotten in a specific test due to copy&paste

### Discarded options

| Option | Why discarded |
|--------|---------------|
| **Continuous simulated mining** — Run a background process that keeps producing blocks on both chains at a fixed interval (similar to production) | Would increase pass rate but make test behavior *less* predictable and harder to debug. Failures would become timing-dependent rather than logic-dependent. Contradicts guideline 3 (predictable system state at each step). |
| **Randomly mine extra blocks** after each test step, unless explicitly documented why they are needed | Same argument as above: it papers over root causes instead of making them visible. Contradicts guidelines 2 and 3. |
| **Modify `sync()` to drop the gating from #978** or to also call `on_x_block` handlers | `sync()` is not expected to trigger externally visible actions (as calling block handlers would). Would violate guideline 1 (no production code changes unless there is a bug). The gating is working as designed; the issue is purely a regtest artifact. |

### Specific solutions per root cause

1. **Race between indexers / background poller**
   1.1. When a bitcoin tx needs to be noticed: first mine one bitcoin block (and wait for indexers to catch up), then mine one liquid block. This way the liquid block will trigger gating only after the needed data is available.
   1.2. When a liquid tx needs to be noticed: either mine one liquid block waiting for indexers and then a second. However that can introduce further race conditions if after the first mined block a test entity (e.g. SDK or Boltz) is issuing the next tx which might already be in the second mined block. To avoid having to track two possible states, this is circumvented by first assuming the block triggers the expected reaction and waiting with a timeout a bit longer than the background poller's cycle time. Only if that times out, mine another liquid block as a last retry. This way the state of the test is always clear and subsequent steps have one relevant state they can assume.

2. **Mempool readiness** — Get expected TX id via available interfaces and explicitly wait for the TX to be in the mempool before mining.

3. **Esplora duplicate reporting** — Proposed long-term solutions:
   3.1. Verify with esplora team if this is expected behavior → raise issue?
   3.2. Make SDK more robust by explicitly checking if relevant tx ids are in the mempool or on chain (regardless of number of txs for that script)
   Current workaround in test: break "skipping_recovery" by mining one bitcoin block (to gain time for indexers to settle) and one liquid block (to give background poller another chance). Marked as "Workaround for #1097".

4. **LWK balance propagation delay** — No publicly available interface found to check if LWK update is complete. So fallback to "Mine one more liquid block to force an update of LWK wallet data". (Possible future approach skipped due to PlanB assignment deadline: poll wallet balance until it meets expected value instead of mining a new block)

### Root cause analysis (#997)

Many issues in WASM environment were fixed by measures introduced for #996. Remaining:

When SDK from WASM tries to upgrade connection to swapproxy to websocket, the request gets declined because the swapproxy is configured to reject upgrades for connections not coming from the same origin. WASM SDK always has a different origin than swapproxy.

**Effect in production:** WASM SDK clients connect from unpredictable origins → WebSocket connection fails.
**Effect in regtest:** WASM tests systematically fail if they rely on the websocket connection working.

### Proposed solution (#997)

Swapproxy: accept WebSocket connections from any origin. Add `OriginPatterns: ["*"]` to allow all origins. Security is maintained by the existing certificate-based API key authentication (`Bearer` token on HTTP(S), first-message `apikey` on WS), which is independent of the Origin header.

**Discarded option:** Explore and incorporate further upstream updates/changes in the swapproxy sub-repo. This was not chosen because the scope of this task was to first establish a stable test environment. The minimal change achieves that. Other changes can be more easily evaluated against this stable baseline afterward. (Also note the swapproxy PR is made against a fork due to the limited scope/timeline of the PlanB programme assignment.)

**Depends on: [breez/swapproxy#16](https://github.com/breez/swapproxy/pull/16)**

> **Note:** The `.gitmodules` URL temporarily points to `maggo83/swapproxy` so the submodule commit resolves. Revert to `breez/swapproxy` once breez/swapproxy#16 is merged.

### Added test (bitcoin amountless receive) + Findings/Fixes (Skip overwriting swaps after fees accepted)

**Not added test cases:**
* Unhappy paths (e.g. boltz going down/rogue -> reclaim via time-out):
  *  Although high value add also complexity to manipulate connection in current regtest setup hard to do. But in my opinion should be added sooner rather than later.
* Bolt12 actual send/receive paths:
   * Not yet fully supported by SDK itself. Adding CLN to regtest also considered too high effort for given amount of time (no prior experience with this so just a gut feel). Will need to be added once feature ready

**Actually added testcase: Bitcoin amountless receive**
* Interesting because boltz initially reports a failed swap but then SDK "fixes" this -> different behavior than simple receive
* Test revealed a possible weakness in the code: repeated triggers from boltz can overwrite an already aligned state of a swap and hence lead to swap state regression 
* As this is considered a bug/robustness issue, a fix is proposed: make repeated failedLockup idempotent. (See <COMMIT ID>)

### Additional Bugfix: wrong block height in receive_swap_handler

- `receive_swap_handler.on_bitcoin_block()` was incorrectly called with `*current_liquid_block` instead of `*current_bitcoin_block` in `sdk.rs`. Found during code review.

**Effect in production:** None as this input seems to be ignored anyway.
**Effect in testing:** None.

## Validation

Ran multiple iterations of the full test suite (native, browser, node — all test types per iteration) on branch rebased to current main: without regressions.

This depends on the fixes
* swapproxy allows all origins (otherwise WASM tests fail)
* make repeated failedLockup idempotent (otherwise bitcoin amountless receive test is flaky)

#847 was no longer encountered in the test runs, hence assumed closed as well.

## Known limitations

The amounts in the send/receive tests are not symmetric. I.e. per iteration of running the test suite wallet/lightning channel balances get shifted. When running the testsuite repeatedly this can lead to their depletion and then either changed behavior (e.g. boltz switching to direct transactions) or no more sends being possible.

**Effect:** After running > 100 test iterations in a row w/o resetting/restarting regtest or manually rebalancing wallets/channels, tests will start systematically failing afterwards (currently bolt11.rs fails first after 116 repeated executions).

**Proposed solution:** No change. Running test cases repeatedly was only needed to check for flakiness which is solved with this PR. If needed again later for some reason, one can easily circumvent this by stopping/starting regtest after some iterations. Also just due to the TX fees in the (very) end this issue will appear sooner or later. Manually rebalancing after each test seems not worth the effort.

#829 is not fully analysed or fixed although referenced in the tests. Initial analysis (not verified yet) points to two possible issues:
* possible race condition (to be added to internal mrh_tx database in handle_receive_swap.rs, the tx has to have a timestamp _strictly_  > the swap's timestamp (resolution seconds). In fast regtest the "=" case [same second mined as swap initiated] might happen)
* insert_or_update_receive_swap_inner has no COALESCE protection unlike try_handle_receive_swap_update

## Further proposals

* The race between background poller and indexers after a (liquid) block is found can delay reaction of the SDK to new chain-info by ~1 min. Maybe it can be considered to change the gating to be not only on directly newly received liquid block but also one cycle after, to give other propagation depended subsystems time to settle / update. This would increase calls by a factor of 2, but the overall saving from #978 (+this) would still be substantial while ensuring high responsiveness of SDK
* In a similar vein: several state transitions are triggered by WS inputs from boltz and fail w/o retry if some information fetched from SDK external sources is not as expected (which might be caused by small propagation delays). Maybe it should be considered to also here add one try after a small settle time to make the overall flows more robust.


## Commits

1. **fix(regtest): wait for block indexer after mining in chain swap test (#996)** [`2a5d333d`] — Replace non-deterministic `sleep(5)` waits with deterministic indexer-readiness checks. Add `Chain` enum, `mine_and_index_blocks()`, `mine_bitcoin_then_liquid()` utilities. Addresses root cause 1 (indexer race / gating deadlock).
2. **fix: pass bitcoin block height to receive_swap_handler.on_bitcoin_block** [`b2c4ed23`] — One-line fix in sdk.rs: `on_bitcoin_block(*current_liquid_block)` → `on_bitcoin_block(*current_bitcoin_block)`. Found during code review.
3. **fix(regtest): eliminate mempool races in chain swap test (#996)** [`b7385eec`] — Add mempool polling helpers (`wait_for_tx_in_mempool`, `poll_boltz_server_lockup_txid`). Wait for each broadcast to reach the mempool before mining its confirming block. Addresses root cause 2.
4. **fix(regtest): improve robustness of bitcoin native test** [`6bfbdedf`] — Handle poller/indexer desync with try-then-mine retry pattern for `PaymentWaitingConfirmation`. Add esplora flakiness workaround (extra block to break `skip_recovery`). Add `drain_mempools()` cleanup between test sections. Addresses root causes 3 and 4.
5. **fix(regtest): roll out stricter test checks to bitcoin SEND and REFUND tests** [`b59b7768`] — Add `poll_boltz_zero_conf_accepted` utility. Apply mempool-aware mining and explicit tx-id tracking to SEND and REFUND sections. Add `prepare_refund` assertions and RBF fee validation.
6. **chore: update swapproxy submodule to accept all WebSocket origins** [`013e1018`] — Points to maggo83/swapproxy@781171c. Depends on [breez/swapproxy#16](https://github.com/breez/swapproxy/pull/16).
7. **chore(regtest): document zero-conf coverage constraints** [`a303ca46`] — Add inline comments explaining why the zero-conf acceptance path cannot be fully covered in the current regtest setup.
8. **fix(regtest): wait for electrs to sync after mining** [`68e42a30`] — Ensure electrs has indexed the freshly mined block before the test proceeds. Complements commit 1 for cases where esplora is the active indexer.
9. **test: add amountless receive E2E test** [`eb28e28f`] — New test for the bitcoin chain swap amountless receive flow (BIP-21 / no pre-specified amount). Exercises the auto-accept fee path and exposes the repeated `lockupFailed` regression fixed in commit 10.
10. **fix: make repeated lockupFailed idempotent after zero-amount fee acceptance** [`53905546`] — Production fix: prevent a subsequent `lockupFailed` WebSocket message from overwriting swap state after fees have already been accepted, avoiding state regression.
11. **test(regtest): introduce wait-with-one-retry helper for robustness** [`0ac393a6`] — Add `wait_for_event_with_retry()`. Replaces ad-hoc mine-and-retry patterns across tests with a consistent, documented utility.
12. **test: harden bolt11 & bolt12 regtest tests** [`8cfb1670`] — Apply mempool-aware mining, indexer waits, and stricter payment/wallet assertions to bolt11.rs and bolt12.rs.
13. **test: harden liquid regtest tests** [`e195ffea`] — Apply the same robustness improvements to the liquid send/receive test flows.
14. **test: extract assert_payment and assert_wallet_settled helpers** [`a4b9e8c2`] — Extract repeated payment verification and settled-balance assertion patterns into shared utilities to prevent omissions across test sections.
15. **test(regtest): add assert_wallet_pending helper and apply across all flows** [`f612bd1d`] — Add `assert_wallet_pending()` for mid-flight balance checks; apply consistently across all test flows.
16. **refactor(regtest): trim verbose comments and tighten test structure** [`9ad900b2`] — Remove scaffolding comments left from development, tighten overall test file structure for readability.