### PR TITLE
feat(swapper): route mainnet swaps to self-hosted Boltz

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use bitcoin::{bip32, ScriptBuf};
 use boltz_client::{
-    boltz::{ChainPair, BOLTZ_MAINNET_URL_V2, BOLTZ_TESTNET_URL_V2},
+    boltz::{ChainPair, BOLTZ_TESTNET_URL_V2},
     network::{BitcoinChain, Chain, LiquidChain},
     swaps::boltz::{
         CreateChainResponse, CreateReverseResponse, CreateSubmarineResponse, Leaf, Side, SwapTree,
@@ -42,6 +42,8 @@ pub const LIQUID_FEE_RATE_MSAT_PER_VBYTE: f32 = (LIQUID_FEE_RATE_SAT_PER_VBYTE *
 pub const BREEZ_SYNC_SERVICE_URL: &str = "https://datasync.breez.technology";
 pub const BREEZ_LIQUID_ESPLORA_URL: &str = "https://lq1.breez.technology/liquid/api";
 pub const BREEZ_SWAP_PROXY_URL: &str = "https://swap.breez.technology/v2";
+/// Default self-hosted Boltz swap API (v2) base URL used on Mainnet.
+pub const SELF_HOSTED_BOLTZ_URL: &str = "https://satsrouting.exchange/v2";
 pub const DEFAULT_ONCHAIN_FEE_RATE_LEEWAY_SAT: u64 = 500;
 const DEFAULT_ONCHAIN_SYNC_PERIOD_SEC: u32 = 10;
 const DEFAULT_ONCHAIN_SYNC_REQUEST_TIMEOUT_SEC: u32 = 7;
@@ -260,13 +262,8 @@ impl Config {
 
     pub(crate) fn default_boltz_url(&self) -> &str {
         match self.network {
-            LiquidNetwork::Mainnet => {
-                if self.breez_api_key.is_some() {
-                    BREEZ_SWAP_PROXY_URL
-                } else {
-                    BOLTZ_MAINNET_URL_V2
-                }
-            }
+            // Default to the self-hosted Boltz instance on Mainnet.
+            LiquidNetwork::Mainnet => SELF_HOSTED_BOLTZ_URL,
             LiquidNetwork::Testnet => BOLTZ_TESTNET_URL_V2,
             // On regtest use the swapproxy instance by default
             LiquidNetwork::Regtest => "http://localhost:8387/v2",

--- a/lib/core/src/swapper/boltz/mod.rs
+++ b/lib/core/src/swapper/boltz/mod.rs
@@ -7,7 +7,7 @@ use crate::model::BREEZ_SWAP_PROXY_URL;
 use crate::{
     error::{PaymentError, SdkError},
     model::LIQUID_FEE_RATE_SAT_PER_VBYTE,
-    prelude::{ChainSwap, Config, Direction, LiquidNetwork, SendSwap, Swap, Transaction, Utxo},
+    prelude::{ChainSwap, Config, Direction, SendSwap, Swap, Transaction, Utxo},
 };
 use anyhow::{anyhow, bail, Result};
 use boltz_client::reqwest::header::HeaderMap;
@@ -24,7 +24,6 @@ use boltz_client::{
 };
 use client::{BitcoinClient, LiquidClient};
 use log::{info, warn};
-use proxy::split_boltz_url;
 use rand::Rng;
 use secp256k1_musig::musig::{
     PartialSignature as MusigPartialSignature, PublicNonce as MusigPubNonce,
@@ -55,6 +54,9 @@ pub struct BoltzSwapper<P: ProxyUrlFetcher> {
     boltz_client: OnceLock<BoltzClient>,
     liquid_client: OnceLock<LiquidClient>,
     bitcoin_client: OnceLock<BitcoinClient>,
+    // Retained for API/constructor compatibility; swap URLs are now selected internally
+    // via `Config::default_boltz_url()`, so the proxy fetcher is no longer queried.
+    #[allow(dead_code)]
     proxy_url: Arc<P>,
     request_notifier: broadcast::Sender<WsRequest>,
     update_notifier: broadcast::Sender<boltz::SwapStatus>,
@@ -84,21 +86,11 @@ impl<P: ProxyUrlFetcher> BoltzSwapper<P> {
             return Ok(client);
         }
 
-        let (boltz_api_base_url, referral_id) = match &self.config.network {
-            LiquidNetwork::Testnet | LiquidNetwork::Regtest => (None, None),
-            LiquidNetwork::Mainnet => match self.proxy_url.fetch().await {
-                Ok(Some(boltz_swapper_urls)) => {
-                    if self.config.breez_api_key.is_some() {
-                        split_boltz_url(&boltz_swapper_urls.proxy_url)
-                    } else {
-                        split_boltz_url(&boltz_swapper_urls.boltz_url)
-                    }
-                }
-                _ => (None, None),
-            },
-        };
-
-        let boltz_url = boltz_api_base_url.unwrap_or(self.config.default_boltz_url().to_string());
+        // The Boltz API base URL is selected per-network by `default_boltz_url()`.
+        // On Mainnet this points to the self-hosted instance (see `SELF_HOSTED_BOLTZ_URL`),
+        // so swaps never go through the Breez swap proxy.
+        let referral_id: Option<String> = None;
+        let boltz_url = self.config.default_boltz_url().to_string();
 
         let mut ws_auth_api_key = None;
         let mut headers = HeaderMap::new();

--- a/lib/core/src/swapper/boltz/proxy.rs
+++ b/lib/core/src/swapper/boltz/proxy.rs
@@ -4,29 +4,13 @@ use crate::PRODUCTION_BREEZSERVER_URL;
 use anyhow::Result;
 use log::warn;
 use sdk_common::prelude::{BoltzSwapperUrls, BreezServer};
-use url::Url;
 
 use crate::{persist::Persister, swapper::ProxyUrlFetcher};
 
+#[allow(dead_code)]
 pub(crate) struct BoltzProxyFetcher {
     url: OnceLock<Option<BoltzSwapperUrls>>,
     persister: std::sync::Arc<Persister>,
-}
-
-pub(crate) fn split_boltz_url(url: &str) -> (Option<String>, Option<String>) {
-    Url::parse(url)
-        .map(|url| {
-            let api_base_url = url.domain().map(|domain| format!("https://{domain}/v2"));
-            let referral_id = url.query().and_then(|q| {
-                q.split('=')
-                    .map(Into::into)
-                    .collect::<Vec<String>>()
-                    .get(1)
-                    .cloned()
-            });
-            (api_base_url, referral_id)
-        })
-        .unwrap_or_default()
 }
 
 impl BoltzProxyFetcher {

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -163,6 +163,9 @@ pub trait SwapperStatusStream: Send + Sync {
     ) -> broadcast::Receiver<boltz_client::boltz::InvoiceRequest>;
 }
 
+// Retained for API compatibility. Swap URLs are now selected internally via
+// `Config::default_boltz_url()`, so this fetcher is no longer queried at runtime.
+#[allow(dead_code)]
 #[sdk_macros::async_trait]
 pub(crate) trait ProxyUrlFetcher: Send + Sync + 'static {
     async fn fetch(&self) -> Result<&Option<BoltzSwapperUrls>>;


### PR DESCRIPTION
Hardcode the mainnet Boltz API base URL to the self-hosted instance (SELF_HOSTED_BOLTZ_URL) and select it directly in the Boltz client, bypassing the Breez swap proxy URL fetch. The proxy fetcher and its plumbing are retained for API/binding compatibility (marked dead_code), so no bindings need regeneration.