### PR TITLE
Recover from a stale wallet UTXO cache

### DIFF
--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -28,10 +28,10 @@ use crate::{
     persist::Persister,
     swapper::Swapper,
     utils,
-    wallet::OnchainWallet,
+    wallet::{handle_stale_cache_broadcast_error, should_retry_after_cache_repair, OnchainWallet},
 };
 use crate::{
-    error::is_txn_mempool_conflict_error, model::DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT,
+    error::is_txn_already_spent_error, model::DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT,
     persist::model::PaymentTxBalance,
 };
 
@@ -775,21 +775,38 @@ impl ChainSwapHandler {
             lockup_details.amount, lockup_details.lockup_address
         );
 
-        let lockup_tx = self
-            .onchain_wallet
-            .build_tx_or_drain_tx(
-                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                &lockup_details.lockup_address,
-                &self.config.lbtc_asset_id().to_string(),
-                lockup_details.amount,
-            )
-            .await?;
+        // An input rejection means our cached utxo set is stale: repair it and rebuild the
+        // tx, since selection must pick different inputs. One retry; then fail fast.
+        let mut repaired_cache = false;
+        let (lockup_tx, lockup_tx_id) = loop {
+            let lockup_tx = self
+                .onchain_wallet
+                .build_tx_or_drain_tx(
+                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                    &lockup_details.lockup_address,
+                    &self.config.lbtc_asset_id().to_string(),
+                    lockup_details.amount,
+                )
+                .await?;
 
-        let lockup_tx_id = self
-            .liquid_chain_service
-            .broadcast(&lockup_tx)
-            .await?
-            .to_string();
+            match self.liquid_chain_service.broadcast(&lockup_tx).await {
+                Ok(tx_id) => break (lockup_tx, tx_id.to_string()),
+                Err(err) => {
+                    if should_retry_after_cache_repair(
+                        &*self.onchain_wallet,
+                        &err,
+                        &mut repaired_cache,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                    return Err(handle_stale_cache_broadcast_error(err));
+                }
+            }
+        };
+
+        self.onchain_wallet.apply_broadcast_tx(&lockup_tx).await;
 
         debug!(
           "Successfully broadcast lockup transaction for Chain Swap {swap_id}. Lockup tx id: {lockup_tx_id}"
@@ -918,7 +935,7 @@ impl ChainSwapHandler {
                     SdkTransaction::Liquid(tx) => {
                         match self.liquid_chain_service.broadcast(&tx).await {
                             Ok(tx_id) => Ok(tx_id.to_hex()),
-                            Err(e) if is_txn_mempool_conflict_error(&e) => {
+                            Err(e) if is_txn_already_spent_error(&e) => {
                                 Err(PaymentError::AlreadyClaimed)
                             }
                             Err(err) => {

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -28,7 +28,7 @@ use crate::{
     persist::Persister,
     swapper::Swapper,
     utils,
-    wallet::{handle_stale_cache_broadcast_error, should_retry_after_cache_repair, OnchainWallet},
+    wallet::{handle_stale_cache_broadcast_error, OnchainWallet},
 };
 use crate::{
     error::is_txn_already_spent_error, model::DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT,
@@ -775,34 +775,20 @@ impl ChainSwapHandler {
             lockup_details.amount, lockup_details.lockup_address
         );
 
-        // An input rejection means our cached utxo set is stale: repair it and rebuild the
-        // tx, since selection must pick different inputs. One retry; then fail fast.
-        let mut repaired_cache = false;
-        let (lockup_tx, lockup_tx_id) = loop {
-            let lockup_tx = self
-                .onchain_wallet
-                .build_tx_or_drain_tx(
-                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                    &lockup_details.lockup_address,
-                    &self.config.lbtc_asset_id().to_string(),
-                    lockup_details.amount,
-                )
-                .await?;
+        let lockup_tx = self
+            .onchain_wallet
+            .build_tx_or_drain_tx(
+                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                &lockup_details.lockup_address,
+                &self.config.lbtc_asset_id().to_string(),
+                lockup_details.amount,
+            )
+            .await?;
 
-            match self.liquid_chain_service.broadcast(&lockup_tx).await {
-                Ok(tx_id) => break (lockup_tx, tx_id.to_string()),
-                Err(err) => {
-                    if should_retry_after_cache_repair(
-                        &*self.onchain_wallet,
-                        &err,
-                        &mut repaired_cache,
-                    )
-                    .await?
-                    {
-                        continue;
-                    }
-                    return Err(handle_stale_cache_broadcast_error(err));
-                }
+        let lockup_tx_id = match self.liquid_chain_service.broadcast(&lockup_tx).await {
+            Ok(tx_id) => tx_id.to_string(),
+            Err(err) => {
+                return Err(handle_stale_cache_broadcast_error(&*self.onchain_wallet, err).await)
             }
         };
 

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use log::warn;
 use lwk_wollet::secp256k1;
 use sdk_common::{
     lightning_with_bolt12::offers::parse::Bolt12SemanticError,
@@ -216,7 +217,17 @@ impl From<boltz_client::bitcoin::hex::HexToArrayError> for PaymentError {
 impl From<lwk_wollet::Error> for PaymentError {
     fn from(err: lwk_wollet::Error) -> Self {
         match err {
-            lwk_wollet::Error::InsufficientFunds { .. } => PaymentError::InsufficientFunds,
+            lwk_wollet::Error::InsufficientFunds {
+                missing_sats,
+                asset_id,
+                is_token,
+            } => {
+                warn!(
+                    "lwk reported insufficient funds: missing {missing_sats} sat of asset \
+                     {asset_id}, is_token: {is_token}"
+                );
+                PaymentError::InsufficientFunds
+            }
             lwk_wollet::Error::TooManyInputs(count) => PaymentError::Generic {
                 err: format!(
                     "Transaction would require {count} inputs, which exceeds the maximum of 256 \

--- a/lib/core/src/error.rs
+++ b/lib/core/src/error.rs
@@ -337,3 +337,17 @@ impl From<PaymentError> for LnUrlWithdrawError {
 pub(crate) fn is_txn_mempool_conflict_error(err: &Error) -> bool {
     err.to_string().contains("txn-mempool-conflict")
 }
+
+/// Whether an input is absent from the node's UTXO set: already spent by a confirmed tx, or its
+/// parent never existed. Unlike [`is_txn_mempool_conflict_error`], which means we merely compete
+/// with an unconfirmed tx, this means our cached UTXO view is stale.
+pub(crate) fn is_txn_inputs_missing_or_spent_error(err: &Error) -> bool {
+    let err = err.to_string();
+    err.contains("bad-txns-inputs-missingorspent") || err.contains("missing-inputs")
+}
+
+/// Whether the output being spent is already claimed by another tx, whether that tx is in the
+/// mempool (`txn-mempool-conflict`) or confirmed (`bad-txns-inputs-missingorspent`).
+pub(crate) fn is_txn_already_spent_error(err: &Error) -> bool {
+    is_txn_mempool_conflict_error(err) || is_txn_inputs_missing_or_spent_error(err)
+}

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -13,7 +13,7 @@ use lwk_wollet::secp256k1::SecretKey;
 use tokio::sync::{broadcast, Mutex};
 
 use crate::chain::liquid::LiquidChainService;
-use crate::error::is_txn_mempool_conflict_error;
+use crate::error::is_txn_already_spent_error;
 use crate::model::{BlockListener, PaymentState::*};
 use crate::model::{Config, PaymentTxData, PaymentType, ReceiveSwap};
 use crate::persist::model::{PaymentTxBalance, PaymentTxDetails};
@@ -434,9 +434,7 @@ impl ReceiveSwapHandler {
                 // We attempt broadcasting via chain service, then fallback to Boltz
                 let broadcast_res = match self.liquid_chain_service.broadcast(&claim_tx).await {
                     Ok(tx_id) => Ok(tx_id.to_hex()),
-                    Err(e) if is_txn_mempool_conflict_error(&e) => {
-                        Err(PaymentError::AlreadyClaimed)
-                    }
+                    Err(e) if is_txn_already_spent_error(&e) => Err(PaymentError::AlreadyClaimed),
                     Err(err) => {
                         debug!(
                             "Could not broadcast claim tx via chain service for Receive swap {swap_id}: {err:?}"

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -65,10 +65,7 @@ use crate::swapper::{
 };
 use crate::utils::bolt12::encode_invoice;
 use crate::utils::run_with_shutdown;
-use crate::wallet::{
-    handle_stale_cache_broadcast_error, should_retry_after_cache_repair, LiquidOnchainWallet,
-    OnchainWallet,
-};
+use crate::wallet::{handle_stale_cache_broadcast_error, LiquidOnchainWallet, OnchainWallet};
 use crate::{
     error::{PaymentError, SdkResult},
     event::EventManager,
@@ -2079,40 +2076,27 @@ impl LiquidSdk {
             PaymentError::AlreadyPaid
         );
 
-        // Stale-cache repair and retry
-        let mut repaired_cache = false;
-        let (tx, tx_id) = loop {
-            let tx = self
-                .onchain_wallet
-                .build_tx_or_drain_tx(
-                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                    &address_data.address,
-                    &asset_id,
-                    receiver_amount_sat,
-                )
-                .await?;
-            let tx_id = tx.txid().to_string();
-            let tx_fees_sat = tx.all_fees().values().sum::<u64>();
-            ensure_sdk!(tx_fees_sat <= fees_sat, PaymentError::InvalidOrExpiredFees);
+        let tx = self
+            .onchain_wallet
+            .build_tx_or_drain_tx(
+                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                &address_data.address,
+                &asset_id,
+                receiver_amount_sat,
+            )
+            .await?;
+        let tx_id = tx.txid().to_string();
+        let tx_fees_sat = tx.all_fees().values().sum::<u64>();
+        ensure_sdk!(tx_fees_sat <= fees_sat, PaymentError::InvalidOrExpiredFees);
 
-            info!(
-                "Built onchain Liquid tx with receiver_amount_sat = {receiver_amount_sat}, fees_sat = {fees_sat} and txid = {tx_id}"
-            );
+        info!(
+            "Built onchain Liquid tx with receiver_amount_sat = {receiver_amount_sat}, fees_sat = {fees_sat} and txid = {tx_id}"
+        );
 
-            match self.liquid_chain_service.broadcast(&tx).await {
-                Ok(tx_id) => break (tx, tx_id.to_string()),
-                Err(err) => {
-                    if should_retry_after_cache_repair(
-                        &*self.onchain_wallet,
-                        &err,
-                        &mut repaired_cache,
-                    )
-                    .await?
-                    {
-                        continue;
-                    }
-                    return Err(handle_stale_cache_broadcast_error(err));
-                }
+        let tx_id = match self.liquid_chain_service.broadcast(&tx).await {
+            Ok(tx_id) => tx_id.to_string(),
+            Err(err) => {
+                return Err(handle_stale_cache_broadcast_error(&*self.onchain_wallet, err).await)
             }
         };
 
@@ -2209,26 +2193,13 @@ impl LiquidSdk {
         );
         swap.check_sufficient_balance(&self.get_info().await?.wallet_info)?;
 
-        // Stale-cache repair and retry
-        let mut repaired_cache = false;
-        let tx_id = loop {
-            match sideswap_service
-                .execute_swap(to_address.clone(), &swap)
-                .await
-            {
-                Ok(tx_id) => break tx_id,
-                Err(err) => {
-                    if should_retry_after_cache_repair(
-                        &*self.onchain_wallet,
-                        &err,
-                        &mut repaired_cache,
-                    )
-                    .await?
-                    {
-                        continue;
-                    }
-                    return Err(handle_stale_cache_broadcast_error(err));
-                }
+        let tx_id = match sideswap_service
+            .execute_swap(to_address.clone(), &swap)
+            .await
+        {
+            Ok(tx_id) => tx_id,
+            Err(err) => {
+                return Err(handle_stale_cache_broadcast_error(&*self.onchain_wallet, err).await)
             }
         };
 
@@ -2292,35 +2263,22 @@ impl LiquidSdk {
             ));
         };
 
-        // Stale-cache repair and retry; see `SendSwapHandler::try_lockup`.
-        let mut repaired_cache = false;
-        let (tx, asset_fees, fees_sat, tx_id) = loop {
-            let (tx, asset_fees) = self
-                .payjoin_service
-                .build_payjoin_tx(&address_data.address, &asset_id, receiver_amount_sat)
-                .await
-                .inspect_err(|e| error!("Error building payjoin tx: {e}"))?;
-            let tx_id = tx.txid().to_string();
-            let fees_sat = tx.all_fees().values().sum::<u64>();
+        let (tx, asset_fees) = self
+            .payjoin_service
+            .build_payjoin_tx(&address_data.address, &asset_id, receiver_amount_sat)
+            .await
+            .inspect_err(|e| error!("Error building payjoin tx: {e}"))?;
+        let tx_id = tx.txid().to_string();
+        let fees_sat = tx.all_fees().values().sum::<u64>();
 
-            info!(
-                "Built payjoin Liquid tx with receiver_amount_sat = {receiver_amount_sat}, asset_fees = {asset_fees}, fees_sat = {fees_sat} and txid = {tx_id}"
-            );
+        info!(
+            "Built payjoin Liquid tx with receiver_amount_sat = {receiver_amount_sat}, asset_fees = {asset_fees}, fees_sat = {fees_sat} and txid = {tx_id}"
+        );
 
-            match self.liquid_chain_service.broadcast(&tx).await {
-                Ok(tx_id) => break (tx, asset_fees, fees_sat, tx_id.to_string()),
-                Err(err) => {
-                    if should_retry_after_cache_repair(
-                        &*self.onchain_wallet,
-                        &err,
-                        &mut repaired_cache,
-                    )
-                    .await?
-                    {
-                        continue;
-                    }
-                    return Err(handle_stale_cache_broadcast_error(err));
-                }
+        let tx_id = match self.liquid_chain_service.broadcast(&tx).await {
+            Ok(tx_id) => tx_id.to_string(),
+            Err(err) => {
+                return Err(handle_stale_cache_broadcast_error(&*self.onchain_wallet, err).await)
             }
         };
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1275,7 +1275,10 @@ impl LiquidSdk {
             Err(PaymentError::InsufficientFunds) if asset_id.eq(&self.config.lbtc_asset_id()) => {
                 self.estimate_drain_tx_fee(Some(amount_sat), Some(address))
                     .await
-                    .map_err(|_| PaymentError::InsufficientFunds)
+                    .map_err(|e| {
+                        warn!("Drain fallback for {amount_sat} sat failed: {e}");
+                        PaymentError::InsufficientFunds
+                    })
             }
             Err(e) => Err(e),
         }

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -15,7 +15,7 @@ use futures_util::{StreamExt, TryFutureExt};
 use lnurl::auth::SdkLnurlAuthSigner;
 use log::{debug, error, info, warn};
 use lwk_wollet::bitcoin::base64::Engine as _;
-use lwk_wollet::elements::AssetId;
+use lwk_wollet::elements::{AssetId, Txid};
 use lwk_wollet::elements_miniscript::elements::bitcoin::bip32::Xpub;
 use lwk_wollet::hashes::{sha256, Hash};
 use persist::model::{PaymentTxBalance, PaymentTxDetails};
@@ -65,7 +65,10 @@ use crate::swapper::{
 };
 use crate::utils::bolt12::encode_invoice;
 use crate::utils::run_with_shutdown;
-use crate::wallet::{LiquidOnchainWallet, OnchainWallet};
+use crate::wallet::{
+    handle_stale_cache_broadcast_error, should_retry_after_cache_repair, LiquidOnchainWallet,
+    OnchainWallet,
+};
 use crate::{
     error::{PaymentError, SdkResult},
     event::EventManager,
@@ -2076,24 +2079,44 @@ impl LiquidSdk {
             PaymentError::AlreadyPaid
         );
 
-        let tx = self
-            .onchain_wallet
-            .build_tx_or_drain_tx(
-                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                &address_data.address,
-                &asset_id,
-                receiver_amount_sat,
-            )
-            .await?;
-        let tx_id = tx.txid().to_string();
-        let tx_fees_sat = tx.all_fees().values().sum::<u64>();
-        ensure_sdk!(tx_fees_sat <= fees_sat, PaymentError::InvalidOrExpiredFees);
+        // Stale-cache repair and retry
+        let mut repaired_cache = false;
+        let (tx, tx_id) = loop {
+            let tx = self
+                .onchain_wallet
+                .build_tx_or_drain_tx(
+                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                    &address_data.address,
+                    &asset_id,
+                    receiver_amount_sat,
+                )
+                .await?;
+            let tx_id = tx.txid().to_string();
+            let tx_fees_sat = tx.all_fees().values().sum::<u64>();
+            ensure_sdk!(tx_fees_sat <= fees_sat, PaymentError::InvalidOrExpiredFees);
 
-        info!(
-            "Built onchain Liquid tx with receiver_amount_sat = {receiver_amount_sat}, fees_sat = {fees_sat} and txid = {tx_id}"
-        );
+            info!(
+                "Built onchain Liquid tx with receiver_amount_sat = {receiver_amount_sat}, fees_sat = {fees_sat} and txid = {tx_id}"
+            );
 
-        let tx_id = self.liquid_chain_service.broadcast(&tx).await?.to_string();
+            match self.liquid_chain_service.broadcast(&tx).await {
+                Ok(tx_id) => break (tx, tx_id.to_string()),
+                Err(err) => {
+                    if should_retry_after_cache_repair(
+                        &*self.onchain_wallet,
+                        &err,
+                        &mut repaired_cache,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                    return Err(handle_stale_cache_broadcast_error(err));
+                }
+            }
+        };
+
+        self.onchain_wallet.apply_broadcast_tx(&tx).await;
 
         // We insert a pseudo-tx in case LWK fails to pick up the new mempool tx for a while
         // This makes the tx known to the SDK (get_info, list_payments) instantly
@@ -2186,9 +2209,41 @@ impl LiquidSdk {
         );
         swap.check_sufficient_balance(&self.get_info().await?.wallet_info)?;
 
-        let tx_id = sideswap_service
-            .execute_swap(to_address.clone(), &swap)
-            .await?;
+        // Stale-cache repair and retry
+        let mut repaired_cache = false;
+        let tx_id = loop {
+            match sideswap_service
+                .execute_swap(to_address.clone(), &swap)
+                .await
+            {
+                Ok(tx_id) => break tx_id,
+                Err(err) => {
+                    if should_retry_after_cache_repair(
+                        &*self.onchain_wallet,
+                        &err,
+                        &mut repaired_cache,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                    return Err(handle_stale_cache_broadcast_error(err));
+                }
+            }
+        };
+
+        // SideSwap completes our partial PSET with its own inputs, so fetch the tx rather than
+        // rebuild it. Best-effort: until it is indexed, the coins stay selectable as before.
+        match Txid::from_str(&tx_id) {
+            Ok(txid) => match self.liquid_chain_service.get_transaction_hex(&txid).await {
+                Ok(Some(tx)) => self.onchain_wallet.apply_broadcast_tx(&tx).await,
+                Ok(None) => {
+                    debug!("SideSwap tx {tx_id} is not retrievable yet, skipping wallet apply")
+                }
+                Err(e) => warn!("Could not fetch SideSwap tx {tx_id} to apply to the wallet: {e}"),
+            },
+            Err(e) => warn!("SideSwap returned an unparsable txid {tx_id}: {e}"),
+        }
 
         // We insert a pseudo-tx in case LWK fails to pick up the new mempool tx for a while
         // This makes the tx known to the SDK (get_info, list_payments) instantly
@@ -2237,19 +2292,39 @@ impl LiquidSdk {
             ));
         };
 
-        let (tx, asset_fees) = self
-            .payjoin_service
-            .build_payjoin_tx(&address_data.address, &asset_id, receiver_amount_sat)
-            .await
-            .inspect_err(|e| error!("Error building payjoin tx: {e}"))?;
-        let tx_id = tx.txid().to_string();
-        let fees_sat = tx.all_fees().values().sum::<u64>();
+        // Stale-cache repair and retry; see `SendSwapHandler::try_lockup`.
+        let mut repaired_cache = false;
+        let (tx, asset_fees, fees_sat, tx_id) = loop {
+            let (tx, asset_fees) = self
+                .payjoin_service
+                .build_payjoin_tx(&address_data.address, &asset_id, receiver_amount_sat)
+                .await
+                .inspect_err(|e| error!("Error building payjoin tx: {e}"))?;
+            let tx_id = tx.txid().to_string();
+            let fees_sat = tx.all_fees().values().sum::<u64>();
 
-        info!(
-            "Built payjoin Liquid tx with receiver_amount_sat = {receiver_amount_sat}, asset_fees = {asset_fees}, fees_sat = {fees_sat} and txid = {tx_id}"
-        );
+            info!(
+                "Built payjoin Liquid tx with receiver_amount_sat = {receiver_amount_sat}, asset_fees = {asset_fees}, fees_sat = {fees_sat} and txid = {tx_id}"
+            );
 
-        let tx_id = self.liquid_chain_service.broadcast(&tx).await?.to_string();
+            match self.liquid_chain_service.broadcast(&tx).await {
+                Ok(tx_id) => break (tx, asset_fees, fees_sat, tx_id.to_string()),
+                Err(err) => {
+                    if should_retry_after_cache_repair(
+                        &*self.onchain_wallet,
+                        &err,
+                        &mut repaired_cache,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                    return Err(handle_stale_cache_broadcast_error(err));
+                }
+            }
+        };
+
+        self.onchain_wallet.apply_broadcast_tx(&tx).await;
 
         // We insert a pseudo-tx in case LWK fails to pick up the new mempool tx for a while
         // This makes the tx known to the SDK (get_info, list_payments) instantly
@@ -4029,9 +4104,7 @@ impl LiquidSdk {
                         .flatten()
                         .collect::<Vec<&String>>()
                     {
-                        if let Some(tx) =
-                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
-                        {
+                        if let Some(tx) = wallet_tx_map.remove(&Txid::from_str(tx_id)?) {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
                         }
@@ -4047,9 +4120,7 @@ impl LiquidSdk {
                         .flatten()
                         .collect::<Vec<&String>>()
                     {
-                        if let Some(tx) =
-                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
-                        {
+                        if let Some(tx) = wallet_tx_map.remove(&Txid::from_str(tx_id)?) {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
                         }
@@ -4070,9 +4141,7 @@ impl LiquidSdk {
                         .flatten()
                         .collect::<Vec<&String>>()
                     {
-                        if let Some(tx) =
-                            wallet_tx_map.remove(&lwk_wollet::elements::Txid::from_str(tx_id)?)
-                        {
+                        if let Some(tx) = wallet_tx_map.remove(&Txid::from_str(tx_id)?) {
                             self.persister
                                 .insert_or_update_payment_with_wallet_tx(&tx)?;
                         }

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -23,7 +23,9 @@ use crate::prelude::{PaymentTxData, PaymentType, Swap};
 use crate::recover::recoverer::Recoverer;
 use crate::swapper::Swapper;
 use crate::utils;
-use crate::wallet::OnchainWallet;
+use crate::wallet::{
+    handle_stale_cache_broadcast_error, should_retry_after_cache_repair, OnchainWallet,
+};
 use crate::{
     error::PaymentError,
     model::{PaymentState, Transaction as SdkTransaction},
@@ -244,32 +246,50 @@ impl SendSwapHandler {
             create_response.expected_amount, create_response.address
         );
 
-        let lockup_tx = self
-            .onchain_wallet
-            .build_tx_or_drain_tx(
-                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                &create_response.address,
-                &self.config.lbtc_asset_id(),
-                create_response.expected_amount,
-            )
-            .await?;
-        let lockup_tx_id = lockup_tx.txid().to_string();
+        // An input rejection means our cached utxo set is stale: repair it and rebuild the
+        // tx, since selection must pick different inputs. One retry; then fail fast.
+        let mut repaired_cache = false;
+        let (lockup_tx, lockup_tx_id) = loop {
+            let lockup_tx = self
+                .onchain_wallet
+                .build_tx_or_drain_tx(
+                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                    &create_response.address,
+                    &self.config.lbtc_asset_id(),
+                    create_response.expected_amount,
+                )
+                .await?;
+            let lockup_tx_id = lockup_tx.txid().to_string();
 
-        self.persister
-            .set_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
-
-        info!("Broadcasting lockup tx {lockup_tx_id} for Send swap {swap_id}",);
-
-        let broadcast_result = self.chain_service.broadcast(&lockup_tx).await;
-
-        if let Err(err) = broadcast_result {
-            debug!("Could not broadcast lockup tx for Send Swap {swap_id}: {err:?}");
             self.persister
-                .unset_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
-            return Err(err.into());
-        }
+                .set_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
+
+            info!("Broadcasting lockup tx {lockup_tx_id} for Send swap {swap_id}",);
+
+            match self.chain_service.broadcast(&lockup_tx).await {
+                Ok(_) => break (lockup_tx, lockup_tx_id),
+                Err(err) => {
+                    debug!("Could not broadcast lockup tx for Send Swap {swap_id}: {err:?}");
+                    self.persister
+                        .unset_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
+
+                    if should_retry_after_cache_repair(
+                        &*self.onchain_wallet,
+                        &err,
+                        &mut repaired_cache,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                    return Err(handle_stale_cache_broadcast_error(err));
+                }
+            }
+        };
 
         info!("Successfully broadcast lockup tx for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}");
+
+        self.onchain_wallet.apply_broadcast_tx(&lockup_tx).await;
 
         // We insert a pseudo-lockup-tx in case LWK fails to pick up the new mempool tx for a while
         // This makes the tx known to the SDK (get_info, list_payments) instantly
@@ -620,19 +640,132 @@ impl SendSwapHandler {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
 
     use anyhow::Result;
 
     use crate::{
         model::PaymentState::{self, *},
         test_utils::{
+            chain::MockLiquidChainService,
             persist::{create_persister, new_send_swap},
-            send_swap::new_send_swap_handler,
+            send_swap::{new_mock_wallet, new_send_swap_handler, new_send_swap_handler_with_mocks},
         },
     };
 
     #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    /// The verbatim rejection observed in the field: the node does not have the input the
+    /// lockup tx spends, because the SDK's cached UTXO set is stale.
+    const MISSING_OR_SPENT_ERR: &str = r#"https://lq1.breez.technology/liquid/api/tx returned HTTP 400: sendrawtransaction RPC error: {"code":-25,"message":"bad-txns-inputs-missingorspent"}"#;
+
+    /// When the cached utxo set is stale but the tx set can explain it, the repair is local and
+    /// instant, so the lockup is rebuilt with fresh inputs and retried within the same call.
+    #[sdk_macros::async_test_all]
+    async fn test_try_lockup_repairs_cache_locally_and_retries() -> Result<()> {
+        create_persister!(storage);
+
+        let chain_service = Arc::new(MockLiquidChainService::new());
+        chain_service.set_broadcast_results(vec![Some(MISSING_OR_SPENT_ERR.to_string()), None]);
+        let onchain_wallet = new_mock_wallet()?;
+        onchain_wallet.set_repair_cache_succeeds(true);
+
+        let send_swap_handler = new_send_swap_handler_with_mocks(
+            storage.clone(),
+            chain_service.clone(),
+            onchain_wallet.clone(),
+        )?;
+
+        let swap = new_send_swap(Some(Created), None);
+        storage.insert_or_update_send_swap(&swap)?;
+        let create_response = swap.get_boltz_create_response()?;
+
+        let res = send_swap_handler.try_lockup(&swap, &create_response).await;
+
+        assert!(res.is_ok(), "expected recovery, got: {:?}", res.err());
+        assert_eq!(onchain_wallet.repair_cache_calls(), 1);
+        assert_eq!(
+            chain_service.broadcast_calls(),
+            2,
+            "expected exactly one retry"
+        );
+
+        let swap = storage.fetch_send_swap_by_id(&swap.id)?.unwrap();
+        assert_eq!(swap.state, Pending);
+        assert!(swap.lockup_tx_id.is_some());
+
+        Ok(())
+    }
+
+    /// When the local repair cannot resolve the drift, the payment fails fast and the cache is
+    /// flagged so the next background scan rescans — the rescan must not stall this call.
+    #[sdk_macros::async_test_all]
+    async fn test_try_lockup_fails_fast_when_local_repair_insufficient() -> Result<()> {
+        create_persister!(storage);
+
+        let chain_service = Arc::new(MockLiquidChainService::new());
+        chain_service.set_broadcast_results(vec![Some(MISSING_OR_SPENT_ERR.to_string())]);
+        let onchain_wallet = new_mock_wallet()?;
+        onchain_wallet.set_repair_cache_succeeds(false);
+
+        let send_swap_handler = new_send_swap_handler_with_mocks(
+            storage.clone(),
+            chain_service.clone(),
+            onchain_wallet.clone(),
+        )?;
+
+        let swap = new_send_swap(Some(Created), None);
+        storage.insert_or_update_send_swap(&swap)?;
+        let create_response = swap.get_boltz_create_response()?;
+
+        assert!(send_swap_handler
+            .try_lockup(&swap, &create_response)
+            .await
+            .is_err());
+        assert_eq!(onchain_wallet.repair_cache_calls(), 1);
+        assert_eq!(
+            chain_service.broadcast_calls(),
+            1,
+            "no retry without a repair"
+        );
+        // Flagging for a rescan is internal to `repair_cache`; what is observable here is
+        // that the payment fails without stalling.
+
+        let swap = storage.fetch_send_swap_by_id(&swap.id)?.unwrap();
+        assert_eq!(swap.state, Created);
+        assert!(swap.lockup_tx_id.is_none());
+
+        Ok(())
+    }
+
+    /// An unrelated broadcast failure must not be mistaken for a stale cache.
+    #[sdk_macros::async_test_all]
+    async fn test_try_lockup_does_not_repair_on_unrelated_error() -> Result<()> {
+        create_persister!(storage);
+
+        let chain_service = Arc::new(MockLiquidChainService::new());
+        chain_service.set_broadcast_results(vec![Some("connection reset by peer".to_string())]);
+        let onchain_wallet = new_mock_wallet()?;
+
+        let send_swap_handler = new_send_swap_handler_with_mocks(
+            storage.clone(),
+            chain_service.clone(),
+            onchain_wallet.clone(),
+        )?;
+
+        let swap = new_send_swap(Some(Created), None);
+        storage.insert_or_update_send_swap(&swap)?;
+        let create_response = swap.get_boltz_create_response()?;
+
+        assert!(send_swap_handler
+            .try_lockup(&swap, &create_response)
+            .await
+            .is_err());
+        assert_eq!(onchain_wallet.repair_cache_calls(), 0);
+
+        Ok(())
+    }
 
     #[sdk_macros::async_test_all]
     async fn test_send_swap_state_transitions() -> Result<()> {

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -23,9 +23,7 @@ use crate::prelude::{PaymentTxData, PaymentType, Swap};
 use crate::recover::recoverer::Recoverer;
 use crate::swapper::Swapper;
 use crate::utils;
-use crate::wallet::{
-    handle_stale_cache_broadcast_error, should_retry_after_cache_repair, OnchainWallet,
-};
+use crate::wallet::{handle_stale_cache_broadcast_error, OnchainWallet};
 use crate::{
     error::PaymentError,
     model::{PaymentState, Transaction as SdkTransaction},
@@ -246,46 +244,28 @@ impl SendSwapHandler {
             create_response.expected_amount, create_response.address
         );
 
-        // An input rejection means our cached utxo set is stale: repair it and rebuild the
-        // tx, since selection must pick different inputs. One retry; then fail fast.
-        let mut repaired_cache = false;
-        let (lockup_tx, lockup_tx_id) = loop {
-            let lockup_tx = self
-                .onchain_wallet
-                .build_tx_or_drain_tx(
-                    Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
-                    &create_response.address,
-                    &self.config.lbtc_asset_id(),
-                    create_response.expected_amount,
-                )
-                .await?;
-            let lockup_tx_id = lockup_tx.txid().to_string();
+        let lockup_tx = self
+            .onchain_wallet
+            .build_tx_or_drain_tx(
+                Some(LIQUID_FEE_RATE_MSAT_PER_VBYTE),
+                &create_response.address,
+                &self.config.lbtc_asset_id(),
+                create_response.expected_amount,
+            )
+            .await?;
+        let lockup_tx_id = lockup_tx.txid().to_string();
 
+        self.persister
+            .set_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
+
+        info!("Broadcasting lockup tx {lockup_tx_id} for Send swap {swap_id}",);
+
+        if let Err(err) = self.chain_service.broadcast(&lockup_tx).await {
+            debug!("Could not broadcast lockup tx for Send Swap {swap_id}: {err:?}");
             self.persister
-                .set_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
-
-            info!("Broadcasting lockup tx {lockup_tx_id} for Send swap {swap_id}",);
-
-            match self.chain_service.broadcast(&lockup_tx).await {
-                Ok(_) => break (lockup_tx, lockup_tx_id),
-                Err(err) => {
-                    debug!("Could not broadcast lockup tx for Send Swap {swap_id}: {err:?}");
-                    self.persister
-                        .unset_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
-
-                    if should_retry_after_cache_repair(
-                        &*self.onchain_wallet,
-                        &err,
-                        &mut repaired_cache,
-                    )
-                    .await?
-                    {
-                        continue;
-                    }
-                    return Err(handle_stale_cache_broadcast_error(err));
-                }
-            }
-        };
+                .unset_send_swap_lockup_tx_id(swap_id, &lockup_tx_id)?;
+            return Err(handle_stale_cache_broadcast_error(&*self.onchain_wallet, err).await);
+        }
 
         info!("Successfully broadcast lockup tx for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}");
 
@@ -660,16 +640,15 @@ mod tests {
     /// lockup tx spends, because the SDK's cached UTXO set is stale.
     const MISSING_OR_SPENT_ERR: &str = r#"https://lq1.breez.technology/liquid/api/tx returned HTTP 400: sendrawtransaction RPC error: {"code":-25,"message":"bad-txns-inputs-missingorspent"}"#;
 
-    /// When the cached utxo set is stale but the tx set can explain it, the repair is local and
-    /// instant, so the lockup is rebuilt with fresh inputs and retried within the same call.
+    /// A stale-input rejection must repair the cache on the way out, so the next attempt sees a
+    /// corrected utxo set. The payment itself still fails: the repair is not a retry.
     #[sdk_macros::async_test_all]
-    async fn test_try_lockup_repairs_cache_locally_and_retries() -> Result<()> {
+    async fn test_try_lockup_repairs_cache_on_missing_or_spent_inputs() -> Result<()> {
         create_persister!(storage);
 
         let chain_service = Arc::new(MockLiquidChainService::new());
-        chain_service.set_broadcast_results(vec![Some(MISSING_OR_SPENT_ERR.to_string()), None]);
+        chain_service.set_broadcast_results(vec![Some(MISSING_OR_SPENT_ERR.to_string())]);
         let onchain_wallet = new_mock_wallet()?;
-        onchain_wallet.set_repair_cache_succeeds(true);
 
         let send_swap_handler = new_send_swap_handler_with_mocks(
             storage.clone(),
@@ -683,58 +662,24 @@ mod tests {
 
         let res = send_swap_handler.try_lockup(&swap, &create_response).await;
 
-        assert!(res.is_ok(), "expected recovery, got: {:?}", res.err());
-        assert_eq!(onchain_wallet.repair_cache_calls(), 1);
+        assert!(res.is_err(), "the payment surfaces the failure");
         assert_eq!(
-            chain_service.broadcast_calls(),
-            2,
-            "expected exactly one retry"
+            onchain_wallet.repair_cache_calls(),
+            1,
+            "the cache must be repaired so the next attempt is not doomed"
         );
-
-        let swap = storage.fetch_send_swap_by_id(&swap.id)?.unwrap();
-        assert_eq!(swap.state, Pending);
-        assert!(swap.lockup_tx_id.is_some());
-
-        Ok(())
-    }
-
-    /// When the local repair cannot resolve the drift, the payment fails fast and the cache is
-    /// flagged so the next background scan rescans — the rescan must not stall this call.
-    #[sdk_macros::async_test_all]
-    async fn test_try_lockup_fails_fast_when_local_repair_insufficient() -> Result<()> {
-        create_persister!(storage);
-
-        let chain_service = Arc::new(MockLiquidChainService::new());
-        chain_service.set_broadcast_results(vec![Some(MISSING_OR_SPENT_ERR.to_string())]);
-        let onchain_wallet = new_mock_wallet()?;
-        onchain_wallet.set_repair_cache_succeeds(false);
-
-        let send_swap_handler = new_send_swap_handler_with_mocks(
-            storage.clone(),
-            chain_service.clone(),
-            onchain_wallet.clone(),
-        )?;
-
-        let swap = new_send_swap(Some(Created), None);
-        storage.insert_or_update_send_swap(&swap)?;
-        let create_response = swap.get_boltz_create_response()?;
-
-        assert!(send_swap_handler
-            .try_lockup(&swap, &create_response)
-            .await
-            .is_err());
-        assert_eq!(onchain_wallet.repair_cache_calls(), 1);
         assert_eq!(
             chain_service.broadcast_calls(),
             1,
-            "no retry without a repair"
+            "the repair is not a retry: selection would reuse the stale utxos"
         );
-        // Flagging for a rescan is internal to `repair_cache`; what is observable here is
-        // that the payment fails without stalling.
 
         let swap = storage.fetch_send_swap_by_id(&swap.id)?.unwrap();
         assert_eq!(swap.state, Created);
-        assert!(swap.lockup_tx_id.is_none());
+        assert!(
+            swap.lockup_tx_id.is_none(),
+            "the lockup slot must be released so the swap stays retriable"
+        );
 
         Ok(())
     }

--- a/lib/core/src/test_utils/chain.rs
+++ b/lib/core/src/test_utils/chain.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::sync::Mutex;
 
 use crate::{
@@ -20,6 +21,10 @@ use crate::{
 #[derive(Default)]
 pub(crate) struct MockLiquidChainService {
     history: Mutex<Vec<LBtcHistory>>,
+    /// Scripted outcomes for the next `broadcast` calls, consumed front to back.
+    /// `Some(err)` fails with that message, `None` succeeds. Calls beyond the script succeed.
+    broadcast_results: Mutex<VecDeque<Option<String>>>,
+    broadcast_calls: Mutex<usize>,
 }
 
 impl MockLiquidChainService {
@@ -35,6 +40,17 @@ impl MockLiquidChainService {
     pub(crate) fn get_history(&self) -> Vec<LBtcHistory> {
         self.history.lock().unwrap().clone()
     }
+
+    /// Scripts the outcome of the next `broadcast` calls. See [`Self::broadcast_results`].
+    pub(crate) fn set_broadcast_results(&self, results: Vec<Option<String>>) -> &Self {
+        *self.broadcast_results.lock().unwrap() = results.into();
+        self
+    }
+
+    /// How many times `broadcast` has been called.
+    pub(crate) fn broadcast_calls(&self) -> usize {
+        *self.broadcast_calls.lock().unwrap()
+    }
 }
 
 #[sdk_macros::async_trait]
@@ -44,6 +60,10 @@ impl LiquidChainService for MockLiquidChainService {
     }
 
     async fn broadcast(&self, tx: &elements::Transaction) -> Result<elements::Txid> {
+        *self.broadcast_calls.lock().unwrap() += 1;
+        if let Some(Some(err)) = self.broadcast_results.lock().unwrap().pop_front() {
+            return Err(anyhow::anyhow!(err));
+        }
         Ok(tx.txid())
     }
 

--- a/lib/core/src/test_utils/send_swap.rs
+++ b/lib/core/src/test_utils/send_swap.rs
@@ -15,14 +15,31 @@ use super::{
     wallet::{MockSigner, MockWallet},
 };
 
+pub(crate) fn new_mock_wallet() -> Result<Arc<MockWallet>> {
+    let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
+    Ok(Arc::new(MockWallet::new(signer)?))
+}
+
 pub(crate) fn new_send_swap_handler(
     persister: std::sync::Arc<Persister>,
 ) -> Result<SendSwapHandler> {
+    new_send_swap_handler_with_mocks(
+        persister,
+        Arc::new(MockLiquidChainService::new()),
+        new_mock_wallet()?,
+    )
+}
+
+/// Same as [`new_send_swap_handler`], but lets the caller keep handles on the chain service used
+/// for broadcasting and on the wallet, so their behaviour can be scripted and asserted on.
+pub(crate) fn new_send_swap_handler_with_mocks(
+    persister: std::sync::Arc<Persister>,
+    chain_service: Arc<MockLiquidChainService>,
+    onchain_wallet: Arc<MockWallet>,
+) -> Result<SendSwapHandler> {
     let config = Config::regtest_esplora();
     let signer: Arc<Box<dyn Signer>> = Arc::new(Box::new(MockSigner::new()?));
-    let onchain_wallet = Arc::new(MockWallet::new(signer.clone())?);
     let swapper = Arc::new(MockSwapper::default());
-    let chain_service = Arc::new(MockLiquidChainService::new());
     let liquid_chain_service = Arc::new(MockLiquidChainService::new());
     let bitcoin_chain_service = Arc::new(MockBitcoinChainService::new());
     let recoverer = Arc::new(Recoverer::new(

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -29,6 +29,9 @@ use lwk_wollet::{
 pub(crate) struct MockWallet {
     signer: SdkLwkSigner,
     utxos: Mutex<Vec<WalletTxOut>>,
+    repair_cache_calls: Mutex<usize>,
+    /// What [`OnchainWallet::repair_cache`] should report.
+    repair_cache_succeeds: Mutex<bool>,
 }
 
 lazy_static! {
@@ -43,11 +46,24 @@ impl MockWallet {
         Ok(Self {
             signer,
             utxos: Mutex::new(vec![]),
+            repair_cache_calls: Mutex::new(0),
+            repair_cache_succeeds: Mutex::new(true),
         })
     }
 
     pub(crate) fn set_utxos(&self, utxos: Vec<WalletTxOut>) -> &Self {
         *self.utxos.lock().unwrap() = utxos;
+        self
+    }
+
+    /// How many times a local cache repair has been attempted.
+    pub(crate) fn repair_cache_calls(&self) -> usize {
+        *self.repair_cache_calls.lock().unwrap()
+    }
+
+    /// Sets whether a local cache repair reports success.
+    pub(crate) fn set_repair_cache_succeeds(&self, succeeds: bool) -> &Self {
+        *self.repair_cache_succeeds.lock().unwrap() = succeeds;
         self
     }
 }
@@ -129,6 +145,13 @@ impl OnchainWallet for MockWallet {
 
     async fn full_scan(&self) -> Result<(), PaymentError> {
         Ok(())
+    }
+
+    async fn apply_broadcast_tx(&self, _tx: &Transaction) {}
+
+    async fn repair_cache(&self) -> Result<bool, PaymentError> {
+        *self.repair_cache_calls.lock().unwrap() += 1;
+        Ok(*self.repair_cache_succeeds.lock().unwrap())
     }
 }
 

--- a/lib/core/src/test_utils/wallet.rs
+++ b/lib/core/src/test_utils/wallet.rs
@@ -30,8 +30,6 @@ pub(crate) struct MockWallet {
     signer: SdkLwkSigner,
     utxos: Mutex<Vec<WalletTxOut>>,
     repair_cache_calls: Mutex<usize>,
-    /// What [`OnchainWallet::repair_cache`] should report.
-    repair_cache_succeeds: Mutex<bool>,
 }
 
 lazy_static! {
@@ -47,7 +45,6 @@ impl MockWallet {
             signer,
             utxos: Mutex::new(vec![]),
             repair_cache_calls: Mutex::new(0),
-            repair_cache_succeeds: Mutex::new(true),
         })
     }
 
@@ -59,12 +56,6 @@ impl MockWallet {
     /// How many times a local cache repair has been attempted.
     pub(crate) fn repair_cache_calls(&self) -> usize {
         *self.repair_cache_calls.lock().unwrap()
-    }
-
-    /// Sets whether a local cache repair reports success.
-    pub(crate) fn set_repair_cache_succeeds(&self, succeeds: bool) -> &Self {
-        *self.repair_cache_succeeds.lock().unwrap() = succeeds;
-        self
     }
 }
 
@@ -151,7 +142,7 @@ impl OnchainWallet for MockWallet {
 
     async fn repair_cache(&self) -> Result<bool, PaymentError> {
         *self.repair_cache_calls.lock().unwrap() += 1;
-        Ok(*self.repair_cache_succeeds.lock().unwrap())
+        Ok(true)
     }
 }
 

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -1230,6 +1230,93 @@ mod tests {
         }
     }
 
+    /// A tx paying `sats` of the policy asset to `script`, plus the secrets it unblinds with.
+    ///
+    /// Unlike [`tx_paying`], the commitments are real and consistent with the secrets. The cache
+    /// tests can leave them `Default::default()` because `extend_unblinded` does no crypto, but
+    /// anything that *builds* a tx blinds and proves against them, so they have to be genuine.
+    fn confidential_tx_paying(
+        script: &lwk_wollet::elements::Script,
+        policy_asset: AssetId,
+        sats: u64,
+        seed: u8,
+    ) -> (Transaction, TxOutSecrets) {
+        use lwk_wollet::elements::confidential::{Asset, Nonce, Value};
+        use lwk_wollet::elements::secp256k1_zkp;
+
+        let secp = secp256k1_zkp::Secp256k1::new();
+        let asset_bf = AssetBlindingFactor::from_slice(&[seed | 0x01; 32]).unwrap();
+        let value_bf = ValueBlindingFactor::from_slice(&[seed | 0x40; 32]).unwrap();
+        let asset_gen = secp256k1_zkp::Generator::new_blinded(
+            &secp,
+            policy_asset.into_tag(),
+            asset_bf.into_inner(),
+        );
+        let value_commit =
+            secp256k1_zkp::PedersenCommitment::new(&secp, sats, value_bf.into_inner(), asset_gen);
+
+        let tx = Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: vec![],
+            output: vec![lwk_wollet::elements::TxOut {
+                asset: Asset::Confidential(asset_gen),
+                value: Value::Confidential(value_commit),
+                nonce: Nonce::Null,
+                script_pubkey: script.clone(),
+                witness: Default::default(),
+            }],
+        };
+        let secrets = TxOutSecrets {
+            asset: policy_asset,
+            value: sats,
+            asset_bf,
+            value_bf,
+        };
+        (tx, secrets)
+    }
+
+    /// Credits the wallet a spendable confirmed utxo of `sats`, returning its outpoint.
+    fn fund(
+        w: &mut Wollet,
+        script: &lwk_wollet::elements::Script,
+        sats: u64,
+        seed: u8,
+    ) -> Result<OutPoint> {
+        use lwk_wollet::clients::LastUnused;
+        use lwk_wollet::elements::bitcoin::bip32::ChildNumber;
+        use lwk_wollet::{DownloadTxResult, Update};
+
+        let (tx, secrets) = confidential_tx_paying(script, w.policy_asset(), sats, seed);
+        let txid = tx.txid();
+        let outpoint = OutPoint::new(txid, 0);
+        let wollet_status = w.status();
+        w.apply_update(Update {
+            version: 4,
+            wollet_status,
+            new_txs: DownloadTxResult {
+                txs: vec![(txid, tx)],
+                unblinds: vec![(outpoint, secrets)],
+            },
+            txid_height_new: vec![(txid, Some(1))],
+            txid_height_delete: vec![],
+            timestamps: vec![(1, 1)],
+            scripts_with_blinding_pubkey: vec![(
+                Chain::External,
+                ChildNumber::from_normal_idx(0)?,
+                script.clone(),
+                None,
+            )],
+            tip: default_tip(),
+            unspent: vec![],
+            last_unused: LastUnused {
+                internal: 0,
+                external: 1,
+            },
+        })?;
+        Ok(outpoint)
+    }
+
     fn tx_spending(outpoint: OutPoint) -> Transaction {
         Transaction {
             version: 2,
@@ -1437,6 +1524,143 @@ mod tests {
         let w = wallet.wallet.lock().await;
         assert!(!has_utxo(&w, first_outpoint)?);
         assert!(find_spent_utxos(&w.transactions()?, &w.utxos()?).is_empty());
+        Ok(())
+    }
+
+    /// Drain hands the whole job to lwk's `drain_lbtc_wallet()` and never consults
+    /// `select_wallet_utxos`, so it must keep spending every utxo regardless of what our own
+    /// coin selection would have picked.
+    #[sdk_macros::async_test_all]
+    async fn test_build_drain_tx_spends_every_utxo() -> Result<()> {
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+
+        let (script, recipient) = {
+            let w = wallet.wallet.lock().await;
+            (
+                descriptor_script(&w)?,
+                w.address(Some(1))?.address().clone(),
+            )
+        };
+
+        // A spread that our own selector would never take whole: a 21 sat send would pick one.
+        let funded = {
+            let mut w = wallet.wallet.lock().await;
+            let outpoints = [
+                fund(&mut w, &script, 100_000, 1)?,
+                fund(&mut w, &script, 50_000, 2)?,
+                fund(&mut w, &script, 25_000, 3)?,
+            ];
+            assert_eq!(w.utxos()?.len(), 3, "wallet should hold the 3 funded utxos");
+            outpoints
+        };
+
+        let tx = wallet
+            .build_drain_tx(None, &recipient.to_string(), None)
+            .await?;
+
+        assert_eq!(
+            tx.input.len(),
+            funded.len(),
+            "a drain must spend every utxo, not a selected subset"
+        );
+        for outpoint in funded {
+            assert!(
+                tx.input.iter().any(|i| i.previous_output == outpoint),
+                "drain tx is missing utxo {outpoint}"
+            );
+        }
+        // The drain output reuses the change slot, so there is no third output to change into.
+        assert_eq!(tx.output.len(), 2, "expected the drain output and the fee");
+        let fee = tx.output.iter().find(|o| o.is_fee()).expect("a fee output");
+        assert!(
+            fee.value.explicit().is_some_and(|sats| sats > 0),
+            "the fee must be explicit and non-zero, so the tx actually balanced"
+        );
+
+        // Contrast: an ordinary send of the same funds goes through `select_wallet_utxos` and
+        // takes a subset. Without this the drain assertion would pass on any built tx.
+        let ordinary = wallet
+            .build_tx(
+                None,
+                &recipient.to_string(),
+                &wallet.config.lbtc_asset_id(),
+                1_000,
+            )
+            .await?;
+        assert!(
+            ordinary.input.len() < funded.len(),
+            "a 1000 sat send should select a subset, got {} of {} inputs",
+            ordinary.input.len(),
+            funded.len()
+        );
+        Ok(())
+    }
+
+    /// `enforce_amount_sat` is the branch `build_tx_or_drain_tx` falls back to when an ordinary
+    /// send cannot be built, and it only passes when the drained amount matches exactly. Getting
+    /// the arithmetic wrong turns an unbuildable tx into a bare "not enough funds".
+    #[sdk_macros::async_test_all]
+    async fn test_build_drain_tx_enforces_the_exact_amount() -> Result<()> {
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+
+        let (script, recipient) = {
+            let w = wallet.wallet.lock().await;
+            (
+                descriptor_script(&w)?,
+                w.address(Some(1))?.address().clone(),
+            )
+        };
+        let total = 175_000;
+        {
+            let mut w = wallet.wallet.lock().await;
+            fund(&mut w, &script, 100_000, 1)?;
+            fund(&mut w, &script, 50_000, 2)?;
+            fund(&mut w, &script, 25_000, 3)?;
+        }
+        let recipient = recipient.to_string();
+
+        // Learn the fee from an unconstrained drain, so the expected amount is derived rather
+        // than hardcoded to a fee model that may change.
+        let fee = wallet
+            .build_drain_tx(None, &recipient, None)
+            .await?
+            .output
+            .iter()
+            .find(|o| o.is_fee())
+            .and_then(|o| o.value.explicit())
+            .expect("an explicit fee output");
+        let drained = total - fee;
+
+        wallet
+            .build_drain_tx(None, &recipient, Some(drained))
+            .await
+            .unwrap_or_else(|e| {
+                panic!("enforcing the actual drained amount {drained} failed: {e}")
+            });
+
+        // Off by one in either direction must be rejected, not silently drained.
+        for wrong in [drained - 1, drained + 1] {
+            let err = match wallet.build_drain_tx(None, &recipient, Some(wrong)).await {
+                // Report the txid rather than the tx, which Debug-prints every rangeproof.
+                Ok(tx) => panic!(
+                    "enforcing {wrong} must fail, but it built {} draining {drained}",
+                    tx.txid()
+                ),
+                Err(e) => e,
+            };
+            assert!(
+                err.to_string().contains("doesn't match enforce_amount_sat"),
+                "expected an enforce mismatch for {wrong}, got: {err}"
+            );
+        }
         Ok(())
     }
 

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod utxo_select;
 use std::collections::HashMap;
 use std::io::Write;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
@@ -110,6 +111,50 @@ pub trait OnchainWallet: Send + Sync {
 
     /// Perform a full scan of the wallet
     async fn full_scan(&self) -> Result<(), PaymentError>;
+
+    /// Records a just-broadcast tx so the coins it spends stop being selectable before the next
+    /// scan sees them; without this a second payment re-selects them and is rejected.
+    async fn apply_broadcast_tx(&self, tx: &Transaction);
+
+    /// Repairs the cached unspent set locally, with no network access, by re-applying the txs
+    /// the wallet already holds that spend outputs still listed as unspent.
+    ///
+    /// Returns whether the cache is consistent afterwards. If not, the wallet flags itself so the
+    /// next scan wipes and rescans.
+    async fn repair_cache(&self) -> Result<bool, PaymentError>;
+}
+
+/// Runs the local repair and reports whether the caller should rebuild its tx and broadcast
+/// again. The tx must be *rebuilt*, not re-broadcast: selection has to pick different inputs.
+///
+/// Retries at most once — the caller owns `already_repaired`. False means the repair could not
+/// resolve the drift, leaving the caller to fail via [`handle_stale_cache_broadcast_error`].
+pub(crate) async fn should_retry_after_cache_repair(
+    onchain_wallet: &dyn OnchainWallet,
+    err: &anyhow::Error,
+    already_repaired: &mut bool,
+) -> Result<bool, PaymentError> {
+    if *already_repaired || !crate::error::is_txn_inputs_missing_or_spent_error(err) {
+        return Ok(false);
+    }
+    *already_repaired = true;
+    let repaired = onchain_wallet.repair_cache().await?;
+    if repaired {
+        info!("Wallet cache repaired locally, retrying the broadcast with fresh inputs");
+    }
+    Ok(repaired)
+}
+
+/// Maps a stale-cache broadcast rejection to an actionable error. The wipe is left to the next
+/// scan (a cold rescan takes minutes and must not stall a payment), and the wallet has already
+/// flagged itself inside [`OnchainWallet::repair_cache`].
+pub(crate) fn handle_stale_cache_broadcast_error(err: anyhow::Error) -> PaymentError {
+    if !crate::error::is_txn_inputs_missing_or_spent_error(&err) {
+        return err.into();
+    }
+    PaymentError::Generic {
+        err: format!("Wallet state was out of date, please retry shortly: {err}"),
+    }
 }
 
 pub enum WalletClient {
@@ -188,6 +233,39 @@ pub struct LiquidOnchainWallet {
     client: Mutex<Option<WalletClient>>,
     pub(crate) signer: SdkLwkSigner,
     wallet_cache_persister: Arc<dyn WalletCachePersister>,
+    /// Whether the next scan should verify the cached unspent set.
+    needs_cache_check: AtomicBool,
+    /// Whether the next scan must wipe the cache first, because a local repair could not fix it.
+    needs_cache_clear: AtomicBool,
+    /// Whether a wipe-and-rescan is running. It holds the wallet lock for a cold rescan, so tx
+    /// building checks this first to fail fast rather than block for minutes.
+    recovery_scan_in_progress: AtomicBool,
+}
+
+/// Clears an [`AtomicBool`] on drop, so the flag is released even on an early return.
+struct FlagGuard<'a>(&'a AtomicBool);
+
+impl Drop for FlagGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Outpoints still listed as unspent despite being spent by a tx the wallet already knows about.
+///
+/// lwk enforced this on every `utxos()` call before the unspent set became materialised state
+/// (`RawCache::spent()`). A violation is permanent without a wipe: selection is deterministic, so
+/// it keeps picking the same spent coin and every broadcast is rejected.
+pub(crate) fn find_spent_utxos(txs: &[WalletTx], utxos: &[WalletTxOut]) -> Vec<OutPoint> {
+    let spent: std::collections::HashSet<OutPoint> = txs
+        .iter()
+        .flat_map(|wtx| wtx.tx.input.iter().map(|i| i.previous_output))
+        .collect();
+    utxos
+        .iter()
+        .map(|u| u.outpoint)
+        .filter(|o| spent.contains(o))
+        .collect()
 }
 
 impl LiquidOnchainWallet {
@@ -212,7 +290,41 @@ impl LiquidOnchainWallet {
             client: Mutex::new(None),
             signer,
             wallet_cache_persister,
+            // Check on startup, so a cache corrupted in a previous session is repaired before a
+            // payment discovers it.
+            needs_cache_check: AtomicBool::new(true),
+            needs_cache_clear: AtomicBool::new(false),
+            recovery_scan_in_progress: AtomicBool::new(false),
         })
+    }
+
+    /// Verifies the cached unspent set against the tx set and repairs any drift. Cheap and
+    /// local; only a repair costs anything. Runs after a scan, never during one.
+    async fn check_and_repair_cache(&self) -> Result<(), PaymentError> {
+        if !self.needs_cache_check.swap(false, Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let spent = {
+            let wallet = self.wallet.lock().await;
+            let txs = wallet.transactions()?;
+            let utxos = wallet.utxos()?;
+            find_spent_utxos(&txs, &utxos)
+        };
+
+        if spent.is_empty() {
+            debug!("Wallet cache check: no utxo is spent by a known tx");
+            return Ok(());
+        }
+
+        error!(
+            "Wallet cache is inconsistent: {} utxo(s) are already spent by known txs. {spent:?}",
+            spent.len()
+        );
+
+        // The local repair usually suffices; if not it schedules a wipe for the next scan.
+        self.repair_cache().await?;
+        Ok(())
     }
 
     async fn create_wallet(
@@ -440,6 +552,12 @@ impl OnchainWallet for LiquidOnchainWallet {
         asset_id: &str,
         amount_sat: u64,
     ) -> Result<Transaction, PaymentError> {
+        ensure_sdk!(
+            !self.recovery_scan_in_progress.load(Ordering::Relaxed),
+            PaymentError::Generic {
+                err: "Wallet state is being repaired, please retry shortly".to_string()
+            }
+        );
         let lwk_wollet = self.wallet.lock().await;
         let address =
             ElementsAddress::from_str(recipient_address).map_err(|e| PaymentError::Generic {
@@ -507,6 +625,12 @@ impl OnchainWallet for LiquidOnchainWallet {
         recipient_address: &str,
         enforce_amount_sat: Option<u64>,
     ) -> Result<Transaction, PaymentError> {
+        ensure_sdk!(
+            !self.recovery_scan_in_progress.load(Ordering::Relaxed),
+            PaymentError::Generic {
+                err: "Wallet state is being repaired, please retry shortly".to_string()
+            }
+        );
         let lwk_wollet = self.wallet.lock().await;
 
         let address =
@@ -662,73 +786,166 @@ impl OnchainWallet for LiquidOnchainWallet {
 
     /// Perform a full scan of the wallet
     async fn full_scan(&self) -> Result<(), PaymentError> {
-        debug!("LiquidOnchainWallet::full_scan: start");
-        let full_scan_started = Instant::now();
-
-        // create electrum client if doesn't already exist
-        let mut client = self.client.lock().await;
-        if client.is_none() {
-            *client = Some(WalletClient::from_config(&self.config)?);
-        }
-        let client = client.as_mut().ok_or_else(|| PaymentError::Generic {
-            err: "Wallet client not initialized".to_string(),
-        })?;
-
-        // Use the cached derivation index with a buffer of 5 to perform the scan
-        let last_derivation_index = self
-            .persister
-            .get_last_derivation_index()?
-            .unwrap_or_default();
-        let index_with_buffer = last_derivation_index + 5;
-        let mut wallet = self.wallet.lock().await;
-
-        // Reunblind the wallet txs if there has been a change in the derivation index since the
-        // last full scan
-        if self
-            .persister
-            .get_last_scanned_derivation_index()?
-            .is_some_and(|index| index != last_derivation_index)
+        // Scoped so the wallet and client locks drop before the repair re-acquires them.
         {
-            debug!("LiquidOnchainWallet::full_scan: reunblinding all transactions");
-            wallet.reunblind()?;
-        }
+            debug!("LiquidOnchainWallet::full_scan: start");
+            let full_scan_started = Instant::now();
 
-        let res = match client
-            .full_scan_to_index(&mut wallet, index_with_buffer)
-            .await
-        {
-            Ok(()) => Ok(()),
-            Err(e)
-                if matches!(
-                    e,
-                    lwk_wollet::Error::UpdateHeightTooOld { .. }
-                        | lwk_wollet::Error::UpdateOnDifferentStatus { .. }
-                        | lwk_wollet::Error::StoreError(_)
-                ) =>
-            {
-                warn!("Full scan failed due to {e}, reloading wallet and retrying");
-                let mut new_wallet = Self::create_wallet(
+            // create electrum client if doesn't already exist
+            let mut client = self.client.lock().await;
+            if client.is_none() {
+                *client = Some(WalletClient::from_config(&self.config)?);
+            }
+            let client = client.as_mut().ok_or_else(|| PaymentError::Generic {
+                err: "Wallet client not initialized".to_string(),
+            })?;
+
+            // Use the cached derivation index with a buffer of 5 to perform the scan
+            let last_derivation_index = self
+                .persister
+                .get_last_derivation_index()?
+                .unwrap_or_default();
+            let index_with_buffer = last_derivation_index + 5;
+            let mut wallet = self.wallet.lock().await;
+
+            // Wipe at the *start* of a scan so this same scan repopulates before the sync runs
+            // `update_wallet_info`; wiping after one would persist an empty balance.
+            let clearing = self.needs_cache_clear.swap(false, Ordering::Relaxed);
+            let _recovery_guard = if clearing {
+                warn!("Wiping the wallet cache; this scan will rebuild it from scratch");
+                self.recovery_scan_in_progress
+                    .store(true, Ordering::Relaxed);
+                self.wallet_cache_persister.clear_cache().await?;
+                *wallet = Self::create_wallet(
                     &self.config,
                     &self.signer,
                     self.wallet_cache_persister.clone(),
                 )
                 .await?;
-                client
-                    .full_scan_to_index(&mut new_wallet, index_with_buffer)
-                    .await?;
-                *wallet = new_wallet;
-                Ok(())
+                Some(FlagGuard(&self.recovery_scan_in_progress))
+            } else {
+                None
+            };
+
+            // Reunblind the wallet txs if there has been a change in the derivation index since the
+            // last full scan
+            if self
+                .persister
+                .get_last_scanned_derivation_index()?
+                .is_some_and(|index| index != last_derivation_index)
+            {
+                debug!("LiquidOnchainWallet::full_scan: reunblinding all transactions");
+                wallet.reunblind()?;
             }
-            Err(e) => Err(e.into()),
-        };
 
-        self.persister
-            .set_last_scanned_derivation_index(last_derivation_index)?;
+            let res: Result<(), PaymentError> = match client
+                .full_scan_to_index(&mut wallet, index_with_buffer)
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(e)
+                    if matches!(
+                        e,
+                        lwk_wollet::Error::UpdateHeightTooOld { .. }
+                            | lwk_wollet::Error::UpdateOnDifferentStatus { .. }
+                            | lwk_wollet::Error::StoreError(_)
+                    ) =>
+                {
+                    warn!("Full scan failed due to {e}, reloading wallet and retrying");
+                    let mut new_wallet = Self::create_wallet(
+                        &self.config,
+                        &self.signer,
+                        self.wallet_cache_persister.clone(),
+                    )
+                    .await?;
+                    let rescan_res = client
+                        .full_scan_to_index(&mut new_wallet, index_with_buffer)
+                        .await;
+                    // Adopt the reloaded wallet even if the rescan failed: `create_wallet` may
+                    // have wiped the cache, and a stale in-memory wallet would then persist a
+                    // delta that cannot reconstruct it.
+                    *wallet = new_wallet;
+                    rescan_res?;
+                    Ok(())
+                }
+                Err(e) => Err(e.into()),
+            };
 
-        let duration_ms = Instant::now().duration_since(full_scan_started).as_millis();
-        info!("lwk wallet full_scan duration: ({duration_ms} ms)");
-        debug!("LiquidOnchainWallet::full_scan: end");
-        res
+            self.persister
+                .set_last_scanned_derivation_index(last_derivation_index)?;
+
+            let duration_ms = Instant::now().duration_since(full_scan_started).as_millis();
+            info!("lwk wallet full_scan duration: ({duration_ms} ms)");
+            debug!("LiquidOnchainWallet::full_scan: end");
+            res?;
+        }
+
+        self.check_and_repair_cache().await
+    }
+
+    async fn apply_broadcast_tx(&self, tx: &Transaction) {
+        // Same mutex `full_scan` holds across scan + apply_update, which is what stops this
+        // racing an update into UpdateOnDifferentStatus.
+        let mut wallet = self.wallet.lock().await;
+        match wallet.apply_transaction(tx.clone()) {
+            Ok(_) => debug!("Applied broadcast tx {} to the wallet state", tx.txid()),
+            Err(e) => warn!(
+                "Could not apply broadcast tx {} to the wallet state: {e}",
+                tx.txid()
+            ),
+        }
+    }
+
+    async fn repair_cache(&self) -> Result<bool, PaymentError> {
+        let mut wallet = self.wallet.lock().await;
+        let txs = wallet.transactions()?;
+        let stale = find_spent_utxos(&txs, &wallet.utxos()?);
+        if stale.is_empty() {
+            // Logged because a retry now only helps if something else changed the set.
+            debug!(
+                "Wallet cache repair found no utxo spent by a known tx; \
+                 the unspent set is unchanged"
+            );
+            return Ok(true);
+        }
+
+        // Each stale utxo is by definition spent by a tx we already hold, so re-applying
+        // those makes lwk drop the stale inputs.
+        let stale: std::collections::HashSet<OutPoint> = stale.into_iter().collect();
+        let spenders: Vec<Transaction> = txs
+            .iter()
+            .filter(|wtx| {
+                wtx.tx
+                    .input
+                    .iter()
+                    .any(|i| stale.contains(&i.previous_output))
+            })
+            .map(|wtx| wtx.tx.clone())
+            .collect();
+
+        warn!(
+            "Repairing wallet cache locally: re-applying {} tx(s) that spend {} stale utxo(s)",
+            spenders.len(),
+            stale.len()
+        );
+        for tx in spenders {
+            let txid = tx.txid();
+            // Note this records the tx as unconfirmed; the next scan restores its real height.
+            if let Err(e) = wallet.apply_transaction(tx) {
+                warn!("Could not re-apply tx {txid} while repairing the wallet cache: {e}");
+            }
+        }
+
+        let remaining = find_spent_utxos(&wallet.transactions()?, &wallet.utxos()?);
+        if remaining.is_empty() {
+            info!("Wallet cache repaired locally, no rescan needed");
+            Ok(true)
+        } else {
+            warn!("Local wallet cache repair left {remaining:?} unresolved, flagging for a rescan");
+            // Only a wipe fixes this now; schedule it rather than stall the call in flight.
+            self.needs_cache_clear.store(true, Ordering::Relaxed);
+            Ok(false)
+        }
     }
 
     fn sign_message(&self, message: &str) -> Result<String> {
@@ -757,6 +974,380 @@ mod tests {
     use crate::test_utils::persist::create_persister;
     use crate::wallet::LiquidOnchainWallet;
     use anyhow::Result;
+    use lwk_common::SignedBalance;
+    use lwk_wollet::elements::confidential::{AssetBlindingFactor, ValueBlindingFactor};
+    use lwk_wollet::elements::{AssetId, TxIn, TxOutSecrets, Txid};
+    use lwk_wollet::Chain;
+    use std::collections::BTreeMap;
+
+    fn test_asset() -> AssetId {
+        AssetId::from_str("6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d")
+            .unwrap()
+    }
+
+    /// A transaction spending `spends`, wrapped as a wallet tx.
+    fn wallet_tx(spends: &[OutPoint]) -> WalletTx {
+        let tx = Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: spends
+                .iter()
+                .map(|o| TxIn {
+                    previous_output: *o,
+                    ..Default::default()
+                })
+                .collect(),
+            output: vec![],
+        };
+        WalletTx {
+            txid: tx.txid(),
+            tx,
+            height: Some(1),
+            balance: SignedBalance::from(BTreeMap::new()),
+            fee: 0,
+            type_: "outgoing".to_string(),
+            timestamp: None,
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+
+    fn wallet_utxo(outpoint: OutPoint) -> WalletTxOut {
+        // p2wpkh so it renders to an address; neither is read by the invariant.
+        let mut bytes = vec![0x00, 0x14];
+        bytes.extend_from_slice(&[7u8; 20]);
+        let script = lwk_wollet::elements::Script::from(bytes);
+        let address =
+            Address::from_script(&script, None, &lwk_wollet::elements::AddressParams::LIQUID)
+                .expect("p2wpkh script should render to an address");
+        WalletTxOut {
+            outpoint,
+            script_pubkey: script,
+            height: Some(1),
+            unblinded: TxOutSecrets::new(
+                test_asset(),
+                AssetBlindingFactor::zero(),
+                1000,
+                ValueBlindingFactor::zero(),
+            ),
+            wildcard_index: 0,
+            ext_int: Chain::External,
+            is_spent: false,
+            address,
+        }
+    }
+
+    /// `repair_cache` rests on this: applying a tx must remove the inputs it spends from
+    /// lwk's unspent set. Against a real `Wollet`, not a mock.
+    #[sdk_macros::async_test_all]
+    async fn test_apply_transaction_drops_spent_inputs() -> Result<()> {
+        use lwk_wollet::clients::LastUnused;
+        use lwk_wollet::elements::bitcoin::bip32::ChildNumber;
+        use lwk_wollet::elements::{BlockExtData, BlockHash, BlockHeader, TxMerkleNode};
+        use lwk_wollet::hashes::Hash as _;
+        use lwk_wollet::{DownloadTxResult, Update};
+
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(mnemonic, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+        let mut w = wallet.wallet.lock().await;
+
+        // Derive a real script from the wallet descriptor so it resolves back to an index.
+        // `None` for the blinding pubkey: lwk derives it from the wallet descriptor.
+        let script: lwk_wollet::elements::Script = {
+            let desc = w.wollet_descriptor();
+            desc.definite_descriptor(Chain::External, 0)?
+                .script_pubkey()
+        };
+        let blinding_pubkey = None;
+
+        // Non-zero blinding factors, or the output counts as explicit and `utxos()` drops it.
+        let secrets = TxOutSecrets::new(
+            test_asset(),
+            AssetBlindingFactor::from_slice(&[3u8; 32])?,
+            1000,
+            ValueBlindingFactor::from_slice(&[4u8; 32])?,
+        );
+
+        let funding = Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: vec![],
+            output: vec![lwk_wollet::elements::TxOut {
+                script_pubkey: script.clone(),
+                ..Default::default()
+            }],
+        };
+        let funding_txid = funding.txid();
+        let outpoint = OutPoint::new(funding_txid, 0);
+
+        let wollet_status = w.status();
+        w.apply_update(Update {
+            version: 4,
+            wollet_status,
+            new_txs: DownloadTxResult {
+                txs: vec![(funding_txid, funding)],
+                unblinds: vec![(outpoint, secrets)],
+            },
+            txid_height_new: vec![(funding_txid, Some(1))],
+            txid_height_delete: vec![],
+            timestamps: vec![(1, 1)],
+            scripts_with_blinding_pubkey: vec![(
+                Chain::External,
+                ChildNumber::from_normal_idx(0)?,
+                script,
+                blinding_pubkey,
+            )],
+            tip: BlockHeader {
+                version: 0,
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                height: 0,
+                ext: BlockExtData::default(),
+            },
+            unspent: vec![],
+            last_unused: LastUnused {
+                internal: 0,
+                external: 1,
+            },
+        })?;
+
+        assert!(
+            w.utxos()?.iter().any(|u| u.outpoint == outpoint),
+            "the funding output should be unspent"
+        );
+
+        let spend = Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: outpoint,
+                ..Default::default()
+            }],
+            output: vec![],
+        };
+        w.apply_transaction(spend)?;
+
+        assert!(
+            !w.utxos()?.iter().any(|u| u.outpoint == outpoint),
+            "apply_transaction must drop the input it spends - repair_cache depends on it"
+        );
+
+        Ok(())
+    }
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn descriptor_script(w: &Wollet) -> Result<lwk_wollet::elements::Script> {
+        Ok(w.wollet_descriptor()
+            .definite_descriptor(Chain::External, 0)?
+            .script_pubkey())
+    }
+
+    fn default_tip() -> lwk_wollet::elements::BlockHeader {
+        use lwk_wollet::elements::{BlockExtData, BlockHash, TxMerkleNode};
+        use lwk_wollet::hashes::Hash as _;
+        lwk_wollet::elements::BlockHeader {
+            version: 0,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            height: 0,
+            ext: BlockExtData::default(),
+        }
+    }
+
+    fn tx_paying(script: &lwk_wollet::elements::Script) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: vec![],
+            output: vec![lwk_wollet::elements::TxOut {
+                script_pubkey: script.clone(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    fn tx_spending(outpoint: OutPoint) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: lwk_wollet::elements::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: outpoint,
+                ..Default::default()
+            }],
+            output: vec![],
+        }
+    }
+
+    fn has_utxo(w: &Wollet, outpoint: OutPoint) -> Result<bool> {
+        Ok(w.utxos()?.iter().any(|u| u.outpoint == outpoint))
+    }
+
+    /// Applies `tx` with the given heights, unblinding any output paying `script`.
+    fn apply(
+        w: &mut Wollet,
+        tx: &Transaction,
+        heights: &[(Txid, Option<u32>)],
+        script: &lwk_wollet::elements::Script,
+    ) -> Result<()> {
+        use lwk_wollet::clients::LastUnused;
+        use lwk_wollet::elements::bitcoin::bip32::ChildNumber;
+        use lwk_wollet::{DownloadTxResult, Update};
+
+        let txid = tx.txid();
+        let unblinds = tx
+            .output
+            .iter()
+            .enumerate()
+            .filter(|(_, o)| &o.script_pubkey == script)
+            .map(|(vout, _)| {
+                (
+                    OutPoint::new(txid, vout as u32),
+                    TxOutSecrets::new(
+                        test_asset(),
+                        AssetBlindingFactor::from_slice(&[3u8; 32]).unwrap(),
+                        1000,
+                        ValueBlindingFactor::from_slice(&[4u8; 32]).unwrap(),
+                    ),
+                )
+            })
+            .collect();
+
+        let wollet_status = w.status();
+        w.apply_update(Update {
+            version: 4,
+            wollet_status,
+            new_txs: DownloadTxResult {
+                txs: vec![(txid, tx.clone())],
+                unblinds,
+            },
+            txid_height_new: heights.to_vec(),
+            txid_height_delete: vec![],
+            timestamps: vec![(1, 1)],
+            scripts_with_blinding_pubkey: vec![(
+                Chain::External,
+                ChildNumber::from_normal_idx(0)?,
+                script.clone(),
+                None,
+            )],
+            tip: default_tip(),
+            unspent: vec![],
+            last_unused: LastUnused {
+                internal: 0,
+                external: 1,
+            },
+        })?;
+        Ok(())
+    }
+
+    /// A height-only delta, as a scan produces when a known tx confirms.
+    fn apply_heights_only(w: &mut Wollet, heights: &[(Txid, Option<u32>)]) -> Result<()> {
+        use lwk_wollet::clients::LastUnused;
+        use lwk_wollet::{DownloadTxResult, Update};
+        let wollet_status = w.status();
+        w.apply_update(Update {
+            version: 4,
+            wollet_status,
+            new_txs: DownloadTxResult {
+                txs: vec![],
+                unblinds: vec![],
+            },
+            txid_height_new: heights.to_vec(),
+            txid_height_delete: vec![],
+            timestamps: vec![(1, 1)],
+            scripts_with_blinding_pubkey: vec![],
+            tip: default_tip(),
+            unspent: vec![],
+            last_unused: LastUnused {
+                internal: 0,
+                external: 1,
+            },
+        })?;
+        Ok(())
+    }
+
+    /// `Cache::update_unspent` re-adds the outputs of every tx in `txid_height_new`
+    /// filtered only by txid. It never checks whether a tx already in the cache
+    /// spends them. So a funding tx confirming *after* the tx spending its output was recorded
+    /// resurrects that output. Which is what happens whenever unconfirmed change is spent.
+    #[sdk_macros::async_test_all]
+    async fn test_lwk_resurrects_outputs_of_reannounced_funding_tx() -> Result<()> {
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+        let mut w = wallet.wallet.lock().await;
+        let script = descriptor_script(&w)?;
+
+        // 1. Funding tx A arrives unconfirmed, paying us.
+        let funding = tx_paying(&script);
+        let a0 = OutPoint::new(funding.txid(), 0);
+        apply(&mut w, &funding, &[(funding.txid(), None)], &script)?;
+        assert!(
+            has_utxo(&w, a0)?,
+            "A:0 should be spendable while unconfirmed"
+        );
+
+        // 2. We spend that unconfirmed output. B is recorded, A:0 correctly leaves the set.
+        let spend = tx_spending(a0);
+        apply(&mut w, &spend, &[(spend.txid(), None)], &script)?;
+        assert!(!has_utxo(&w, a0)?, "A:0 should be spent by B");
+
+        // 3. A confirms. Only A is in this delta, so B is never consulted.
+        apply_heights_only(&mut w, &[(funding.txid(), Some(1))])?;
+
+        let resurrected = has_utxo(&w, a0)?;
+        let spender_known = w.transactions()?.iter().any(|t| t.txid == spend.txid());
+
+        assert!(
+            resurrected && spender_known,
+            "expected the observed corruption shape (A:0 unspent + spender still known), \
+             got resurrected={resurrected} spender_known={spender_known}"
+        );
+        assert_eq!(
+            find_spent_utxos(&w.transactions()?, &w.utxos()?),
+            vec![a0],
+            "and our invariant should catch it"
+        );
+        Ok(())
+    }
+
+    /// The invariant that drives both detection and repair: a utxo the wallet still lists as
+    /// unspent, but which a transaction it already knows about spends, is stale.
+    #[sdk_macros::test_all]
+    fn test_find_spent_utxos() {
+        let a = OutPoint::new(Txid::from_str(&"a".repeat(64)).unwrap(), 0);
+        let b = OutPoint::new(Txid::from_str(&"b".repeat(64)).unwrap(), 1);
+
+        // Healthy: nothing the wallet holds spends either utxo.
+        let unrelated = wallet_tx(&[OutPoint::new(Txid::from_str(&"c".repeat(64)).unwrap(), 0)]);
+        assert!(find_spent_utxos(
+            std::slice::from_ref(&unrelated),
+            &[wallet_utxo(a), wallet_utxo(b)]
+        )
+        .is_empty());
+
+        // Corrupt: `a` is still listed as unspent although a known tx spends it.
+        let spender = wallet_tx(&[a]);
+        assert_eq!(
+            find_spent_utxos(
+                &[unrelated.clone(), spender.clone()],
+                &[wallet_utxo(a), wallet_utxo(b)]
+            ),
+            vec![a],
+            "a utxo spent by a known tx must be reported"
+        );
+
+        // An empty utxo set cannot be corrupt, however many spends are known.
+        assert!(find_spent_utxos(&[spender], &[]).is_empty());
+    }
 
     #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -797,11 +797,16 @@ impl OnchainWallet for LiquidOnchainWallet {
 
             // Wipe at the *start* of a scan so this same scan repopulates before the sync runs
             // `update_wallet_info`; wiping after one would persist an empty balance.
-            let clearing = self.needs_cache_clear.swap(false, Ordering::Relaxed);
-            let _recovery_guard = if clearing {
+            let clearing = self.needs_cache_clear.load(Ordering::Relaxed);
+            // Guard before anything fallible: an early return here must still release the flag,
+            // or tx building fails fast forever.
+            let _recovery_guard = clearing.then(|| {
                 warn!("Wiping the wallet cache; this scan will rebuild it from scratch");
                 self.recovery_scan_in_progress
                     .store(true, Ordering::Relaxed);
+                FlagGuard(&self.recovery_scan_in_progress)
+            });
+            if clearing {
                 self.wallet_cache_persister.clear_cache().await?;
                 *wallet = Self::create_wallet(
                     &self.config,
@@ -809,10 +814,10 @@ impl OnchainWallet for LiquidOnchainWallet {
                     self.wallet_cache_persister.clone(),
                 )
                 .await?;
-                Some(FlagGuard(&self.recovery_scan_in_progress))
-            } else {
-                None
-            };
+                // Only now is the wipe complete. Clearing earlier would strand a wiped store
+                // beside the old in-memory wallet if `create_wallet` failed.
+                self.needs_cache_clear.store(false, Ordering::Relaxed);
+            }
 
             // Reunblind the wallet txs if there has been a change in the derivation index since the
             // last full scan
@@ -867,7 +872,12 @@ impl OnchainWallet for LiquidOnchainWallet {
             res?;
         }
 
-        self.check_and_repair_cache().await
+        // Best-effort: a failed check must not abort the scan, or `sync_inner` returns before
+        // syncing payments.
+        if let Err(e) = self.check_and_repair_cache().await {
+            error!("Wallet cache check failed, continuing: {e}");
+        }
+        Ok(())
     }
 
     async fn apply_broadcast_tx(&self, tx: &Transaction) {
@@ -884,55 +894,64 @@ impl OnchainWallet for LiquidOnchainWallet {
     }
 
     async fn repair_cache(&self) -> Result<bool, PaymentError> {
+        // Re-applying a spender drops its stale inputs, but re-adds its own outputs. If one of
+        // those was itself already spent, the drift simply moves one hop down the chain, so
+        // iterate to a fixpoint rather than giving up and scheduling a wipe.
+        const MAX_PASSES: usize = 16;
+
         let mut wallet = self.wallet.lock().await;
-        let txs = wallet.transactions()?;
-        let stale = find_spent_utxos(&txs, &wallet.utxos()?);
-        if stale.is_empty() {
-            // Logged because a retry now only helps if something else changed the set.
-            debug!(
-                "Wallet cache repair found no utxo spent by a known tx; \
-                 the unspent set is unchanged"
+        let mut previous: Option<Vec<OutPoint>> = None;
+
+        for _ in 0..MAX_PASSES {
+            let txs = wallet.transactions()?;
+            let stale = find_spent_utxos(&txs, &wallet.utxos()?);
+            if stale.is_empty() {
+                if previous.is_some() {
+                    info!("Wallet cache repaired locally, no rescan needed");
+                }
+                return Ok(true);
+            }
+
+            // No progress since the last pass means re-applying cannot resolve the rest.
+            if previous.as_deref() == Some(stale.as_slice()) {
+                break;
+            }
+            previous = Some(stale.clone());
+
+            let stale: std::collections::HashSet<OutPoint> = stale.into_iter().collect();
+            let spenders: Vec<Transaction> = txs
+                .iter()
+                .filter(|wtx| {
+                    wtx.tx
+                        .input
+                        .iter()
+                        .any(|i| stale.contains(&i.previous_output))
+                })
+                .map(|wtx| wtx.tx.clone())
+                .collect();
+            if spenders.is_empty() {
+                break;
+            }
+
+            warn!(
+                "Repairing wallet cache locally: re-applying {} tx(s) that spend {} stale utxo(s)",
+                spenders.len(),
+                stale.len()
             );
-            return Ok(true);
-        }
-
-        // Each stale utxo is by definition spent by a tx we already hold, so re-applying
-        // those makes lwk drop the stale inputs.
-        let stale: std::collections::HashSet<OutPoint> = stale.into_iter().collect();
-        let spenders: Vec<Transaction> = txs
-            .iter()
-            .filter(|wtx| {
-                wtx.tx
-                    .input
-                    .iter()
-                    .any(|i| stale.contains(&i.previous_output))
-            })
-            .map(|wtx| wtx.tx.clone())
-            .collect();
-
-        warn!(
-            "Repairing wallet cache locally: re-applying {} tx(s) that spend {} stale utxo(s)",
-            spenders.len(),
-            stale.len()
-        );
-        for tx in spenders {
-            let txid = tx.txid();
-            // Note this records the tx as unconfirmed; the next scan restores its real height.
-            if let Err(e) = wallet.apply_transaction(tx) {
-                warn!("Could not re-apply tx {txid} while repairing the wallet cache: {e}");
+            for tx in spenders {
+                let txid = tx.txid();
+                // Note this records the tx as unconfirmed; the next scan restores its real height.
+                if let Err(e) = wallet.apply_transaction(tx) {
+                    warn!("Could not re-apply tx {txid} while repairing the wallet cache: {e}");
+                }
             }
         }
 
         let remaining = find_spent_utxos(&wallet.transactions()?, &wallet.utxos()?);
-        if remaining.is_empty() {
-            info!("Wallet cache repaired locally, no rescan needed");
-            Ok(true)
-        } else {
-            warn!("Local wallet cache repair left {remaining:?} unresolved, flagging for a rescan");
-            // Only a wipe fixes this now; schedule it rather than stall the call in flight.
-            self.needs_cache_clear.store(true, Ordering::Relaxed);
-            Ok(false)
-        }
+        warn!("Local wallet cache repair left {remaining:?} unresolved, flagging for a rescan");
+        // Only a wipe fixes this now; schedule it rather than stall the call in flight.
+        self.needs_cache_clear.store(true, Ordering::Relaxed);
+        Ok(false)
     }
 
     fn sign_message(&self, message: &str) -> Result<String> {
@@ -1259,6 +1278,62 @@ mod tests {
         Ok(())
     }
 
+    /// Re-applying a spender re-adds its own outputs, so if one of those was already spent the
+    /// drift moves one hop down the chain. Raised in review: the repair must iterate, not give up
+    /// after a single pass and schedule a wipe.
+    #[sdk_macros::async_test_all]
+    async fn test_repair_cache_resolves_a_chain_of_spends() -> Result<()> {
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+
+        let (a0, b0) = {
+            let mut w = wallet.wallet.lock().await;
+            let script = descriptor_script(&w)?;
+
+            // A funds us; B spends A:0 and pays us change; C spends that change.
+            let a = tx_paying(&script);
+            let a0 = OutPoint::new(a.txid(), 0);
+            apply(&mut w, &a, &[(a.txid(), None)], &script)?;
+
+            let mut b = tx_paying(&script);
+            b.input = vec![TxIn {
+                previous_output: a0,
+                ..Default::default()
+            }];
+            let b0 = OutPoint::new(b.txid(), 0);
+            apply(&mut w, &b, &[(b.txid(), None)], &script)?;
+
+            let c = tx_spending(b0);
+            apply(&mut w, &c, &[(c.txid(), None)], &script)?;
+
+            assert!(!has_utxo(&w, a0)?, "A:0 is spent by B");
+            assert!(!has_utxo(&w, b0)?, "B:0 is spent by C");
+
+            // A confirms, resurrecting A:0 (the lwk bug).
+            apply_heights_only(&mut w, &[(a.txid(), Some(1))])?;
+            assert!(has_utxo(&w, a0)?, "A:0 resurrected");
+            (a0, b0)
+        };
+
+        // One pass would drop A:0 but re-add B:0, which C spends. Only iterating resolves both.
+        assert!(
+            wallet.repair_cache().await?,
+            "the repair should resolve the chain without needing a wipe"
+        );
+
+        let w = wallet.wallet.lock().await;
+        assert!(!has_utxo(&w, a0)?, "A:0 must not survive the repair");
+        assert!(
+            !has_utxo(&w, b0)?,
+            "B:0 must not be left behind by the repair"
+        );
+        assert!(find_spent_utxos(&w.transactions()?, &w.utxos()?).is_empty());
+        Ok(())
+    }
+
     /// `Cache::update_unspent` re-adds the outputs of every tx in `txid_height_new`
     /// filtered only by txid. It never checks whether a tx already in the cache
     /// spends them. So a funding tx confirming *after* the tx spending its output was recorded
@@ -1299,8 +1374,8 @@ mod tests {
             resurrected && spender_known,
             "lwk no longer resurrects outputs of a re-announced funding tx \
              (resurrected={resurrected}, spender_known={spender_known}). If this failed after an \
-             lwk bump, the upstream bug is likely fixed: see LWK_ISSUE.md and reassess whether \
-             repair_cache / check_and_repair_cache are still needed."
+             lwk bump the upstream bug is likely fixed, so reassess whether repair_cache and \
+             check_and_repair_cache are still needed."
         );
         assert_eq!(
             find_spent_utxos(&w.transactions()?, &w.utxos()?),

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -124,33 +124,20 @@ pub trait OnchainWallet: Send + Sync {
     async fn repair_cache(&self) -> Result<bool, PaymentError>;
 }
 
-/// Runs the local repair and reports whether the caller should rebuild its tx and broadcast
-/// again. The tx must be *rebuilt*, not re-broadcast: selection has to pick different inputs.
+/// Maps a stale-cache broadcast rejection to an actionable error, repairing the cache on the way.
 ///
-/// Retries at most once — the caller owns `already_repaired`. False means the repair could not
-/// resolve the drift, leaving the caller to fail via [`handle_stale_cache_broadcast_error`].
-pub(crate) async fn should_retry_after_cache_repair(
+/// The repair is local and instant, so a retry by the caller succeeds. If it cannot resolve the
+/// drift it schedules a wipe for the next scan, which runs in the background.
+pub(crate) async fn handle_stale_cache_broadcast_error(
     onchain_wallet: &dyn OnchainWallet,
-    err: &anyhow::Error,
-    already_repaired: &mut bool,
-) -> Result<bool, PaymentError> {
-    if *already_repaired || !crate::error::is_txn_inputs_missing_or_spent_error(err) {
-        return Ok(false);
-    }
-    *already_repaired = true;
-    let repaired = onchain_wallet.repair_cache().await?;
-    if repaired {
-        info!("Wallet cache repaired locally, retrying the broadcast with fresh inputs");
-    }
-    Ok(repaired)
-}
-
-/// Maps a stale-cache broadcast rejection to an actionable error. The wipe is left to the next
-/// scan (a cold rescan takes minutes and must not stall a payment), and the wallet has already
-/// flagged itself inside [`OnchainWallet::repair_cache`].
-pub(crate) fn handle_stale_cache_broadcast_error(err: anyhow::Error) -> PaymentError {
+    err: anyhow::Error,
+) -> PaymentError {
     if !crate::error::is_txn_inputs_missing_or_spent_error(&err) {
         return err.into();
+    }
+    warn!("Broadcast rejected for spending inputs the node does not have, repairing the cache");
+    if let Err(e) = onchain_wallet.repair_cache().await {
+        warn!("Could not repair the wallet cache: {e}");
     }
     PaymentError::Generic {
         err: format!("Wallet state was out of date, please retry shortly: {err}"),
@@ -1306,10 +1293,14 @@ mod tests {
         let resurrected = has_utxo(&w, a0)?;
         let spender_known = w.transactions()?.iter().any(|t| t.txid == spend.txid());
 
+        // Asserts the bug is still PRESENT, so this fails if lwk ever fixes it. That is the
+        // point: it is the signal to revisit the recovery code, not a regression in this crate.
         assert!(
             resurrected && spender_known,
-            "expected the observed corruption shape (A:0 unspent + spender still known), \
-             got resurrected={resurrected} spender_known={spender_known}"
+            "lwk no longer resurrects outputs of a re-announced funding tx \
+             (resurrected={resurrected}, spender_known={spender_known}). If this failed after an \
+             lwk bump, the upstream bug is likely fixed: see LWK_ISSUE.md and reassess whether \
+             repair_cache / check_and_repair_cache are still needed."
         );
         assert_eq!(
             find_spent_utxos(&w.transactions()?, &w.utxos()?),

--- a/lib/core/src/wallet/mod.rs
+++ b/lib/core/src/wallet/mod.rs
@@ -227,6 +227,9 @@ pub struct LiquidOnchainWallet {
     /// Whether a wipe-and-rescan is running. It holds the wallet lock for a cold rescan, so tx
     /// building checks this first to fail fast rather than block for minutes.
     recovery_scan_in_progress: AtomicBool,
+    /// Whether a wipe already ran this session. A cold rescan costs minutes, and if one did not
+    /// produce a clean unspent set a second will not either, so this bounds it to one attempt.
+    cache_wiped: AtomicBool,
 }
 
 /// Clears an [`AtomicBool`] on drop, so the flag is released even on an early return.
@@ -281,12 +284,31 @@ impl LiquidOnchainWallet {
             // payment discovers it.
             needs_cache_check: AtomicBool::new(true),
             needs_cache_clear: AtomicBool::new(false),
+            cache_wiped: AtomicBool::new(false),
             recovery_scan_in_progress: AtomicBool::new(false),
         })
     }
 
     /// Verifies the cached unspent set against the tx set and repairs any drift. Cheap and
     /// local; only a repair costs anything. Runs after a scan, never during one.
+    /// Schedules a wipe-and-rescan for the next scan, unless one already ran this session.
+    ///
+    /// A cold rescan costs minutes and rebuilds the unspent set from an empty cache, so if it did
+    /// not produce a clean one, repeating it will not either. Bounding it keeps a wallet whose
+    /// drift the rescan cannot resolve from wiping on every scan for the rest of the session.
+    fn schedule_cache_wipe(&self) -> bool {
+        if self.cache_wiped.load(Ordering::Relaxed) {
+            error!(
+                "Wallet cache is still inconsistent after a full rescan this session, not wiping \
+                 again. Coin selection may keep offering spent utxos until the next restart."
+            );
+            return false;
+        }
+        warn!("Flagging the wallet cache to be wiped and rebuilt on the next scan");
+        self.needs_cache_clear.store(true, Ordering::Relaxed);
+        true
+    }
+
     async fn check_and_repair_cache(&self) -> Result<(), PaymentError> {
         if !self.needs_cache_check.swap(false, Ordering::Relaxed) {
             return Ok(());
@@ -300,7 +322,11 @@ impl LiquidOnchainWallet {
         };
 
         if spent.is_empty() {
-            debug!("Wallet cache check: no utxo is spent by a known tx");
+            if self.cache_wiped.load(Ordering::Relaxed) {
+                info!("Wallet cache verified clean after the rescan");
+            } else {
+                debug!("Wallet cache check: no utxo is spent by a known tx");
+            }
             return Ok(());
         }
 
@@ -817,6 +843,10 @@ impl OnchainWallet for LiquidOnchainWallet {
                 // Only now is the wipe complete. Clearing earlier would strand a wiped store
                 // beside the old in-memory wallet if `create_wallet` failed.
                 self.needs_cache_clear.store(false, Ordering::Relaxed);
+                self.cache_wiped.store(true, Ordering::Relaxed);
+                // Re-arm the check so this scan verifies its own result. Without it a wipe that
+                // failed to produce a clean set would look identical to one that succeeded.
+                self.needs_cache_check.store(true, Ordering::Relaxed);
             }
 
             // Reunblind the wallet txs if there has been a change in the derivation index since the
@@ -894,63 +924,84 @@ impl OnchainWallet for LiquidOnchainWallet {
     }
 
     async fn repair_cache(&self) -> Result<bool, PaymentError> {
-        // Re-applying a spender drops its stale inputs, but re-adds its own outputs. If one of
-        // those was itself already spent, the drift simply moves one hop down the chain, so
-        // iterate to a fixpoint rather than giving up and scheduling a wipe.
-        const MAX_PASSES: usize = 16;
+        use std::collections::HashSet;
 
         let mut wallet = self.wallet.lock().await;
-        let mut previous: Option<Vec<OutPoint>> = None;
+        let txs = wallet.transactions()?;
+        let stale: HashSet<OutPoint> = find_spent_utxos(&txs, &wallet.utxos()?)
+            .into_iter()
+            .collect();
+        if stale.is_empty() {
+            debug!("Wallet cache repair found nothing to do; the unspent set is unchanged");
+            return Ok(true);
+        }
 
-        for _ in 0..MAX_PASSES {
-            let txs = wallet.transactions()?;
-            let stale = find_spent_utxos(&txs, &wallet.utxos()?);
-            if stale.is_empty() {
-                if previous.is_some() {
-                    info!("Wallet cache repaired locally, no rescan needed");
-                }
-                return Ok(true);
-            }
-
-            // No progress since the last pass means re-applying cannot resolve the rest.
-            if previous.as_deref() == Some(stale.as_slice()) {
-                break;
-            }
-            previous = Some(stale.clone());
-
-            let stale: std::collections::HashSet<OutPoint> = stale.into_iter().collect();
-            let spenders: Vec<Transaction> = txs
+        // Re-applying a spender drops its stale inputs but re-adds its own outputs, so if one of
+        // those was itself already spent the drift just moves a hop down the chain. Walk the whole
+        // chain first and re-apply it in one go, otherwise a chain of N spends needs N passes.
+        let mut to_apply: Vec<&WalletTx> = vec![];
+        let mut queued: HashSet<Txid> = HashSet::new();
+        let mut frontier = stale.clone();
+        while !frontier.is_empty() {
+            let spenders: Vec<&WalletTx> = txs
                 .iter()
+                .filter(|wtx| !queued.contains(&wtx.txid))
                 .filter(|wtx| {
                     wtx.tx
                         .input
                         .iter()
-                        .any(|i| stale.contains(&i.previous_output))
+                        .any(|i| frontier.contains(&i.previous_output))
                 })
-                .map(|wtx| wtx.tx.clone())
                 .collect();
             if spenders.is_empty() {
                 break;
             }
+            // The next hop is whatever those spenders paid back to us.
+            frontier = spenders
+                .iter()
+                .flat_map(|wtx| wtx.outputs.iter().flatten().map(|o| o.outpoint))
+                .collect();
+            for wtx in spenders {
+                queued.insert(wtx.txid);
+                to_apply.push(wtx);
+            }
+        }
 
+        if to_apply.is_empty() {
             warn!(
-                "Repairing wallet cache locally: re-applying {} tx(s) that spend {} stale utxo(s)",
-                spenders.len(),
+                "Wallet cache has {} stale utxo(s) with no known spender",
                 stale.len()
             );
-            for tx in spenders {
-                let txid = tx.txid();
-                // Note this records the tx as unconfirmed; the next scan restores its real height.
-                if let Err(e) = wallet.apply_transaction(tx) {
-                    warn!("Could not re-apply tx {txid} while repairing the wallet cache: {e}");
-                }
+            self.schedule_cache_wipe();
+            return Ok(false);
+        }
+
+        // Oldest first, so a child removes what its parent re-adds rather than the reverse.
+        to_apply.sort_by_key(|wtx| wtx.height.unwrap_or(u32::MAX));
+
+        warn!(
+            "Repairing wallet cache locally: re-applying {} tx(s) that spend {} stale utxo(s)",
+            to_apply.len(),
+            stale.len()
+        );
+        for wtx in to_apply {
+            let txid = wtx.txid;
+            // Note this records the tx as unconfirmed; the next scan restores its real height.
+            if let Err(e) = wallet.apply_transaction(wtx.tx.clone()) {
+                warn!("Could not re-apply tx {txid} while repairing the wallet cache: {e}");
             }
         }
 
         let remaining = find_spent_utxos(&wallet.transactions()?, &wallet.utxos()?);
-        warn!("Local wallet cache repair left {remaining:?} unresolved, flagging for a rescan");
-        // Only a wipe fixes this now; schedule it rather than stall the call in flight.
-        self.needs_cache_clear.store(true, Ordering::Relaxed);
+        if remaining.is_empty() {
+            info!("Wallet cache repaired locally, no rescan needed");
+            return Ok(true);
+        }
+        warn!(
+            "Local wallet cache repair left {} utxo(s) unresolved",
+            remaining.len()
+        );
+        self.schedule_cache_wipe();
         Ok(false)
     }
 
@@ -1331,6 +1382,89 @@ mod tests {
             "B:0 must not be left behind by the repair"
         );
         assert!(find_spent_utxos(&w.transactions()?, &w.utxos()?).is_empty());
+        Ok(())
+    }
+
+    /// A long chain of change spends. Each re-applied spender re-adds its own change, which the
+    /// next spender consumes, so a hop-by-hop repair needs one pass per hop and stalls on chains
+    /// longer than its pass limit. Seen in the field as 16 identical passes over 34 stale utxos
+    /// before falling back to a wipe. The repair must walk the whole chain in one go.
+    #[sdk_macros::async_test_all]
+    async fn test_repair_cache_resolves_a_long_chain_in_one_pass() -> Result<()> {
+        const CHAIN: usize = 25; // longer than any sane pass limit
+
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+
+        let first_outpoint = {
+            let mut w = wallet.wallet.lock().await;
+            let script = descriptor_script(&w)?;
+
+            // tx0 pays us; each following tx spends the previous change and pays us again.
+            let tx0 = tx_paying(&script);
+            let first = OutPoint::new(tx0.txid(), 0);
+            apply(&mut w, &tx0, &[(tx0.txid(), None)], &script)?;
+
+            let mut prev = first;
+            for _ in 0..CHAIN {
+                let mut next = tx_paying(&script);
+                next.input = vec![TxIn {
+                    previous_output: prev,
+                    ..Default::default()
+                }];
+                apply(&mut w, &next, &[(next.txid(), None)], &script)?;
+                prev = OutPoint::new(next.txid(), 0);
+            }
+
+            // Only the tip of the chain should be unspent.
+            assert!(!has_utxo(&w, first)?, "the head of the chain is spent");
+            assert!(has_utxo(&w, prev)?, "the tip of the chain is unspent");
+
+            // Confirm tx0, resurrecting its already-spent output at the head of the chain.
+            apply_heights_only(&mut w, &[(tx0.txid(), Some(1))])?;
+            assert!(has_utxo(&w, first)?, "head resurrected");
+            first
+        };
+
+        assert!(
+            wallet.repair_cache().await?,
+            "a {CHAIN}-hop chain must resolve without falling back to a wipe"
+        );
+
+        let w = wallet.wallet.lock().await;
+        assert!(!has_utxo(&w, first_outpoint)?);
+        assert!(find_spent_utxos(&w.transactions()?, &w.utxos()?).is_empty());
+        Ok(())
+    }
+
+    /// A wipe costs a cold rescan (minutes on a large wallet, 221s when measured against the
+    /// affected one), so drift a rescan cannot resolve must not re-trigger it on every scan.
+    #[sdk_macros::async_test_all]
+    async fn test_cache_wipe_is_bounded_to_once_per_session() -> Result<()> {
+        let signer: Arc<Box<dyn Signer>> =
+            Arc::new(Box::new(SdkSigner::new(TEST_MNEMONIC, "", false).unwrap()));
+        create_persister!(storage);
+        let wallet =
+            LiquidOnchainWallet::new(Config::regtest_esplora(), storage, signer.clone()).await?;
+
+        assert!(wallet.schedule_cache_wipe(), "the first wipe is allowed");
+        assert!(wallet.needs_cache_clear.load(Ordering::Relaxed));
+
+        // Stand in for `full_scan` performing the wipe.
+        wallet.needs_cache_clear.store(false, Ordering::Relaxed);
+        wallet.cache_wiped.store(true, Ordering::Relaxed);
+
+        assert!(
+            !wallet.schedule_cache_wipe(),
+            "a second wipe in the same session must be refused"
+        );
+        assert!(
+            !wallet.needs_cache_clear.load(Ordering::Relaxed),
+            "a refused wipe must not leave the scan flagged, or every scan would rescan cold"
+        );
         Ok(())
     }
 

--- a/lib/core/src/wallet/utxo_select.rs
+++ b/lib/core/src/wallet/utxo_select.rs
@@ -190,7 +190,11 @@ where
     for utxo_count in 1..=utxos.len() {
         let fee = get_fee(utxo_count, 1);
         if fee < best_fee {
-            let target_incl_fee = target_value + fee;
+            // At least one sat of change, not just enough to cover `target + fee`. When the
+            // inputs leave no room for change lwk drops the change output and then requires
+            // them to cover the *changeless* fee exactly, which is lower. A sum equal to
+            // `target + fee` satisfies neither branch and fails to build.
+            let target_incl_fee = target_value + fee + 1;
             let upper_bound_delta = available_value.saturating_sub(target_incl_fee);
             if let Some(selected_utxos) =
                 utxo_select_in_range(target_incl_fee, upper_bound_delta, utxo_count, utxos)
@@ -464,6 +468,27 @@ mod tests {
         // With target count
         let selected = utxo_select_in_range(250, 0, 2, &utxos);
         assert_eq!(selected, Some(vec![200, 50]));
+    }
+
+    /// lwk builds a changeless tx only when the inputs cover the changeless fee *exactly*, and a
+    /// tx with change only when they leave at least one sat of it. Between those, `target + fee`
+    /// inclusive, nothing is buildable, so selection must not return a sum that lands there.
+    ///
+    /// Taken from a real wallet: a 21 sat send with a 47 sat utxo, where `fee(1 in, change) = 26`
+    /// and `fee(1 in, no change) = 20`. Selecting 47 gives zero change and lwk rejects it with
+    /// `InsufficientFunds { missing_sats: 1 }` despite a 20.5M sat balance.
+    #[sdk_macros::test_all]
+    fn test_utxo_select_dynamic_leaves_room_for_change() {
+        let fee = |_utxo_count: usize, change_count: usize| if change_count > 0 { 26 } else { 20 };
+
+        // 47 == 21 + 26 is the dead zone: too little for change, too much for changeless.
+        assert_eq!(utxo_select_dynamic(21, &[47], fee), None);
+        // One more sat and a change output fits.
+        assert_eq!(utxo_select_dynamic(21, &[48], fee), Some(vec![48]));
+        // An exact changeless match is still preferred, and costs the lower fee.
+        assert_eq!(utxo_select_dynamic(21, &[41], fee), Some(vec![41]));
+        // With a real spread, skip the unusable 47 rather than fail the payment.
+        assert_eq!(utxo_select_dynamic(21, &[47, 2876], fee), Some(vec![2876]));
     }
 
     #[sdk_macros::test_all]


### PR DESCRIPTION
Send swap lockups fail permanently with:

```
sendrawtransaction RPC error: {"code":-25,"message":"bad-txns-inputs-missingorspent"}
```

A reported wallet had 4 UTXOs that lwk listed as unspent but which a single confirmed tx had spent ~286 days earlier. Coin selection is deterministic branch-and-bound, so it re-picked the same coin on every attempt, meaning small payments could never succeed again.

The cache was internally inconsistent rather than merely stale: its *transaction* set was correct (the tx-derived balance matched the chain) and only `Wollet::utxos()` was wrong.

### Root cause

In lwk `Cache::update_unspent` re-adds the outputs of every tx in `txid_height_new`, filtered only by txid, with no check for whether a tx already in the cache spends them:

```rust
self.unblinded.keys().filter(|op| txids_new.contains(&op.txid))   // no spent-check
```

`inputs_new`, which removes spent outpoints, is computed from that same delta, so an existing spender is never consulted. Re-announcing a funding tx therefore resurrects its spent outputs permanently. The spender stays in `heights`, so balances stay correct and nothing surfaces it.

**Trigger:** anything that changes a funding tx's cached height once its outputs are spent, most commonly an output spent while unconfirmed whose funding tx then confirms. `utxos()` returns height-`None` outputs and our selection has no confirmation filter, so ordinary zero-conf change spending is enough.

### Fix

Detect the lost invariant, that no unspent outpoint may be spent by a known tx, and repair it:
1. **Local repair on rejection**: The spending tx is normally already held, so re-applying it makes lwk drop the stale inputs. Since that re-adds the spender's own outputs, it iterates until nothing changes, which resolves chains of spends. Instant, no network. The payment still fails, but the cache is corrected before the error returns, so a retry succeeds.
2. **Wipe otherwise**: If the tx set cannot explain the drift, schedule a cache wipe for the start of the next scan, which repopulates it. Left to the background, since a cold rescan takes minutes and must not stall a payment.
3. **Proactive check on startup**: So a wallet corrupted in an earlier session is repaired before a payment discovers it. Both entry points are needed: the trigger is a scan outcome, so corruption appears mid-session as well as across restarts.

Plus `apply_broadcast_tx` after every successful broadcast, closing the window where a second payment re-selects coins already in flight. This uses `Wollet::apply_transaction` to notify lwk of a transaction broadcast before the sync so it can update its UTXO cache.

Note that `test_lwk_resurrects_outputs_of_reannounced_funding_tx` asserts the lwk bug is *present*, reproducing it against a real `Wollet`. It will fail once lwk fixes this, which is deliberate: the failure message says so and points at the recovery code to reassess.

