### PR TITLE
Fix stale service-timeout Runnable disconnecting the shared SDK

### DIFF
--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlin.io.path.Path
 
@@ -55,6 +56,9 @@ abstract class ForegroundService :
     protected var logger: ServiceLogger = ServiceLogger()
     private var jobs: MutableList<Job> = arrayListOf()
 
+    @Volatile
+    private var destroyed = false
+
     companion object {
         private const val TAG = "ForegroundService"
     }
@@ -64,6 +68,17 @@ abstract class ForegroundService :
     // =========================================================== //
 
     override fun onBind(intent: Intent): IBinder? = null
+
+    /** Called when the service instance is destroyed. Cancels any pending delayed
+     *  callbacks so a stale timer from this (now dead) instance can't later fire and
+     *  disconnect the process-wide SDK shared with a newer instance. */
+    override fun onDestroy() {
+        destroyed = true
+        serviceTimeoutHandler.removeCallbacksAndMessages(null)
+        shutdownHandler.removeCallbacksAndMessages(null)
+        serviceScope.cancel()
+        super.onDestroy()
+    }
 
     /** Called by a Job to signal that it is complete. */
     override fun onFinished(job: Job) {
@@ -97,17 +112,25 @@ abstract class ForegroundService :
         serviceTimeoutHandler.removeCallbacksAndMessages(null)
         shutdownHandler.removeCallbacksAndMessages(null)
 
-        shutdownHandler.postDelayed(serviceTimeoutRunnable, SERVICE_TIMEOUT_MS)
+        serviceTimeoutHandler.postDelayed(serviceTimeoutRunnable, SERVICE_TIMEOUT_MS)
     }
 
     private fun delayedShutdown() {
-        if (jobs.isEmpty()) {
-            shutdownHandler.postDelayed(shutdownRunnable, SHUTDOWN_DELAY_MS)
+        synchronized(this) {
+            if (jobs.isEmpty()) {
+                shutdownHandler.postDelayed(shutdownRunnable, SHUTDOWN_DELAY_MS)
+            }
         }
     }
 
     open fun shutdown() {
+        if (destroyed) {
+            logger.log(TAG, "Ignoring shutdown; service instance already destroyed", "DEBUG")
+            return
+        }
         logger.log(TAG, "Shutting down foreground service", "DEBUG")
+        serviceTimeoutHandler.removeCallbacksAndMessages(null)
+        shutdownHandler.removeCallbacksAndMessages(null)
         cancelNotification(applicationContext, NOTIFICATION_ID_REPLACEABLE)
         shutdownSdkConnection()
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -233,7 +256,9 @@ abstract class ForegroundService :
             }
 
             liquidSDK?.let {
-                jobs.add(job)
+                synchronized(this) {
+                    jobs.add(job)
+                }
                 job.start(liquidSDK!!, getPluginConfigs())
             }
         }

--- a/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
+++ b/lib/bindings/langs/android/lib/src/main/kotlin/breez_sdk_liquid_notification/ForegroundService.kt
@@ -256,7 +256,7 @@ abstract class ForegroundService :
             }
 
             liquidSDK?.let {
-                synchronized(this) {
+                synchronized(sdkListener) {
                     jobs.add(job)
                 }
                 job.start(liquidSDK!!, getPluginConfigs())


### PR DESCRIPTION
`ForegroundService` armed a 3-minute `serviceTimeoutRunnable` on every `onStartCommand` but never cancelled it on teardown (no `onDestroy`; `shutdown()` → `stopSelf()` left it queued). Because `Handler` callbacks live on the shared main `Looper` and aren't tied to the `Service` lifecycle, a timer from a **destroyed** instance would later fire and call `shutdownSDK()` on `BreezSdkLiquidConnector` — a process-wide singleton — tearing the SDK out from under a *newer* instance mid-job. This surfaced as intermittent `Liquid SDK instance is not running` failures (e.g. the LNURL-pay info→invoice two-push sequence).

### Changes
- **`onDestroy()`**: cancel both handlers' pending callbacks and the `serviceScope`, and set a `@Volatile destroyed` flag — so a dead instance's timers/coroutines can never touch the shared connector, even on teardown paths that don't go through `shutdown()`.
- **`shutdown()`**: no-op when `destroyed`, and clear both handlers up front so one timer's shutdown cancels its sibling (kills the latent double-shutdown).
- **Handler tidy-up**: post `serviceTimeoutRunnable` on `serviceTimeoutHandler` (it was mis-posted to `shutdownHandler`, leaving that handler unused).
- **Concurrency**: guard the remaining off-main-thread `jobs` accesses (`add`, `isEmpty` check) with `synchronized(sdkListener)` to match the existing lock discipline.

[Android build](https://github.com/breez/misty-breez/actions/runs/28673250290)

Fixes #1101